### PR TITLE
[ICONS] made clarity-icons importable in typescript

### DIFF
--- a/build/npm/clarity-icons.json
+++ b/build/npm/clarity-icons.json
@@ -3,7 +3,8 @@
     "version": "/* @echo VERSION */",
     "description": "Custom Element Icons for Clarity",
     "homepage": "https://vmware.github.io/clarity/",
-    "main": "clarity-icons.min.js",
+    "main": "index.js",
+    "types": "index.d.ts",
     "repository" : {
         "type" : "git",
         "url" : "ssh://git@git.eng.vmware.com/clarity.git"

--- a/build/tasks/bundle.js
+++ b/build/tasks/bundle.js
@@ -8,29 +8,6 @@ var gulp = require("gulp");
 var Builder = require("systemjs-builder");
 var zip = require('gulp-zip');
 
-
-/**
- * Bundles the compiled icon js files into define-clarity-icons.min.js
- */
-gulp.task("bundle:icons", ["typescript:icons"], function() {
-    var buildOpts = { minify: true, mangle: false, normalize: true };
-
-    var builder = new Builder("dist/");
-    builder.config({
-        packages: {
-            'clarity-icons': { defaultExtension: 'js' }
-        }
-    });
-
-    return builder.bundle("clarity-icons/**/*.js", "dist/bundles/define-clarity-icons.min.js", buildOpts)
-        .catch(function(err) {
-            console.error(err);
-            process.exit(1);
-        });
-
-
-});
-
 /**
  * Bundles the compiled icon js files into self-executing clarity-icons.min.js,
  * which will be used for publishing clarity icons as an independent package
@@ -42,7 +19,7 @@ gulp.task("bundle:icons:sfx", ["typescript:icons"], function() {
     var builder = new Builder("dist/");
     builder.config({
         packages: {
-            'clarity-icons': { defaultExtension: 'js' }
+            'clarity-icons': { main: 'index.js', defaultExtension: 'js' }
         }
     });
 
@@ -130,7 +107,7 @@ gulp.task("bundle:zip", ["bundle:clarity:js", "sass:static"], function() {
  * Also creates a zip with our css and js deliverables and our definition files
  * for third-party devs, then adds it to the bundles/ folder.
  */
-gulp.task("bundle", ["bundle:icons", "bundle:icons:sfx", "bundle:clarity:js", "bundle:zip"], function(){});
+gulp.task("bundle", ["bundle:icons:sfx", "bundle:clarity:js", "bundle:zip"], function(){});
 
 /**
  * Watches for changes in the transpiled js files to rebundle them

--- a/build/tasks/publish.js
+++ b/build/tasks/publish.js
@@ -23,7 +23,9 @@ gulp.task("npm:icons:bundles", function () {
     return gulp.src([
         "dist/bundles/clarity-icons.min.js",
         "dist/bundles/clarity-icons.min.css",
-        "dist/clarity-icons/svg-icon-templates.js"
+        "dist/clarity-icons/**/*.ts",
+        "dist/clarity-icons/**/*.js",
+        "!dist/clarity-icons/interfaces/**/*.js"
     ]).pipe(gulp.dest(npmFolder + "/clarity-icons"));
 });
 

--- a/src/app/index.html
+++ b/src/app/index.html
@@ -36,7 +36,7 @@
     <!-- @endif -->
 
     <!-- @if NODE_ENV='prod' -->
-    <script src="bundles/define-clarity-icons.min.js"></script>
+    <script src="bundles/clarity-icons.min.js"></script>
     <script src="bundles/clarity-angular.min.js"></script>
 
     <!--Add font-awesome dependency. Needed for select boxes and check boxes-->
@@ -57,7 +57,6 @@
             // map tells the System loader where to look for things
             var map = {
                 'app':                                  'app',
-                'clarity-icons':                        'clarity-icons',
                 'rxjs':                                 'node_modules/rxjs',
                 '@angular/core':                        'node_modules/@angular/core/bundles/core.umd.js',
                 '@angular/common':                      'node_modules/@angular/common/bundles/common.umd.js',
@@ -73,7 +72,7 @@
                 'app':                        { defaultExtension: 'js' },
                 'rxjs':                       { main: 'Rx.js', defaultExtension: 'js' },
                 'clarity-angular':            { main: 'index.js', defaultExtension: 'js' },
-                'clarity-icons':              { defaultExtension: 'js' },
+                'clarity-icons':              { main: 'index.js', defaultExtension: 'js' },
                 'clarity-demos':              { defaultExtension: 'js' }
             };
 
@@ -88,7 +87,7 @@
       window.addEventListener("load", function() {
 
         System.import('app/boot').then(null, console.error.bind(console));
-        System.import('clarity-icons/define-clarity-icons').then(null, console.error.bind(console));
+        System.import('clarity-icons').then(null, console.error.bind(console));
 
       });
     </script>

--- a/src/clarity-icons/clarity-icon.ts
+++ b/src/clarity-icons/clarity-icon.ts
@@ -4,16 +4,9 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { IconTemplate } from "./interfaces/icon-template";
-import { ClarityIconsApi } from "./extend-clarity-icons";
+import { ClarityIconsApi } from "./clarity-icons-api";
 
-/* CLARTIYICONS GLOBAL OBJECT */
-
-let ClrIconsApi: ClarityIconsApi = new ClarityIconsApi();
-let allClrIconsShapes: IconTemplate = ClrIconsApi.get();
-
-//Setting a global object called "ClarityIcons" to expose the "userIcons".
-window.ClarityIcons = ClrIconsApi;
-
+let allClrIconsShapes: IconTemplate = ClarityIconsApi.instance.get();
 
 /* CLR-ICON CUSTOM ELEMENT */
 
@@ -30,7 +23,7 @@ if (typeof Reflect === "object") {
     };
 }
 
-function ClarityIconElement() {
+export function ClarityIconElement() {
     "use strict";
     return (parentConstructor as any).apply(this, arguments);
 }
@@ -38,7 +31,9 @@ function ClarityIconElement() {
 (ClarityIconElement as any).observedAttributes = [ "shape", "size" ];
 
 ClarityIconElement.prototype = Object.create(HTMLElement.prototype);
+
 ClarityIconElement.prototype.constructor = ClarityIconElement;
+
 let generateIcon =
     function (element: any, shape: string) {
 
@@ -55,6 +50,7 @@ let generateIcon =
                 }());
         }
     };
+
 let setIconSize =
     function (element: any, size: string) {
 
@@ -69,6 +65,7 @@ let setIconSize =
         }
 
     };
+
 ClarityIconElement.prototype.connectedCallback =
     function () {
 
@@ -81,6 +78,7 @@ ClarityIconElement.prototype.connectedCallback =
             setIconSize(host, host.getAttribute("size"));
         }
     };
+
 ClarityIconElement.prototype.attributeChangedCallback =
     function (attributeName: string, oldValue: string, newValue: string) {
 
@@ -95,7 +93,5 @@ ClarityIconElement.prototype.attributeChangedCallback =
 
 
     };
-
-customElements.define("clr-icon", ClarityIconElement);
 
 

--- a/src/clarity-icons/clarity-icons-api.ts
+++ b/src/clarity-icons/clarity-icons-api.ts
@@ -12,6 +12,22 @@ let ALL_ICON_TEMPLATES: IconTemplate = Object.assign({}, SVG_ICON_TEMPLATES);
 
 export class ClarityIconsApi {
 
+    private static singleInstance: ClarityIconsApi;
+
+    protected constructor(){}
+
+    static get instance(): ClarityIconsApi {
+
+        if (!ClarityIconsApi.singleInstance) {
+
+            ClarityIconsApi.singleInstance = new ClarityIconsApi();
+
+        }
+
+        return ClarityIconsApi.singleInstance;
+
+    }
+
     private validateName(name: string): boolean {
 
         if (name.length === 0) {
@@ -56,6 +72,23 @@ export class ClarityIconsApi {
 
     }
 
+    private setIconAliases(templates: IconTemplate, shapeName: string, aliasNames: string[]): void {
+        for (let aliasName of aliasNames) {
+
+            if (this.validateName(aliasName)) {
+                Object.defineProperty(templates, aliasName, {
+                    get: function () {
+                        return templates[ shapeName ];
+                    },
+                    enumerable: true,
+                    configurable: true
+                });
+            }
+
+        }
+
+    }
+
     add(icons: IconTemplate): void {
 
         for (let shapeName in icons) {
@@ -84,23 +117,6 @@ export class ClarityIconsApi {
         }
 
         return ALL_ICON_TEMPLATES[ shapeName ];
-
-    }
-
-    private setIconAliases(templates: IconTemplate, shapeName: string, aliasNames: string[]): void {
-        for (let aliasName of aliasNames) {
-
-            if (this.validateName(aliasName)) {
-                Object.defineProperty(templates, aliasName, {
-                    get: function () {
-                        return templates[ shapeName ];
-                    },
-                    enumerable: true,
-                    configurable: true
-                });
-            }
-
-        }
 
     }
 
@@ -133,8 +149,8 @@ export class ClarityIconsApi {
 
     }
 
-
 }
+
 
 
 

--- a/src/clarity-icons/index.ts
+++ b/src/clarity-icons/index.ts
@@ -3,4 +3,20 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-export * from "./svg-icon-templates"
+import { ClarityIconsApi } from "./clarity-icons-api";
+import { ClarityIconElement } from "./clarity-icon";
+
+export const ClarityIcons: ClarityIconsApi = ClarityIconsApi.instance;
+
+//check if there is a global object called "ClarityIcons"
+if (!window.ClarityIcons) {
+
+    //Setting a global object called "ClarityIcons" to expose the ClarityIconsApi.
+    window.ClarityIcons = ClarityIcons;
+
+    //Defining clr-icon custom element
+    customElements.define("clr-icon", ClarityIconElement);
+
+}
+
+


### PR DESCRIPTION
- Made Clarity-Icons importable and loadable in typescript files in the following way:
`import { ClarityIcons } from "clarity-icons"`

Signed-off-by: Shijir Tsogoo <stsogoo@vmware.com>