### PR TITLE
[ui] Update pre style to have newlines by default

### DIFF
--- a/src/clarity/code/_code.clarity.scss
+++ b/src/clarity/code/_code.clarity.scss
@@ -14,7 +14,6 @@
     }
 
     pre {
-        white-space: normal;
         border: 1px solid $gray-light-midtone;
         max-height: baselineRem(15);
         border-radius: 3px;


### PR DESCRIPTION
- closes #185
- this preserves the existing code snippets as is but makes sure that all pre elements have newlines by default
- changes were tested on the following: IE 10, 11 Edge, Chrome (latest) Firefox (Latest) and Safari (Latest)

See the below screen capture of a pre tag on the website
![screen shot 2016-12-09 at 4 01 08 pm](https://cloud.githubusercontent.com/assets/433692/21068770/f2ec6ca8-be28-11e6-9e11-8d812046f154.png)

See screen captures of existing pre elements for checkboxes and buttons are below:
![screen shot 2016-12-08 at 4 22 17 pm](https://cloud.githubusercontent.com/assets/433692/21033057/bc8af164-bd62-11e6-8c12-c629f604e595.png)
![screen shot 2016-12-08 at 4 21 47 pm](https://cloud.githubusercontent.com/assets/433692/21033065/c59cd768-bd62-11e6-8a06-73b78e17c31b.png)

Signed-off-by: Matt Hippely <mhippely@vmware.com>