### PR TITLE
[WEB] Header Demo Styles Fix

### DIFF
--- a/_sass/header.scss
+++ b/_sass/header.scss
@@ -255,54 +255,59 @@ header .branding > a.sliding-nav-toggle {
         display: none;
     }
 
-    .main-container {
-        & > header {
-            .branding {
-                .clr-vmw-logo {
-                    visibility: hidden;
-                    margin-right: $bl-0_25;
+    .layout-documentation,
+    .layout-get-started,
+    .layout-community,
+    .layout-news {
+        & > .main-container {
+            & > header {
+                .branding {
+                    .clr-vmw-logo {
+                        visibility: hidden;
+                        margin-right: $bl-0_25;
+                    }
+
+                    & > a.sliding-nav-toggle {
+                        display: block;
+                        height: $bl-2_5;
+                        width: $bl-1_5;
+                        background: url(../images/home/menu.svg) 50% 50% no-repeat;
+                        position: absolute;
+                        top: -1px;
+                        left: $bl-0_75;
+                    }
                 }
 
-                & > a.sliding-nav-toggle {
-                    display: block;
-                    height: $bl-2_5;
-                    width: $bl-1_5;
-                    background: url(../images/home/menu.svg) 50% 50% no-repeat;
-                    position: absolute;
-                    top: -1px;
-                    left: $bl-0_75;
+                .settings {
+                    & > a.sliding-sidenav-toggle {
+                        display: block;
+                        width: $bl-1_5;
+                        background: url(../images/home/slider.svg) 50% 50% no-repeat;
+                        position: absolute;
+                        top: $bl-0_75;
+                        right: 8px;
+                        height: $bl-1_0;
+                    }
                 }
             }
+        }
 
-            .settings {
-                & > a.sliding-sidenav-toggle {
-                    display: block;
-                    width: $bl-1_5;
-                    background: url(../images/home/slider.svg) 50% 50% no-repeat;
-                    position: absolute;
-                    top: $bl-0_75;
-                    right: 8px;
-                    height: $bl-1_0;
+        & > .main-container {
+            & > header {
+                div.header-nav, .divider, .header-nav {
+                    // funkiness of the homepage navbar makes this the path of least resistance
+                    display: none !important;
                 }
             }
         }
-    }
 
-    .main-container {
-        & > header {
-            div.header-nav, .divider, .header-nav {
-                // funkiness of the homepage navbar makes this the path of least resistance
-                display: none !important;
-            }
-        }
-    }
+        & > .main-container {
+            & > header, & > .header {
+                padding: 0 $bl-1_0;
 
-    .main-container {
-        & > header, & > .header {
-            padding: 0 $bl-1_0;
-
-            .branding {
-                padding-left: 0;
+                .branding {
+                    padding-left: 0;
+                }
             }
         }
     }


### PR DESCRIPTION
Styles specific to the header on the website were being applied to the header demos in the header documentation as well.

Before:
![image](https://cloud.githubusercontent.com/assets/1426805/20319886/ac613460-ab24-11e6-99cf-3cc7a916f63d.png)

After:
![image](https://cloud.githubusercontent.com/assets/1426805/20319897/b31ea8d2-ab24-11e6-9d6e-da39039f1c17.png)

Tested on: Chrome only because just added a stricter selector to apply the styles on the website header instead of the demos.

fixes #56 

Signed-off-by: Aditya Bhandari <adityab@vmware.com>
Signed-off-by: Aditya Bhandari <arb492@nyu.edu>