### PR TITLE
[NG] Avoid redundant events on modals

### DIFF
--- a/src/clarity/modal/modal.spec.ts
+++ b/src/clarity/modal/modal.spec.ts
@@ -91,6 +91,18 @@ describe("Modal", () => {
         flushAndExpectOpen(fixture, true);
     }));
 
+    it("should not open if already opened", fakeAsync(() => {
+        spyOn(getModalInstance(fixture)._openChanged, "emit");
+        getModalInstance(fixture).open();
+        expect(getModalInstance(fixture)._openChanged.emit).not.toHaveBeenCalled();
+    }));
+
+    it("should not close when already closed", fakeAsync(() => {
+        fixture.componentInstance.opened = false;
+        spyOn(getModalInstance(fixture), "close");
+        expect(getModalInstance(fixture).close).not.toHaveBeenCalled();
+    }));
+
     it("offers two-way binding on clrModalOpen", fakeAsync(() => {
         expect(fixture.componentInstance.opened).toBe(true);
         getModalInstance(fixture).close();

--- a/src/clarity/modal/modal.ts
+++ b/src/clarity/modal/modal.ts
@@ -63,12 +63,15 @@ export class Modal implements OnChanges, OnDestroy {
     }
 
     open(): void {
+        if (this._open) {
+            return;
+        }
         this._open = true;
         this._openChanged.emit(true);
     }
 
     close(): void {
-        if (!this.closable) {
+        if (!this.closable || this._open === false) {
             return;
         }
         this._open = false;
@@ -81,7 +84,7 @@ export class Modal implements OnChanges, OnDestroy {
     @HostListener("body:keyup", ["$event.keyCode"])
     globalKeyUp(keyCode: number): void {
         // Close when the user presses escape
-        if (keyCode === 27) {
+        if (this._open && keyCode === 27) {
             this.close();
         }
     }


### PR DESCRIPTION
Fixes: https://github.com/vmware/clarity/issues/5

- Add check for multiple escape key presses when modal closed
- Add check for multiple modal open calls when already open

Signed-off-by: Matt Hippely <mhippelyy@vmware.com>