### PR TITLE
[docs] Updated plunkr template link for 0.8.0

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -13,7 +13,7 @@ PLEASE FILL OUT THE FOLLOWING. WE MAY CLOSE INCOMPLETE ISSUES.
 <!-- Describe the expected behavior. -->
 
 ### Actual behavior
-<!-- Describe the actual behavior and provide a minimal app that demonstrates the issue. Fork the Clarity Plunker Template here: https://plnkr.co/edit/VPxyl7?p=preview and recreate the issue. Then submit your link with the issue. -->
+<!-- Describe the actual behavior and provide a minimal app that demonstrates the issue. Fork the Clarity Plunker Template here: https://plnkr.co/edit/8TwwdL?p=preview and recreate the issue. Then submit your link with the issue. -->
 
 ### Reproduction of behavior
 <!-- Include a working plunker link reproducing the behavior. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ These documents provide guidance creating a well-crafted commit message:
 
 You can submit an issue or a bug to our [GitHub repository](https://github.com/vmware/clarity/issues).  You must provide:
 
-* The link to the reproduction scenario you created using the [Clarity Plunker Template](https://plnkr.co/edit/VPxyl7?p=preview)
+* The link to the reproduction scenario you created using the [Clarity Plunker Template](https://plnkr.co/edit/8TwwdL?p=preview)
 * The version number of Angular
 * The version number of Clarity
 * The browser name and version number

--- a/README.md
+++ b/README.md
@@ -148,4 +148,4 @@ The Clarity project team welcomes contributions from the community. For more det
 
 If you find a bug or want to request a new feature, please open a [GitHub issue](https://github.com/vmware/clarity/issues).
 If possible please provide a minimal demo illustrating the issue with https://plunkr.co
-- Fork the [Clarity Plunker Template](https://plnkr.co/edit/VPxyl7?p=preview) and submit your link with the issue.
+- Fork the [Clarity Plunker Template](https://plnkr.co/edit/8TwwdL?p=preview and submit your link with the issue.


### PR DESCRIPTION
This updates three files that use the plunker template link.

Signed-off-by: Matt Hippely <mhippely@vmware.com>