### PR TITLE
[CORE] Remove clarity-demos publish command

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,6 @@
     "test": "gulp test",
     "test:watch": "gulp test:watch",
     "prepublish:all": "gulp npm:prepare --version $npm_package_version",
-    "publish:all": "npm publish dist/npm/clarity-ui; npm publish dist/npm/clarity-angular; npm publish dist/npm/clarity-icons; npm publish dist/npm/clarity-demos"
+    "publish:all": "npm publish dist/npm/clarity-ui; npm publish dist/npm/clarity-angular; npm publish dist/npm/clarity-icons"
   }
 }


### PR DESCRIPTION
Removed clarity-demos publish command because after AOT and the new angular website, the demos are being moved to the website branch


Signed-off-by: Aditya Bhandari <adityab@vmware.com>