### PR TITLE
[ui] Datagrid content should scroll within its container when content is too wide

### DIFF
--- a/src/clarity-angular/datagrid/_datagrid.clarity.scss
+++ b/src/clarity-angular/datagrid/_datagrid.clarity.scss
@@ -10,8 +10,12 @@
 @import "../tables/tables.clarity";
 
 @include exports('datagrid.clarity') {
+    @include basic-table(".datagrid", ".datagrid-head", ".datagrid-body",
+        ".datagrid-row", ".datagrid-column", ".datagrid-cell");
+
     .datagrid {
         display: table;
+        max-width: none; // override the basic-table's style of max-width: 100%
     }
     .datagrid-head {
         display: table-header-group;
@@ -29,10 +33,12 @@
         display: table-cell;
     }
 
-    @include basic-table(".datagrid", ".datagrid-head", ".datagrid-body",
-        ".datagrid-row", ".datagrid-column", ".datagrid-cell");
-
     $clr-datagrid-icon-size: rem(1);
+
+    .datagrid-content-wrapper {
+        display: block;
+        overflow: auto;
+    }
 
     .datagrid-wrapper {
         position: relative;

--- a/src/clarity-angular/datagrid/datagrid.html
+++ b/src/clarity-angular/datagrid/datagrid.html
@@ -5,23 +5,25 @@
   -->
 
 <div class="datagrid-wrapper">
-    <div class="datagrid">
-        <div class="datagrid-head">
-            <div class="datagrid-row">
-                <div class="datagrid-column datagrid-select" *ngIf="selection.selectable">
+    <div class="datagrid-content-wrapper">
+        <div class="datagrid">
+            <div class="datagrid-head">
+                <div class="datagrid-row">
+                    <div class="datagrid-column datagrid-select" *ngIf="selection.selectable">
                     <span class="datagrid-column-title">
                         <clr-checkbox [(ngModel)]="allSelected"></clr-checkbox>
                     </span>
+                    </div>
+                    <ng-content select="clr-dg-column"></ng-content>
                 </div>
-                <ng-content select="clr-dg-column"></ng-content>
             </div>
-        </div>
 
-        <div class="datagrid-body">
-            <template *ngIf="iterator"
-                      ngFor [ngForOf]="items.displayed" [ngForTrackBy]="iterator.trackBy"
-                      [ngForTemplate]="iterator.template"></template>
-            <ng-content *ngIf="!iterator"></ng-content>
+            <div class="datagrid-body">
+                <template *ngIf="iterator"
+                          ngFor [ngForOf]="items.displayed" [ngForTrackBy]="iterator.trackBy"
+                          [ngForTemplate]="iterator.template"></template>
+                <ng-content *ngIf="!iterator"></ng-content>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
Tested on:
- Chrome
- FF
- Safari
- IE 10
- IE 11
- IE edge

Screenshots:
<img width="1149" alt="screen shot 2017-02-06 at 2 41 47 pm" src="https://cloud.githubusercontent.com/assets/1827742/22670405/d57261f4-ec7d-11e6-98bc-5b783f0d5456.png">
<img width="1133" alt="screen shot 2017-02-06 at 2 41 54 pm" src="https://cloud.githubusercontent.com/assets/1827742/22670407/d66fa79c-ec7d-11e6-9329-483ac5ef3c92.png">

Resolves #395.

Signed-off-by: Jeeyun Lim <jeeyun.lim@gmail.com>