### PR TITLE
update git clone instructions

### DIFF
--- a/get-started/index.md
+++ b/get-started/index.md
@@ -50,7 +50,7 @@ For a new project, the best approach is to clone the Clarity seed project and mo
 <li>Clone the seed app:
 <pre>
     <code class="clr-code">
-    git@github.com:vmware/clarity-seed.git
+    git clone https://github.com/vmware/clarity-seed.git
     </code>
 </pre>
 </li>


### PR DESCRIPTION
HTTPS is the preferred way to clone a repo by GitHub, as SSH only works if you have the key setup in your account.