### PR TITLE
[NG] Add forRoot() and forChild() to ClarityModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ application doesn't support IE10, you can skip the following installation:
     @NgModule({
         imports: [
             BrowserModule,
-            ClarityModule,
+            ClarityModule.forRoot(),
             ....
          ],
          declarations: [ AppComponent ],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,7 +18,7 @@ import {ClarityModule} from "../clarity/clarity.module";
         BrowserModule,
         FormsModule,
         ROUTING,
-        ClarityModule
+        ClarityModule.forRoot()
     ],
     declarations: [
         AppComponent,

--- a/src/clarity/alert/alert.spec.ts
+++ b/src/clarity/alert/alert.spec.ts
@@ -40,7 +40,7 @@ describe("Alert", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ClarityModule],
+            imports: [ClarityModule.forRoot()],
             declarations: [TestComponent]
         });
 

--- a/src/clarity/checkboxes/checkbox.spec.ts
+++ b/src/clarity/checkboxes/checkbox.spec.ts
@@ -100,7 +100,10 @@ describe("Checkbox", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ClarityModule, FormsModule],
+            imports: [
+                ClarityModule.forRoot(),
+                FormsModule
+            ],
             declarations: [BasicCheckbox, CheckboxWithNgModel, CheckboxWithLabel, CheckboxWithName, InlineCheckbox,
                 IndeterminateCheckbox]
         });

--- a/src/clarity/clarity.module.ts
+++ b/src/clarity/clarity.module.ts
@@ -54,10 +54,13 @@ import {ClrResponsiveNavigationService} from "./nav/clrResponsiveNavigationServi
         TABS_DIRECTIVES,
         WIZARD_DIRECTIVES,
         ICON_DIRECTIVES
-    ],
-    providers: [
-        ClrResponsiveNavigationService
     ]
 })
 export class ClarityModule {
+    static forRoot() {
+        return {
+            ngModule: ClarityModule,
+            providers: [ ClrResponsiveNavigationService ]
+        };
+    }
 }

--- a/src/clarity/clarity.module.ts
+++ b/src/clarity/clarity.module.ts
@@ -63,4 +63,11 @@ export class ClarityModule {
             providers: [ ClrResponsiveNavigationService ]
         };
     }
+
+    static forChild() {
+        return {
+            ngModule: ClarityModule,
+            providers: []
+        };
+    }
 }

--- a/src/clarity/code/code-highlight.spec.ts
+++ b/src/clarity/code/code-highlight.spec.ts
@@ -24,7 +24,7 @@ describe("CodeHighlight", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ClarityModule],
+            imports: [ClarityModule.forRoot()],
             declarations: [TestComponent]
         });
         fixture = TestBed.createComponent(TestComponent);

--- a/src/clarity/datagrid/datagrid-items.spec.ts
+++ b/src/clarity/datagrid/datagrid-items.spec.ts
@@ -20,7 +20,7 @@ export default function(): void {
              * we can't use our usual shortcut, we need to rely on @ViewChild
              */
             TestBed.configureTestingModule({
-                imports: [ClarityModule],
+                imports: [ClarityModule.forRoot()],
                 declarations: [FullTest],
                 providers: [Items, Filters, Sort, Page]
             });

--- a/src/clarity/datagrid/helpers.spec.ts
+++ b/src/clarity/datagrid/helpers.spec.ts
@@ -57,7 +57,7 @@ export function addHelpers(): void {
          */
         this.create = <D, C>(clarityDirective: Type<D>, testComponent: Type<C>, providers: any[] = []) => {
             TestBed.configureTestingModule({
-                imports: [ClarityModule],
+                imports: [ClarityModule.forRoot()],
                 declarations: [testComponent],
                 providers: providers
             });

--- a/src/clarity/dropdown/dropdown.spec.ts
+++ b/src/clarity/dropdown/dropdown.spec.ts
@@ -41,7 +41,7 @@ describe("Dropdown", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ClarityModule],
+            imports: [ClarityModule.forRoot()],
             declarations: [TestComponent]
         });
 

--- a/src/clarity/layout/main-container.spec.ts
+++ b/src/clarity/layout/main-container.spec.ts
@@ -64,7 +64,7 @@ describe("MainContainer", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ClarityModule],
+            imports: [ClarityModule.forRoot()],
             declarations: [TestComponent]
         });
 

--- a/src/clarity/modal/modal.spec.ts
+++ b/src/clarity/modal/modal.spec.ts
@@ -47,7 +47,7 @@ describe("Modal", () => {
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
-            imports: [ClarityModule],
+            imports: [ClarityModule.forRoot()],
             declarations: [TestComponent]
         });
 

--- a/src/clarity/modal/modal.spec.ts
+++ b/src/clarity/modal/modal.spec.ts
@@ -11,7 +11,6 @@ import {
     tick
 } from "@angular/core/testing";
 import {Component, ViewChild} from "@angular/core";
-import {ScrollingService} from "../main/scrolling-service";
 import {ClarityModule} from "../clarity.module";
 import {Modal} from "./modal";
 
@@ -29,8 +28,7 @@ import {Modal} from "./modal";
                 <button (click)="opened = false">Footer</button>
             </div>
         </clr-modal>
-   `,
-    viewProviders: [ScrollingService]
+   `
 })
 class TestComponent {
     @ViewChild(Modal) modalInstance: Modal;

--- a/src/clarity/nav/header.spec.ts
+++ b/src/clarity/nav/header.spec.ts
@@ -34,7 +34,7 @@ describe("Header", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ClarityModule],
+            imports: [ClarityModule.forRoot()],
             declarations: [TestComponent]
         });
 

--- a/src/clarity/stack-view/stack-block.spec.ts
+++ b/src/clarity/stack-view/stack-block.spec.ts
@@ -65,7 +65,7 @@ export default function(): void {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 imports: [
-                    ClarityModule,
+                    ClarityModule.forRoot(),
                     FormsModule
                 ],
                 declarations: [

--- a/src/clarity/stack-view/stack-header.spec.ts
+++ b/src/clarity/stack-view/stack-header.spec.ts
@@ -29,7 +29,7 @@ export default function(): void {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 imports: [
-                    ClarityModule,
+                    ClarityModule.forRoot(),
                     FormsModule
                 ],
                 declarations: [TestComponent],

--- a/src/clarity/stack-view/stack-view.spec.ts
+++ b/src/clarity/stack-view/stack-view.spec.ts
@@ -31,7 +31,7 @@ export default function(): void {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 imports: [
-                    ClarityModule,
+                    ClarityModule.forRoot(),
                     FormsModule
                 ],
                 declarations: [TestComponent]

--- a/src/clarity/tabs/tab-content.spec.ts
+++ b/src/clarity/tabs/tab-content.spec.ts
@@ -24,7 +24,7 @@ describe("TabContent", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ClarityModule],
+            imports: [ClarityModule.forRoot()],
             declarations: [TestComponent]
         });
         fixture = TestBed.createComponent(TestComponent);

--- a/src/clarity/tabs/tab-link.spec.ts
+++ b/src/clarity/tabs/tab-link.spec.ts
@@ -25,7 +25,7 @@ describe("TabLink", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ClarityModule],
+            imports: [ClarityModule.forRoot()],
             declarations: [TestComponent],
             providers: [TABS_DIRECTIVES]
         });

--- a/src/clarity/tabs/tabs.spec.ts
+++ b/src/clarity/tabs/tabs.spec.ts
@@ -52,7 +52,7 @@ describe("Tabs", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ClarityModule],
+            imports: [ClarityModule.forRoot()],
             declarations: [TestComponent],
             providers: [TabLink, TabContent]
         });

--- a/src/clarity/wizard/wizard-page.spec.ts
+++ b/src/clarity/wizard/wizard-page.spec.ts
@@ -48,7 +48,7 @@ describe("WizardPage", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ClarityModule],
+            imports: [ClarityModule.forRoot()],
             declarations: [TestComponent]
         });
         fixture = TestBed.createComponent(TestComponent);

--- a/src/clarity/wizard/wizard-step.spec.ts
+++ b/src/clarity/wizard/wizard-step.spec.ts
@@ -28,7 +28,7 @@ describe("WizardStep", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ClarityModule],
+            imports: [ClarityModule.forRoot()],
             declarations: [TestComponent],
             providers: [Wizard, ScrollingService],
         });

--- a/src/clarity/wizard/wizard.spec.ts
+++ b/src/clarity/wizard/wizard.spec.ts
@@ -135,7 +135,7 @@ describe("Wizard", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ClarityModule],
+            imports: [ClarityModule.forRoot()],
             declarations: [AdvancedWizard, BasicWizard]
         });
     });


### PR DESCRIPTION
This is a cover version of #88, I preserved his commit.

Fixes #59.