### PR TITLE
[UI] Header overflow trigger bug fix

### DIFF
--- a/src/clarity-angular/nav/_header.clarity.scss
+++ b/src/clarity-angular/nav/_header.clarity.scss
@@ -363,7 +363,7 @@ $clr-header-nav-text-horizontal-padding: $clr_baselineRem_1;
                 //Pull the dropdown menus of all dropdowns up to compensate
                 //for the height of the header.
                 &.bottom-right > .dropdown-menu,
-                &.bottom-left > .dropdown-menu, {
+                &.bottom-left > .dropdown-menu {
                     top: 85%;
                 }
 

--- a/src/clarity-angular/nav/_responsive-nav.clarity.scss
+++ b/src/clarity-angular/nav/_responsive-nav.clarity.scss
@@ -292,6 +292,11 @@ $clr-transition-style: ease;
                         display: none;
                     }
                 }
+
+                .branding + .header-overflow-trigger,
+                .header-nav + .header-overflow-trigger {
+                    margin-left: auto;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes: #347 

Fixed the alignment issue when the header-overflow-trigger is directly after the `.header-nav` or the `.branding`

Before:
![image](https://cloud.githubusercontent.com/assets/1426805/22135602/08a86c42-de84-11e6-94e0-b94de1b6b36c.png)


After:
![image](https://cloud.githubusercontent.com/assets/1426805/22135562/c87b8d5c-de83-11e6-8522-9e63c3062364.png)

Tested on: Chrome, Firefox, IE 10, 11, Edge, Safari


Signed-off-by: Aditya Bhandari <adityab@vmware.com>