### PR TITLE
[UI] Link buttons horizontal padding causes alignment issues

### DIFF
--- a/src/clarity/buttons/_buttons.clarity.scss
+++ b/src/clarity/buttons/_buttons.clarity.scss
@@ -120,8 +120,8 @@ $clr-button-appearance-map: (
         letter-spacing: 0.073em,
         font-size: rem(11/$clr-rem-denominator),
         font-weight: 400,
-        height: $clr-button-height-sm,
-        padding: $clr-button-padding
+        height: $clr-button-height-sm
+        //padding: $clr-button-padding
     ),
     form: (
         line-height: $clr-button-height,
@@ -210,6 +210,13 @@ $clr-button-appearance-map: (
     @include btn-text-properties();
 }
 
+@mixin applyDynamicPadding() {
+  padding: 0;
+  & + .btn {
+    padding: 0 $clr-button-horizontal-padding
+  }
+}
+
 @include exports('buttons.clarity') {
 
     .btn {
@@ -257,7 +264,7 @@ $clr-button-appearance-map: (
 
         &.btn-link {
             @include populateButtonProperties(link);
-            padding: 0;
+            @include applyDynamicPadding();
         }
 
         &.btn-inverse {

--- a/src/clarity/buttons/_buttons.clarity.scss
+++ b/src/clarity/buttons/_buttons.clarity.scss
@@ -194,7 +194,7 @@ $clr-button-appearance-map: (
 @mixin btn-appearance() {
     cursor: pointer;
     display: inline-block;
-    margin: $clr-button-vertical-margin $clr-button-horizontal-margin $clr-button-vertical-margin 0;
+    // margin: $clr-button-vertical-margin $clr-button-horizontal-margin $clr-button-vertical-margin 0;
 
     // Overrides a Fix for IOS in BS4 _normalize.scss (~ln 330)
     // `!important` is to override specificity in this instance
@@ -257,7 +257,7 @@ $clr-button-appearance-map: (
 
         &.btn-link {
             @include populateButtonProperties(link);
-            margin: $clr-button-vertical-margin 0;
+            padding: 0;
         }
 
         &.btn-inverse {

--- a/src/clarity/card/_card.clarity.scss
+++ b/src/clarity/card/_card.clarity.scss
@@ -67,7 +67,7 @@ $card-children-space-between: $clr_baselineRem_0_5;
 
         .card-subtitle, //TODO: Deprecate in 0.8.0
         .card-header,
-        .card-title, {
+        .card-title {
             @include clr-getTypePropertiesForDomElement(card_title, (color, font-size, font-weight, letter-spacing));
         }
 
@@ -114,7 +114,7 @@ $card-children-space-between: $clr_baselineRem_0_5;
             //NOTE: Set left and right padding of link buttons to 0. aligning these buttons
             //without removing the paddings is a huge task and leads to a brittle card css
             //plus the alignment doesn't work in all the cases
-            padding: 0;
+            //padding: 0;
         }
 
         &.card-block,

--- a/src/clarity/stack-view/_stack-view.clarity.scss
+++ b/src/clarity/stack-view/_stack-view.clarity.scss
@@ -33,13 +33,13 @@ $clr-stack-font-weight: clr-getTypePropertyValueForDomElement(stackview_text, fo
 
                 &.btn {
                     min-width: 0;
-                    padding: 0 $clr_baselineRem_0_5;
+                    //padding: 0 $clr_baselineRem_0_5;
                 }
 
                 &.btn-link {
                     // Weird negative margin to make the button aligned with the stack view
                     // in its default state. It then looks unaligned on hover only.
-                    margin-right: -1 * $clr_baselineRem_0_5;
+                    //margin-right: -1 * $clr_baselineRem_0_5;
                 }
             }
         }


### PR DESCRIPTION
    - Please add in release notes: 'button padding has been removed for link type buttons; button margin has been removed as default for all buttons.  Update external components accordingly.'
    - As this is my first commit here I'm definitely open to reviews and suggestions

    #184, #181 (for the removal of margin)

BY BYTEX ROMANIA
Signed-off-by:   Prisecaru Bogdan <bogdan.prisecaru@xivic.com>