### PR TITLE
[ICONS,UI] Caret Icon update + Dropdown Fixes

### DIFF
--- a/src/clarity/dropdown/demo/dropdown-angular-close-item-false.demo.html
+++ b/src/clarity/dropdown/demo/dropdown-angular-close-item-false.demo.html
@@ -7,7 +7,7 @@
 <div class="clr-example squeeze">
     <clr-dropdown [clrMenuPosition]="'bottom-right'" [clrCloseMenuOnItemClick]="false">
         <button clrDropdownToggle>
-            <clr-icon shape="danger" class="icon-color-danger icon-size-md"></clr-icon>
+            <clr-icon shape="danger" class="icon-color-danger" size="24"></clr-icon>
             <clr-icon shape="caret" class="icon-orient-down"></clr-icon>
         </button>
         <div class="dropdown-menu">
@@ -24,7 +24,7 @@
 <code clr-code-highlight="language-html">
 &lt;clr-dropdown [clrMenuPosition]=&quot;'bottom-right'&quot; [clrCloseMenuOnItemClick]=&quot;false&quot;&gt;
     &lt;button clrDropdownToggle&gt;
-        &lt;clr-icon shape=&quot;danger&quot; class=&quot;icon-color-danger icon-size-md&quot;&gt;&lt;/clr-icon&gt;
+        &lt;clr-icon shape=&quot;danger&quot; class=&quot;icon-color-danger&quot; size=&quot;24&quot;&gt;&lt;/clr-icon&gt;
         &lt;clr-icon shape=&quot;caret&quot; class=&quot;icon-orient-down&quot;&gt;&lt;/clr-icon&gt;
     &lt;/button&gt;
     &lt;div class=&quot;dropdown-menu&quot;&gt;

--- a/src/clarity/utils/_variables.clarity.scss
+++ b/src/clarity/utils/_variables.clarity.scss
@@ -458,7 +458,7 @@ $clr-icon-dimension-sm: rem(16/$clr-rem-denominator) !default;
 
 //12. Dropdowns Caret Icon
 $clr-dropdown-caret-icon-dimension: 10px;
-$clr-dropdown-caret-left-margin: $clr_baselineRem_0_25;
+$clr-dropdown-caret-left-margin: 2px;
 
 //BS4 overrides
 $enable-flex: true;

--- a/src/icons/svg-icon-templates.ts
+++ b/src/icons/svg-icon-templates.ts
@@ -105,7 +105,7 @@ export const SVG_ICON_TEMPLATES: any = {
             <svg version="1.1" viewBox="0 0 36 36" preserveAspectRatio="xMidYMid meet"
                 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                 <title>angle</title>
-                <path class="outer-shape" d="M29,24.5a1,1,0,0,1-.71-.29L18,13.91,7.71,24.21a1,1,0,0,1-1.41-1.41L18,11.09,29.71,22.79A1,1,0,0,1,29,24.5Z"/>
+                <path class="outer-shape" d="M29.52,22.52,18,10.6,6.48,22.52a1.7,1.7,0,0,0,2.45,2.36L18,15.49l9.08,9.39a1.7,1.7,0,0,0,2.45-2.36Z"/>
             </svg>
         `,
 


### PR DESCRIPTION
Caret Icon update
Dropdown Caret distance reduced to 2px

Before:
![image](https://cloud.githubusercontent.com/assets/1426805/20685508/92260b30-b569-11e6-9e6a-7c72cc099bdb.png)

![image](https://cloud.githubusercontent.com/assets/1426805/20685519/9cb2e960-b569-11e6-8236-1abba2674d49.png)

After:
![image](https://cloud.githubusercontent.com/assets/1426805/20685539/a8e9a480-b569-11e6-921c-0ac16a553f92.png)

![image](https://cloud.githubusercontent.com/assets/1426805/20685552/ae84e7f6-b569-11e6-9c7c-4cc0e8741d70.png)

Browser Tests: Chrome, IE 10, 11, Edge, Firefox, Safari

Signed-off-by: Aditya Bhandari <adityab@vmware.com>