### PR TITLE
[UI,DOC] Card Title Doc Update

### DIFF
--- a/src/clarity/card/_card.clarity.scss
+++ b/src/clarity/card/_card.clarity.scss
@@ -65,9 +65,9 @@ $card-children-space-between: $clr_baselineRem_0_5;
             padding: $card-children-padding-vertical $card-children-padding-horizontal;
         }
 
+        .card-subtitle, //TODO: Deprecate in 0.8.0
         .card-header,
-        .card-title,
-        .card-subtitle {
+        .card-title, {
             @include clr-getTypePropertiesForDomElement(card_title, (color, font-size, font-weight, letter-spacing));
         }
 
@@ -174,9 +174,9 @@ $card-children-space-between: $clr_baselineRem_0_5;
         }
 
         .card-title,
-        .card-subtitle,
+        .card-subtitle, //TODO: Deprecate in 0.8.0
         .card-text,
-        .group, //TODO: Deprecate this
+        .group, //TODO: Deprecate in 0.8.0
         .card-media-block,
         .list,
         .list-unstyled {

--- a/src/clarity/typography/demo/typography-headers.html
+++ b/src/clarity/typography/demo/typography-headers.html
@@ -62,7 +62,7 @@
             <td class="left">
                 <ul class="list compact list-unstyled">
                     <li>Secondary content header <em>(page_secondaryHeading)</em></li>
-                    <li>Modal/Wizard/Dialog Header <em>(modal_header)</em></li>
+                    <li>Modal/Wizard/Dialog header <em>(modal_header)</em></li>
                 </ul>
             </td>
         </tr>
@@ -80,6 +80,7 @@
             <td class="left">
                 <ul class="list compact list-unstyled">
                     <li>Tertiary content header <em>(page_tertiaryHeading)</em></li>
+                    <li>Card header/title <em>(card_title)</em></li>
                 </ul>
             </td>
         </tr>


### PR DESCRIPTION
- Added the card title style in the header section of the Typography documentation
- Marked .card-subtitle for deprecation in 0.8.0

![image](https://cloud.githubusercontent.com/assets/1426805/20929875/5c95c218-bb80-11e6-8b31-4fd5574f135e.png)

Browser: Chrome