### PR TITLE
Enabling SASS overwrites

### DIFF
--- a/build/tasks/publish.js
+++ b/build/tasks/publish.js
@@ -65,10 +65,11 @@ gulp.task("npm:ui:deliverables", function () {
 });
 
 /**
- * We publish SCSS sources just for information.
+ * We publish SCSS sources so users can make changes to them and compile on their own.
  */
 gulp.task("npm:ui:sources", function () {
     return gulp.src([
+        "src/clarity/main.scss",
         "src/clarity/**/*.clarity.scss",
         "!src/clarity/**/demo/**"
     ])

--- a/src/clarity/alert/_alert.clarity.scss
+++ b/src/clarity/alert/_alert.clarity.scss
@@ -5,73 +5,73 @@
 @import "../buttons/buttons.clarity";
 @import "../typography/typography.clarity";
 
-$app-level-alert-color: $clr-white;
-$icon-margin-right: $clr_baselineRem_0_25;
+$clr-app-level-alert-color: $clr-white !default;
+$clr-icon-margin-right: $clr_baselineRem_0_25 !default;
 
 //Regular Alert
-$alert-top-margin: $clr_baselineRem_0_25;
-$alert-min-height: $clr_baselineRem_1_5;
-$alert-font-size: clr-getTypePropertyValueForDomElement(alert_text, font-size);
-$alert-horizontal-padding: $clr_baselineRem_0_5;
-$alert-top-padding: $clr_baselineRem_0_125;
-$alert-bottom-padding: $clr_baselineRem_0_375;
-$alert-item-top-margin: $alert-bottom-padding - $alert-top-padding;
-$alert-item-min-height: $clr-icon-dimension-sm;
+$clr-alert-top-margin: $clr_baselineRem_0_25 !default;
+$clr-alert-min-height: $clr_baselineRem_1_5 !default;
+$clr-alert-font-size: clr-getTypePropertyValueForDomElement(alert_text, font-size);
+$clr-alert-horizontal-padding: $clr_baselineRem_0_5 !default;
+$clr-alert-top-padding: $clr_baselineRem_0_125 !default;
+$clr-alert-bottom-padding: $clr_baselineRem_0_375 !default;
+$clr-alert-item-top-margin: $clr-alert-bottom-padding - $clr-alert-top-padding !default;
+$clr-alert-item-min-height: $clr-icon-dimension-sm !default;
 
 //Small Alert
-$alert-sm-min-height: $clr_baselineRem_1;
-$alert-sm-font-size: clr-getTypePropertyValueForDomElement(alert-small_text, font-size);
-$alert-sm-horizontal-padding: $clr_baselineRem_0_25;
-$alert-sm-top-padding: 0;
-$alert-sm-bottom-padding: $clr_baselineRem_0_125;
-$alert-sm-item-top-margin: $alert-sm-bottom-padding - $alert-sm-top-padding;
-$alert-sm-item-min-height: $clr-icon-dimension-sm;
+$clr-alert-sm-min-height: $clr_baselineRem_1 !default;
+$clr-alert-sm-font-size: clr-getTypePropertyValueForDomElement(alert-small_text, font-size);
+$clr-alert-sm-horizontal-padding: $clr_baselineRem_0_25 !default;
+$clr-alert-sm-top-padding: 0 !default;
+$clr-alert-sm-bottom-padding: $clr_baselineRem_0_125 !default;
+$clr-alert-sm-item-top-margin: $clr-alert-sm-bottom-padding - $clr-alert-sm-top-padding !default;
+$clr-alert-sm-item-min-height: $clr-icon-dimension-sm !default;
 
-$alert-colors: (
+$clr-alert-colors: (
         info: (
-                background: $action-blues-lightest,
-                font: $action-blues-dark,
-                border: $action-blues-light
+                background: $clr-action-blue-lightest,
+                font: $clr-action-blue-dark,
+                border: $clr-action-blue-light
         ),
         success: (
-                background: $greens-lightest,
-                font: $greens-dark,
-                border: $greens-light
+                background: $clr-green-lightest,
+                font: $clr-green-dark,
+                border: $clr-green
         ),
         warning: (
-                background: $yellows-lighter,
-                font: $gray-darkest,
-                border: $yellows-light
+                background: $clr-yellow-lighter,
+                font: $clr-near-black,
+                border: $clr-yellow
         ),
         danger: (
-                background: $reds-lighter,
-                font: $reds-dark,
-                border: $reds-light
+                background: $clr-red-lighter,
+                font: $clr-red-dark,
+                border: $clr-red-light
         ),
         app-info: (
-                background: $clr-actionblue,
-                font: $app-level-alert-color,
+                background: $clr-action-blue,
+                font: $clr-app-level-alert-color,
                 border: none
         ),
         app-success: (
-                background: $greens-light-midtone,
-                font: $app-level-alert-color,
+                background: $clr-green-light-midtone,
+                font: $clr-app-level-alert-color,
                 border: none
         ),
         app-warning: (
-                background: $yellows-dark,
-                font: $app-level-alert-color,
+                background: $clr-yellow-dark,
+                font: $clr-app-level-alert-color,
                 border: none
         ),
         app-danger: (
                 background: $clr-red,
-                font: $app-level-alert-color,
+                font: $clr-app-level-alert-color,
                 border: none
         )
-);
+) !default;
 
 @mixin generateAlertType($alertType:"info") {
-    $propMap: map-get($alert-colors, $alertType);
+    $propMap: map-get($clr-alert-colors, $alertType);
     background: map-get($propMap, background);
     color: map-get($propMap, font);
 
@@ -97,16 +97,16 @@ $alert-colors: (
 
     .alert {
         @include clr-getTypePropertiesForDomElement(alert_text, (font-size, letter-spacing));
-        line-height: $alert-font-size;
+        line-height: $clr-alert-font-size;
         position: relative;
         box-sizing: border-box;
         display: flex;
         flex-direction: column;
-        min-height: $alert-min-height;
+        min-height: $clr-alert-min-height;
         width: auto;
-        padding: $alert-top-padding $alert-horizontal-padding $alert-bottom-padding $alert-horizontal-padding;
+        padding: $clr-alert-top-padding $clr-alert-horizontal-padding $clr-alert-bottom-padding $clr-alert-horizontal-padding;
         border-radius: $clr-default-borderradius;
-        margin-top: $alert-top-margin;
+        margin-top: $clr-alert-top-margin;
         @include generateAlertType(info);
 
         &.alert-info {
@@ -130,8 +130,8 @@ $alert-colors: (
             display: flex;
             align-items: center;
             flex-wrap: nowrap;
-            margin-top: $alert-item-top-margin;
-            min-height: $alert-item-min-height;
+            margin-top: $clr-alert-item-top-margin;
+            min-height: $clr-alert-item-min-height;
 
             //display: inline-block and max-width were specifically added for IE 10.
             //Flexbox content wouldn't wrap otherwise :(. 98% was just an estimate to distance the text from the
@@ -141,7 +141,7 @@ $alert-colors: (
                 display: inline-block;
                 max-width: 98%;
                 margin-right: $clr_baselineRem_0_5;
-                padding-left: $clr-icon-dimension-sm + $icon-margin-right;
+                padding-left: $clr-icon-dimension-sm + $clr-icon-margin-right;
 
                 //TODO: Added 1px padding top to help with the vertical alignment. Figure out why vertical alignment
                 //doesn't work without this.
@@ -159,7 +159,7 @@ $alert-colors: (
             .clr-icon {
                 height: $clr-icon-dimension-sm;
                 width: $clr-icon-dimension-sm;
-                margin-right: $icon-margin-right;
+                margin-right: $clr-icon-margin-right;
             }
 
             .clr-icon + .alert-text {
@@ -273,23 +273,23 @@ $alert-colors: (
 
             //Icons
             & > .alert-item > .alert-text::before, &.alert-info > .alert-item > .alert-text::before {
-                background-image: generateInfoIcon($app-level-alert-color);
+                background-image: generateInfoIcon($clr-app-level-alert-color);
             }
 
             &.alert-success > .alert-item > .alert-text::before {
-                background-image: generateSuccessIcon($app-level-alert-color);
+                background-image: generateSuccessIcon($clr-app-level-alert-color);
             }
 
             &.alert-warning > .alert-item > .alert-text::before {
-                background-image: generateWarningIcon($app-level-alert-color);
+                background-image: generateWarningIcon($clr-app-level-alert-color);
             }
 
             &.alert-danger > .alert-item > .alert-text::before {
-                background-image: generateErrorIcon($app-level-alert-color);
+                background-image: generateErrorIcon($clr-app-level-alert-color);
             }
 
             .close {
-                color: $app-level-alert-color;
+                color: $clr-app-level-alert-color;
                 top: 8px;
                 opacity: 0.75;
 
@@ -303,14 +303,14 @@ $alert-colors: (
     .alert {
         &.alert-sm {
             @include clr-getTypePropertiesForDomElement(alert-small_text, (font-size, letter-spacing));
-            line-height: $alert-sm-font-size;
+            line-height: $clr-alert-sm-font-size;
 
-            min-height: $alert-item-min-height;
+            min-height: $clr-alert-item-min-height;
             //Rigth padding same as regular alert to factor in the close button
-            padding: $alert-sm-top-padding $alert-horizontal-padding $alert-sm-bottom-padding $alert-sm-horizontal-padding;
+            padding: $clr-alert-sm-top-padding $clr-alert-horizontal-padding $clr-alert-sm-bottom-padding $clr-alert-sm-horizontal-padding;
 
             .alert-item {
-                margin-top: $alert-sm-item-top-margin;
+                margin-top: $clr-alert-sm-item-top-margin;
 
                 .alert-text{
 
@@ -339,7 +339,7 @@ $alert-colors: (
 
             .alert-actions {
                 margin-top: $clr_baselineRem_0_125;
-                margin-left: $clr-icon-dimension-sm + $icon-margin-right;
+                margin-left: $clr-icon-dimension-sm + $clr-icon-margin-right;
             }
         }
 
@@ -356,10 +356,9 @@ $alert-colors: (
     //1.cards
     .card {
         .alert {
-            $alert-card-horizontal-margin: 0;
-            $alert-card-vertical-margin: $clr_baselineRem_0_25;
-
-            margin: $alert-card-vertical-margin $alert-card-horizontal-margin;
+            $clr-alert-card-horizontal-margin: 0;
+            $clr-alert-card-vertical-margin: $clr_baselineRem_0_25;
+            margin: $clr-alert-card-vertical-margin $clr-alert-card-horizontal-margin;
         }
     }
 

--- a/src/clarity/buttons/_buttons.clarity.scss
+++ b/src/clarity/buttons/_buttons.clarity.scss
@@ -104,10 +104,10 @@ $clr-global-button-properties-map: (
 );
 
 //Button Variables
-$clr-button-horizontal-padding: $clr_baselineRem_0_5;
-$clr-button-height: $clr_baselineRem_1_5;
-$clr-button-height-sm: $clr_baselineRem_1;
-$clr-button-padding: 0 $clr-button-horizontal-padding;
+$clr-button-horizontal-padding: $clr_baselineRem_0_5 !default;
+$clr-button-height: $clr_baselineRem_1_5 !default;
+$clr-button-height-sm: $clr_baselineRem_1 !default;
+$clr-button-padding: 0 $clr-button-horizontal-padding !default;
 
 //Call to Action & Standard Button Appearance
 $clr-button-appearance-map: (

--- a/src/clarity/color/demo/color-contrast.demo.scss
+++ b/src/clarity/color/demo/color-contrast.demo.scss
@@ -67,8 +67,8 @@
 
     $allMyTextColors: (
         "gray": map-get($clr-grays, text-colors),
-        "action": map-get($clr-actionblues, text-colors),
-        "purple": map-get($clr-actionpurples, text-colors),
+        "action": map-get($clr-action-blues, text-colors),
+        "purple": map-get($clr-action-purples, text-colors),
         "red": map-get($clr-reds, text-colors),
         "yellow": map-get($clr-yellows, text-colors),
         "green": map-get($clr-greens, text-colors)

--- a/src/clarity/color/demo/color-palette.demo.scss
+++ b/src/clarity/color/demo/color-palette.demo.scss
@@ -3,7 +3,7 @@
 @import "../color.clarity";
 @import "./color-shared.demo";
 
-$clrdemo-colormaps: ($clr-base-colors, $clr-grays, $clr-actionblues, $clr-actionpurples, $clr-reds, $clr-yellows, $clr-greens);
+$clrdemo-colormaps: ($clr-base-colors, $clr-grays, $clr-action-blues, $clr-action-purples, $clr-reds, $clr-yellows, $clr-greens);
 
 .card-block {
     padding-bottom: 0;

--- a/src/clarity/color/utils/_helpers.clarity.scss
+++ b/src/clarity/color/utils/_helpers.clarity.scss
@@ -51,9 +51,9 @@
         base: $clr-base-colors,
         grays: $clr-grays,
         neutrals: $clr-grays,
-        action-blues: $clr-actionblues,
-        action-purples: $clr-actionpurples,
-        purples: $clr-actionpurples,
+        action-blues: $clr-action-blues,
+        action-purples: $clr-action-purples,
+        purples: $clr-action-purples,
         reds: $clr-reds,
         greens: $clr-greens,
         yellows: $clr-yellows

--- a/src/clarity/forms/_forms.clarity.scss
+++ b/src/clarity/forms/_forms.clarity.scss
@@ -8,15 +8,15 @@
 $styledInputs: inputs("text", "password", "number", "email");
 $styledInputs1: inputs("button","submit");
 
-$clr-form-field-border-color: $gray-dark-midtone;
-$clr-form-field-background-color: $action-blues-light-midtone;
-$clr-form-disabled-background-color: $gray-light-midtone;
-$clr-form-field-disabled-color: $gray-dark;
+$clr-form-field-border-color: $clr-dark-midtone-gray !default;
+$clr-form-field-background-color: $clr-action-blue-light-midtone !default;
+$clr-form-disabled-background-color: $clr-light-midtone-gray !default;
+$clr-form-field-disabled-color: $clr-gray !default;
 
-$clr-checkbox-radio-height: $clr-icon-dimension-sm;
-$clr-form-icon-dim: $clr-icon-dimension-sm;
+$clr-checkbox-radio-height: $clr-icon-dimension-sm !default;
+$clr-form-icon-dim: $clr-icon-dimension-sm !default;
 
-$clr-custom-checkbox-radio-top: ($clr_baselineRem_1 - $clr-checkbox-radio-height) / 2;
+$clr-custom-checkbox-radio-top: ($clr_baselineRem_1 - $clr-checkbox-radio-height) / 2 !default;
 
 //Standard Clarity Input Bottom Border Animation
 @mixin input-border-bottom-animation($border-color: clr-getColor(light-midtone,action-blues)) {

--- a/src/clarity/images/_images.clarity.scss
+++ b/src/clarity/images/_images.clarity.scss
@@ -3,8 +3,6 @@
 @import 'node_modules/bootstrap/scss/images';
 @import './icons.clarity';
 
-$clr-icon-dimension-sm: rem(1);
-
 @include exports('images.clarity') {
     %icon-styles {
         display: inline-block;

--- a/src/clarity/labels/_labels.clarity.scss
+++ b/src/clarity/labels/_labels.clarity.scss
@@ -4,34 +4,34 @@
 @import "../utils/helpers.clarity";
 @import "../typography/typography.clarity";
 
-$padding-top-bottom: $clr_baselineRem_0_125;
-$padding-left-right: $clr_baselineRem_0_5;
+$clr-padding-top-bottom: $clr_baselineRem_0_125 !default;
+$clr-padding-left-right: $clr_baselineRem_0_5 !default;
 
-$label-colors: (
+$clr-label-colors: (
     gray: (
-        background: $gray-dark,
-        font: $gray-lightest
+        background: $clr-gray,
+        font: $clr-white
     ),
     purple: (
-        background: $action-purples-light-midtone,
-        font: $gray-lightest
+        background: $clr-action-purple-light-midtone,
+        font: $clr-white
     ),
     blue: (
-        background: $action-blues-dark,
-        font: $gray-lightest
+        background: $clr-action-blue-dark,
+        font: $clr-white
     ),
     orange: (
-        background: $yellows-light-midtone,
-        font: black
+        background: $clr-yellow-light-midtone,
+        font: $clr-black
     ),
     light-blue: (
-        background: $action-blues-lighter,
-        font: black
+        background: $clr-action-blue-lighter,
+        font: $clr-black
     )
-);
+) !default;
 
 @mixin generateLabelStyles($color:gray,$alias:1) {
-    $color-map: map-get($label-colors,$color);
+    $color-map: map-get($clr-label-colors,$color);
     &.label-#{$color},&.label-#{$alias} {
         border: 1px solid map-get($color-map,background);
     }
@@ -55,7 +55,7 @@ $label-colors: (
 };
 
 @mixin generateBadgeStyles($color:gray,$alias:1) {
-    $color-map: map-get($label-colors,$color);
+    $color-map: map-get($clr-label-colors,$color);
     &.badge-#{$color},&.badge-#{$alias} {
         background: map-get($color-map,background);
         color: map-get($color-map,font)
@@ -126,8 +126,6 @@ $badge-status: (
     //instead of using our baselineRem function. This was done to achieve the desired look
     //and to align this with our vertical baseline. Not sure why but aligning inline-blocks within inline-blocks
     //is a bit tricky. I initially used display: inline-block but I wasn't able to align the labels properly.
-    //TODO: I still am unable to align the labels center of the baseline but have managed to aligned it to the
-    //bottom. There are no margins which are influencing this. Need to figure out whats the issue.
     .label, a.label {
         //default
 
@@ -136,11 +134,11 @@ $badge-status: (
         // line-height needed to be adjusted to force center alignment
         line-height: 11px;
 
-        $color-map: map-get($label-colors, gray);
+        $color-map: map-get($clr-label-colors, gray);
         display: inline-flex;
         justify-content: center;
         align-items: center;
-        padding: 0 $padding-left-right;
+        padding: 0 $clr-padding-left-right;
         border-radius: $clr_baselineRem_0_5;
         border: 1px solid $gray-dark;
         height: baselineRem(0.875);
@@ -190,7 +188,7 @@ $badge-status: (
     //TODO: I still am unable to align the badges center of the baseline but have managed to aligned it to the
     //bottom. There are no margins which are influencing this. Need to figure out whats the issue.
     .badge {
-        $color-map: map-get($label-colors, gray);
+        $color-map: map-get($clr-label-colors, gray);
         $equiDimensions: rem(15/$clr-rem-denominator);
         $rem_10: rem(10/$clr-rem-denominator);
 

--- a/src/clarity/login/_login.clarity.scss
+++ b/src/clarity/login/_login.clarity.scss
@@ -5,20 +5,20 @@
 @import "../images/icons.clarity";
 @import "../typography/typography.clarity";
 
-$login-background-color: $clr-white;
-$login_width: baselineRem(21);
-$login_icon_size: $clr-icon-dimension-sm;
+$clr-login-background-color: $clr-white !default;
+$clr-login-width: baselineRem(21) !default;
+$clr-login-icon-size: $clr-icon-dimension-sm !default;
 
 @include exports('login.clarity') {
     .login-wrapper {
         display: flex;
         background: generateLoginBackground();
         background-size: cover;
-        background-position: $login_width 0;
+        background-position: $clr-login-width 0;
         background-repeat: no-repeat;
 
         .login {
-            background: $login-background-color;
+            background: $clr-login-background-color;
             position: relative;
             display: flex;
             flex-direction: column;
@@ -26,7 +26,7 @@ $login_icon_size: $clr-icon-dimension-sm;
             padding: $clr_baselineRem_1 $clr_baselineRem_4;
             height: auto;
             min-height: 100vh;
-            width: $login_width;
+            width: $clr-login-width;
 
             .title {
                 @include clr-getTypePropertiesForDomElement(login_productName, (color, font-weight, font-family, font-size, letter-spacing));
@@ -68,24 +68,24 @@ $login_icon_size: $clr-icon-dimension-sm;
                     margin: $clr_baselineRem_0_25 0 0 0;
                     padding: $clr_baselineRem_0_375 $clr_baselineRem_0_5;
                     background: clr-getColor(dark-midtone, reds);
-                    color: $login-background-color;
+                    color: $clr-login-background-color;
                     border-radius: $clr-default-borderradius;
                     line-height: $clr_baselineRem_0_75;
 
                     &:before {
                         display: inline-block; //needed for IE. display: none to display:flex on parent doesnt work
                         content: '';
-                        background: generateErrorIcon($login-background-color);
+                        background: generateErrorIcon($clr-login-background-color);
                         margin: 0 $clr_baselineRem_0_25 0 0;
-                        height: $login_icon_size;
-                        width: $login_icon_size;
+                        height: $clr-login-icon-size;
+                        width: $clr-login-icon-size;
                     }
 
                     &.active {
                         display: flex;
 
                         &:before {
-                            flex: 0 0 $login_icon_size;
+                            flex: 0 0 $clr-login-icon-size;
                         }
                     }
                 }
@@ -122,7 +122,7 @@ $login_icon_size: $clr-icon-dimension-sm;
     @media screen and (max-width: map-get($clr-breakpoints, medium)) {
         .login-wrapper {
             justify-content: center;
-            background: $login-background-color;
+            background: $clr-login-background-color;
 
             .login {
                 width: 100%;

--- a/src/clarity/main.scss
+++ b/src/clarity/main.scss
@@ -1,3 +1,4 @@
+@import "./utils/overwrites.clarity";
 @import "./utils/mixins.clarity";
 @import "./utils/normalize.clarity";
 @import "./utils/reboot.clarity";

--- a/src/clarity/modal/_modal.clarity.scss
+++ b/src/clarity/modal/_modal.clarity.scss
@@ -5,10 +5,10 @@
 @import "../utils/layers.clarity";
 @import "../typography/typography.clarity";
 
-$clr-modal-sm-width: baselineRem(12);
-$clr-modal-md-width: baselineRem(24);
-$clr-modal-lg-width: baselineRem(36);
-$clr-modal-xl-width: baselineRem(48);
+$clr-modal-sm-width: baselineRem(12) !default;
+$clr-modal-md-width: baselineRem(24) !default;
+$clr-modal-lg-width: baselineRem(36) !default;
+$clr-modal-xl-width: baselineRem(48) !default;
 
 .modal {
     position: fixed;

--- a/src/clarity/nav/_sidenav.clarity.scss
+++ b/src/clarity/nav/_sidenav.clarity.scss
@@ -4,7 +4,7 @@
 @import "../color/color.clarity";
 @import "../typography/typography.clarity";
 
-$sidenav-border-color: $gray-light-midtone;
+$clr-sidenav-border-color: $clr-light-midtone-gray !default;
 
 @mixin nav-link-colors {
     &:hover {
@@ -27,7 +27,7 @@ $sidenav-border-color: $gray-light-midtone;
         max-width: baselineRem(13);
         min-width: baselineRem(9);
         width: $clr-sidenav-width;
-        border-right: 1px solid $sidenav-border-color;
+        border-right: 1px solid $clr-sidenav-border-color;
         display: flex;
         flex-direction: column;
 
@@ -36,7 +36,7 @@ $sidenav-border-color: $gray-light-midtone;
             height: $clr_baselineRem_2;
             padding-left: $clr_baselineRem_1_5;
             width: 100%;
-            border-bottom: 1px solid $sidenav-border-color;
+            border-bottom: 1px solid $clr-sidenav-border-color;
 
             .select {
                 width: 100%;

--- a/src/clarity/progress-bars/_progress-bars.clarity.scss
+++ b/src/clarity/progress-bars/_progress-bars.clarity.scss
@@ -9,7 +9,7 @@
 @import "./utils/mixins.clarity";
 @import "../card/card.clarity";
 
-$clr-progress-defaultBarColor: $clr-actionblue !default;
+$clr-progress-defaultBarColor: $clr-action-blue !default;
 $clr-progress-bgColor: $clr-light-gray !default;
 
 @include exports('prgross-bars.clarity') {

--- a/src/clarity/progress-bars/utils/mixins.clarity.scss
+++ b/src/clarity/progress-bars/utils/mixins.clarity.scss
@@ -1,4 +1,4 @@
-@mixin clr-progress-color($color: $clr-actionblue) {
+@mixin clr-progress-color($color: $clr-action-blue) {
     // for IE...
     color: $color;
 

--- a/src/clarity/tables/_tables.clarity.scss
+++ b/src/clarity/tables/_tables.clarity.scss
@@ -4,26 +4,28 @@
 @import "../typography/typography.clarity";
 
 // Backgrounds
-$clr-table-bgcolor: clr-getColor(white);
-$clr-thead-bgcolor: clr-getColor(lighter);
+$clr-table-bgcolor: $clr-white !default;
+$clr-thead-bgcolor: $clr-near-white !default;
 
 // Borders
-$clr-tablerow-bordercolor: clr-getColor(light); // #EEE
-$clr-table-bordercolor: clr-getColor(light-midtone); // #CCC
-$clr-table-borderwidth: 1px;
-$clr-table-borderstyle: $clr-table-borderwidth solid $clr-table-bordercolor;
+$clr-tablerow-bordercolor: $clr-light-gray !default;
+$clr-table-bordercolor: $clr-light-midtone-gray !default;
+$clr-table-borderwidth: 1px !default;
+$clr-table-borderstyle: $clr-table-borderwidth solid $clr-table-bordercolor !default;
 
 // Etc.
 $clr-table-fontsize: clr-getTypePropertyValueForDomElement(table_text, font-size);
-$clr-table-lineheight: rem(1);
-$clr-table-cellpadding: $clr_baselineRem_0_5;
-$clr-table-lineheightPaddingShim: ($clr_baselineRem_1 - $clr-table-lineheight)/2;
+$clr-table-lineheight: rem(1) !default;
+$clr-table-cellpadding: $clr_baselineRem_0_5 !default;
+$clr-table-smallpadding: 0.5 * $clr-table-cellpadding !default;
+
+$clr-table-lineheightPaddingShim: ($clr_baselineRem_1 - $clr-table-lineheight)/2 !default;
 $clr-table-headerLineheightPaddingShim: ($clr_baselineRem_1 - clr-getTypePropertyValueForDomElement(table_header, font-size))/2;
-$clr-table-vertpadding: (($clr-table-cellpadding - $clr-table-borderwidth) * 0.5) + $clr-table-lineheightPaddingShim; // have to account for border...
-$clr-table-smallpadding: 0.5 * $clr-table-cellpadding;
+$clr-table-vertpadding: (($clr-table-cellpadding - $clr-table-borderwidth) * 0.5) + $clr-table-lineheightPaddingShim !default; // have to account for border...
+
 // Border radius of corner cells needs to be slightly less than the table's,
 // To make sure they correctly cover the whole area up to the border.
-$clr-table-cornercellradius: $clr-default-borderradius - 1;
+$clr-table-cornercellradius: $clr-default-borderradius - 1 !default;
 
 // Mixin for basic table styles to be able to reuse them on non-table elements.
 @mixin basic-table($table, $thead, $tbody, $tr, $th, $td) {

--- a/src/clarity/tooltips/_tooltips.clarity.scss
+++ b/src/clarity/tooltips/_tooltips.clarity.scss
@@ -5,24 +5,24 @@
 @import "../utils/layers.clarity";
 @import "../typography/typography.clarity";
 
-$tooltip-font-color: clr-getColor(lightest);
-$tooltip-background-color: clr-getColor(black);
-$tooltip-default-width: baselineRem(10);
-$margin-value: $clr_baselineRem_0_25;
-$arrow-height: $clr_baselineRem_0_25;
-$arrow-width: baselineRem(5/24); //I wanted the arrow width to be 9. If I use 4.5/24 it still rounds up to 10.
-$tooltip-adjusted-margin: $margin-value + $arrow-width * 2;
+$clr-tooltip-font-color: $clr-white !default;
+$clr-tooltip-background-color: $clr-black !default;
+$clr-tooltip-default-width: baselineRem(10) !default;
+$margin-value: $clr_baselineRem_0_25 !default;
+$arrow-height: $clr_baselineRem_0_25 !default;
+$arrow-width: baselineRem(5/24) !default; //I wanted the arrow width to be 9. If I use 4.5/24 it still rounds up to 10.
+$clr-tooltip-adjusted-margin: $margin-value + $arrow-width * 2 !default;
 
 @mixin common-tooltip-styles {
     @include clr-getTypePropertiesForDomElement(tooltip_text, (font-size, font-weight, letter-spacing));
 
-    background: $tooltip-background-color;
+    background: $clr-tooltip-background-color;
     border-radius: $clr_baselineRem_0_125;
-    color: $tooltip-font-color;
+    color: $clr-tooltip-font-color;
     line-height: $clr_baselineRem_0_75;
     margin: 0; //Resetting any margin that might be applied to span/div elements inside forms
     padding: $clr_baselineRem_0_375 $clr_baselineRem_0_5;
-    width: $tooltip-default-width;
+    width: $clr-tooltip-default-width;
 }
 
 @mixin vertical-tooltip-generator($dirA:top, $dirB:right) {
@@ -38,7 +38,7 @@ $tooltip-adjusted-margin: $margin-value + $arrow-width * 2;
     #{$dirB}: auto;
 
     border-#{$oppA}-#{$oppB}-radius: 0;
-    margin-#{$oppA}: $tooltip-adjusted-margin;
+    margin-#{$oppA}: $clr-tooltip-adjusted-margin;
 
     &::before {
         position: absolute;
@@ -47,8 +47,8 @@ $tooltip-adjusted-margin: $margin-value + $arrow-width * 2;
         #{$dirA}: auto;
         #{$dirB}: auto;
         content: '';
-        border-#{$oppB}: $arrow-height solid $tooltip-background-color;
-        border-#{$dirA}: $arrow-width solid $tooltip-background-color;
+        border-#{$oppB}: $arrow-height solid $clr-tooltip-background-color;
+        border-#{$dirA}: $arrow-width solid $clr-tooltip-background-color;
         border-#{$dirB}: $arrow-height solid transparent;
         border-#{$oppA}: $arrow-width solid transparent;
     }
@@ -66,7 +66,7 @@ $tooltip-adjusted-margin: $margin-value + $arrow-width * 2;
     @include common-tooltip-styles;
 
     border-top-#{$oppA}-radius: 0;
-    margin-#{$oppA}: $tooltip-adjusted-margin;
+    margin-#{$oppA}: $clr-tooltip-adjusted-margin;
 
     &::before {
         position: absolute;
@@ -75,8 +75,8 @@ $tooltip-adjusted-margin: $margin-value + $arrow-width * 2;
         bottom: auto;
         #{$dirA}: auto;
         content: '';
-        border-top: $arrow-height solid $tooltip-background-color;
-        border-#{$dirA}: $arrow-width solid $tooltip-background-color;
+        border-top: $arrow-height solid $clr-tooltip-background-color;
+        border-#{$dirA}: $arrow-width solid $clr-tooltip-background-color;
         border-bottom: $arrow-height solid transparent;
         border-#{$oppA}: $arrow-width solid transparent;
     }
@@ -142,7 +142,7 @@ $tooltip-adjusted-margin: $margin-value + $arrow-width * 2;
         }
 
         &.tooltip-md > .tooltip-content {
-            width: $tooltip-default-width;
+            width: $clr-tooltip-default-width;
         }
 
         &.tooltip-lg > .tooltip-content {
@@ -159,16 +159,16 @@ $tooltip-adjusted-margin: $margin-value + $arrow-width * 2;
         & > .btn + .tooltip-content,
         &.tooltip-top-right > .btn + .tooltip-content,
         &.tooltip-top-left > .btn + .tooltip-content {
-            margin-bottom: $tooltip-adjusted-margin - $clr-button-vertical-margin;
+            margin-bottom: $clr-tooltip-adjusted-margin - $clr-button-vertical-margin;
         }
 
         &.tooltip-bottom-right > .btn + .tooltip-content,
         &.tooltip-bottom-left > .btn + .tooltip-content {
-            margin-top: $tooltip-adjusted-margin - $clr-button-vertical-margin;
+            margin-top: $clr-tooltip-adjusted-margin - $clr-button-vertical-margin;
         }
 
         &.tooltip-right > .btn + .tooltip-content {
-            margin-left: $tooltip-adjusted-margin - $clr-button-horizontal-margin;
+            margin-left: $clr-tooltip-adjusted-margin - $clr-button-horizontal-margin;
         }
     }
 

--- a/src/clarity/utils/_colors.clarity.scss
+++ b/src/clarity/utils/_colors.clarity.scss
@@ -1,13 +1,14 @@
-$clr-white: #fff;
-$clr-near-white: #fafafa;
-$clr-light-gray: #eee;
-$clr-lighter-midtone-gray: #ddd;
-$clr-light-midtone-gray: #ccc;
-$clr-dark-midtone-gray: #9a9a9a;
-$clr-gray: #747474;
-$clr-dark-gray:  #565656;
-$clr-near-black: #313131;
-$clr-black: #000;
+$clr-white: #fff !default;
+$clr-black: #000 !default;
+
+$clr-near-white: #fafafa !default; // clr-getColor(lighter)
+$clr-light-gray: #eee !default; // clr-getColor(light)
+$clr-lighter-midtone-gray: #ddd !default;
+$clr-light-midtone-gray: #ccc !default; // clr-getColor(light-midtone)
+$clr-dark-midtone-gray: #9a9a9a !default;
+$clr-gray: #747474 !default; //$gray-dark
+$clr-dark-gray: #565656 !default; //$gray-darker
+$clr-near-black: #313131 !default; //$gray-darkest
 
 // a value of 0 defaults to white; a value of 9 defaults to black
 // anyone this deep in the implementation details is either lost or
@@ -60,7 +61,19 @@ $clr-paletteIndexDefault-darkBg-clicked: 0;
     @return $returnMap;
 }
 
-$clr-gray-list: ($clr-white, $clr-near-white, $clr-light-gray, $clr-lighter-midtone-gray, $clr-light-midtone-gray, $clr-dark-midtone-gray, $clr-gray, $clr-dark-gray, $clr-near-black, $clr-black);
+$clr-gray-list: (
+    $clr-white,
+    $clr-near-white,
+    $clr-light-gray,
+    $clr-lighter-midtone-gray,
+    $clr-light-midtone-gray,
+    $clr-dark-midtone-gray,
+    $clr-gray,
+    $clr-dark-gray,
+    $clr-near-black,
+    $clr-black
+);
+
 $clr-gray-textColorOverrides: (
     lightest: nth($clr-gray-list, 2),
     darkest: nth($clr-gray-list, 9),
@@ -74,30 +87,86 @@ $clr-gray-textColorOverrides: (
 $clr-gray-textColorMap: _buildTextColorMap($clr-gray-textColorOverrides);
 $clr-grays: (label: gray, base: $clr-dark-gray, hex-colors: $clr-gray-list, text-colors: $clr-gray-textColorMap);
 
-$clr-blue: #006a91;
+$clr-blue: #006a91 !default;
+$clr-action-blue-lightest: #e1f1f6 !default;
+$clr-action-blue-lighter: #89cbdf !default;
+$clr-action-blue-light: #49afd9 !default;
+$clr-action-blue-light-midtone: #0094d2 !default;
+$clr-action-blue: #007cbb !default;
+$clr-action-blue-dark-midtone: #007cbb !default;
+$clr-action-blue-dark: #004a70 !default;
+$clr-action-blue-darker: #003a59 !default;
+$clr-action-blue-darkest: #002538 !default;
 
-$clr-actionblue: #007cbb;
-$clr-actionblue-list: (#e1f1f6, #89cbdf, #49afd9, #0094d2, $clr-actionblue, #004a70, #003a59, #002538);
-$clr-actionblue-textColorOverrides: (
-    lightest: lighten(nth($clr-actionblue-list, 1), 7%),
-    lightBg-hoverable: nth($clr-actionblue-list, 5),
-    darkBg-hoverable: lighten(nth($clr-actionblue-list, 1), 7%),
-    darkBg-subtext: darken(nth($clr-actionblue-list, 1), 7%)
+$clr-action-blue-list: (
+        $clr-action-blue-lightest,
+        $clr-action-blue-lighter,
+        $clr-action-blue-light,
+        $clr-action-blue-light-midtone,
+        $clr-action-blue,
+        $clr-action-blue-dark,
+        $clr-action-blue-darker,
+        $clr-action-blue-darkest
 );
-$clr-actionblue-textColorMap: _buildTextColorMap($clr-actionblue-textColorOverrides, $clr-actionblue-list);
-$clr-actionblues: (label: action-blue, base: $clr-actionblue, hex-colors: $clr-actionblue-list, text-colors: $clr-actionblue-textColorMap);
 
-$clr-actionpurple: #853fb3;
-$clr-actionpurple-list: (#f3ecf7, #e7d9f0, #b68cd1, #9460b8, $clr-actionpurple, #660092, #50266b, #281336);
-$clr-actionpurple-textColorOverrides: (
-    lightBg-hoverable: nth($clr-actionpurple-list, 5),
-    lightBg-hovered: nth($clr-actionpurple-list, 6)
+$clr-action-blue-textColorOverrides: (
+    lightest: lighten(nth($clr-action-blue-list, 1), 7%),
+    lightBg-hoverable: nth($clr-action-blue-list, 5),
+    darkBg-hoverable: lighten(nth($clr-action-blue-list, 1), 7%),
+    darkBg-subtext: darken(nth($clr-action-blue-list, 1), 7%)
 );
-$clr-actionpurple-textColorMap: _buildTextColorMap($clr-actionpurple-textColorOverrides, $clr-actionpurple-list);
-$clr-actionpurples: (label: action-purple, base: $clr-actionpurple, hex-colors: $clr-actionpurple-list, text-colors: $clr-actionpurple-textColorMap);
+$clr-action-blue-textColorMap: _buildTextColorMap($clr-action-blue-textColorOverrides, $clr-action-blue-list);
+$clr-action-blues: (label: action-blue, base: $clr-action-blue, hex-colors: $clr-action-blue-list, text-colors: $clr-action-blue-textColorMap);
 
-$clr-red: #c92100;
-$clr-red-list: (#fbf1f2, #f5dbd9, #ebafa6, #e62700, $clr-red, #a32100, #7d2100, #642100);
+$clr-action-purple-lightest: #f3ecf7 !default;
+$clr-action-purple-lighter: #e7d9f0 !default;
+$clr-action-purple-light: #b68cd1 !default;
+$clr-action-purple-light-midtone: #9460b8 !default;
+$clr-action-purple: #853fb3 !default;
+$clr-action-purple-dark-midtone: #853fb3 !default;
+$clr-action-purple-dark: #660092 !default;
+$clr-action-purple-darker: #50266b !default;
+$clr-action-purple-darkest: #281336 !default;
+
+$clr-action-purple-list: (
+    $clr-action-purple-lightest,
+    $clr-action-purple-lighter,
+    $clr-action-purple-light,
+    $clr-action-purple-light-midtone,
+    $clr-action-purple,
+    $clr-action-purple-dark,
+    $clr-action-purple-darker,
+    $clr-action-purple-darkest
+);
+
+$clr-action-purple-textColorOverrides: (
+    lightBg-hoverable: nth($clr-action-purple-list, 5),
+    lightBg-hovered: nth($clr-action-purple-list, 6)
+);
+$clr-action-purple-textColorMap: _buildTextColorMap($clr-action-purple-textColorOverrides, $clr-action-purple-list);
+$clr-action-purples: (label: action-purple, base: $clr-action-purple, hex-colors: $clr-action-purple-list, text-colors: $clr-action-purple-textColorMap);
+
+$clr-red-lightest: #fbf1f2 !default;
+$clr-red-lighter: #f5dbd9 !default;
+$clr-red-light: #ebafa6 !default;
+$clr-red-light-midtone: #e62700 !default;
+$clr-red: #c92100 !default;
+$clr-red-dark-midtone: #c92100 !default;
+$clr-red-dark: #a32100 !default;
+$clr-red-darker: #7d2100 !default;
+$clr-red-darkest: #642100 !default;
+
+$clr-red-list: (
+    $clr-red-lightest,
+    $clr-red-lighter,
+    $clr-red-light,
+    $clr-red-light-midtone,
+    $clr-red,
+    $clr-red-dark,
+    $clr-red-darker,
+    $clr-red-darkest
+);
+
 $clr-red-textColorOverrides: (
     lightBg-hoverable: nth($clr-red-list, 5),
     lightBg-hovered: nth($clr-red-list, 6)
@@ -105,14 +174,52 @@ $clr-red-textColorOverrides: (
 $clr-red-textColorMap: _buildTextColorMap($clr-red-textColorOverrides, $clr-red-list);
 $clr-reds: (label: stoplight-red, base: $clr-red, hex-colors: $clr-red-list, text-colors: $clr-red-textColorMap);
 
-$clr-yellow: #efd603;
-$clr-yellow-list: (#f9f0e1, #feecb5, $clr-yellow, #eb8d00, #ce5c00, #c25400, #9e4100, #642100);
+
+$clr-yellow-lightest: #f9f0e1 !default;
+$clr-yellow-lighter: #feecb5 !default;
+$clr-yellow: #efd603 !default;
+$clr-yellow-light-midtone: #eb8d00 !default;
+$clr-yellow-dark-midtone: #ce5c00 !default;
+$clr-yellow-dark: #c25400 !default;
+$clr-yellow-darker: #9e4100 !default;
+$clr-yellow-darkest: #642100 !default;
+
+$clr-yellow-list: (
+    $clr-yellow-lightest,
+    $clr-yellow-lighter,
+    $clr-yellow,
+    $clr-yellow-light-midtone,
+    $clr-yellow-dark-midtone,
+    $clr-yellow-dark,
+    $clr-yellow-darker,
+    $clr-yellow-darkest
+);
+
 $clr-yellow-textColorOverrides: ();
 $clr-yellow-textColorMap: _buildTextColorMap($clr-yellow-textColorOverrides, $clr-yellow-list);
 $clr-yellows: (label: stoplight-yellow, base: $clr-yellow, hex-colors: $clr-yellow-list, text-colors: $clr-yellow-textColorMap);
 
-$clr-green: #60b515;
-$clr-green-list: (#dff0d0, #c6e4ab, $clr-green, #62a420, #318700, #266900, #1d5100, #0f2900);
+$clr-green-lightest: #dff0d0 !default;
+$clr-green-lighter: #c6e4ab !default;
+$clr-green: #60b515 !default;
+$clr-green-light-midtone: #62a420 !default;
+$clr-green-dark-midtone: #318700 !default;
+$clr-green-dark: #266900 !default;
+$clr-green-darker: #1d5100 !default;
+$clr-green-darkest: #0f2900 !default;
+
+
+$clr-green-list: (
+    $clr-green-lightest,
+    $clr-green-lighter,
+    $clr-green,
+    $clr-green-light-midtone,
+    $clr-green-dark-midtone,
+    $clr-green-dark,
+    $clr-green-darker,
+    $clr-green-darkest
+);
+
 $clr-green-textColorOverrides: (
     lightest: lighten(nth($clr-green-list, 1), 7%),
     lightBg-hoverable: nth($clr-green-list, 5)
@@ -120,5 +227,5 @@ $clr-green-textColorOverrides: (
 $clr-green-textColorMap: _buildTextColorMap($clr-green-textColorOverrides, $clr-green-list);
 $clr-greens: (label: stoplight-green, base: $clr-green, hex-colors: $clr-green-list, text-colors: $clr-green-textColorMap);
 
-$clr-base-color-list: ($clr-white, $clr-dark-gray, $clr-blue, $clr-actionblue, $clr-green);
+$clr-base-color-list: ($clr-white, $clr-dark-gray, $clr-blue, $clr-action-blue, $clr-green);
 $clr-base-colors: (label: base, base: $clr-white, hex-colors: $clr-base-color-list);

--- a/src/clarity/utils/_contrast-cache.clarity.scss
+++ b/src/clarity/utils/_contrast-cache.clarity.scss
@@ -122,7 +122,7 @@ $clr-blue-contrastCache: (
     )
 );
 
-$clr-actionblue-contrastCache: (
+$clr-action-blue-contrastCache: (
     #89cbdf: (
         lightest: ( low: $clr-near-black, default: $clr-near-black, high: $clr-near-black, superHigh: null ),
         darkest: ( low: $clr-black, default: $clr-black, high: $clr-black, superHigh: null ),
@@ -161,7 +161,7 @@ $clr-actionblue-contrastCache: (
     )
 );
 
-$clr-actionpurple-contrastCache: (
+$clr-action-purple-contrastCache: (
     #9460b8: (
         lightest: ( low: $clr-white, default: $clr-white, high: null, superHigh: null ),
         darkest: ( low: $clr-near-white, default: $clr-white, high: null, superHigh: null ),
@@ -261,8 +261,8 @@ $clr-green-contrastCache: (
 // more readable than a bunch of hex-colors in one assignement.
 $clr-contrastCache: $clr-gray-contrastCache;
 $clr-contrastCache:  map-merge($clr-contrastCache, $clr-blue-contrastCache);
-$clr-contrastCache:  map-merge($clr-contrastCache, $clr-actionblue-contrastCache);
-$clr-contrastCache:  map-merge($clr-contrastCache, $clr-actionpurple-contrastCache);
+$clr-contrastCache:  map-merge($clr-contrastCache, $clr-action-blue-contrastCache);
+$clr-contrastCache:  map-merge($clr-contrastCache, $clr-action-purple-contrastCache);
 $clr-contrastCache:  map-merge($clr-contrastCache, $clr-red-contrastCache);
 $clr-contrastCache:  map-merge($clr-contrastCache, $clr-yellow-contrastCache);
 $clr-contrastCache:  map-merge($clr-contrastCache, $clr-green-contrastCache);

--- a/src/clarity/utils/_helpers.clarity.scss
+++ b/src/clarity/utils/_helpers.clarity.scss
@@ -1,11 +1,13 @@
 //Because the "rem" unit does not work on pseudo-elements in IE,
 //we use a function to compute "rem" to "px" with Sass.
+
+$clr-baseline: 24px !default;
+
 @function rem($remSize) {
     @return $remSize * $clr-font-size;
 };
 
 @function baselineRem($remSize) {
-    $clr-baseline: 24px;
     @return $remSize * $clr-baseline;
 }
 

--- a/src/clarity/utils/_layers.clarity.scss
+++ b/src/clarity/utils/_layers.clarity.scss
@@ -10,4 +10,4 @@ $clr-layers: (
     modal-bg: 1040,
     modal: 1050,
     tooltips: 1070
-);
+) !default;

--- a/src/clarity/utils/_overwrites.clarity.scss
+++ b/src/clarity/utils/_overwrites.clarity.scss
@@ -1,0 +1,351 @@
+/*================================================================================*/
+/* Overwrite the default variable assignments in _layers.clarity.scss here:       */
+/*================================================================================*/
+
+$clr-layers: null;
+
+/*
+    (content: 0,
+    select-box: 2,
+    dropdown-menu: 1000,
+    alert: 1033,
+    sidepanel-bg: 1038,
+    sidepanel: 1039,
+    modal-bg: 1040,
+    modal: 1050,
+    tooltips: 1070);
+*/
+
+
+
+/*================================================================================*/
+/* Overwrite the default variable assignments in _variables.clarity.scss here:    */
+/*================================================================================*/
+
+
+// Breakpoints
+$clr-breakpoints: null; // (small: 544px, medium: 768px, large : 992px, xlarge: 1200px);
+
+// Fonts Options
+$clr-font: null; // Metropolis, 'Avenir Next', 'Helvetica Neue', Arial, sans-serif; //Default font stack for Clarity
+$clr-altFont: null; // $clr-font; //TODO: TBD. Alternative font for Clarity
+$clr-font-base-size: null; // 14;
+$clr-font-size: null; // unquote($clr-font-base-size+'px');
+$clr-rem-denominator: null; // $clr-font-base-size;
+$clr-kerning-lotsatext: null; // normal; // 14px, but a lot of it
+$clr-kerning-smalltext: null; // normal; // 14px-12px
+$clr-kerning-bigtext: null; // 0.01em; // some types of 16px over dark background
+$clr-kerning-tinytext: null; // 0.03em; // 11px and lower
+
+$clr-font-weights: null; // (light: 200, regular: 400, bold: 600);
+
+$clr-baseline: null; // 24px;
+
+// Paragraphs
+$clr-typography-smalltext: null; // 13/$clr-rem-denominator*$clr-font-size;
+$clr-typography-xsmalltext: null;  // 12/$clr-rem-denominator*$clr-font-size;
+$clr-typography-xxsmalltext: null;  // 11/$clr-rem-denominator*$clr-font-size;
+$clr-typography-tinytext: null;  // 10/$clr-rem-denominator*$clr-font-size;
+
+// Navigation
+$clr-sidenav-width: null; // 18%;
+$clr-header-height: null; // $clr-baseline*2.5;
+$clr-subnav-height: null; // $clr-baseline*1.5;
+
+//Content Area Paddings
+$clr-content-area-padding-top: null; // $clr-baseline*1;
+$clr-content-area-padding-right: null; // $clr-baseline*1;
+$clr-content-area-padding-bottom: null; // $clr-baseline*1;
+$clr-content-area-padding-left: null; // $clr-baseline*1;
+
+// Cards
+$clr-card-outer-margin: null; // $clr-baseline*0.75;
+$clr-card-inner-margin: null; // $clr-baseline*0.5;
+
+// Modal
+$clr-modal-content-padding-top: null; // $clr-baseline*1;
+$clr-modal-content-padding-right: null; // $clr-baseline*1;
+$clr-modal-content-padding-bottom: null; // $clr-baseline*1;
+$clr-modal-content-padding-left: null; // $clr-baseline*1;
+
+//Other Colors
+$clr-links-visited-color: null; // #5659b9;
+$clr-selection-color: null; // #D9E4EA;
+
+// Misc
+$clr-default-borderradius: null; // $clr-baseline*0.125;
+
+// Buttons
+$clr-button-vertical-margin: null; // $clr-baseline*0.25;
+$clr-button-horizontal-margin: null; // $clr-baseline*0.5;
+
+// Icons
+$clr-icon-dimension-sm: null; // 16/$clr-rem-denominator*$clr-font-size;
+
+
+
+/*================================================================================*/
+/* Overwrite the default variable assignments in _colors.clarity.scss here:       */
+/*================================================================================*/
+
+$clr-white: null; // #fff;
+$clr-black: null; // #000;
+
+$clr-near-white: null; // #fafafa;
+$clr-light-gray: null; // #eee;
+$clr-lighter-midtone-gray: null; // #ddd;
+$clr-light-midtone-gray: null; // #ccc;
+$clr-dark-midtone-gray: null; // #9a9a9a;
+$clr-gray: null; // #747474;
+$clr-dark-gray: null; // #565656;
+$clr-near-black: null; // #313131;
+
+$clr-blue: null; // #006a91;
+$clr-action-blue-lightest: null; // #e1f1f6;
+$clr-action-blue-lighter: null; // #89cbdf;
+$clr-action-blue-light: null; // #49afd9;
+$clr-action-blue-light-midtone: null; // #0094d2;
+$clr-action-blue: null; // #007cbb;
+$clr-action-blue-dark-midtone: null; // #007cbb;
+$clr-action-blue-dark: null; // #004a70;
+$clr-action-blue-darker: null; // #003a59;
+$clr-action-blue-darkest: null; // #002538;
+
+$clr-action-purple-lightest: null; // #f3ecf7;
+$clr-action-purple-lighter: null; // #e7d9f0;
+$clr-action-purple-light: null; // #b68cd1;
+$clr-action-purple-light-midtone: null; // #9460b8;
+$clr-action-purple: null; // #853fb3;
+$clr-action-purple-dark-midtone: null; // #853fb3;
+$clr-action-purple-dark: null; // #660092;
+$clr-action-purple-darker: null; // #50266b;
+$clr-action-purple-darkest: null; // #281336;
+
+$clr-red-lightest: null; // #fbf1f2;
+$clr-red-lighter: null; // #f5dbd9;
+$clr-red-light: null; // #ebafa6;
+$clr-red-light-midtone: null; // #e62700;
+$clr-red: null; // #c92100;
+$clr-red-dark-midtone: null; // #c92100;
+$clr-red-dark: null; // #a32100;
+$clr-red-darker: null; // #7d2100;
+$clr-red-darkest: null; // #642100;
+
+$clr-yellow-lightest: null; // #f9f0e1;
+$clr-yellow-lighter: null; // #feecb5;
+$clr-yellow: null; // #efd603;
+$clr-yellow-light-midtone: null; // #eb8d00;
+$clr-yellow-dark-midtone: null; // #ce5c00;
+$clr-yellow-dark: null; // #c25400;
+$clr-yellow-darker: null; // #9e4100;
+$clr-yellow-darkest: null; // #642100;
+
+$clr-green-lightest: null; //  #dff0d0;
+$clr-green-lighter: null; //  #c6e4ab;
+$clr-green: null; //  #60b515;
+$clr-green-light-midtone: null; //  #62a420;
+$clr-green-dark-midtone: null; //  #318700;
+$clr-green-dark: null; //  #266900;
+$clr-green-darker: null; //  #1d5100;
+$clr-green-darkest: null; //  #0f2900;
+
+
+
+/*================================================================================*/
+/* Overwrite the default variable assignments in _tooltips.clarity.scss here:     */
+/*================================================================================*/
+
+$clr-tooltip-font-color: null; // $clr-white;
+$clr-tooltip-background-color: null; // $clr-black;
+$clr-tooltip-default-width: null; // 10*$clr-baseline;
+$margin-value: null; // $clr-baseline*0.25;
+$arrow-height: null; // $clr-baseline*0.25;
+$arrow-width: null; // 5/24*$clr-baseline;
+$clr-tooltip-adjusted-margin: null; // $margin-value + $arrow-width * 2;
+
+
+
+
+/*================================================================================*/
+/* Overwrite the default variable assignments in _tables.clarity.scss here:       */
+/*================================================================================*/
+
+// Backgrounds
+$clr-table-bgcolor: null; // $clr-white;
+$clr-thead-bgcolor: null; // $clr-near-white;
+
+// Borders
+$clr-tablerow-bordercolor: null; // $clr-light-gray;
+$clr-table-bordercolor: null; // $clr-light-midtone-gray;
+$clr-table-borderwidth: null; // 1px;
+$clr-table-borderstyle: null; // $clr-table-borderwidth solid $clr-table-bordercolor;
+
+// Etc.
+$clr-table-lineheight: null; // 1*$clr-font-size;
+$clr-table-cellpadding: null; // $clr-baseline*0.5;
+$clr-table-smallpadding: null; // 0.5 * $clr-table-cellpadding;
+
+$clr-table-lineheightPaddingShim: null; // ($clr-baseline*1 - $clr-table-lineheight)/2;
+$clr-table-vertpadding: null; // (($clr-table-cellpadding - $clr-table-borderwidth) * 0.5) + $clr-table-lineheightPaddingShim; // have to account for border...
+
+// Border radius of corner cells needs to be slightly less than the table's,
+// To make sure they correctly cover the whole area up to the border.
+$clr-table-cornercellradius: null; // $clr-default-borderradius - 1;
+
+
+
+/*================================================================================*/
+/* Overwrite the default variable assignments in _sidenav.clarity.scss here:      */
+/*================================================================================*/
+
+$clr-sidenav-border-color: null; // $clr-light-midtone-gray;
+
+
+
+/*================================================================================*/
+/* Overwrite the default variable assignments in _modal.clarity.scss here:        */
+/*================================================================================*/
+
+$clr-modal-sm-width: null; // 12*$clr-baseline;
+$clr-modal-md-width: null; // 24*$clr-baseline;
+$clr-modal-lg-width: null; // 36*$clr-baseline;
+$clr-modal-xl-width: null; // 48*$clr-baseline;
+
+
+
+/*================================================================================*/
+/* Overwrite the default variable assignments in _login.clarity.scss here:        */
+/*================================================================================*/
+
+$clr-login-background-color: null; // $clr-white;
+$clr-login-width: null; // 21*$clr-baseline;
+$clr-login-icon-size: null; // $clr-icon-dimension-sm;
+
+
+
+/*================================================================================*/
+/* Overwrite the default variable assignments in _labels.clarity.scss here:        */
+/*================================================================================*/
+
+$clr-padding-top-bottom: null; // $clr-baseline*0.125;
+$clr-padding-left-right: null; // $clr-baseline*0.5;
+
+$clr-label-colors: null; /* (
+    gray: (
+        background: $clr-gray,
+        font: $clr-white
+    ),
+    purple: (
+        background: $clr-action-purple-light-midtone,
+        font: $clr-white
+    ),
+    blue: (
+        background: $clr-action-blue-dark,
+        font: $clr-white
+    ),
+    orange: (
+        background: $clr-yellow-light-midtone,
+        font: $clr-black
+    ),
+    light-blue: (
+        background: $clr-action-blue-lighter,
+        font: $clr-black
+    )
+); */
+
+
+
+/*================================================================================*/
+/* Overwrite the default variable assignments in _forms.clarity.scss here:        */
+/*================================================================================*/
+
+$clr-form-field-border-color: null; // $clr-dark-midtone-gray;
+$clr-form-field-background-color: null; // $clr-action-blue-light-midtone;
+$clr-form-disabled-background-color: null; // $clr-light-midtone-gray;
+$clr-form-field-disabled-color: null; // $clr-gray;
+
+$clr-checkbox-radio-height: null; // $clr-icon-dimension-sm;
+$clr-form-icon-dim: null; // $clr-icon-dimension-sm;
+
+$clr-custom-checkbox-radio-top: null; // ($clr-baseline - $clr-checkbox-radio-height) / 2;
+
+
+
+/*================================================================================*/
+/* Overwrite the default variable assignments in _buttons.clarity.scss here:      */
+/*================================================================================*/
+
+$clr-button-horizontal-padding: null; // $clr-baseline*0.5;
+$clr-button-height: null; // $clr-baseline*1.5;
+$clr-button-height-sm: null; // $clr-baseline;
+$clr-button-padding: null; // 0 $clr-button-horizontal-padding;
+
+
+
+/*================================================================================*/
+/* Overwrite the default variable assignments in _alert.clarity.scss here:        */
+/*================================================================================*/
+
+$clr-app-level-alert-color: null; // $clr-white;
+$clr-icon-margin-right: null; // $clr-baseline*0.25;
+
+//Regular Alert
+$clr-alert-top-margin: null; // $clr-baseline*0.25;
+$clr-alert-min-height: null; // $clr-baseline*1.5;
+$clr-alert-horizontal-padding: null; // $clr-baseline*0.5;
+$clr-alert-top-padding: null; // $clr-baseline*0.125;
+$clr-alert-bottom-padding: null; // $clr-baseline*0.375;
+$clr-alert-item-top-margin: null; // $clr-alert-bottom-padding - $clr-alert-top-padding;
+$clr-alert-item-min-height: null; // $clr-icon-dimension-sm;
+
+//Small Alert
+$clr-alert-sm-min-height: null; // $clr-baseline*1;
+$clr-alert-sm-horizontal-padding: null; // $clr-baseline*0.25;
+$clr-alert-sm-top-padding: null; // 0;
+$clr-alert-sm-bottom-padding: null; // $clr-baseline*0.125;
+$clr-alert-sm-item-top-margin: null; // $clr-alert-sm-bottom-padding - $clr-alert-sm-top-padding;
+$clr-alert-sm-item-min-height: null; // $clr-icon-dimension-sm;
+
+$clr-alert-colors: null;
+/* (
+        info: (
+                background: $clr-action-blue-lightest,
+                font: $clr-action-blue-dark,
+                border: $clr-action-blue-light
+        ),
+        success: (
+                background: $clr-green-lightest,
+                font: $clr-green-dark,
+                border: $clr-green
+        ),
+        warning: (
+                background: $clr-yellow-lighter,
+                font: $clr-near-black,
+                border: $clr-yellow
+        ),
+        danger: (
+                background: $clr-red-lighter,
+                font: $clr-red-dark,
+                border: $clr-red-light
+        ),
+        app-info: (
+                background: $clr-action-blue,
+                font: $clr-app-level-alert-color,
+                border: none
+        ),
+        app-success: (
+                background: $clr-green-light-midtone,
+                font: $clr-app-level-alert-color,
+                border: none
+        ),
+        app-warning: (
+                background: $clr-yellow-dark,
+                font: $clr-app-level-alert-color,
+                border: none
+        ),
+        app-danger: (
+                background: $clr-red,
+                font: $clr-app-level-alert-color,
+                border: none
+        )
+); */

--- a/src/clarity/utils/_variables.clarity.scss
+++ b/src/clarity/utils/_variables.clarity.scss
@@ -28,24 +28,25 @@ $clr-breakpoints: (
     medium: 768px,
     large : 992px,
     xlarge: 1200px
-);
+) !default;
 
 //1. Fonts Options
-$clr-font: Metropolis, 'Avenir Next', 'Helvetica Neue', Arial, sans-serif; //Default font stack for Clarity
-$clr-altFont: $clr-font; //TODO: TBD. Alternative font for Clarity
-$clr-font-size: 14px;
-$clr-rem-denominator: 14;
-$clr-kerning-lotsatext: normal; // 14px, but a lot of it
-$clr-kerning-smalltext: normal; // 14px-12px
-$clr-kerning-bigtext: 0.01em; // some types of 16px over dark background
-$clr-kerning-tinytext: 0.03em; // 11px and lower
+$clr-font: Metropolis, 'Avenir Next', 'Helvetica Neue', Arial, sans-serif !default; //Default font stack for Clarity
+$clr-altFont: $clr-font !default; //TODO: TBD. Alternative font for Clarity
+$clr-font-base-size: 14 !default;
+$clr-font-size: unquote($clr-font-base-size+'px') !default;
+$clr-rem-denominator: $clr-font-base-size !default;
+$clr-kerning-lotsatext: normal !default; // 14px, but a lot of it
+$clr-kerning-smalltext: normal !default; // 14px-12px
+$clr-kerning-bigtext: 0.01em !default; // some types of 16px over dark background
+$clr-kerning-tinytext: 0.03em !default; // 11px and lower
 
 $clr-font-weights: (
     light: 200,
     regular: 400,
     semibold: 500,
     bold: 600
-);
+) !default;
 
 //2. Headers
 // NOTE: one day we may support responsive resizing of fonts. that day is not today, however.
@@ -159,10 +160,10 @@ $clr-h6:(
 
 
 //3. Paragraphs
-$clr-typography-smalltext: rem(13/$clr-rem-denominator);
-$clr-typography-xsmalltext: rem(12/$clr-rem-denominator);
-$clr-typography-xxsmalltext: rem(11/$clr-rem-denominator);
-$clr-typography-tinytext: rem(10/$clr-rem-denominator);
+$clr-typography-smalltext: rem(13/$clr-rem-denominator) !default;
+$clr-typography-xsmalltext: rem(12/$clr-rem-denominator) !default;
+$clr-typography-xxsmalltext: rem(11/$clr-rem-denominator) !default;
+$clr-typography-tinytext: rem(10/$clr-rem-denominator) !default;
 
 // keeping this here as an easter egg. we use it on the website and it's not hurting anything. usage = intro text
 $clr-p0: (
@@ -355,25 +356,25 @@ $clr-typography-dom-to-type-element: (
 );
 
 //4. Navigation
-$clr-sidenav-width: 18%;
-$clr-header-height: $clr_baselineRem_2_5;
-$clr-subnav-height: $clr_baselineRem_1_5;
+$clr-sidenav-width: 18% !default;
+$clr-header-height: $clr_baselineRem_2_5 !default;
+$clr-subnav-height: $clr_baselineRem_1_5 !default;
 
 //5.Content Area Paddings
-$clr-content-area-padding-top: $clr_baselineRem_1;
-$clr-content-area-padding-right: $clr_baselineRem_1;
-$clr-content-area-padding-bottom: $clr_baselineRem_1;
-$clr-content-area-padding-left: $clr_baselineRem_1;
+$clr-content-area-padding-top: $clr_baselineRem_1 !default;
+$clr-content-area-padding-right: $clr_baselineRem_1 !default;
+$clr-content-area-padding-bottom: $clr_baselineRem_1 !default;
+$clr-content-area-padding-left: $clr_baselineRem_1 !default;
 
 //6. Cards
-$clr-card-outer-margin: $clr_baselineRem_0_75;
-$clr-card-inner-margin: $clr_baselineRem_0_5;
+$clr-card-outer-margin: $clr_baselineRem_0_75 !default;
+$clr-card-inner-margin: $clr_baselineRem_0_5 !default;
 
 //7. Modal
-$clr-modal-content-padding-top: $clr_baselineRem_1;
-$clr-modal-content-padding-right: $clr_baselineRem_1;
-$clr-modal-content-padding-bottom: $clr_baselineRem_1;
-$clr-modal-content-padding-left: $clr_baselineRem_1;
+$clr-modal-content-padding-top: $clr_baselineRem_1 !default;
+$clr-modal-content-padding-right: $clr_baselineRem_1 !default;
+$clr-modal-content-padding-bottom: $clr_baselineRem_1 !default;
+$clr-modal-content-padding-left: $clr_baselineRem_1 !default;
 
 //8. Colors
 //TODO: Refactor colors across clarity to use these variables so that there
@@ -434,18 +435,18 @@ $yellows-darkest: clr-getColor(darkest,yellows);
 
 //Other Colors
 //TODO: Add these to the color palette
-$clr-links-visited-color: #5659b9;
-$clr-selection-color: #D9E4EA;
+$clr-links-visited-color: #5659b9 !default;
+$clr-selection-color: #D9E4EA !default;
 
 // 9. Misc
-$clr-default-borderradius: $clr_baselineRem_0_125;
+$clr-default-borderradius: $clr_baselineRem_0_125 !default;
 
 //10. Buttons
-$clr-button-vertical-margin: $clr_baselineRem_0_25;
-$clr-button-horizontal-margin: $clr_baselineRem_0_5;
+$clr-button-vertical-margin: $clr_baselineRem_0_25 !default;
+$clr-button-horizontal-margin: $clr_baselineRem_0_5 !default;
 
 //11. Icons
-$clr-icon-dimension-sm: rem(16/$clr-rem-denominator);
+$clr-icon-dimension-sm: rem(16/$clr-rem-denominator) !default;
 
 //BS4 overrides
 $enable-flex: true;

--- a/src/icons/clarity-icons.scss
+++ b/src/icons/clarity-icons.scss
@@ -40,13 +40,13 @@ clr-icon {
         @include setIconColor($reds-light-midtone);
     }
     &.icon-color-info {
-        @include setIconColor($clr-actionblue);
+        @include setIconColor($clr-action-blue);
     }
     &.icon-color-inverse {
         @include setIconColor($clr-white);
     }
     &.icon-color-highlight {
-        @include setIconColor($clr-actionblue);
+        @include setIconColor($clr-action-blue);
     }
     &.icon-orient-up {
         svg {


### PR DESCRIPTION
We will publish main.scss, which imports _overwrites.clarity.scss, to allow users to compile it on their own. _overwrites.clarity.scss will make default variables easily accessible to users to change their values. That way users can customize the default ClarityUI look without meddling in our complex SASS codes. I selectively placed specific variables in _overwrites.clarity.scss. These selected variables in _overwrites.clarity.scss should give users the adequate capability to customize the general look of ClarityUI.

I think it's good to have default assignment values commented out next to `null` in _overwrites.clarity.scss so it will be easy for users to get the idea of the default variable assignments before assigning their custom values.