### PR TITLE
[UI] Modal Grid Overflow Fix

### DIFF
--- a/src/clarity-angular/modal/_modal.clarity.scss
+++ b/src/clarity-angular/modal/_modal.clarity.scss
@@ -80,6 +80,7 @@ $clr-modal-xl-width: baselineRem(48) !default;
             // it doesn't mess up the modal's proportions.
             max-height: 55vh;
             overflow-y: auto;
+            overflow-x: hidden;
 
             @extend %clr-container;
         }


### PR DESCRIPTION
This PR fixes: #252 

Scrollbars appear inside of the modals whenever a grid is used because the `.modal-body` does not have the `overflow-x: hidden` property and because of the negative margins on the `.row` of the bootstrap grid.

Before:
<img width="659" alt="screen shot 2017-01-11 at 5 48 10 am" src="https://cloud.githubusercontent.com/assets/1426805/21851033/3f255ac8-d7c2-11e6-93ea-c645d05000cd.png">

After:
<img width="653" alt="screen shot 2017-01-11 at 5 48 34 am" src="https://cloud.githubusercontent.com/assets/1426805/21851040/42eef5d8-d7c2-11e6-87cb-f2fee0fb439f.png">


Tested on: Chrome, Firefox, IE

Signed-off-by: Aditya Bhandari <adityab@vmware.com>