### PR TITLE
[ui] moved rem method to _variables.clarity.scss

### DIFF
--- a/src/clarity-angular/utils/_helpers.clarity.scss
+++ b/src/clarity-angular/utils/_helpers.clarity.scss
@@ -2,18 +2,6 @@
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
-//Because the "rem" unit does not work on pseudo-elements in IE,
-//we use a function to compute "rem" to "px" with Sass.
-
-$clr-baseline: 24px !default;
-
-@function rem($remSize) {
-    @return $remSize * $clr-font-size;
-};
-
-@function baselineRem($remSize) {
-    @return $remSize * $clr-baseline;
-}
 
 //Get a selector for all the input types specified
 @function inputs($types...) {

--- a/src/clarity-angular/utils/_variables.clarity.scss
+++ b/src/clarity-angular/utils/_variables.clarity.scss
@@ -6,6 +6,12 @@
 @import "./helpers.clarity";
 @import "../color/color.clarity";
 
+$clr-baseline: 24px !default;
+
+@function baselineRem($remSize) {
+  @return $remSize * $clr-baseline;
+}
+
 //BaselineRem Variables
 $clr_baselineRem_0_1: baselineRem(0.1);
 $clr_baselineRem_0_125: baselineRem(0.125);
@@ -47,6 +53,15 @@ $clr-kerning-lotsatext: normal !default; // 14px, but a lot of it
 $clr-kerning-smalltext: normal !default; // 14px-12px
 $clr-kerning-bigtext: 0.01em !default; // some types of 16px over dark background
 $clr-kerning-tinytext: 0.03em !default; // 11px and lower
+
+
+//Because the "rem" unit does not work on pseudo-elements in IE,
+//we use a function to compute "rem" to "px" with Sass.
+@function rem($remSize) {
+  @return $remSize * $clr-font-base-size * 1px;
+};
+
+
 
 $clr-font-weights: (
     light: 200,


### PR DESCRIPTION
- This PR is the fix to the error we've faced while publishing the website.

Signed-off-by: Shijir Tsogoo <stsogoo@vmware.com>