### PR TITLE
[ui] fixed minor css bug in button group + added padding to datagrid's action bar

### DIFF
--- a/src/clarity-angular/button-group/_button-group.clarity.scss
+++ b/src/clarity-angular/button-group/_button-group.clarity.scss
@@ -7,17 +7,18 @@
 
 @include exports('button-group.clarity') {
 
-  $clr_btn-group-right-margin: baselineRem(5/24);
-
   .btn-group {
 
+    display: flex;
+
     .btn {
-      margin-right: -$clr_btn-group-right-margin;
+      margin-right: 0;
     }
 
     .btn:not(:last-child) {
       border-top-right-radius: 0;
       border-bottom-right-radius: 0;
+      border-right: none; /* Prevent double borders */
     }
 
     .btn:not(:first-child) {

--- a/src/clarity-angular/datagrid/_datagrid.clarity.scss
+++ b/src/clarity-angular/datagrid/_datagrid.clarity.scss
@@ -364,12 +364,13 @@
     }
 
     .datagrid-action-bar {
+        padding: $clr_baselineRem_0_125;
         display: flex;
         flex-flow: row nowrap;
         align-items: stretch;
         width: 100%;
-        min-height: $clr_baselineRem_1_5;
-        line-height: $clr_baselineRem_1_5 - 3px;
+        min-height: $clr_baselineRem_1_75;
+        line-height: $clr_baselineRem_1_75 - 3px;
         margin-bottom: -$clr_baselineRem_1;
     }
 


### PR DESCRIPTION
Earlier implementation was rendering inconsistently in browsers. Now using `display: flex` rather than a fixed value to change the margin.

Before:
<img width="504" alt="screen shot 2017-02-14 at 4 06 33 pm" src="https://cloud.githubusercontent.com/assets/1827742/22956132/ff8a23e8-f2d4-11e6-8a5b-e2ec67560c37.png">

After:
<img width="506" alt="screen shot 2017-02-14 at 4 05 07 pm" src="https://cloud.githubusercontent.com/assets/1827742/22956133/05c6ab32-f2d5-11e6-90de-d04d8c932c65.png">

Also added some padding to datagrid's action bar.

Tested manually on:
- IE 10/11/Edge
- FF
- Chrome
- Safari

Note: the icons are not rendering in demo app but I am not including those icons in our component, as they are inside projected content, which should be added by the implementing app.

Signed-off-by: Jeeyun Lim <jeeyun.lim@gmail.com>