### PR TITLE
[ng] Fixes issue #59

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ If you already have an Angular 2 application, you can follow the installation st
     @NgModule({
         imports: [
             BrowserModule,
-            ClarityModule,
+            ClarityModule.forRoot(),
             ....
          ],
          declarations: [ AppComponent ],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,7 +18,7 @@ import {ClarityModule} from "../clarity/clarity.module";
         BrowserModule,
         FormsModule,
         ROUTING,
-        ClarityModule
+        ClarityModule.forRoot()
     ],
     declarations: [
         AppComponent,

--- a/src/clarity/alert/alert.spec.ts
+++ b/src/clarity/alert/alert.spec.ts
@@ -40,7 +40,7 @@ describe("Alert", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ClarityModule],
+            imports: [ClarityModule.forRoot()],
             declarations: [TestComponent]
         });
 

--- a/src/clarity/checkboxes/checkbox.spec.ts
+++ b/src/clarity/checkboxes/checkbox.spec.ts
@@ -85,7 +85,10 @@ describe("Checkbox", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ClarityModule, FormsModule],
+            imports: [
+                ClarityModule.forRoot(),
+                FormsModule
+            ],
             declarations: [BasicCheckbox, CheckboxWithNgModel, CheckboxWithLabel, CheckboxWithName, InlineCheckbox]
         });
     });

--- a/src/clarity/clarity.module.ts
+++ b/src/clarity/clarity.module.ts
@@ -54,10 +54,13 @@ import {ClrResponsiveNavigationService} from "./nav/clrResponsiveNavigationServi
         TABS_DIRECTIVES,
         WIZARD_DIRECTIVES,
         ICON_DIRECTIVES
-    ],
-    providers: [
-        ClrResponsiveNavigationService
     ]
 })
 export class ClarityModule {
+    static forRoot() {
+        return {
+            ngModule: ClarityModule,
+            providers: [ ClrResponsiveNavigationService ]
+        };
+    }
 }

--- a/src/clarity/code/code-highlight.spec.ts
+++ b/src/clarity/code/code-highlight.spec.ts
@@ -24,7 +24,7 @@ describe("CodeHighlight", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ClarityModule],
+            imports: [ClarityModule.forRoot()],
             declarations: [TestComponent]
         });
         fixture = TestBed.createComponent(TestComponent);

--- a/src/clarity/datagrid/datagrid-items.spec.ts
+++ b/src/clarity/datagrid/datagrid-items.spec.ts
@@ -20,7 +20,7 @@ export default function(): void {
              * we can't use our usual shortcut, we need to rely on @ViewChild
              */
             TestBed.configureTestingModule({
-                imports: [ClarityModule],
+                imports: [ClarityModule.forRoot()],
                 declarations: [FullTest],
                 providers: [Items, Filters, Sort, Page]
             });

--- a/src/clarity/datagrid/helpers.spec.ts
+++ b/src/clarity/datagrid/helpers.spec.ts
@@ -51,7 +51,7 @@ export function addHelpers(): void {
          */
         this.create = <D, C>(clarityDirective: Type<D>, testComponent: Type<C>, providers: any[] = []) => {
             TestBed.configureTestingModule({
-                imports: [ClarityModule],
+                imports: [ClarityModule.forRoot()],
                 declarations: [testComponent],
                 providers: providers
             });

--- a/src/clarity/dropdown/dropdown.spec.ts
+++ b/src/clarity/dropdown/dropdown.spec.ts
@@ -41,7 +41,7 @@ describe("Dropdown", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ClarityModule],
+            imports: [ClarityModule.forRoot()],
             declarations: [TestComponent]
         });
 

--- a/src/clarity/layout/main-container.spec.ts
+++ b/src/clarity/layout/main-container.spec.ts
@@ -64,7 +64,7 @@ describe("MainContainer", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ClarityModule],
+            imports: [ClarityModule.forRoot()],
             declarations: [TestComponent]
         });
 

--- a/src/clarity/modal/modal.spec.ts
+++ b/src/clarity/modal/modal.spec.ts
@@ -47,7 +47,7 @@ describe("Modal", () => {
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
-            imports: [ClarityModule],
+            imports: [ClarityModule.forRoot()],
             declarations: [TestComponent]
         });
 

--- a/src/clarity/nav/header.spec.ts
+++ b/src/clarity/nav/header.spec.ts
@@ -34,7 +34,7 @@ describe("Header", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ClarityModule],
+            imports: [ClarityModule.forRoot()],
             declarations: [TestComponent]
         });
 

--- a/src/clarity/stack-view/stack-block.spec.ts
+++ b/src/clarity/stack-view/stack-block.spec.ts
@@ -65,7 +65,7 @@ export default function(): void {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 imports: [
-                    ClarityModule,
+                    ClarityModule.forRoot(),
                     FormsModule
                 ],
                 declarations: [

--- a/src/clarity/stack-view/stack-header.spec.ts
+++ b/src/clarity/stack-view/stack-header.spec.ts
@@ -29,7 +29,7 @@ export default function(): void {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 imports: [
-                    ClarityModule,
+                    ClarityModule.forRoot(),
                     FormsModule
                 ],
                 declarations: [TestComponent],

--- a/src/clarity/stack-view/stack-view.spec.ts
+++ b/src/clarity/stack-view/stack-view.spec.ts
@@ -31,7 +31,7 @@ export default function(): void {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 imports: [
-                    ClarityModule,
+                    ClarityModule.forRoot(),
                     FormsModule
                 ],
                 declarations: [TestComponent]

--- a/src/clarity/tabs/tab-content.spec.ts
+++ b/src/clarity/tabs/tab-content.spec.ts
@@ -24,7 +24,7 @@ describe("TabContent", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ClarityModule],
+            imports: [ClarityModule.forRoot()],
             declarations: [TestComponent]
         });
         fixture = TestBed.createComponent(TestComponent);

--- a/src/clarity/tabs/tab-link.spec.ts
+++ b/src/clarity/tabs/tab-link.spec.ts
@@ -25,7 +25,7 @@ describe("TabLink", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ClarityModule],
+            imports: [ClarityModule.forRoot()],
             declarations: [TestComponent],
             providers: [TABS_DIRECTIVES]
         });

--- a/src/clarity/tabs/tabs.spec.ts
+++ b/src/clarity/tabs/tabs.spec.ts
@@ -52,7 +52,7 @@ describe("Tabs", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ClarityModule],
+            imports: [ClarityModule.forRoot()],
             declarations: [TestComponent],
             providers: [TabLink, TabContent]
         });

--- a/src/clarity/wizard/wizard-page.spec.ts
+++ b/src/clarity/wizard/wizard-page.spec.ts
@@ -48,7 +48,7 @@ describe("WizardPage", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ClarityModule],
+            imports: [ClarityModule.forRoot()],
             declarations: [TestComponent]
         });
         fixture = TestBed.createComponent(TestComponent);

--- a/src/clarity/wizard/wizard-step.spec.ts
+++ b/src/clarity/wizard/wizard-step.spec.ts
@@ -28,7 +28,7 @@ describe("WizardStep", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ClarityModule],
+            imports: [ClarityModule.forRoot()],
             declarations: [TestComponent],
             providers: [Wizard, ScrollingService],
         });

--- a/src/clarity/wizard/wizard.spec.ts
+++ b/src/clarity/wizard/wizard.spec.ts
@@ -122,7 +122,7 @@ describe("Wizard", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ClarityModule],
+            imports: [ClarityModule.forRoot()],
             declarations: [AdvancedWizard, BasicWizard]
         });
     });


### PR DESCRIPTION
- Adds forRoot() to ClarityModule
- Adds forRoot() call to specs

Signed-off-by: Matt Hippely <mhippely@vmware.com>