### PR TITLE
[web] scrollbar fix for Chrome

### DIFF
--- a/_sass/whats-new.scss
+++ b/_sass/whats-new.scss
@@ -78,6 +78,7 @@ ul.whats-new-highlights {
     margin-top: $bl-0_5;
     padding-bottom: $bl-0_25;
     padding-top: $bl-0_5;
+    position: static;
 
     .summary-blocks {
         &::before, &::after {


### PR DESCRIPTION
This issue only affected Chrome.

• It appeared to be related to card-blocks, position relative, and floats.
• Setting the What’s New Summary block to position: static fixed it

Tested in:
✔︎ Chrome
✔︎ Firefox
✔︎ Safari
✔︎ IE10
✔︎ IE11
✔︎  Edge

Closes: #109

Signed-off-by: Scott Mathis <smathis@vmware.com>