### PR TITLE
Implement an onCancel event fo Wizard component

### DIFF
--- a/src/clarity/wizard/demo/wizard-options.demo.html
+++ b/src/clarity/wizard/demo/wizard-options.demo.html
@@ -32,6 +32,14 @@
         </td>
     </tr>
     <tr>
+        <td class="left">(clrWizardOnCancel)</td>
+        <td>any</td>
+        <td>N/A</td>
+        <td class="left">
+            Emits an event when the close or cancel button is clicked on the wizard page.
+        </td>
+    </tr>
+    <tr>
         <td class="left">[clrWizardSize]</td>
         <td>"md", "lg", "xl"</td>
         <td>"xl"</td>

--- a/src/clarity/wizard/wizard.html
+++ b/src/clarity/wizard/wizard.html
@@ -14,7 +14,7 @@
    <div class="modal-body">
       <div class="content-container">
          <main class="content-area">
-            <button type="button" class="close" aria-label="Close" (click)="close()">
+            <button type="button" class="close" aria-label="Close" (click)="_close($event)">
                <span aria-hidden="true">&times;</span>
             </button>
             <ng-content></ng-content>
@@ -33,7 +33,7 @@
    </div>
 
    <div class="modal-footer">
-      <button class="btn btn-link" (click)="close()">Cancel</button>
+      <button class="btn btn-link" (click)="_close($event)">Cancel</button>
       <button class="btn btn-outline"
             *ngIf="!isFirst" (click)="prev($event)">Back</button>
       <button class="btn btn-primary"

--- a/src/clarity/wizard/wizard.spec.ts
+++ b/src/clarity/wizard/wizard.spec.ts
@@ -33,7 +33,10 @@ class BasicWizard {
 
 @Component({
     template: `
-    <clr-wizard [(clrWizardOpen)]="open">
+    <clr-wizard 
+        [(clrWizardOpen)]="open"
+         (clrWizardOnCancel)="myOnCancel($event)">
+         
          <div class="wizard-title">
             New Virtual Machine
          </div>
@@ -89,6 +92,7 @@ class AdvancedWizard {
     nextDisabled: boolean = false;
     content1: String = "Content1";
     content3: String = "Content3";
+    hasBeenCanceled = false;
 
     myOnLoad(): void {
         this.content1 = "This Works Better";
@@ -100,6 +104,10 @@ class AdvancedWizard {
 
     myOnCommit(event: any): void {
         event.preventDefault();
+    }
+
+    myOnCancel(event: any): void {
+        this.hasBeenCanceled = true;
     }
 };
 
@@ -117,6 +125,12 @@ describe("Wizard", () => {
     let moveToPrevious: Function = function (el: any): void {
         let back: HTMLElement = el.querySelector(".btn-outline");
         back.click();
+        fixture.detectChanges();
+    };
+
+    let doCancel: Function = function(el: any): void {
+        let cancel: HTMLElement = el.querySelector(".close");
+        cancel.click();
         fixture.detectChanges();
     };
 
@@ -465,6 +479,11 @@ describe("Wizard", () => {
             expect(tab2).toBeDefined();
             expect(tab3).toBeDefined();
             expect(tab4).toBeDefined();
+        });
+
+        it("calls the user-defined onCancel handler when the Cancel button is clicked", () => {
+            doCancel(compiled);
+            expect(fixture.componentInstance.hasBeenCanceled).toBe(true);
         });
     });
 

--- a/src/clarity/wizard/wizard.ts
+++ b/src/clarity/wizard/wizard.ts
@@ -10,7 +10,7 @@ import {
     Output,
     EventEmitter,
     QueryList,
-    SimpleChange
+    SimpleChange, HostListener
 } from "@angular/core";
 
 import {Tabs} from "../tabs/tabs";
@@ -46,6 +46,10 @@ export class Wizard extends Tabs {
     // EventEmitter which is emitted on open/close of the wizard.
     @Output("clrWizardOpenChanged") private _openChanged: EventEmitter<boolean> =
         new EventEmitter<boolean>(false);
+
+    // User can bind his event handler for onCancel of the main content
+    @Output("clrWizardOnCancel") onCancel: EventEmitter<any> =
+        new EventEmitter<any>(false);
 
     // Flag to toggle between Next and Finish button
     isLast: boolean = false;
@@ -122,6 +126,17 @@ export class Wizard extends Tabs {
     close(): void {
         this._open = false;
         this._openChanged.emit(false);
+    }
+
+    // _close --
+    //
+    // This is a private function that is called on the click of the close / cancel
+    // button and emits the onCancel event of the active tab.
+    @HostListener("body:keyup.escape")
+    _close(): void {
+        this.onCancel.emit(null);
+
+        this.close();
     }
 
     // _next --


### PR DESCRIPTION
For issue #152

This is a new implementation of an onCancel event in wizard component (first try was on PR 179).
The first implementation was wrong because it was binded on wizardPage instead of main component.

I still need help on testing the feature:
 * i want to test that the property of the component has been modified by the onCancel method
 * i want to test that the _close method has been called after clicking on cancel

but my test doesn't work coz i have certainly missed something around the component

Signed-off-by: Benjamin RICHARD <benjamin.richard@ext.euronews.com>