### PR TITLE
[NG] Select row by clicking the row in the datagrid

### DIFF
--- a/src/clarity/datagrid/datagrid-row.spec.ts
+++ b/src/clarity/datagrid/datagrid-row.spec.ts
@@ -58,6 +58,20 @@ export default function(): void {
             expect(selectionProvider.current).toEqual([]);
         });
 
+        it("selects the model when the row is clicked", function () {
+            selectionProvider.selectable = true;
+            context.testComponent.item = {id: 1};
+            context.detectChanges();
+            let row = context.clarityElement;
+            expect(selectionProvider.current).toEqual([]);
+            row.click();
+            context.detectChanges();
+            expect(selectionProvider.current).toEqual([context.testComponent.item]);
+            row.click();
+            context.detectChanges();
+            expect(selectionProvider.current).toEqual([]);
+        });
+
         it("adds the .datagrid-selected class to the host when the row is selected", function() {
             selectionProvider.selectable = true;
             context.testComponent.item = {id: 1};

--- a/src/clarity/datagrid/datagrid-row.ts
+++ b/src/clarity/datagrid/datagrid-row.ts
@@ -16,7 +16,8 @@ import {Selection} from "./providers/selection";
     `,
     host: {
         "[class.datagrid-row]": "true",
-        "[class.datagrid-selected]": "selected"
+        "[class.datagrid-selected]": "selected",
+        "(click)": "toggleSelection($event.target)"
     }
 })
 export class DatagridRow {
@@ -35,5 +36,15 @@ export class DatagridRow {
     }
     public set selected(value: boolean) {
         this.selection.setSelected(this.item, value);
+    }
+
+    /**
+     * Select / Unselect while click on row
+     */
+    public toggleSelection(element: HTMLElement) {
+        if (this.selection.selectable && element.nodeName !== "INPUT") {
+            this.selected = !this.selected;
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Currently the row can be selected only by clicking on the checkbox, this allows the user to click anywhere in the row to select the row.

Signed-off-by: Sivakumar Annamalai <kpa.siva@hotmail.com>

![screen shot 2016-11-18 at 3 46 22 pm](https://cloud.githubusercontent.com/assets/6573919/20426748/8dfab4cc-ada6-11e6-812b-1eee12766534.png)