### PR TITLE
Adding Composer support for Clarity.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ _site/
 js/
 .vscode
 .stylelintrc
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "vmw/clarity",
+    "description": "Clarity Design System: UX guidelines, HTML/CSS framework, and Angular 2 components working together to craft exceptional experiences.",
+    "type": "library",
+    "license": "MIT",
+    "keywords": ["angular", "angular2", "javascript", "html", "css", "design"],
+    "homepage": "https://vmware.github.io/clarity/",
+    "support": {
+        "issues": "https://github.com/vmware/clarity/issues",
+        "wiki": "https://github.com/vmware/clarity/wiki",
+        "source": "https://github.com/vmware/clarity",
+        "docs": "https://vmware.github.io/clarity/documentation"
+    }
+}


### PR DESCRIPTION
I have added a standard Composer package metadata file to the project. Composer is a package management system for PHP projects, similar to NPM or or Bower and such.

I have rooted the namespace of the project to "vmw" as currently, in Packagist (the repository where Composer packages are stored) the "vmware" namespace is currently in use located [here](https://packagist.org/packages/vmware/) by this [organization](https://github.com/purple-dbu).

In the future if VMware discusses the transfer of this namespace, it can be accomplished easily by editing the composer.json file.

Some reference information about Composer and Packagist is located here:
* https://getcomposer.org/doc/00-intro.md#introduction
* https://packagist.org/about

Once this merge request is accepted, I will repoint the namespace I already registered to this project. If a VMware team member would like to contact me, I'll gladly relinquish the ownership of the "vmw" namespace I have already registered on Packagist. Maintaining security over your namespace is important, as it prevents malicious actors from claiming to be VMware falsely to users and forcing them to download code from unauthorized sources or locations.

Thanks!