### PR TITLE
Nav header links in Safari and MSEdge were looking pixelated; Upping …

### DIFF
--- a/src/clarity/nav/_header.clarity.scss
+++ b/src/clarity/nav/_header.clarity.scss
@@ -32,7 +32,7 @@ $clr-search-icon-width: $clr_baselineRem_1;
 
 @mixin header-nav-appearance() {
     color: $clr-header-textColor;
-    opacity: 0.85;
+    opacity: 0.65;
 
     &:hover {
         opacity: 1;
@@ -63,6 +63,7 @@ $clr-search-icon-width: $clr_baselineRem_1;
         //text-link
         .nav-text {
             padding: 0 $clr_baselineRem_1;
+            font-weight: 500;
         }
 
         //.nav-text acts like the alt attribute for screens where responsiveness kicks in.


### PR DESCRIPTION
…font-weight to fix that

BEFORE
![screen shot 2016-10-31 at 8 28 33 am](https://cloud.githubusercontent.com/assets/2728359/19856443/5e6dd300-9f47-11e6-9f4d-de571e0864df.png)

AFTER
![screen shot 2016-10-31 at 8 42 26 am](https://cloud.githubusercontent.com/assets/2728359/19856442/5e6a0428-9f47-11e6-875f-b160e65f4942.png)

