### PR TITLE
[core] name globals in rollup config

### DIFF
--- a/build/rollup-clarity.config.js
+++ b/build/rollup-clarity.config.js
@@ -12,6 +12,13 @@ export default {
         '@angular/platform-browser',
         'rxjs'
     ],
+    globals: {
+        '@angular/core' : 'ng.core',
+        '@angular/common' : 'ng.common',
+        '@angular/forms' : 'ng.forms',
+        '@angular/platform-browser' : 'ng.platformBrowser',
+        'rxjs' : 'rxjs'
+    },
     plugins: [
         buble()
     ],


### PR DESCRIPTION
Not explicitly giving names for external modules in the `rollup-clarity-config.js` file produces the following output in console:
```
No name was provided for external module '@angular/common' in options.globals – guessing '_angular_common'
No name was provided for external module '@angular/forms' in options.globals – guessing '_angular_forms'
No name was provided for external module '@angular/core' in options.globals – guessing '_angular_core'
No name was provided for external module 'rxjs' in options.globals – guessing 'rxjs'
No name was provided for external module '@angular/platform-browser' in options.globals – guessing '_angular_platformBrowser'
```

Opting to explicitly name them rather than rely on rollup to come up with a name.

Signed-off-by: Jeeyun Lim <jeeyun.lim@gmail.com>