### PR TITLE
[NG] Datagrid: expose a method to allow manual refresh

### DIFF
--- a/src/clarity-angular/datagrid/datagrid.spec.ts
+++ b/src/clarity-angular/datagrid/datagrid.spec.ts
@@ -12,11 +12,30 @@ import {Selection} from "./providers/selection";
 import {Sort} from "./providers/sort";
 import {Filters} from "./providers/filters";
 import {Page} from "./providers/page";
+import {Items} from "./providers/items";
 import {Comparator} from "./interfaces/comparator";
 import {Filter} from "./interfaces/filter";
 
 export default function(): void {
     describe("Datagrid component", function() {
+        describe("Typescript API", function() {
+            let context: TestContext<Datagrid, FullTest>;
+
+            beforeEach(function () {
+                context = this.create(Datagrid, FullTest);
+            });
+
+            it("allows to manually force a refresh of displayed items when data mutates", function() {
+                let items: Items = context.getClarityProvider(Items);
+                let refreshed = false;
+                items.change.subscribe(() => refreshed = true);
+                expect(refreshed).toBe(false);
+                context.clarityDirective.dataChanged();
+                expect(refreshed).toBe(true);
+            });
+
+        });
+
         describe("Template API", function() {
             let context: TestContext<Datagrid, FullTest>;
 

--- a/src/clarity-angular/datagrid/datagrid.ts
+++ b/src/clarity-angular/datagrid/datagrid.ts
@@ -103,6 +103,13 @@ export class Datagrid implements AfterContentInit, AfterViewInit, OnDestroy {
     }
 
     /**
+     * Public method to re-trigger the computation of displayed items manually
+     */
+    public dataChanged() {
+        this.items.refresh();
+    }
+
+    /**
      * We grab the smart iterator from projected content
      */
     @ContentChild(DatagridItems) public iterator: DatagridItems;

--- a/src/clarity-angular/datagrid/providers/items.ts
+++ b/src/clarity-angular/datagrid/providers/items.ts
@@ -70,6 +70,15 @@ export class Items {
     }
 
     /**
+     * Manually recompute the list of displayed items
+     */
+    public refresh() {
+        if (this.smart) {
+            this._filterItems();
+        }
+    }
+
+    /**
      * Internal temporary step, which we preserve to avoid re-filtering or re-sorting if not necessary
      */
     private _filtered: any[];


### PR DESCRIPTION
When consumers mutate the data they pass to the Datagrid, we have no way of detecting that the data has changed and that it should be re-processed by the filters, the comparators, ...
Although we recommend the data given to Datagrid should be immutable, we now provide a way for consumers to manually re-trigger this processing if they still decide to mutate the data. The way to do this is simply to grab the instance the the Datagrid (through @ViewChild, template variables, ...) and to call `.dataChanged()` on it.

Fixes #140 (kinda).

NOTE: once this is merged in, I will add an example of this on the website's datagrid documentation. Which is going to start growing slightly to big, if we continue adding to it.