### PR TITLE
Adding entry point for clarity-icons

### DIFF
--- a/build/npm/clarity-icons.json
+++ b/build/npm/clarity-icons.json
@@ -3,6 +3,7 @@
     "version": "/* @echo VERSION */",
     "description": "Custom Element Icons for Clarity",
     "homepage": "https://vmware.github.io/clarity/",
+    "main": "clarity-icons.min.js",
     "repository" : {
         "type" : "git",
         "url" : "ssh://git@git.eng.vmware.com/clarity.git"


### PR DESCRIPTION
This adds an entry point for `clarity-icons`. It allows to better use `webpack` or other module loaders.