### PR TITLE
[NG] Fix datagrid property comparator - handle null values

### DIFF
--- a/src/clarity-angular/datagrid/built-in/comparators/datagrid-property-comparator.spec.ts
+++ b/src/clarity-angular/datagrid/built-in/comparators/datagrid-property-comparator.spec.ts
@@ -28,6 +28,13 @@ export default function(): void {
             expect(this.comparator.compare({}, {})).toBe(0);
         });
 
+        it("considers null greater than everything", function() {
+            this.comparator = new DatagridPropertyComparator("a");
+            expect(this.comparator.compare({a: 42}, {a: null})).toBeLessThan(0);
+            expect(this.comparator.compare({a: null}, {a: 42})).toBeGreaterThan(0);
+            expect(this.comparator.compare({a: null}, {a: null})).toBe(0);
+        });
+
         it("supports nested properties", function() {
             this.comparator = new DatagridPropertyComparator("a.b");
             expect(this.comparator.compare({a: {b: 1}}, {a: {b: 10}})).toBeLessThan(0);

--- a/src/clarity-angular/datagrid/built-in/comparators/datagrid-property-comparator.ts
+++ b/src/clarity-angular/datagrid/built-in/comparators/datagrid-property-comparator.ts
@@ -17,14 +17,14 @@ export class DatagridPropertyComparator implements Comparator<any> {
     public compare(a: any, b: any): number {
         let propA = this.nestedProp.getPropValue(a);
         let propB = this.nestedProp.getPropValue(b);
-        if (typeof propA === "undefined") {
-            if (typeof propB === "undefined") {
+        if (typeof propA === "undefined" || propA === null) {
+            if (typeof propB === "undefined" || propB === null) {
                 return 0;
             } else {
                 return 1;
             }
         } else {
-            if (typeof propB === "undefined") {
+            if (typeof propB === "undefined" || propB === null) {
                 return -1;
             } else if (propA < propB) {
                 return -1;


### PR DESCRIPTION
The built-in datagrid property comparator handles comparison of undefined values, but not null values. This can lead to incorrect sorting if such values are present in the data source.

Signed-off-by: Ivan Donchev <idonchev@vmware.com>