### PR TITLE
[DOCS] Override Modal z-index for documentation

### DIFF
--- a/src/app/_utils/code.scss
+++ b/src/app/_utils/code.scss
@@ -6,6 +6,7 @@
 @import "../../clarity-angular/utils/mixins.clarity";
 @import "../../clarity-angular/utils/helpers.clarity";
 @import "../../clarity-angular/utils/colors.clarity";
+@import "../../clarity-angular/utils/layers.clarity";
 
 //Styles for Clarity Demos
 .clr-example{
@@ -29,6 +30,7 @@
 .modal.static {
     position: relative;
     padding: $clr_baselineRem_3;
+    z-index: map-get($clr-layers,sidepanel-bg) - 1;
 }
 
 .modal-backdrop.static {
@@ -37,6 +39,7 @@
     right: 0;
     bottom: 0;
     left: 0;
+    z-index: map-get($clr-layers,sidepanel-bg) - 2;
 }
 
 .modal-icon {


### PR DESCRIPTION
Override z-index just for the docs so that the navigation remains accessible on smaller screens

Before:
![image](https://cloud.githubusercontent.com/assets/1426805/22889955/b04dcb7e-f1bf-11e6-9e16-20c9cd146ae5.png)

After:
![image](https://cloud.githubusercontent.com/assets/1426805/22890009/d4120ec6-f1bf-11e6-9d7c-057e85340b7c.png)



Signed-off-by: Aditya Bhandari <adityab@vmware.com>