### PR TITLE
[NG] Support manual selection of Datagrid row

### DIFF
--- a/src/clarity-angular/datagrid/datagrid-row.spec.ts
+++ b/src/clarity-angular/datagrid/datagrid-row.spec.ts
@@ -79,6 +79,18 @@ export default function(): void {
             flushAndAssertSelected(false);
         }));
 
+        it("supports selected rows even if the datagrid isn't selectable", fakeAsync(function () {
+            expect(selectionProvider.selectable).toBe(false);
+            expect(context.testComponent.item).toBeUndefined();
+            expect(context.clarityDirective.selected).toBe(false);
+            context.testComponent.selected = true;
+            context.detectChanges();
+            expect(context.clarityDirective.selected).toBe(true);
+            context.testComponent.selected = false;
+            context.detectChanges();
+            expect(context.clarityDirective.selected).toBe(false);
+        }));
+
         function flushAndAssertSelected(selected: boolean) {
             context.detectChanges();
             // ngModel is asynchronous, we need an extra change detection

--- a/src/clarity-angular/datagrid/datagrid-row.ts
+++ b/src/clarity-angular/datagrid/datagrid-row.ts
@@ -27,15 +27,24 @@ export class DatagridRow {
 
     constructor(private selection: Selection) {}
 
+    private _selected = false;
     /**
      * Indicates if the row is selected
      */
     public get selected() {
-        return this.selection.isSelected(this.item);
+        if (this.selection.selectable) {
+            return this.selection.isSelected(this.item);
+        } else {
+            return this._selected;
+        }
     }
     @Input("clrDgSelected")
     public set selected(value: boolean) {
-        this.selection.setSelected(this.item, value);
+        if (this.selection.selectable) {
+            this.selection.setSelected(this.item, value);
+        } else {
+            this._selected = value;
+        }
     }
 
     @Output("clrDgSelectedChange") selectedChanged = new EventEmitter<boolean>(false);


### PR DESCRIPTION
Binding to [clrDgSelected] was completely ignored when the entire datagrid was not selectable, which prevented people from manually creating single-row selection with the entire row as click target. They had to bind to an internal class, and even then it resulted in conflicts with our own implementation overriding their initial value.

To fix this, we now support the [clrDgSelected] input on rows all the time, but it only handles styling when the whole datagrid is not selectable.

Fixes #388.