### PR TITLE
[NG] Two-way binding on row selection

### DIFF
--- a/src/clarity-angular/datagrid/datagrid-row.spec.ts
+++ b/src/clarity-angular/datagrid/datagrid-row.spec.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import {Component} from "@angular/core";
-import {TestBed} from "@angular/core/testing";
+import {TestBed, fakeAsync, tick} from "@angular/core/testing";
 import {TestContext} from "./helpers.spec";
 import {DatagridRow} from "./datagrid-row";
 import {Selection} from "./providers/selection";
@@ -66,12 +66,34 @@ export default function(): void {
             context.detectChanges();
             expect(context.clarityElement.classList.contains("datagrid-selected")).toBeTruthy();
         });
+
+        it("offers two-way binding on the selected state of the row", fakeAsync(function () {
+            selectionProvider.selectable = true;
+            context.testComponent.item = {id: 1};
+            flushAndAssertSelected(false);
+            // Input
+            context.testComponent.selected = true;
+            flushAndAssertSelected(true);
+            // Output
+            context.clarityElement.querySelector("input[type='checkbox']").click();
+            flushAndAssertSelected(false);
+        }));
+
+        function flushAndAssertSelected(selected: boolean) {
+            context.detectChanges();
+            // ngModel is asynchronous, we need an extra change detection
+            tick();
+            context.detectChanges();
+            expect(context.testComponent.selected).toBe(selected);
+            expect(context.clarityDirective.selected).toBe(selected);
+        }
     });
 }
 
 @Component({
-    template: `<clr-dg-row [clrDgItem]="item">Hello world</clr-dg-row>`
+    template: `<clr-dg-row [clrDgItem]="item" [(clrDgSelected)]="selected">Hello world</clr-dg-row>`
 })
 class FullTest {
     item: any;
+    selected = false;
 }

--- a/src/clarity-angular/datagrid/datagrid-row.ts
+++ b/src/clarity-angular/datagrid/datagrid-row.ts
@@ -3,14 +3,14 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import {Component, Input} from "@angular/core";
+import {Component, Input, Output, EventEmitter} from "@angular/core";
 import {Selection} from "./providers/selection";
 
 @Component({
     selector: "clr-dg-row",
     template: `
         <clr-dg-cell *ngIf="selection.selectable" class="datagrid-select">
-            <clr-checkbox [(ngModel)]="selected"></clr-checkbox>
+            <clr-checkbox [ngModel]="selected" (ngModelChange)="toggle($event)"></clr-checkbox>
         </clr-dg-cell>
         <ng-content></ng-content>
     `,
@@ -33,7 +33,17 @@ export class DatagridRow {
     public get selected() {
         return this.selection.isSelected(this.item);
     }
+    @Input("clrDgSelected")
     public set selected(value: boolean) {
         this.selection.setSelected(this.item, value);
+    }
+
+    @Output("clrDgSelectedChange") selectedChanged = new EventEmitter<boolean>(false);
+
+    public toggle(selected = !this.selected) {
+        if (selected !== this.selected) {
+            this.selected = selected;
+            this.selectedChanged.emit(selected);
+        }
     }
 }

--- a/src/clarity-angular/datagrid/datagrid.spec.ts
+++ b/src/clarity-angular/datagrid/datagrid.spec.ts
@@ -41,6 +41,14 @@ export default function(): void {
                 expect(context.testComponent.selected).toEqual([2, 1]);
             });
 
+            it("allows to set pre-selected items when initializing the full list of items", function() {
+                let selection: Selection = context.getClarityProvider(Selection);
+                context.testComponent.items = [4, 5, 6];
+                context.testComponent.selected = [5];
+                context.detectChanges();
+                expect(selection.current).toEqual([5]);
+            });
+
             describe("clrDgRefresh output", function() {
                 it("emits once when the datagrid is ready", function() {
                     expect(context.testComponent.nbRefreshed).toBe(1);

--- a/src/clarity-angular/datagrid/providers/selection.ts
+++ b/src/clarity-angular/datagrid/providers/selection.ts
@@ -12,7 +12,7 @@ import {Items} from "./items";
 export class Selection {
     constructor(private _items: Items) {
         this._itemsSub = _items.change.subscribe(() => {
-            if (!this._selectable) {
+            if (!this._selectable || this.debounce) {
                 return;
             }
             /* TODO */
@@ -20,6 +20,11 @@ export class Selection {
             this.emitChange();
         });
     }
+
+    /**
+     * Ignore items changes in the same change detection cycle.
+     */
+    private debounce = false;
 
     /**
      * Subscriptions to the other providers changes.
@@ -58,6 +63,9 @@ export class Selection {
     public set current(value: any[]) {
         this._current = value;
         this.emitChange();
+        // Ignore items changes in the same change detection cycle.
+        this.debounce = true;
+        setTimeout(() => this.debounce = false);
     }
 
     /**


### PR DESCRIPTION
We now offer a boolean two-way binding on the <clr-dg-row> component for its selected state. This allows users to select items programmatically more easily, or keep up-to date with the current selection status of a single row:
```
<clr-dg-row *clrDgItems="let item of users" [clrDgItem]="item"
    [(clrDgSelected)]="item.selected">
        ...
</clr-dg-row>
```

Fixes #111. The first commit addresses the opening description, the second one handles the unrelated issue several people raised in the comments.