### PR TITLE
[NG] Datagrid: no placeholder while loading

### DIFF
--- a/src/clarity/datagrid/datagrid-placeholder.spec.ts
+++ b/src/clarity/datagrid/datagrid-placeholder.spec.ts
@@ -66,6 +66,12 @@ export default function(): void {
                 expect(context.clarityElement.textContent.trim()).toMatch("");
             });
 
+            it("is empty when the data is loading", function() {
+                itemsProvider.loading = true;
+                context.detectChanges();
+                expect(context.clarityElement.textContent.trim()).toMatch("");
+            });
+
             it("projects content when there are no items", function() {
                 expect(context.clarityElement.textContent.trim()).toMatch("Hello world");
             });

--- a/src/clarity/datagrid/datagrid-placeholder.ts
+++ b/src/clarity/datagrid/datagrid-placeholder.ts
@@ -29,7 +29,7 @@ export class DatagridPlaceholder {
      * Tests if the datagrid is empty, meaning it doesn't contain any items
      */
     public get emptyDatagrid() {
-        return !this.items.displayed || this.items.displayed.length === 0;
+        return !this.items.loading && (!this.items.displayed || this.items.displayed.length === 0);
     }
 
     /**

--- a/src/clarity/datagrid/datagrid.ts
+++ b/src/clarity/datagrid/datagrid.ts
@@ -35,7 +35,13 @@ export class Datagrid implements AfterContentInit, AfterViewInit, OnDestroy {
     /**
      * Freezes the datagrid while data is loading
      */
-    @Input("clrDgLoading") public loading = false;
+    public get loading(): boolean {
+        return this.items.loading;
+    }
+    @Input("clrDgLoading")
+    public set loading(value: boolean) {
+        this.items.loading = value;
+    }
 
     /**
      * Output emitted whenever the data needs to be refreshed, based on user action or external ones

--- a/src/clarity/datagrid/providers/items.ts
+++ b/src/clarity/datagrid/providers/items.ts
@@ -15,6 +15,11 @@ export class Items {
     constructor(private _filters: Filters, private _sort: Sort, private _page: Page) {}
 
     /**
+     * Indicates if the data is currently loading
+     */
+    public loading = false;
+
+    /**
      * Subscriptions to the other providers changes.
      */
     private _filtersSub: Subscription;


### PR DESCRIPTION
The placeholder image and projected text are not displayed if the
data is currently loading.

Fixes #162.