### PR TITLE
Adding clarity-icons entry point

### DIFF
--- a/build/npm/clarity-icons.json
+++ b/build/npm/clarity-icons.json
@@ -3,6 +3,7 @@
     "version": "/* @echo VERSION */",
     "description": "Custom Element Icons for Clarity",
     "homepage": "https://vmware.github.io/clarity/",
+    "main": "clarity-icons.min.js",
     "repository" : {
         "type" : "git",
         "url" : "ssh://git@git.eng.vmware.com/clarity.git"


### PR DESCRIPTION
This adds an entry point for the `clarity-icons` package. It should exist, as to more easily use this package with module loaders like Webpack.