### PR TITLE
[UI] TreeView Firefox Animation Fix

### DIFF
--- a/src/clarity-angular/tree-view/_tree-view.clarity.scss
+++ b/src/clarity-angular/tree-view/_tree-view.clarity.scss
@@ -91,6 +91,12 @@ clr-tree-node {
     //Display
     display: block;
 
+    //Not sure why Firefox doesn't add this by default using the collapse
+    //animation directive.
+    @include fixForFirefox() {
+        overflow-y: hidden;
+    }
+
     & > clr-checkbox,
     & > .checkbox {
         //Positioning


### PR DESCRIPTION
Overflow hidden was not being applied by default in firefox using the collapse animation function

Issue:
![image](https://cloud.githubusercontent.com/assets/1426805/22434794/636a8e8e-e6d2-11e6-8754-b5b1ae5b61a7.png)



Tested on Firefox

Signed-off-by: Aditya Bhandari <adityab@vmware.com>