### PR TITLE
[ICONS] created a class for icon error color

### DIFF
--- a/src/clarity/iconography/demo/icon-colors.demo.html
+++ b/src/clarity/iconography/demo/icon-colors.demo.html
@@ -7,7 +7,7 @@
 <span class="clr-example">
     <clr-icon shape="info-circle"></clr-icon>
     <clr-icon shape="info-circle" class="icon-color-highlight"></clr-icon>
-    <clr-icon shape="info-circle" class="icon-color-danger"></clr-icon>
+    <clr-icon shape="info-circle" class="icon-color-error"></clr-icon>
     <clr-icon shape="info-circle" class="icon-color-warning"></clr-icon>
     <clr-icon shape="info-circle" class="icon-color-success"></clr-icon>
     <clr-icon shape="info-circle" class="icon-color-info"></clr-icon>
@@ -17,7 +17,7 @@
 <code clr-code-highlight="language-html">
 &lt;clr-icon shape=&quot;info-circle&quot;&gt;&lt;/clr-icon&gt;
 &lt;clr-icon shape=&quot;info-circle&quot; class=&quot;icon-color-highlight&quot;&gt;&lt;/clr-icon&gt;
-&lt;clr-icon shape=&quot;info-circle&quot; class=&quot;icon-color-danger&quot;&gt;&lt;/clr-icon&gt;
+&lt;clr-icon shape=&quot;info-circle&quot; class=&quot;icon-color-error&quot;&gt;&lt;/clr-icon&gt;
 &lt;clr-icon shape=&quot;info-circle&quot; class=&quot;icon-color-warning&quot;&gt;&lt;/clr-icon&gt;
 &lt;clr-icon shape=&quot;info-circle&quot; class=&quot;icon-color-success&quot;&gt;&lt;/clr-icon&gt;
 &lt;clr-icon shape=&quot;info-circle&quot; class=&quot;icon-color-info&quot;&gt;&lt;/clr-icon&gt;

--- a/src/icons/clarity-icons.scss
+++ b/src/icons/clarity-icons.scss
@@ -6,8 +6,9 @@
 
 $clr-icon-size: 16px;
 $clr-icon-color-success: #318700;
-$clr-icon-color-danger: #a32100;
+$clr-icon-color-danger: #e62700;
 $clr-icon-color-warning: #e62700;
+$clr-icon-color-error: #e62700;
 $clr-icon-color-info: #007CBB;
 $clr-icon-color-inverse: #FFFFFF;
 $clr-icon-color-highlight: #007CBB;
@@ -49,6 +50,9 @@ clr-icon {
     }
     &.icon-color-success {
         @include setIconColor($clr-icon-color-success);
+    }
+    &.icon-color-error {
+        @include setIconColor($clr-icon-color-error);
     }
     &.icon-color-danger {
         @include setIconColor($clr-icon-color-danger);


### PR DESCRIPTION
- made .icon-color-danger the same color as .icon-color-warning
- added .icon-color-error that is the same color as .icon-color-warning
- updated the icon colors demo to reflect the changes

Signed-off-by: Shijir Tsogoo <stsogoo@vmware.com>