### PR TITLE
[ui] Remove active style for focused anchor tag

### DIFF
--- a/src/clarity-angular/nav/_nav.clarity.scss
+++ b/src/clarity-angular/nav/_nav.clarity.scss
@@ -49,8 +49,7 @@ $clr-active-nav-link-shadow: 0 -3px 0 $action-blues-dark-midtone inset;
             }
 
             &:hover,
-            &.active,
-            &:focus {
+            &.active {
                 box-shadow: $clr-active-nav-link-shadow;
                 transition: box-shadow 0.2s ease-in;
                 outline: 0; //box-shadow above will ensure that the links are accessible.


### PR DESCRIPTION
Currently, we apply the "active" style of an anchor tag on hover, active, and focus. This introduces a bug in which when the user navigates to another page through back/forward button on browser, the previous active anchor tag in nav keeps the "active" style until the focus is taken out by user clicking on another area. Let me know if this fix of removing the style for focus sounds reasonable, or if there's a better alternative fix.

Tested the newly generated css on seed.

Fixes #374.

Signed-off-by: Jeeyun Lim <jeeyun.lim@gmail.com>