### PR TITLE
[UI] Dropdown Caret Examples Update

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -25,7 +25,7 @@
             <clr-dropdown [clrMenuPosition]="'bottom-right'">
                 <button class="nav-icon" clrDropdownToggle>
                     <clr-icon shape="cog"></clr-icon>
-                    <clr-icon shape="caret" class="icon-orient-down"></clr-icon>
+                    <clr-icon shape="caret down"></clr-icon>
                 </button>
                 <div class="dropdown-menu">
                     <a href="javascript://" clrDropdownItem>About</a>

--- a/src/clarity/alert/demo/angular/alert-angular-not-closable.demo.html
+++ b/src/clarity/alert/demo/angular/alert-angular-not-closable.demo.html
@@ -22,7 +22,7 @@
                             <clr-dropdown [clrMenuPosition]="'bottom-right'">
                                 <button class="dropdown-toggle" clrDropdownToggle>
                                     Actions
-                                    <clr-icon shape="caret" class="icon-orient-down"></clr-icon>
+                                    <clr-icon shape="caret down"></clr-icon>
                                 </button>
                                 <div class="dropdown-menu">
                                     <a href="javascript://" class="dropdown-item" clrDropdownItem>Shutdown</a>
@@ -65,7 +65,7 @@
             &lt;clr-dropdown [clrMenuPosition]=&quot;'bottom-right'&quot;&gt;
                 &lt;button class=&quot;dropdown-toggle&quot; clrDropdownToggle&gt;
                     Actions
-                    &lt;clr-icon shape=&quot;caret&quot; class=&quot;icon-orient-down&quot;&gt;&lt;/clr-icon&gt;
+                    &lt;clr-icon shape=&quot;caret down&quot;&gt;&lt;/clr-icon&gt;
                 &lt;/button&gt;
                 &lt;div class=&quot;dropdown-menu&quot;&gt;
                     &lt;a href=&quot;javascript://&quot; class=&quot;dropdown-item&quot; clrDropdownItem&gt;Shutdown&lt;/a&gt;

--- a/src/clarity/alert/demo/static/alert-styles.demo.html
+++ b/src/clarity/alert/demo/static/alert-styles.demo.html
@@ -22,7 +22,7 @@
                             <div class="alert-action dropdown bottom-right">
                                 <button class="dropdown-toggle">
                                     Actions
-                                    <clr-icon shape="caret" class="icon-orient-down"></clr-icon>
+                                    <clr-icon shape="caret down"></clr-icon>
                                 </button>
                                 <div class="dropdown-menu">
                                     <a class="dropdown-item" href="javascript://">Shutdown</a>
@@ -40,7 +40,7 @@
                             <div class="alert-action dropdown bottom-right">
                                 <button class="dropdown-toggle">
                                     Actions
-                                    <clr-icon shape="caret" class="icon-orient-down"></clr-icon>
+                                    <clr-icon shape="caret down"></clr-icon>
                                 </button>
                                 <div class="dropdown-menu">
                                     <a class="dropdown-item" href="javascript://">Shutdown</a>
@@ -63,7 +63,7 @@
                             <div class="alert-action dropdown bottom-right open">
                                 <button class="dropdown-toggle">
                                     Actions
-                                    <clr-icon shape="caret" class="icon-orient-down"></clr-icon>
+                                    <clr-icon shape="caret down"></clr-icon>
                                 </button>
                                 <div class="dropdown-menu">
                                     <a class="dropdown-item" href="javascript://">Shutdown</a>
@@ -110,7 +110,7 @@
             &lt;div class=&quot;alert-action dropdown bottom-right&quot;&gt;
             &lt;button class=&quot;dropdown-toggle&quot;&gt;
                 Actions
-                &lt;clr-icon shape=&quot;caret&quot; class=&quot;icon-orient-down&quot;&gt;&lt;/clr-icon&gt;
+                &lt;clr-icon shape=&quot;caret down&quot;&gt;&lt;/clr-icon&gt;
             &lt;/button&gt;
                 &lt;div class=&quot;dropdown-menu&quot;&gt;
                     &lt;a class=&quot;dropdown-item&quot; href=&quot;javascript://&quot;&gt;Shutdown&lt;/a&gt;
@@ -128,7 +128,7 @@
             &lt;div class=&quot;alert-action dropdown bottom-right&quot;&gt;
                 &lt;button class=&quot;dropdown-toggle&quot;&gt;
                     Actions
-                    &lt;clr-icon shape=&quot;caret&quot; class=&quot;icon-orient-down&quot;&gt;&lt;/clr-icon&gt;
+                    &lt;clr-icon shape=&quot;caret down&quot;&gt;&lt;/clr-icon&gt;
                 &lt;/button&gt;
                 &lt;div class=&quot;dropdown-menu&quot;&gt;
                     &lt;a class=&quot;dropdown-item&quot; href=&quot;javascript://&quot;&gt;Shutdown&lt;/a&gt;
@@ -151,7 +151,7 @@
             &lt;div class=&quot;alert-action dropdown bottom-right open&quot;&gt;
                 &lt;button class=&quot;dropdown-toggle&quot;&gt;
                     Actions
-                    &lt;clr-icon shape=&quot;caret&quot; class=&quot;icon-orient-down&quot;&gt;&lt;/clr-icon&gt;
+                    &lt;clr-icon shape=&quot;caret down&quot;&gt;&lt;/clr-icon&gt;
                 &lt;/button&gt;
                 &lt;div class=&quot;dropdown-menu&quot;&gt;
                     &lt;a class=&quot;dropdown-item&quot; href=&quot;javascript://&quot;&gt;Shutdown&lt;/a&gt;

--- a/src/clarity/card/demo/card-dropdown.html
+++ b/src/clarity/card/demo/card-dropdown.html
@@ -32,7 +32,7 @@
                     <div class="dropdown top-left open">
                         <button class="dropdown-toggle btn btn-sm btn-link">
                             Dropdown 1
-                            <clr-icon shape="caret" class="icon-orient-down"></clr-icon>
+                            <clr-icon shape="caret down"></clr-icon>
                         </button>
                         <div class="dropdown-menu">
                             <a href="javascript://" class="dropdown-item">Item 1</a>
@@ -72,7 +72,7 @@
                 &lt;div class=&quot;dropdown top-left open&quot;&gt;
                     &lt;button class=&quot;dropdown-toggle btn btn-sm btn-link&quot;&gt;
                         Dropdown 1
-                        &lt;clr-icon shape=&quot;caret&quot; class=&quot;icon-orient-down&quot;&gt;&lt;/clr-icon&gt;
+                        &lt;clr-icon shape=&quot;caret down&quot;&gt;&lt;/clr-icon&gt;
                     &lt;/button&gt;
                     &lt;div class=&quot;dropdown-menu&quot;&gt;
                         &lt;a href=&quot;javascript://&quot; class=&quot;dropdown-item&quot;&gt;Item 1&lt;/a&gt;

--- a/src/clarity/dropdown/_dropdown.clarity.scss
+++ b/src/clarity/dropdown/_dropdown.clarity.scss
@@ -35,7 +35,7 @@ $dropdown-white: clr-getColor(lightest);
                 margin: 0;
             }
 
-            clr-icon[shape="caret"] {
+            clr-icon[shape^="caret"] {
                 position: absolute;
                 top: 50%;
                 transform: translateY(-50%);
@@ -48,7 +48,7 @@ $dropdown-white: clr-getColor(lightest);
             &.btn {
                 padding-right: $clr-button-horizontal-padding + $clr-dropdown-caret-icon-dimension + $clr-dropdown-caret-left-margin;
 
-                clr-icon[shape="caret"] {
+                clr-icon[shape^="caret"] {
                     right: $clr-button-horizontal-padding;
                 }
             }
@@ -56,7 +56,7 @@ $dropdown-white: clr-getColor(lightest);
             &:not(.btn) {
                 padding: 0 $clr-dropdown-caret-icon-dimension + $clr-dropdown-caret-left-margin 0 0;
 
-                clr-icon[shape="caret"] {
+                clr-icon[shape^="caret"] {
                     right: 0;
                 }
             }

--- a/src/clarity/dropdown/demo/dropdown-angular-close-item-false.demo.html
+++ b/src/clarity/dropdown/demo/dropdown-angular-close-item-false.demo.html
@@ -8,7 +8,7 @@
     <clr-dropdown [clrMenuPosition]="'bottom-right'" [clrCloseMenuOnItemClick]="false">
         <button clrDropdownToggle>
             <clr-icon shape="danger" class="icon-color-danger" size="24"></clr-icon>
-            <clr-icon shape="caret" class="icon-orient-down"></clr-icon>
+            <clr-icon shape="caret down"></clr-icon>
         </button>
         <div class="dropdown-menu">
             <label class="dropdown-header">Dropdown header</label>
@@ -25,7 +25,7 @@
 &lt;clr-dropdown [clrMenuPosition]=&quot;'bottom-right'&quot; [clrCloseMenuOnItemClick]=&quot;false&quot;&gt;
     &lt;button clrDropdownToggle&gt;
         &lt;clr-icon shape=&quot;danger&quot; class=&quot;icon-color-danger&quot; size=&quot;24&quot;&gt;&lt;/clr-icon&gt;
-        &lt;clr-icon shape=&quot;caret&quot; class=&quot;icon-orient-down&quot;&gt;&lt;/clr-icon&gt;
+        &lt;clr-icon shape=&quot;caret down&quot;&gt;&lt;/clr-icon&gt;
     &lt;/button&gt;
     &lt;div class=&quot;dropdown-menu&quot;&gt;
         &lt;label class=&quot;dropdown-header&quot;&gt;Dropdown header&lt;/label&gt;

--- a/src/clarity/dropdown/demo/dropdown-angular-positioning.demo.html
+++ b/src/clarity/dropdown/demo/dropdown-angular-positioning.demo.html
@@ -8,7 +8,7 @@
     <clr-dropdown [clrMenuPosition]="'top-left'">
         <button class="btn btn-outline-primary" clrDropdownToggle>
             Dropdown
-            <clr-icon shape="caret" class="icon-orient-down"></clr-icon>
+            <clr-icon shape="caret down"></clr-icon>
         </button>
         <div class="dropdown-menu">
             <label class="dropdown-header">Dropdown header</label>
@@ -27,7 +27,7 @@
 &lt;clr-dropdown [clrMenuPosition]=&quot;'top-left'&quot;&gt;
     &lt;button class=&quot;btn btn-outline-primary&quot; clrDropdownToggle&gt;
         Dropdown
-        &lt;clr-icon shape=&quot;caret&quot; class=&quot;icon-orient-down&quot;&gt;&lt;/clr-icon&gt;
+        &lt;clr-icon shape=&quot;caret down&quot;&gt;&lt;/clr-icon&gt;
     &lt;/button&gt;
     &lt;div class=&quot;dropdown-menu&quot;&gt;
         &lt;label class=&quot;dropdown-header&quot;&gt;Dropdown header&lt;/label&gt;

--- a/src/clarity/dropdown/demo/dropdown-static-buttonlink-toggle.demo.html
+++ b/src/clarity/dropdown/demo/dropdown-static-buttonlink-toggle.demo.html
@@ -8,7 +8,7 @@
     <div class="dropdown open">
         <button class="dropdown-toggle btn btn-link">
             Dropdown Toggle
-            <clr-icon shape="caret" class="icon-orient-down"></clr-icon>
+            <clr-icon shape="caret down"></clr-icon>
         </button>
         <div class="dropdown-menu">
             <h4 class="dropdown-header">Dropdown header</h4>
@@ -25,7 +25,7 @@
 &lt;div class=&quot;dropdown open&quot;&gt;
     &lt;button class=&quot;dropdown-toggle btn btn-link&quot;&gt;
         Dropdown Toggle
-        &lt;clr-icon shape=&quot;caret&quot; class=&quot;icon-orient-down&quot;&gt;&lt;/clr-icon&gt;
+        &lt;clr-icon shape=&quot;caret down&quot;&gt;&lt;/clr-icon&gt;
     &lt;/button&gt;
     &lt;div class=&quot;dropdown-menu&quot;&gt;
         &lt;h4 class=&quot;dropdown-header&quot;&gt;Dropdown header&lt;/h4&gt;

--- a/src/clarity/dropdown/demo/dropdown-static-default.demo.html
+++ b/src/clarity/dropdown/demo/dropdown-static-default.demo.html
@@ -8,7 +8,7 @@
     <div class="dropdown open">
         <button class="dropdown-toggle btn btn-primary" type="button">
             Dropdown
-            <clr-icon shape="caret" class="icon-orient-down"></clr-icon>
+            <clr-icon shape="caret down"></clr-icon>
         </button>
         <div class="dropdown-menu">
             <h4 class="dropdown-header">Dropdown header</h4>
@@ -25,7 +25,7 @@
 &lt;div class=&quot;dropdown open&quot;&gt;
     &lt;button class=&quot;dropdown-toggle btn btn-primary&quot; type=&quot;button&quot;&gt;
         Dropdown
-        &lt;clr-icon shape=&quot;caret&quot; class=&quot;icon-orient-down&quot;&gt;&lt;/clr-icon&gt;
+        &lt;clr-icon shape=&quot;caret down&quot;&gt;&lt;/clr-icon&gt;
     &lt;/button&gt;
     &lt;div class=&quot;dropdown-menu&quot;&gt;
         &lt;h4 class=&quot;dropdown-header&quot;&gt;Dropdown header&lt;/h4&gt;

--- a/src/clarity/dropdown/demo/dropdown-static-fontawesome-toggle.demo.html
+++ b/src/clarity/dropdown/demo/dropdown-static-fontawesome-toggle.demo.html
@@ -8,7 +8,7 @@
     <div class="dropdown bottom-right open">
         <button class="dropdown-toggle">
             <span class="fa fa-home fa-fw"></span>
-            <clr-icon shape="caret" class="icon-orient-down"></clr-icon>
+            <clr-icon shape="caret down"></clr-icon>
         </button>
         <div class="dropdown-menu">
             <h4 class="dropdown-header">Dropdown header</h4>
@@ -25,7 +25,7 @@
 &lt;div class=&quot;dropdown bottom-right open&quot;&gt;
     &lt;button class=&quot;dropdown-toggle&quot;&gt;
         &lt;span class=&quot;fa fa-home fa-fw&quot;&gt;&lt;/span&gt;
-        &lt;clr-icon shape=&quot;caret&quot; class=&quot;icon-orient-down&quot;&gt;&lt;/clr-icon&gt;
+        &lt;clr-icon shape=&quot;caret down&quot;&gt;&lt;/clr-icon&gt;
     &lt;/button&gt;
     &lt;div class=&quot;dropdown-menu&quot;&gt;
         &lt;h4 class=&quot;dropdown-header&quot;&gt;Dropdown header&lt;/h4&gt;

--- a/src/clarity/dropdown/demo/dropdown-static-icon-toggle.demo.html
+++ b/src/clarity/dropdown/demo/dropdown-static-icon-toggle.demo.html
@@ -8,7 +8,7 @@
     <div class="dropdown bottom-left open">
         <button class="dropdown-toggle">
             <clr-icon shape="danger" class="icon-color-danger icon-size-md"></clr-icon>
-            <clr-icon shape="caret" class="icon-orient-down"></clr-icon>
+            <clr-icon shape="caret down"></clr-icon>
         </button>
         <div class="dropdown-menu">
             <h4 class="dropdown-header">Dropdown header</h4>
@@ -25,7 +25,7 @@
 &lt;div class=&quot;dropdown bottom-left open&quot;&gt;
     &lt;button class=&quot;dropdown-toggle&quot;&gt;
         &lt;clr-icon shape=&quot;danger&quot; class=&quot;icon-color-danger icon-size-md&quot;&gt;&lt;/clr-icon&gt;
-        &lt;clr-icon shape=&quot;caret&quot; class=&quot;icon-orient-down&quot;&gt;&lt;/clr-icon&gt;
+        &lt;clr-icon shape=&quot;caret down&quot;&gt;&lt;/clr-icon&gt;
     &lt;/button&gt;
     &lt;div class=&quot;dropdown-menu&quot;&gt;
         &lt;h4 class=&quot;dropdown-header&quot;&gt;Dropdown header&lt;/h4&gt;

--- a/src/clarity/dropdown/demo/dropdown-static-positioning.demo.html
+++ b/src/clarity/dropdown/demo/dropdown-static-positioning.demo.html
@@ -8,7 +8,7 @@
     <div class="dropdown bottom-right open">
         <button class="dropdown-toggle btn btn-primary">
             Dropdown
-            <clr-icon shape="caret" class="icon-orient-down"></clr-icon>
+            <clr-icon shape="caret down"></clr-icon>
         </button>
         <div class="dropdown-menu">
             <h4 class="dropdown-header">Dropdown header</h4>
@@ -25,7 +25,7 @@
 &lt;div class=&quot;dropdown bottom-right open&quot;&gt;
     &lt;button class=&quot;dropdown-toggle btn btn-primary&quot;&gt;
         Dropdown
-        &lt;clr-icon shape=&quot;caret&quot; class=&quot;icon-orient-down&quot;&gt;&lt;/clr-icon&gt;
+        &lt;clr-icon shape=&quot;caret down&quot;&gt;&lt;/clr-icon&gt;
     &lt;/button&gt;
     &lt;div class=&quot;dropdown-menu&quot;&gt;
         &lt;h4 class=&quot;dropdown-header&quot;&gt;Dropdown header&lt;/h4&gt;

--- a/src/clarity/dropdown/dropdown.spec.ts
+++ b/src/clarity/dropdown/dropdown.spec.ts
@@ -15,7 +15,7 @@ import {ClarityModule} from "../clarity.module";
         <clr-dropdown [clrMenuPosition]="menuPosition" [clrCloseMenuOnItemClick]="menuClosable">
             <button class="btn btn-primary" type="button" clrDropdownToggle>
                 Dropdown
-                <clr-icon shape="caret" class="icon-orient-down"></clr-icon>
+                <clr-icon shape="caret down"></clr-icon>
             </button>
             <div class="dropdown-menu">
                 <label class="dropdown-header">Header</label>

--- a/src/clarity/nav/_header.clarity.scss
+++ b/src/clarity/nav/_header.clarity.scss
@@ -341,7 +341,7 @@ $clr-header-nav-text-horizontal-padding: $clr_baselineRem_1;
                     right: ($clr-dropdown-caret-icon-dimension + $clr-header-action-caret-icon-right-position + $clr-header-dropdown-caret-distance);
                 }
 
-                .dropdown-toggle.nav-icon clr-icon[shape="caret"] {
+                .dropdown-toggle.nav-icon clr-icon[shape^="caret"] {
                     left: auto;
                     right: $clr-header-action-caret-icon-right-position;
                     height: $clr-dropdown-caret-icon-dimension;
@@ -353,7 +353,7 @@ $clr-header-nav-text-horizontal-padding: $clr_baselineRem_1;
                 .dropdown-toggle.nav-text {
                     padding: 0 $dropdown-nav-text-dist 0 $clr-header-nav-text-horizontal-padding;
 
-                    clr-icon[shape="caret"] {
+                    clr-icon[shape^="caret"] {
                         right: $clr-header-nav-text-horizontal-padding;
                     }
                 }

--- a/src/clarity/nav/demo/header-types.demo.html
+++ b/src/clarity/nav/demo/header-types.demo.html
@@ -54,7 +54,7 @@
                 <clr-dropdown class="dropdown bottom-right">
                     <button class="nav-icon" clrDropdownToggle>
                         <clr-icon shape="cog"></clr-icon>
-                        <clr-icon shape="caret" class="icon-orient-down"></clr-icon>
+                        <clr-icon shape="caret down"></clr-icon>
                     </button>
                     <div class="dropdown-menu">
                         <a href="javascript://" clrDropdownItem>About</a>
@@ -89,7 +89,7 @@
                 <clr-dropdown class="dropdown bottom-right">
                     <button class="nav-icon" clrDropdownToggle>
                         <clr-icon shape="user"></clr-icon>
-                        <clr-icon shape="caret" class="icon-orient-down"></clr-icon>
+                        <clr-icon shape="caret down"></clr-icon>
                     </button>
                     <div class="dropdown-menu">
                         <a href="javascript://" clrDropdownItem>About</a>
@@ -165,7 +165,7 @@
         &lt;clr-dropdown class=&quot;dropdown bottom-right&quot;&gt;
             &lt;button class=&quot;nav-icon&quot; clrDropdownToggle&gt;
                 &lt;clr-icon shape=&quot;cog&quot;&gt;&lt;/clr-icon&gt;
-                &lt;clr-icon shape=&quot;caret&quot; class=&quot;icon-orient-down&quot;&gt;&lt;/clr-icon&gt;
+                &lt;clr-icon shape=&quot;caret down&quot;&gt;&lt;/clr-icon&gt;
             &lt;/button&gt;
             &lt;div class=&quot;dropdown-menu&quot;&gt;
                 &lt;a href=&quot;javascript://&quot; clrDropdownItem&gt;About&lt;/a&gt;
@@ -200,7 +200,7 @@
         &lt;clr-dropdown class=&quot;dropdown bottom-right&quot;&gt;
             &lt;button class=&quot;nav-icon&quot; clrDropdownToggle&gt;
                 &lt;clr-icon shape=&quot;user&quot;&gt;&lt;/clr-icon&gt;
-                &lt;clr-icon shape=&quot;caret&quot; class=&quot;icon-orient-down&quot;&gt;&lt;/clr-icon&gt;
+                &lt;clr-icon shape=&quot;caret down&quot;&gt;&lt;/clr-icon&gt;
             &lt;/button&gt;
             &lt;div class=&quot;dropdown-menu&quot;&gt;
                 &lt;a href=&quot;javascript://&quot; clrDropdownItem&gt;About&lt;/a&gt;


### PR DESCRIPTION
Updated carets in dropdowns to use this markup:
`<clr-icon shape=“caret” class=“icon-orient-down”></clr-icon>`

to:
`<clr-icon shape=“caret down”></clr-icon>`

Tested on: Chrome, IE10, IE11, Edge, Firefox, Safari

Signed-off-by: Aditya Bhandari <adityab@vmware.com>