### PR TITLE
[ui] adjusting margin/capitalization of form headers

### DIFF
--- a/src/clarity/forms/_forms.clarity.scss
+++ b/src/clarity/forms/_forms.clarity.scss
@@ -139,8 +139,7 @@ $clr-custom-checkbox-radio-top: ($clr_baselineRem_1 - $clr-checkbox-radio-height
             & > label {
                 @include clr-getTypePropertiesForDomElement(form_block_label, (font-size, letter-spacing, font-weight));
                 color: $clr-black;
-                text-transform: uppercase;
-                margin-bottom: $clr_baselineRem_1;
+                margin-bottom: $clr_baselineRem_0_25;
             }
         }
 
@@ -619,7 +618,7 @@ $clr-custom-checkbox-radio-top: ($clr_baselineRem_1 - $clr-checkbox-radio-height
             .form-block {
                 margin: $clr_baselineRem_0_5 0 $clr_baselineRem_1 0;
                 & > label {
-                    margin-bottom: $clr_baselineRem_0_5;
+                    margin-bottom: 0;
                 }
             }
 


### PR DESCRIPTION
• compact forms margin bottom is 0
• regular forms margin is 6px
• form headers are no longer titlecase

BEFORE
<img width="883" alt="screen shot 2016-11-22 at 2 24 55 pm" src="https://cloud.githubusercontent.com/assets/2728359/20540757/0c5a5f7c-b0c0-11e6-9ebf-b70cd8b300b0.png">

AFTER
<img width="868" alt="screen shot 2016-11-22 at 2 25 57 pm" src="https://cloud.githubusercontent.com/assets/2728359/20540768/148904b4-b0c0-11e6-936d-e6f5b80579cc.png">

COMPACT FORM (AFTER)
<img width="881" alt="screen shot 2016-11-22 at 2 26 14 pm" src="https://cloud.githubusercontent.com/assets/2728359/20540781/1e2cb56a-b0c0-11e6-9001-0b54d9a66b5f.png">


Tested in:
✔︎ Chrome

Closes: #100 


Signed-off-by: Scott Mathis <smathis@vmware.com>