### PR TITLE
[docs] Update readme / issue files with links to multiple plunkers

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -13,10 +13,13 @@ PLEASE FILL OUT THE FOLLOWING. WE MAY CLOSE INCOMPLETE ISSUES.
 <!-- Describe the expected behavior. -->
 
 ### Actual behavior
-<!-- Describe the actual behavior and provide a minimal app that demonstrates the issue. Fork the Clarity Plunker Template here: https://plnkr.co/edit/8TwwdL?p=preview and recreate the issue. Then submit your link with the issue. -->
+<!-- Describe the actual behavior and provide a minimal app that demonstrates the issue. Fork one of the Clarity Plunker Templates and recreate the issue. Then submit your link with the issue. -->
 
 ### Reproduction of behavior
 <!-- Include a working plunker link reproducing the behavior. -->
+<!-- Clarity Plunker Tempplates -->
+<!-- Clarity Version: [Latest](https://plnkr.co/8TwwdL) -->
+<!-- Clarity Version: [0.7.6](https://plnkr.co/iWrQNL) -->
 
 ### Environment details
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,10 @@ These documents provide guidance creating a well-crafted commit message:
 
 You can submit an issue or a bug to our [GitHub repository](https://github.com/vmware/clarity/issues).  You must provide:
 
-* The link to the reproduction scenario you created using the [Clarity Plunker Template](https://plnkr.co/edit/8TwwdL?p=preview)
+* The link to the reproduction scenario you created using one of the Clarity Plunker Templates
+* If possible please provide a minimal demo illustrating the issue by forking one of the Clarity Plunker Templates
+  - Clarity Version: [Latest](https://plnkr.co/8TwwdL)
+  - Clarity Version: [0.7.6](https://plnkr.co/iWrQNL)
 * The version number of Angular
 * The version number of Clarity
 * The browser name and version number

--- a/README.md
+++ b/README.md
@@ -147,5 +147,6 @@ The Clarity project team welcomes contributions from the community. For more det
 ## Feedback
 
 If you find a bug or want to request a new feature, please open a [GitHub issue](https://github.com/vmware/clarity/issues).
-If possible please provide a minimal demo illustrating the issue with https://plunkr.co
-- Fork the [Clarity Plunker Template](https://plnkr.co/edit/8TwwdL?p=preview and submit your link with the issue.
+If possible please provide a minimal demo illustrating the issue by forking one of the Clarity Plunker Templates 
+- Clarity Version: [Latest](https://plnkr.co/8TwwdL)
+- Clarity Version: [0.7.6](https://plnkr.co/iWrQNL)


### PR DESCRIPTION
I added multiple plunker links for latest and the last three Clarity Versions. This may not be the best way to surface multiple Clarity Plunker Templates in the project files so I am open to suggestions. 