### PR TITLE
[ICONS] Depend on custom-elements NPM package

### DIFF
--- a/build/npm/clarity-icons.json
+++ b/build/npm/clarity-icons.json
@@ -9,7 +9,7 @@
     },
     "peerDependencies": {
         "mutationobserver-shim": "^0.3.2",
-        "@webcomponents/custom-elements": "github:webcomponents/custom-elements.git#v1.0.0-alpha.3"
+        "@webcomponents/custom-elements": "1.0.0-alpha.3"
     },
     //@exclude
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@angular/platform-browser-dynamic": "2.2.0",
     "@angular/router": "3.2.0",
     "@angular/upgrade": "2.2.0",
-    "@webcomponents/custom-elements": "github:webcomponents/custom-elements",
+    "@webcomponents/custom-elements": "1.0.0-alpha.3",
     "angular": "1.5.x",
     "core-js": "^2.4.0",
     "font-awesome": "^4.5.0",


### PR DESCRIPTION
Our peer dependency (and our internal one) was to their GitHub repo
directly, which creates a lot of issues. Moved to their NPM package
with a hard version number for now.

Signed-off-by: Eudes Petonnet-Vincent <epetonnetvince@vmware.com>