### PR TITLE
[NG] Datagrid: proper change detection for the smart iterator

### DIFF
--- a/src/clarity/datagrid/datagrid-items.spec.ts
+++ b/src/clarity/datagrid/datagrid-items.spec.ts
@@ -48,6 +48,9 @@ export default function(): void {
             this.testComponent.numbers[0] = 6;
             this.fixture.detectChanges();
             expect(this.itemsProvider.displayed).toEqual([6, 2, 3, 4, 5]);
+            this.testComponent.numbers = [];
+            this.fixture.detectChanges();
+            expect(this.itemsProvider.displayed).toEqual([]);
         });
 
         it("receives an input for the trackBy option", function () {

--- a/src/clarity/datagrid/datagrid-items.ts
+++ b/src/clarity/datagrid/datagrid-items.ts
@@ -4,15 +4,15 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import {ChangeDetectorRef, Directive, DoCheck, Input, IterableDiffer, IterableDiffers,
-    TemplateRef, TrackByFn} from "@angular/core";
+    TemplateRef, TrackByFn, OnChanges, SimpleChanges} from "@angular/core";
 
 import {Items} from "./providers/items";
 
 @Directive({
     selector: "[clrDgItems][clrDgItemsOf]",
 })
-export class DatagridItems implements DoCheck {
-    private _rawItems: any[];
+export class DatagridItems implements OnChanges, DoCheck {
+    @Input("clrDgItemsOf") private rawItems: any[];
 
     private _differ: IterableDiffer;
 
@@ -21,11 +21,12 @@ export class DatagridItems implements DoCheck {
         _items.smartenUp();
     }
 
-    @Input("clrDgItemsOf")
-    public set items(rawItems: any[]) {
-        this._rawItems = rawItems;
-        if (rawItems) {
-            this._differ = this._differs.find(rawItems).create(this._changeDetector, this.trackBy);
+    ngOnChanges(changes: SimpleChanges): void {
+        if ("rawItems" in changes) {
+            const currentItems = changes["rawItems"].currentValue;
+            if (!this._differ && currentItems) {
+                this._differ = this._differs.find(currentItems).create(this._changeDetector, this.trackBy);
+            }
         }
     }
 
@@ -36,11 +37,11 @@ export class DatagridItems implements DoCheck {
 
     ngDoCheck() {
         if (this._differ) {
-            const changes = this._differ.diff(this._rawItems);
+            const changes = this._differ.diff(this.rawItems);
             if (changes) {
                 // TODO: not very efficient right now,
                 // but premature optimization is the root of all evil.
-                this._items.all = this._rawItems;
+                this._items.all = this.rawItems;
             }
         }
     }

--- a/src/clarity/datagrid/datagrid.html
+++ b/src/clarity/datagrid/datagrid.html
@@ -19,7 +19,7 @@
 
         <div class="datagrid-body">
             <template *ngIf="iterator"
-                      ngFor [ngForOf]="items.displayed" [ngForTrackBy]="items.trackBy"
+                      ngFor [ngForOf]="items.displayed" [ngForTrackBy]="iterator.trackBy"
                       [ngForTemplate]="iterator.template"></template>
             <ng-content *ngIf="!iterator"></ng-content>
         </div>

--- a/src/clarity/datagrid/datagrid.spec.ts
+++ b/src/clarity/datagrid/datagrid.spec.ts
@@ -115,16 +115,25 @@ export default function(): void {
         });
 
         describe("Iterators", function() {
+            it("projects rows when using ngFor", function () {
+                this.context = this.create(Datagrid, NgForTest);
+                let body = this.context.clarityElement.querySelector(".datagrid-body");
+                expect(body.textContent).toMatch(/1\s*1\s*2\s*4\s*3\s*9/);
+            });
+
             it("uses the rows template when using clrDgItems", function () {
                 this.context = this.create(Datagrid, FullTest);
                 let body = this.context.clarityElement.querySelector(".datagrid-body");
                 expect(body.textContent).toMatch(/1\s*1\s*2\s*4\s*3\s*9/);
             });
 
-            it("projects rows when using ngFor", function () {
-                this.context = this.create(Datagrid, NgForTest);
-                let body = this.context.clarityElement.querySelector(".datagrid-body");
-                expect(body.textContent).toMatch(/1\s*1\s*2\s*4\s*3\s*9/);
+            it("respects the trackBy option when using clrDgItems", function () {
+                this.context = this.create(Datagrid, TrackByTest);
+                let oldFirstRow = this.context.clarityElement.querySelector("clr-dg-row");
+                this.context.testComponent.items = [42];
+                this.context.detectChanges();
+                let newFirstRow = this.context.clarityElement.querySelector("clr-dg-row");
+                expect(newFirstRow).toBe(oldFirstRow);
             });
         });
 
@@ -177,6 +186,28 @@ class FullTest {
 })
 class NgForTest {
     items = [1, 2, 3];
+}
+
+@Component({
+    template: `
+    <clr-datagrid>
+        <clr-dg-column>First</clr-dg-column>
+        <clr-dg-column>Second</clr-dg-column>
+    
+        <clr-dg-row *clrDgItems="let item of items; trackBy: trackByIndex">
+            <clr-dg-cell>{{item}}</clr-dg-cell>
+            <clr-dg-cell>{{item * item}}</clr-dg-cell>
+        </clr-dg-row>
+    
+        <clr-dg-footer>{{items.length}} items</clr-dg-footer>
+    </clr-datagrid>
+`
+})
+class TrackByTest {
+    items = [1, 2, 3];
+    trackByIndex(index: number, item: any) {
+        return index;
+    }
 }
 
 class TestComparator implements Comparator<number> {


### PR DESCRIPTION
We overwrote our differ every time instead of just on initialization,
which makes no sense.
Also fixes an uncaught bug with the trackBy option which was not
correctly renamed during a refactor. Added a unit test to make sure
it wouldn't happen again.

Fixes #131.