### PR TITLE
[UI] Hide branding icon on smaller screens

### DIFF
--- a/src/clarity/nav/_responsive-nav.clarity.scss
+++ b/src/clarity/nav/_responsive-nav.clarity.scss
@@ -279,8 +279,10 @@ $clr-transition-style: ease;
                 .header-hamburger-trigger + .branding {
                     padding-left: 0;
 
+                    //deprecate .clr-icon, .logo
                     .clr-icon,
-                    .logo {
+                    .logo,
+                    clr-icon {
                         display: none;
                     }
                 }
@@ -366,11 +368,14 @@ $clr-transition-style: ease;
                             overflow: hidden;
                         }
 
+                        //deprecate .clr-icon, .logo
                         .clr-icon,
-                        .logo {
+                        .logo,
+                        clr-icon {
                             display: inline-block;
                         }
 
+                        clr-icon[shape="vm-bug"],
                         .clr-vmw-logo {
                             background-color: $gray-dark;
                             border-radius: $clr-default-borderradius;


### PR DESCRIPTION
Hide branding icon on medium and smaller breakpoints.

Before:
![image](https://cloud.githubusercontent.com/assets/1426805/20363235/5235f816-abf3-11e6-8103-36f54003fbdc.png)


After:
![image](https://cloud.githubusercontent.com/assets/1426805/20363233/4e1c9a64-abf3-11e6-81c3-05be89121df8.png)

Fixes: #82 

Tested on: Chrome

Signed-off-by: Aditya Bhandari <adityab@vmware.com>
Signed-off-by: Aditya Bhandari <arb492@nyu.edu>