### PR TITLE
[ui] Padding around progress blocks in cards is no longer necessary

### DIFF
--- a/src/clarity/progress-bars/_progress-bars.clarity.scss
+++ b/src/clarity/progress-bars/_progress-bars.clarity.scss
@@ -487,7 +487,7 @@ $clr-progress-bgColor: $clr-light-gray !default;
     $clr-progressInline__inCard-height: rem(8/15);
     .card-block .progress-block {
         margin-bottom: $clr_baselineRem_0_5;
-        padding: 0 $clr_baselineRem_0_75;
+        padding: 0;
 
         &:last-child {
             margin-bottom: 0;


### PR DESCRIPTION
BEFORE
<img width="607" alt="before" src="https://cloud.githubusercontent.com/assets/2728359/20351281/cf640c68-abd7-11e6-89c1-7c97ed8cccae.png">

AFTER
<img width="620" alt="after" src="https://cloud.githubusercontent.com/assets/2728359/20351285/d3c9adbc-abd7-11e6-88d7-45873b6d0afa.png">

Tested in:
✔︎ Chrome

Closes: https://github.com/vmware/clarity/issues/60

Signed-off-by: Scott Mathis <smathis@vmware.com>