### PR TITLE
[core] Making inputs/outputs public for AoT

### DIFF
--- a/src/clarity-angular/checkboxes/checkbox.ts
+++ b/src/clarity-angular/checkboxes/checkbox.ts
@@ -36,7 +36,7 @@ let latestId = 0;
 export class Checkbox implements ControlValueAccessor {
     // If our host has an ID attribute, we use this instead of our index.
     @Input("id")
-    private _id: string = (latestId++).toString();
+    _id: string = (latestId++).toString();
 
     public get id() {
         return `clr-checkbox-${this._id}`;
@@ -50,7 +50,7 @@ export class Checkbox implements ControlValueAccessor {
     @Input("clrInline") public inline = false;
 
     @Input("clrChecked")
-    private _checked = false;
+    _checked = false;
 
     public get checked() {
         return this._checked;

--- a/src/clarity-angular/dropdown/dropdown.ts
+++ b/src/clarity-angular/dropdown/dropdown.ts
@@ -38,10 +38,9 @@ const menuPositions: string[] = [
 export class Dropdown {
 
     @HostBinding("class.open")
-    @Input("clrDropdownMenuOpen")
-    private _open: boolean = false;
+    @Input("clrDropdownMenuOpen") _open: boolean = false;
 
-    @Output("clrDropdownMenuOpenChange") private _openChanged: EventEmitter<boolean> = new EventEmitter<boolean>(false);
+    @Output("clrDropdownMenuOpenChange") _openChanged: EventEmitter<boolean> = new EventEmitter<boolean>(false);
 
     @Input("clrCloseMenuOnItemClick") isMenuClosable: boolean = true;
 


### PR DESCRIPTION
I realized I missed a couple of components in making sure that all their inputs and outputs are public. The following components will currently (v0.8.1) throw an error when compiling (when the consuming app compiles in AoT):
- dropdown
- checkbox

Tested by building npm package candidates and testing on a seed.

Signed-off-by: Jeeyun Lim <jeeyun.lim@gmail.com>