### PR TITLE
[NG] Remove last import from RxJS' main

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,8 @@ application doesn't support IE10, you can skip the following installation:
     export class AppModule {    }
     ```
     
-    If your application uses [systemjs](https://github.com/systemjs/systemjs), add the clarity-angular configurations
-    as in the example below. If your application already has packages setting for `rxjs` but doesn't have the `main`
-    file, add it in.
+    If your application uses [systemjs](https://github.com/systemjs/systemjs), add the clarity-angular configuration
+    as in the example below.
     ```
     System.config({
     	...
@@ -123,10 +122,6 @@ application doesn't support IE10, you can skip the following installation:
     	   ...
     	   'clarity-angular': 'node_modules/clarity-angular/clarity-angular.umd.js',
     	},
-    	packages: {
-            ...
-            'rxjs' : { main: 'Rx.js', defaultExtension: 'js' },
-    	}
     	...
     });
     ```

--- a/build/karma-test-shim.js
+++ b/build/karma-test-shim.js
@@ -34,7 +34,7 @@ var packages = {
     'dist/tests': { defaultExtension: "js" },
     'clarity-angular': { defaultExtension: "js" },
     'clarity-icons': { defaultExtension: 'js' },
-    'rxjs': { defaultExtension: 'js', main: 'Rx.js'}
+    'rxjs': { defaultExtension: 'js'}
 };
 
 System.config({

--- a/src/app/index.html
+++ b/src/app/index.html
@@ -70,7 +70,7 @@
             // packages tells the System loader how to load when no filename and/or no extension
             var packages = {
                 'app':                        { defaultExtension: 'js' },
-                'rxjs':                       { main: 'Rx.js', defaultExtension: 'js' },
+                'rxjs':                       { defaultExtension: 'js' },
                 'clarity-angular':            { main: 'index.js', defaultExtension: 'js' },
                 'clarity-icons':              { main: 'index.js', defaultExtension: 'js' },
                 'clarity-demos':              { defaultExtension: 'js' }

--- a/src/app/ng1.html
+++ b/src/app/ng1.html
@@ -76,7 +76,7 @@
             'app':                        { defaultExtension: 'js' },
             'clarity-angular':            { main: 'index.js', defaultExtension: 'js' },
             'ng2-translate':              { defaultExtension: 'js' },
-            'rxjs':                       { main: Rx.js, defaultExtension: 'js' },
+            'rxjs':                       { defaultExtension: 'js' },
             "clarity-demos": {
                 defaultExtension: "js"
             }

--- a/src/clarity-angular/tree-view/providers/treeSelection.service.ts
+++ b/src/clarity-angular/tree-view/providers/treeSelection.service.ts
@@ -1,6 +1,6 @@
 import {Injectable} from "@angular/core";
-import { Subject } from "rxjs/Subject";
-import { Observable } from "rxjs/Observable";
+import {Observable} from "rxjs/Observable";
+import {Subject} from "rxjs/Subject";
 import {TreeSelection} from "../tree-selection";
 
 @Injectable()


### PR DESCRIPTION
It slept through the cracks because it was worked on in parallel of #400.
To avoid further issues, I removed the `main` configuration from all setups, so that using `import {} from "rxjs"` again will raise an actual error.