### PR TITLE
Removing Dropdown Menu Close Transition

### DIFF
--- a/src/clarity/dropdown/_dropdown.clarity.scss
+++ b/src/clarity/dropdown/_dropdown.clarity.scss
@@ -89,7 +89,6 @@ $dropdown-white: clr-getColor(lightest);
             max-width: baselineRem(15);
             border-radius: $clr-default-borderradius;
             visibility: hidden;
-            transition: visibility 0.2s ease-in;
             z-index: map-get($clr-layers, dropdown-menu);
 
             .dropdown-header {


### PR DESCRIPTION
Removed Dropdown Menu Close Transition

Browser Tests: Chrome

Fixes #86 

Signed-off-by: Aditya Bhandari <adityab@vmware.com>
Signed-off-by: Aditya Bhandari <arb492@nyu.edu>