### PR TITLE
[UI] Fixing small alert line height

### DIFF
--- a/src/clarity/alert/_alert.clarity.scss
+++ b/src/clarity/alert/_alert.clarity.scss
@@ -31,6 +31,8 @@ $clr-alert-sm-bottom-padding: $clr_baselineRem_0_125 !default;
 $clr-alert-sm-item-top-margin: $clr-alert-sm-bottom-padding - $clr-alert-sm-top-padding !default;
 $clr-alert-sm-item-min-height: $clr-icon-dimension-sm !default;
 
+$clr-alert-text-line-height: rem(16/$clr-rem-denominator);
+
 $clr-alert-colors: (
         info: (
                 background: $clr-action-blue-lightest,
@@ -101,7 +103,7 @@ $clr-alert-colors: (
 
     .alert {
         @include clr-getTypePropertiesForDomElement(alert_text, (font-size, letter-spacing));
-        line-height: rem(16/$clr-rem-denominator);
+        line-height: $clr-alert-text-line-height;
         position: relative;
         box-sizing: border-box;
         display: flex;
@@ -312,7 +314,7 @@ $clr-alert-colors: (
     .alert {
         &.alert-sm {
             @include clr-getTypePropertiesForDomElement(alert-small_text, (font-size, letter-spacing));
-            line-height: $clr-alert-sm-font-size;
+            line-height: $clr-alert-text-line-height;
 
             min-height: $clr-alert-item-min-height;
             //Rigth padding same as regular alert to factor in the close button


### PR DESCRIPTION
`.alert-text` in small alerts didn't have the correct line-height set.

Before:
![image](https://cloud.githubusercontent.com/assets/1426805/20388975/2e6d7574-ac7c-11e6-801f-f69fc9e0a984.png)

After:
![image](https://cloud.githubusercontent.com/assets/1426805/20388991/45241f7a-ac7c-11e6-9b7d-893ed83e67ad.png)

Tested on: Chrome, Firefox, IE10, 11, Edge, Safari

Fixes: #92 

Signed-off-by: Aditya Bhandari <adityab@vmware.com>
Signed-off-by: Aditya Bhandari <arb492@nyu.edu>