### PR TITLE
[NG] Responsive Nav - Expose Observables instead of Subjects

### DIFF
--- a/build/rollup-clarity.config.js
+++ b/build/rollup-clarity.config.js
@@ -12,7 +12,7 @@ export default {
         '@angular/platform-browser',
         'rxjs',
         'rxjs/Subject',
-        'rxjs/BehaviorSubject'
+        'rxjs/Observable'
     ],
     globals: {
         '@angular/core' : 'ng.core',
@@ -21,7 +21,7 @@ export default {
         '@angular/platform-browser' : 'ng.platformBrowser',
         'rxjs' : 'rxjs',
         'rxjs/Subject' : 'rxjs.Subject',
-        'rxjs/BehaviorSubject' : 'rxjs/BehaviorSubject'
+        'rxjs/Observable' : 'rxjs/Observable'
     },
     plugins: [
         buble()

--- a/src/clarity-angular/datagrid/datagrid-action-overflow.spec.ts
+++ b/src/clarity-angular/datagrid/datagrid-action-overflow.spec.ts
@@ -64,6 +64,10 @@ export default function(): void {
         });
 
         it("doesn't close the menu when an action menu item container is clicked", () => {
+            // should open when the ellipses icon is clicked
+            toggle.click();
+            context.detectChanges();
+
             let actionOverflowMenu: HTMLElement = context.clarityElement.querySelector(".datagrid-action-overflow");
             actionOverflowMenu.click();
             context.detectChanges();
@@ -71,6 +75,10 @@ export default function(): void {
         });
 
         it("closes the menu when an action menu item is clicked", () => {
+            // should open when the ellipses icon is clicked
+            toggle.click();
+            context.detectChanges();
+
             let actionItem: HTMLElement = context.clarityElement.querySelector(".action-item");
             actionItem.click();
             context.detectChanges();
@@ -94,7 +102,7 @@ export default function(): void {
             This is an area outside of the action overflow
         </div>
         <clr-dg-action-overflow [(clrDgActionOverflowOpen)]="open">
-            <a class="action-item" href="#">Hello world</a>
+            <button class="action-item">Hello world</button>
         </clr-dg-action-overflow>`
 })
 class SimpleTest {

--- a/src/clarity-angular/layout/main-container.ts
+++ b/src/clarity-angular/layout/main-container.ts
@@ -32,7 +32,7 @@ export class MainContainer implements OnDestroy, OnInit {
 
     ngOnInit() {
         this._classList = this.elRef.nativeElement.classList;
-        this._subscription = this.responsiveNavService.controlNavSubject.subscribe({
+        this._subscription = this.responsiveNavService.navControl.subscribe({
             next: (message: ClrResponsiveNavControlMessage) => {
                 this.processMessage(message);
             }

--- a/src/clarity-angular/nav/clrResponsiveNavigationService.ts
+++ b/src/clarity-angular/nav/clrResponsiveNavigationService.ts
@@ -4,23 +4,31 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import {Injectable} from "@angular/core";
-import {BehaviorSubject} from "rxjs/BehaviorSubject";
 
 import { ClrResponsiveNavCodes } from "./clrResponsiveNavCodes";
 import { ClrResponsiveNavControlMessage } from "./clrResponsiveNavControlMessage";
+import { Subject } from "rxjs/Subject";
+import { Observable } from "rxjs/Observable";
 
 @Injectable()
 export class ClrResponsiveNavigationService {
     public responsiveNavList: number[] = [];
-    public registerNavSubject: BehaviorSubject<number[]>
-        = new BehaviorSubject<number[]>([]);
-    public controlNavSubject: BehaviorSubject<ClrResponsiveNavControlMessage>
-        = new BehaviorSubject<ClrResponsiveNavControlMessage>(
-                new ClrResponsiveNavControlMessage(
-                    ClrResponsiveNavCodes.NAV_CLOSE_ALL,
-                    -999
-                )
-            );
+    private registerNavSubject: Subject<number[]>
+        = new Subject<number[]>();
+    private controlNavSubject: Subject<ClrResponsiveNavControlMessage>
+        = new Subject<ClrResponsiveNavControlMessage>();
+
+    get registeredNavs(): Observable<number[]> {
+        return this.registerNavSubject.asObservable();
+    }
+
+    get navControl(): Observable<ClrResponsiveNavControlMessage> {
+        return this.controlNavSubject.asObservable();
+    }
+
+    constructor() {
+        this.closeAllNavs(); //We start with all navs closed
+    }
 
     registerNav(navLevel: number): void {
         if (!navLevel || this.isNavRegistered(navLevel)) {

--- a/src/clarity-angular/nav/header.ts
+++ b/src/clarity-angular/nav/header.ts
@@ -5,7 +5,6 @@
  */
 import {
     Component,
-    ElementRef,
     OnDestroy,
     OnInit
 } from "@angular/core";
@@ -40,12 +39,11 @@ export class Header implements OnDestroy, OnInit {
     public isNavLevel2OnPage: boolean = false;
 
     constructor(
-        private elRef: ElementRef,
         private responsiveNavService: ClrResponsiveNavigationService
     ) {}
 
     ngOnInit() {
-        this._subscription = this.responsiveNavService.registerNavSubject.subscribe({
+        this._subscription = this.responsiveNavService.registeredNavs.subscribe({
             next: (navLevelList: number[]) => {
                 this.initializeNavTriggers(navLevelList);
             }

--- a/src/clarity-angular/nav/navLevelDirective.spec.ts
+++ b/src/clarity-angular/nav/navLevelDirective.spec.ts
@@ -28,25 +28,33 @@ describe("NavLevel1Directive", () => {
 
     it("#registers nav on init. sends the registration code on registerNavSubject in the service", () => {
         service.registerNav(ClrResponsiveNavCodes.NAV_LEVEL_1);
-        expect(service.registerNavSubject.getValue()[0]).toBe(ClrResponsiveNavCodes.NAV_LEVEL_1);
+        service.registeredNavs.subscribe(navArray => {
+            expect(navArray[0]).toBe(ClrResponsiveNavCodes.NAV_LEVEL_1);
+        });
     });
 
     it("#sends the open code on controlNavSubject in the service when open() is called", () => {
         navLevel.open();
-        expect(service.controlNavSubject.getValue().controlCode).toBe(
-            ClrResponsiveNavCodes.NAV_OPEN
-        );
+        service.navControl.subscribe(controlMessage => {
+            expect(controlMessage.controlCode).toBe(
+                ClrResponsiveNavCodes.NAV_OPEN
+            );
+        });
     });
 
     it("#sends the close code on controlNavSubject when close() is called", () => {
         navLevel.close();
-        expect(service.controlNavSubject.getValue().controlCode).toBe(
-            ClrResponsiveNavCodes.NAV_CLOSE
-        );
+        service.navControl.subscribe(controlMessage => {
+            expect(controlMessage.controlCode).toBe(
+                ClrResponsiveNavCodes.NAV_CLOSE
+            );
+        });
     });
 
     it("#unregisters itself from the registerNavSubject when ngOnDestroy() is called", () => {
         navLevel.ngOnDestroy();
-        expect(service.registerNavSubject.getValue().length).toBe(0);
+        service.registeredNavs.subscribe(navArray => {
+            expect(navArray.length).toBe(0);
+        });
     });
 });

--- a/src/clarity-angular/tree-view/providers/treeSelection.service.ts
+++ b/src/clarity-angular/tree-view/providers/treeSelection.service.ts
@@ -1,5 +1,6 @@
 import {Injectable} from "@angular/core";
-import {Subject, Observable} from "rxjs";
+import { Subject } from "rxjs/Subject";
+import { Observable } from "rxjs/Observable";
 import {TreeSelection} from "../tree-selection";
 
 @Injectable()


### PR DESCRIPTION
- Removed BehaviorSubjects
- Exposed Observables instead of RXJS Subjects

Browser Tests: Chrome

Unit Tests:
MainContainer
    ✔ projects content
    ✔ toggles the ClrResponsiveNavCodes.NAV_CLASS_HAMBURGER_MENU class to the host when NAV_LEVEL_1 is passed
    ✔ toggles the ClrResponsiveNavCodes.NAV_CLASS_OVERFLOW_MENU class to the host when NAV_LEVEL_2 is passed
    ✔ removes the open trigger classes when NAV_CLOSE_ALL is passed
    ✔ adds the NAV_CLASS_HAMBURGER_MENU class when NAV_OPEN_LEVEL_1 is passed
    ✔ removes the NAV_CLASS_HAMBURGER_MENU class when NAV_CLOSE_LEVEL_1 is passed
    ✔ adds the NAV_CLASS_OVERFLOW_MENU class when NAV_OPEN_LEVEL_2 is passed
    ✔ removes the NAV_CLASS_OVERFLOW_MENU class when NAV_CLOSE_LEVEL_2 is passed

ResponsiveNavigationService
    ✔ #initializes an empty nav level list
    ✔ #registers Nav Level 1
    ✔ #registers Nav Level 2
ERROR: 'Multiple clr-nav-level 1 attributes found. Please make sure that only one exists'
    ✔ #registers maximun 2 nav levels
    ✔ #unregisters nav levels
  Header
    ✔ projects content
    ✔ shows the hamburger trigger when the level1 directive is registered
    ✔ shows the overflow trigger when the level2 directive is registered
  NavLevel1Directive
    ✔ #level is set to 1
    ✔ #level is set to 2
    ✔ #registers nav on init. sends the registration code on registerNavSubject in the service
    ✔ #sends the open code on controlNavSubject in the service when open() is called
    ✔ #sends the close code on controlNavSubject when close() is called
    ✔ #unregisters itself from the registerNavSubject when ngOnDestroy() is called

Signed-off-by: Aditya Bhandari <adityab@vmware.com>