### PR TITLE
[ng] adding clrWizardClosable attribute to wizards

### DIFF
--- a/src/clarity/wizard/demo/wizard-angular.demo.html
+++ b/src/clarity/wizard/demo/wizard-angular.demo.html
@@ -8,4 +8,5 @@
 <clr-wizard-simple></clr-wizard-simple>
 <clr-wizard-form-validation></clr-wizard-form-validation>
 <clr-wizard-async-validation></clr-wizard-async-validation>
+<clr-wizard-not-closable></clr-wizard-not-closable>
 <clr-wizard-options></clr-wizard-options>

--- a/src/clarity/wizard/demo/wizard-not-closable.demo.html
+++ b/src/clarity/wizard/demo/wizard-not-closable.demo.html
@@ -1,0 +1,21 @@
+<!--
+  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<button class="btn btn-primary" (click)="wizardClosable.open()">Wizard, Not Closable</button>
+
+<clr-wizard #wizardclos [(clrWizardOpen)]="open" [clrWizardClosable]="false" [clrWizardSize]="'md'">
+    <div class="wizard-title">Wizard Title</div>
+
+    <clr-wizard-step>Step 1</clr-wizard-step>
+    <clr-wizard-step>Step 2</clr-wizard-step>
+    <clr-wizard-step>Step 3</clr-wizard-step>
+
+    <clr-wizard-page>Note that there is no closing &times; icon in the top right.</clr-wizard-page>
+    <clr-wizard-page>Content for step 2</clr-wizard-page>
+    <clr-wizard-page>Content for step 3</clr-wizard-page>
+</clr-wizard>
+
+<clr-example [clrLanguage]="'html'" [clrCode]="html"></clr-example>

--- a/src/clarity/wizard/demo/wizard-not-closable.demo.ts
+++ b/src/clarity/wizard/demo/wizard-not-closable.demo.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component, ViewChild} from "@angular/core";
+import {Wizard} from "../wizard";
+import {CodeHighlight} from "../../code/code-highlight";
+
+@Component({
+    selector: "clr-wizard-not-closable",
+    templateUrl: "./wizard-not-closable.demo.html"
+})
+export class WizardNotClosable {
+    @ViewChild("wizardclos") wizardClosable: Wizard;
+    @ViewChild(CodeHighlight) codeHighlight: CodeHighlight;
+
+    html: string = `
+<clr-wizard [(clrWizardOpen)]="open" [clrWizardClosable]="false" [clrWizardSize]="'md'">
+    <div class="wizard-title">Wizard Title</div>
+
+    <clr-wizard-step>Step 1</clr-wizard-step>
+    <clr-wizard-step>Step 2</clr-wizard-step>
+    <clr-wizard-step>Step 3</clr-wizard-step>
+
+    <clr-wizard-page>Note that there is no closing &times; icon in the top right.</clr-wizard-page>
+    <clr-wizard-page>Content for step 2</clr-wizard-page>
+    <clr-wizard-page>Content for step 3</clr-wizard-page>
+</clr-wizard>
+    `;
+}

--- a/src/clarity/wizard/demo/wizard-options.demo.html
+++ b/src/clarity/wizard/demo/wizard-options.demo.html
@@ -112,5 +112,14 @@
             Emits an event when loading the wizard page.
         </td>
     </tr>
+    <tr>
+        <td class="left">[clrWizardClosable]</td>
+        <td>boolean</td>
+        <td>true</td>
+        <td class="left">
+            If set to false, this will remove the closing &times; element in the top right. This 
+            means that users will need to click the Cancel button to exit the wizard without finishing.
+        </td>
+    </tr>
     </tbody>
 </table>

--- a/src/clarity/wizard/demo/wizard.demo.module.ts
+++ b/src/clarity/wizard/demo/wizard.demo.module.ts
@@ -15,6 +15,7 @@ import {WizardSimple} from "./wizard-simple.demo";
 import {WizardBasic} from "./wizard-basic.demo";
 import {WizardFormValidation} from "./wizard-form-validation.demo";
 import {WizardAsyncValidation} from "./wizard-async-validation.demo";
+import {WizardNotClosable} from "./wizard-not-closable.demo";
 import {CodeExample} from "./code-example";
 import {WizardOptionsDemo} from "./wizard-options.demo";
 
@@ -34,7 +35,8 @@ import {WizardOptionsDemo} from "./wizard-options.demo";
         WizardDemo,
         WizardAngularDemo,
         WizardStaticDemo,
-        WizardOptionsDemo
+        WizardOptionsDemo,
+        WizardNotClosable
     ],
     exports: [
         WizardBasic,
@@ -44,7 +46,8 @@ import {WizardOptionsDemo} from "./wizard-options.demo";
         WizardDemo,
         WizardAngularDemo,
         WizardStaticDemo,
-        WizardOptionsDemo
+        WizardOptionsDemo,
+        WizardNotClosable
     ]
 })
 export default class WizardDemoModule {

--- a/src/clarity/wizard/wizard.html
+++ b/src/clarity/wizard/wizard.html
@@ -7,16 +7,13 @@
 <clr-modal
       [clrModalOpen]="_open"
       [clrModalSize]="size"
-      [clrModalClosable]="false"
+      [clrModalClosable]="closable"
       [clrModalStaticBackdrop]="true"
       (clrModalOpenChange)="close()">
 
    <div class="modal-body">
       <div class="content-container">
          <main class="content-area">
-            <button type="button" class="close" aria-label="Close" (click)="_close($event)">
-               <span aria-hidden="true">&times;</span>
-            </button>
             <ng-content></ng-content>
          </main>
 

--- a/src/clarity/wizard/wizard.spec.ts
+++ b/src/clarity/wizard/wizard.spec.ts
@@ -11,7 +11,7 @@ import {Wizard} from "./wizard";
 
 @Component({
     template: `
-    <clr-wizard [(clrWizardOpen)]="open">
+    <clr-wizard [(clrWizardOpen)]="open" [clrWizardClosable]="false">
         <div class="wizard-title">Title</div>
         <clr-wizard-step>Tab1</clr-wizard-step>
         <clr-wizard-step>Tab2</clr-wizard-step>
@@ -35,8 +35,7 @@ class BasicWizard {
     template: `
     <clr-wizard 
         [(clrWizardOpen)]="open"
-         (clrWizardOnCancel)="myOnCancel($event)">
-         
+        (clrWizardOnCancel)="myOnCancel($event)">
          <div class="wizard-title">
             New Virtual Machine
          </div>
@@ -107,6 +106,8 @@ class AdvancedWizard {
     }
 
     myOnCancel(event: any): void {
+        console.log("here");
+
         this.hasBeenCanceled = true;
     }
 };
@@ -265,6 +266,12 @@ describe("Wizard", () => {
             moveToNext(compiled);
             let primaryButtonText: string = compiled.querySelector(".btn-primary").textContent;
             expect(primaryButtonText).not.toMatch(/NEXT/);
+        });
+
+        it("passes clrWizardClosable false to the modal", () => {
+            let closeButton = compiled.querySelector("button.close");
+            expect(instance.closable).toBe(false);
+            expect(closeButton).toBeNull();
         });
     });
 
@@ -485,6 +492,11 @@ describe("Wizard", () => {
             doCancel(compiled);
             expect(fixture.componentInstance.hasBeenCanceled).toBe(true);
         });
-    });
 
+        it("defaults clrWizardClosable to true", () => {
+            let closeButton = compiled.querySelector("button.close");
+            expect(instance.closable).toBe(true);
+            expect(closeButton).not.toBeNull();
+        });
+    });
 });

--- a/src/clarity/wizard/wizard.spec.ts
+++ b/src/clarity/wizard/wizard.spec.ts
@@ -106,8 +106,6 @@ class AdvancedWizard {
     }
 
     myOnCancel(event: any): void {
-        console.log("here");
-
         this.hasBeenCanceled = true;
     }
 };

--- a/src/clarity/wizard/wizard.ts
+++ b/src/clarity/wizard/wizard.ts
@@ -43,6 +43,9 @@ export class Wizard extends Tabs {
     // Variable that toggles open/close of the wizard component.
     @Input("clrWizardOpen") private _open: boolean = false;
 
+    // Variable that toggles open/close of the wizard component.
+    @Input("clrWizardClosable") closable: boolean = true;
+
     // EventEmitter which is emitted on open/close of the wizard.
     @Output("clrWizardOpenChanged") private _openChanged: EventEmitter<boolean> =
         new EventEmitter<boolean>(false);
@@ -125,6 +128,7 @@ export class Wizard extends Tabs {
     // wizard.
     close(): void {
         this._open = false;
+        this.onCancel.emit(null);
         this._openChanged.emit(false);
     }
 
@@ -134,8 +138,6 @@ export class Wizard extends Tabs {
     // button and emits the onCancel event of the active tab.
     @HostListener("body:keyup.escape")
     _close(): void {
-        this.onCancel.emit(null);
-
         this.close();
     }
 


### PR DESCRIPTION
• added clrWizardClosable flag to wizard component
• this delegates to clrModalClosable
• effectively removes X from top-right corner of modal
• defaults to true, which is the current default
• added unit tests
• moved emission of onCancel event on close out of the private function
• when we moved the close functionality to be a delegate of the modal closing functionality, the onCancel event was not being fired

Tested in:
✔︎ Chrome

Closes: #155

Signed-off-by: Scott Mathis <smathis@vmware.com>
