### PR TITLE
[ng,web] Make the checkbox component public

### DIFF
--- a/src/demos/checkboxes/checkboxes.demo.html
+++ b/src/demos/checkboxes/checkboxes.demo.html
@@ -48,59 +48,148 @@
         <div class="form-group">
             <label>Indeterminate Checkbox</label>
             <div class="checkbox-inline">
-                <clr-checkbox type="checkbox" id="checkrads_9" [clrIndeterminate]="indeterminateState"></clr-checkbox>
-                <label for="checkrads_9">
-                    <button class="btn btn-primary" (click)="onToggleIndeterminateState($event)">
+                <clr-checkbox type="checkbox" id="checkbox_9" [(clrIndeterminate)]="indeterminateState">
+                    Clarity indeterminate checkbox
+                </clr-checkbox>
+                <div>
+                    <button class="btn btn-sm" (click)="onToggleIndeterminateState($event)" type="button">
                         Toggle Indeterminate State
                     </button>
-                </label>
+                </div>
+                <div class="checkbox-inline">
+                    <input type="checkbox"
+                           id="checkrads_10"
+                           [indeterminate]="nativeIndeterminateState">
+                    <label for="checkrads_10">Native indeterminate checkbox</label>
+                    <div>
+                        <b>NOTE:</b> Native checkbox elements must set indeterminate state with JavaScript.
+                    </div>
+                </div>
             </div>
         </div>
     </section>
 </form>
 
-<pre><code clr-code-highlight="language-html">
-&lt;form&gt;
-    &lt;section class=&quot;form-block&quot;&gt;
-        &lt;label&gt;Checkboxes&lt;/label&gt;
-        &lt;div class=&quot;form-group&quot;&gt;
-            &lt;label&gt;Default/Stacked checkbox group&lt;/label&gt;
-            &lt;div class=&quot;checkbox&quot;&gt;
-                &lt;input type=&quot;checkbox&quot; id=&quot;checkrads_1&quot;&gt;
-                &lt;label for=&quot;checkrads_1&quot;&gt;Checkbox 1&lt;/label&gt;
+<form #form="ngForm" novalidate>
+    <section class="form-block">
+        <div class="form-group">
+            <label>With ngForm & ngModel</label>
+            <clr-checkbox
+                    name="termsCheckbox"
+                    id="checkrads_11"
+                    [clrInline]="true"
+                    [(ngModel)]="termsAgreement">
+                I agree to the terms and conditions. {{ form.value | json }}
+            </clr-checkbox>
+        </div>
+    </section>
+</form>
+
+<form>
+    <section class="form-block">
+        <div class="form-group">
+            <label>With a list of objects</label>
+            <clr-checkbox *ngFor="let item of list"
+                          [(clrChecked)]="item.running"
+                          [clrDisabled]="item.disabled">
+                {{ item.disabled ? ' is disabled.' : (item.running ? ' is running.' : 'is off.') }}
+            </clr-checkbox>
+        </div>
+    </section>
+</form>
+<pre>
+    <code clr-code-highlight="language-html">
+    &lt;form&gt;
+        &lt;section class=&quot;form-block&quot;&gt;
+            &lt;label&gt;Checkboxes&lt;/label&gt;
+            &lt;div class=&quot;form-group&quot;&gt;
+                &lt;label&gt;Default/Stacked checkbox group&lt;/label&gt;
+                &lt;div class=&quot;checkbox&quot;&gt;
+                    &lt;input type=&quot;checkbox&quot; id=&quot;checkrads_1&quot;&gt;
+                    &lt;label for=&quot;checkrads_1&quot;&gt;Checkbox 1&lt;/label&gt;
+                &lt;/div&gt;
+                &lt;div class=&quot;checkbox&quot;&gt;
+                    &lt;input type=&quot;checkbox&quot; id=&quot;checkrads_2&quot; checked&gt;
+                    &lt;label for=&quot;checkrads_2&quot;&gt;Checkbox 2&lt;/label&gt;
+                &lt;/div&gt;
+                &lt;div class=&quot;checkbox disabled&quot;&gt;
+                    &lt;input type=&quot;checkbox&quot; id=&quot;checkrads_3&quot; disabled&gt;
+                    &lt;label for=&quot;checkrads_3&quot;&gt;A disabled and unchecked checkbox&lt;/label&gt;
+                &lt;/div&gt;
+                &lt;div class=&quot;checkbox disabled&quot;&gt;
+                    &lt;input type=&quot;checkbox&quot; id=&quot;checkrads_4&quot; disabled checked&gt;
+                    &lt;label for=&quot;checkrads_4&quot;&gt;A disabled and checked checkbox&lt;/label&gt;
+                &lt;/div&gt;
             &lt;/div&gt;
-            &lt;div class=&quot;checkbox&quot;&gt;
-                &lt;input type=&quot;checkbox&quot; id=&quot;checkrads_2&quot; checked&gt;
-                &lt;label for=&quot;checkrads_2&quot;&gt;Checkbox 2&lt;/label&gt;
+            &lt;div class=&quot;form-group&quot;&gt;
+                &lt;label&gt;Inline checkbox group&lt;/label&gt;
+                &lt;div class=&quot;checkbox-inline&quot;&gt;
+                    &lt;input type=&quot;checkbox&quot; id=&quot;checkrads_5&quot;&gt;
+                    &lt;label for=&quot;checkrads_5&quot;&gt;Checkbox 1&lt;/label&gt;
+                &lt;/div&gt;
+                &lt;div class=&quot;checkbox-inline&quot;&gt;
+                    &lt;input type=&quot;checkbox&quot; id=&quot;checkrads_6&quot; checked&gt;
+                    &lt;label for=&quot;checkrads_6&quot;&gt;Checkbox 2&lt;/label&gt;
+                &lt;/div&gt;
+                &lt;div class=&quot;checkbox-inline disabled&quot;&gt;
+                    &lt;input type=&quot;checkbox&quot; id=&quot;checkrads_7&quot; disabled&gt;
+                    &lt;label for=&quot;checkrads_7&quot;&gt;A disabled and unchecked checkbox&lt;/label&gt;
+                &lt;/div&gt;
+                &lt;div class=&quot;checkbox-inline disabled&quot;&gt;
+                    &lt;input type=&quot;checkbox&quot; id=&quot;checkrads_8&quot; disabled checked&gt;
+                    &lt;label for=&quot;checkrads_8&quot;&gt;A disabled and checked checkbox&lt;/label&gt;
+                &lt;/div&gt;
+                &lt;div class="form-group"&gt;
+                    &lt;label&gt;Indeterminate Checkbox&lt;/label&gt;
+                    &lt;div class="checkbox-inline"&gt;
+                        &lt;clr-checkbox type="checkbox" id="checkbox_9" [(clrIndeterminate)]="indeterminateState"&gt;
+                            Clarity indeterminate checkbox
+                        &lt;/clr-checkbox&gt;
+                        &lt;div&gt;
+                            &lt;button class="btn btn-sm" (click)="onToggleIndeterminateState($event)" type="button"&gt;
+                                Toggle Indeterminate State
+                            &lt;/button&gt;
+                        &lt;/div&gt;
+                        &lt;div class="checkbox-inline"&gt;
+                            &lt;input type="checkbox"
+                                   id="checkrads_10"
+                                   [indeterminate]="nativeIndeterminateState"&gt;
+                            &lt;label for="checkrads_10"&gt;Native indeterminate checkbox&lt;/label&gt;
+                            &lt;div&gt;
+                                &lt;b&gt;NOTE:&lt;/b&gt; Native checkbox elements must set indeterminate state with JavaScript.
+                            &lt;/div&gt;
+                        &lt;/div&gt;
+                    &lt;/div&gt;
+                &lt;/div&gt;
+        &lt;/section&gt;
+    &lt;/form&gt;
+    &lt;form #form="ngForm" novalidate&gt;
+        &lt;section class="form-block"&gt;
+            &lt;div class="form-group"&gt;
+                &lt;label&gt;With ngForm & ngModel&lt;/label&gt;
+                &lt;clr-checkbox
+                        name="termsCheckbox"
+                        class="checkbox-inline"
+                        id="checkrads_11"
+                        [clrInline]="true"
+                        [(ngModel)]="termsAgreement"&gt;
+                    I agree to the terms and conditions. {{ "{{ form.value | json \}\}" }}
+                &lt;/clr-checkbox&gt;
             &lt;/div&gt;
-            &lt;div class=&quot;checkbox disabled&quot;&gt;
-                &lt;input type=&quot;checkbox&quot; id=&quot;checkrads_3&quot; disabled&gt;
-                &lt;label for=&quot;checkrads_3&quot;&gt;A disabled and unchecked checkbox&lt;/label&gt;
+        &lt;/section&gt;
+    &lt;/form&gt;
+    &lt;form&gt;
+        &lt;section class="form-block"&gt;
+            &lt;div class="form-group"&gt;
+                &lt;label&gt;With a list of objects&lt;/label&gt;
+                &lt;clr-checkbox
+                        *ngFor="let item of list"
+                        [(clrChecked)]="item.running"
+                        [clrDisabled]="item.disabled"&gt;
+                            {{ "{{ item.ip \}\} \{\{ item.disabled ? ' Is disabled' : '' \}\}" }}
+                &lt;/clr-checkbox&gt;
             &lt;/div&gt;
-            &lt;div class=&quot;checkbox disabled&quot;&gt;
-                &lt;input type=&quot;checkbox&quot; id=&quot;checkrads_4&quot; disabled checked&gt;
-                &lt;label for=&quot;checkrads_4&quot;&gt;A disabled and checked checkbox&lt;/label&gt;
-            &lt;/div&gt;
-        &lt;/div&gt;
-        &lt;div class=&quot;form-group&quot;&gt;
-            &lt;label&gt;Inline checkbox group&lt;/label&gt;
-            &lt;div class=&quot;checkbox-inline&quot;&gt;
-                &lt;input type=&quot;checkbox&quot; id=&quot;checkrads_5&quot;&gt;
-                &lt;label for=&quot;checkrads_5&quot;&gt;Checkbox 1&lt;/label&gt;
-            &lt;/div&gt;
-            &lt;div class=&quot;checkbox-inline&quot;&gt;
-                &lt;input type=&quot;checkbox&quot; id=&quot;checkrads_6&quot; checked&gt;
-                &lt;label for=&quot;checkrads_6&quot;&gt;Checkbox 2&lt;/label&gt;
-            &lt;/div&gt;
-            &lt;div class=&quot;checkbox-inline disabled&quot;&gt;
-                &lt;input type=&quot;checkbox&quot; id=&quot;checkrads_7&quot; disabled&gt;
-                &lt;label for=&quot;checkrads_7&quot;&gt;A disabled and unchecked checkbox&lt;/label&gt;
-            &lt;/div&gt;
-            &lt;div class=&quot;checkbox-inline disabled&quot;&gt;
-                &lt;input type=&quot;checkbox&quot; id=&quot;checkrads_8&quot; disabled checked&gt;
-                &lt;label for=&quot;checkrads_8&quot;&gt;A disabled and checked checkbox&lt;/label&gt;
-            &lt;/div&gt;
-        &lt;/div&gt;
-    &lt;/section&gt;
-&lt;/form&gt;
-</code></pre>
+        &lt;/section&gt;
+    &lt;/form&gt;
+    </code>
+</pre>

--- a/src/demos/checkboxes/checkboxes.demo.module.ts
+++ b/src/demos/checkboxes/checkboxes.demo.module.ts
@@ -5,17 +5,24 @@
  */
 import {NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
+import {FormsModule} from "@angular/forms";
 import {ClarityModule} from 'clarity-angular';
 
 import {CheckboxesDemo} from "./checkboxes.demo";
 
+import {Status} from "./data/status";
+
 @NgModule({
     imports: [
         CommonModule,
+        FormsModule,
         ClarityModule.forChild(),
     ],
     declarations: [
         CheckboxesDemo
+    ],
+    providers: [
+        Status
     ],
     exports: [
         CheckboxesDemo

--- a/src/demos/checkboxes/checkboxes.demo.ts
+++ b/src/demos/checkboxes/checkboxes.demo.ts
@@ -4,6 +4,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import {Component} from "@angular/core";
+import {Server} from "./data/server";
+import {Status} from "./data/status";
 
 @Component({
     selector: "clr-checkboxes-demo",
@@ -12,10 +14,16 @@ import {Component} from "@angular/core";
 
 export class CheckboxesDemo {
 
+    list: Server[];
     indeterminateState: boolean = true;
+    nativeIndeterminateState: boolean = true;
+    termsAgreement: boolean = true;
+
+    constructor(private status: Status) {
+        this.list = status.fetch();
+    }
 
     onToggleIndeterminateState() {
-        event.preventDefault();
         this.indeterminateState = !this.indeterminateState;
     }
 

--- a/src/demos/checkboxes/data/server.ts
+++ b/src/demos/checkboxes/data/server.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+export interface Server {
+    disabled: boolean;
+    ip: string;
+    name: string;
+    running: boolean;
+}

--- a/src/demos/checkboxes/data/status.ts
+++ b/src/demos/checkboxes/data/status.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Server } from "./server";
+import { SERVERS } from "./values";
+
+export class Status {
+    private _all: Server[];
+    constructor() {
+        this._all = SERVERS;
+    }
+    fetch(): Server[] {
+        return this._all;
+    }
+}

--- a/src/demos/checkboxes/data/values.ts
+++ b/src/demos/checkboxes/data/values.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Server } from "./server";
+
+export const SERVERS: Server[] = [
+    {
+        ip: "192.168.1.42",
+        running: false,
+        name: "Crystal View",
+        disabled: true
+    }, {
+        ip: "192.268.1.19",
+        running: true,
+        name: "Turbulent Foam",
+        disabled: false
+    }, {
+        ip: "192.268.1.11",
+        running: false,
+        name: "Bright Sunshine",
+        disabled: false
+    }, {
+        ip: "192.268.1.3",
+        running: true,
+        name: "Scary Numbers",
+        disabled: true
+    }, {
+        ip: "192.268.1.180",
+        running: false,
+        name: "Loud Silence",
+        disabled: false
+    },
+];


### PR DESCRIPTION
**NOTE: Do not merge this to the website branch until after v0.8.4 is release to npm.**

- Adds code and docs for the website for clr-checkbox, native checkbox usage by porting over the demo app from clarity-angular
- closes #319

## Screen shot of the new demo:
![screen shot 2017-01-20 at 12 18 28 pm](https://cloud.githubusercontent.com/assets/433692/22164114/a715510c-df0a-11e6-8443-8e815ca0fdd3.png)


Signed-off-by: Matt Hippely <mhippely@vmware.com>