### PR TITLE
[UI] Main Container Utility Class

### DIFF
--- a/src/clarity-angular/layout/_layout.clarity.scss
+++ b/src/clarity-angular/layout/_layout.clarity.scss
@@ -9,6 +9,7 @@
 @import "../utils/layers.clarity";
 
 @include exports('layout.clarity') {
+
     .main-container {
         display: flex;
         flex-direction: column;
@@ -20,13 +21,26 @@
             overflow-x: hidden;
         }
 
-        header, .header {
+        header,
+        .header {
             flex: 0 0 $clr-header-height;
         }
 
         .sub-nav,
         .subnav {
             flex: 0 0 $clr-subnav-height;
+        }
+
+        //This is a utility class which mimics the main-container class
+        //and occupies the remaining space inside of the main-container
+        //after the header just in case our users app layout requires
+        //that the .subnav and the .content-container be inside of an
+        //angular component
+        .u-main-container {
+            display: flex;
+            flex-direction: column;
+            flex: 1 1 auto;
+            overflow: hidden; //IE 10 doesn't like it if we don't use this
         }
 
         .content-container {


### PR DESCRIPTION
Creates a utility class `.u-main-container` which can be used as a wrapper in cases where the `.subnav` and the `.content-container` are not the direct children of the `.main-container`. The `.u-main-container` class is a vertical flex box which occupies the rest of the `100vh` after the `.header`.

Fixes: #481 

Tested on:
Chrome,
Firefox,
IE 10, 11
Edge

Signed-off-by: Aditya Bhandari <adityab@vmware.com>