### PR TITLE
[ICONS] CE v1 install guide uses npm package instead of github now

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you already have an Angular 2 application, you can follow the installation st
 
 2. Install the polyfill for Custom Elements: 
     ```
-    npm install github:webcomponents/custom-elements.git#v1.0.0-alpha.3 --save
+    npm install @webcomponents/custom-elements@1.0.0-alpha.3 --save
     ```
 
 3. (Optional) If your application supports IE10, the polyfill will require the MutationObserver shim to work. If your 

--- a/build/npm/clarity-icons-README.md
+++ b/build/npm/clarity-icons-README.md
@@ -7,7 +7,7 @@
 
 2. Install the polyfill for Custom Elements:
     ```
-    npm install github:webcomponents/custom-elements.git#v1.0.0-alpha.3
+    npm install @webcomponents/custom-elements@1.0.0-alpha.3
     ```
 
 3. If your application supports IE10, the polyfill will require the MutationObserver shim to work. If your application doesn't support IE10, you can skip the following installation:


### PR DESCRIPTION
This is for our README.md to reflect the changes made in the following commit:
- 80a4d89072675f611a9573e9310230927869f1de

Signed-off-by: Shijir Tsogoo <stsogoo@vmware.com>