### PR TITLE
[NG] Modal: wait for the fade out animation before emitting output

### DIFF
--- a/src/clarity-angular/modal/modal.html
+++ b/src/clarity-angular/modal/modal.html
@@ -7,7 +7,8 @@
 
 <div class="modal" *ngIf="_open">
     <!--fixme: revisit when ngClass works with exit animation-->
-    <div [@fadeDown] class="modal-dialog"
+    <div [@fadeDown] (@fadeDown.done)="fadeDone($event)"
+         class="modal-dialog"
          [class.modal-sm]="size == 'sm'"
          [class.modal-lg]="size == 'lg'"
          [class.modal-xl]="size == 'xl'"

--- a/src/clarity-angular/modal/modal.spec.ts
+++ b/src/clarity-angular/modal/modal.spec.ts
@@ -109,6 +109,10 @@ describe("Modal", () => {
     it("offers two-way binding on clrModalOpen", fakeAsync(() => {
         expect(fixture.componentInstance.opened).toBe(true);
         getModalInstance(fixture).close();
+        fixture.detectChanges();
+        // We make sure to wait for the animation to be over before emitting the output
+        expect(fixture.componentInstance.opened).toBe(true);
+        tick();
         expect(fixture.componentInstance.opened).toBe(false);
     }));
 

--- a/src/clarity-angular/modal/modal.ts
+++ b/src/clarity-angular/modal/modal.ts
@@ -15,7 +15,8 @@ import {
     animate,
     style,
     transition,
-    trigger
+    trigger,
+    AnimationTransitionEvent
 } from "@angular/core";
 import {ScrollingService} from "../main/scrolling-service";
 
@@ -63,8 +64,6 @@ import {ScrollingService} from "../main/scrolling-service";
 
 })
 export class Modal implements OnChanges, OnDestroy {
-    // We grab animated children from the view, to wait for them to finish animating out
-    // before completely hiding the component itself.
     @Input("clrModalOpen") _open: boolean = false;
     @Output("clrModalOpenChange") _openChanged: EventEmitter<boolean> = new EventEmitter<boolean>(false);
 
@@ -112,6 +111,11 @@ export class Modal implements OnChanges, OnDestroy {
             return;
         }
         this._open = false;
-        this._openChanged.emit(false);
+    }
+
+    fadeDone(e: AnimationTransitionEvent) {
+        if (e.toState === "void") {
+            this._openChanged.emit(false);
+        }
     }
 }

--- a/src/clarity-angular/wizard/wizard.spec.ts
+++ b/src/clarity-angular/wizard/wizard.spec.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import {ComponentFixture, TestBed} from "@angular/core/testing";
+import {ComponentFixture, TestBed, fakeAsync, tick} from "@angular/core/testing";
 import {Component, ViewChild} from "@angular/core";
 import {ScrollingService} from "../main/scrolling-service";
 import {ClarityModule} from "../clarity.module";
@@ -131,6 +131,7 @@ describe("Wizard", () => {
         let cancel: HTMLElement = el.querySelector(".close");
         cancel.click();
         fixture.detectChanges();
+        tick();
     };
 
     beforeEach(() => {
@@ -486,10 +487,10 @@ describe("Wizard", () => {
             expect(tab4).toBeDefined();
         });
 
-        it("calls the user-defined onCancel handler when the Cancel button is clicked", () => {
+        it("calls the user-defined onCancel handler when the Cancel button is clicked", fakeAsync(() => {
             doCancel(compiled);
             expect(fixture.componentInstance.hasBeenCanceled).toBe(true);
-        });
+        }));
 
         it("defaults clrWizardClosable to true", () => {
             let closeButton = compiled.querySelector("button.close");


### PR DESCRIPTION
### Do not merge this without me, it needs confirmation from product devs external to the team.

The `(clrModelOpenChange)` output is now emitted when the modal has finished hiding, so that potential teardown or cleanup from the application isn't visible to the user.

Fixes #449.