### PR TITLE
[WEB] Clarity nav margin-top fix

### DIFF
--- a/_sass/global.scss
+++ b/_sass/global.scss
@@ -173,7 +173,7 @@ a.btn-primary {
 }
 
 // had to remove these from clarity-ui... putting back here
-ul:not(.pagination) {
+ul:not(.pagination):not(.nav) {
     margin-top: $bl-1_0;
 
     ul {


### PR DESCRIPTION
Added a not selector for `.nav` since the margin-top: 24px style is only meant for unordered lists on the website. These lists don't use the `.nav` class.

Before:
![image](https://cloud.githubusercontent.com/assets/1426805/20308582/70e18f50-aaf9-11e6-849b-a3416c55a534.png)


After:
![image](https://cloud.githubusercontent.com/assets/1426805/20308602/83c5b42a-aaf9-11e6-98f4-9e5402ca277a.png)

Unordered lists used on the website remain unaffected:
![image](https://cloud.githubusercontent.com/assets/1426805/20308623/a724e2f6-aaf9-11e6-9b3b-0bbf6f9ef3a8.png)

Datagrid Pagination remains unaffected:
![image](https://cloud.githubusercontent.com/assets/1426805/20308654/c996d2cc-aaf9-11e6-86f4-5c8862558648.png)

fixes #39 


Signed-off-by: Aditya Bhandari <adityab@vmware.com>
Signed-off-by: Aditya Bhandari <arb492@nyu.edu>