### PR TITLE
[NG] Datagrid: switch to flexbox layout

### DIFF
--- a/build/tasks/sass.js
+++ b/build/tasks/sass.js
@@ -47,12 +47,16 @@ var VERSION = `
 `;
 // var VERSION = "/*! \n\s*\n\\s*Clarity v" + process.env.BUILD_VERSION + " | MIT license | https://github.com/vmware/clarity \n\\s*/";
 
+var SUPPORTED_BROWSERS = ['last 3 versions','ie 10','ie 11','> 5%','Firefox > 35','Chrome > 35'];
 /**
  * compiles the .clarity.sass files from the src/ folder to create the bundled clarity css
  * and its sourcemap in the dist/ folder
  */
 gulp.task("sass:static", function(){
     var prod = process.env.NODE_ENV==="prod";
+    if (process.env.TESTING) {
+        SUPPORTED_BROWSERS.push('safari >= 4');
+    }
 
     return gulp.src(["src/clarity-angular/main.scss"], {base: "src"})
         // Sourcemaps only for development
@@ -62,7 +66,7 @@ gulp.task("sass:static", function(){
         .pipe(prod ? util.noop() : sourcemaps.write({includeContent: false}))
         .pipe(prod ? util.noop() : sourcemaps.init({loadMaps: true}))
         .pipe(autoprefixer({
-                browsers: ['last 3 versions','ie 10','ie 11','> 5%','Firefox > 35','Chrome > 35'],
+                browsers: SUPPORTED_BROWSERS,
     			cascade: false
     		}))
         .pipe(concat(prod ? 'clarity-ui.min.css' : 'clarity-ui.css'))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,6 +55,7 @@ gulp.task("serve", function (callback) {
  */
 gulp.task("test", function (callback) {
     env.set({NODE_ENV: "prod"}); // We only run tests in production mode for now
+    env.set({TESTING: true});
     return runSequence(
         'build',
         'karma:verbose',
@@ -69,6 +70,7 @@ gulp.task("test", function (callback) {
  */
 gulp.task("test:watch", function(callback) {
     env.set({NODE_ENV: "prod"}); // We only run tests in production mode for now
+    env.set({TESTING: true});
     return runSequence(
         'build',
         ['sass:watch', 'typescript:watch', 'html:watch', 'bundle:watch'],

--- a/src/app/datagrid/column-sizing/column-sizing.html
+++ b/src/app/datagrid/column-sizing/column-sizing.html
@@ -1,0 +1,46 @@
+<!--
+  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<h2>Smart column sizing</h2>
+
+<clr-datagrid>
+    <clr-dg-column>This column as a long header but short data</clr-dg-column>
+    <clr-dg-column>Short header</clr-dg-column>
+    <clr-dg-column>Large data</clr-dg-column>
+
+    <clr-dg-row *clrDgItems="let user of users">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed tortor tellus,
+            tincidunt eget mauris molestie, ullamcorper facilisis lacus. Vivamus sagittis
+            suscipit libero, et tristique justo consectetur eget.
+        </clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>{{users.length}} users</clr-dg-footer>
+</clr-datagrid>
+
+
+<h2>Forcing columns width</h2>
+
+<clr-datagrid>
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column>Name</clr-dg-column>
+    <clr-dg-column [style.width.px]="200">Style binding to 200px</clr-dg-column>
+    <clr-dg-column>Pokemon</clr-dg-column>
+    <clr-dg-column class="lorem-ipsum">300px specified through CSS</clr-dg-column>
+
+    <clr-dg-row *clrDgItems="let user of users">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>{{user.pokemon.name}}</clr-dg-cell>
+        <clr-dg-cell>This column always is 300px wide.</clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>{{users.length}} users</clr-dg-footer>
+</clr-datagrid>

--- a/src/app/datagrid/column-sizing/column-sizing.ts
+++ b/src/app/datagrid/column-sizing/column-sizing.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component} from "@angular/core";
+
+import {Inventory} from "../inventory/inventory";
+import {User} from "../inventory/user";
+
+@Component({
+    moduleId: module.id,
+    selector: "clr-datagrid-column-sizing-demo",
+    providers: [Inventory],
+    templateUrl: "column-sizing.html",
+    styleUrls: ["../datagrid.demo.scss"]
+})
+export class DatagridColumnSizingDemo {
+    users: User[];
+
+    constructor(private inventory: Inventory) {
+        inventory.size = 10;
+        inventory.reset();
+        this.users = inventory.all;
+    }
+}

--- a/src/app/datagrid/datagrid.demo.html
+++ b/src/app/datagrid/datagrid.demo.html
@@ -19,6 +19,8 @@
     <li><a [routerLink]="['./selection-single']">Selection (Single)</a></li>
     <li><a [routerLink]="['./server-driven']">Server-driven datagrid</a></li>
     <li><a [routerLink]="['./placeholder']">Placeholder</a></li>
+    <li><a [routerLink]="['./scrolling']">Scrolling</a></li>
+    <li><a [routerLink]="['./column-sizing']">Column sizing</a></li>
     <li><a [routerLink]="['./full']">Full demo</a></li>
 </ul>
 

--- a/src/app/datagrid/datagrid.demo.module.ts
+++ b/src/app/datagrid/datagrid.demo.module.ts
@@ -23,6 +23,8 @@ import {DatagridSmartIteratorDemo} from "./smart-iterator/smart-iterator";
 import {DatagridSortingDemo} from "./sorting/sorting";
 import {DatagridStringFilteringDemo} from "./string-filtering/string-filtering";
 import {DatagridPlaceholderDemo} from "./placeholder/placeholder";
+import {DatagridScrollingDemo} from "./scrolling/scrolling";
+import {DatagridColumnSizingDemo} from "./column-sizing/column-sizing";
 
 import {ColorFilter} from "./utils/color-filter";
 import {Example} from "./utils/example";
@@ -50,6 +52,8 @@ import {Example} from "./utils/example";
         DatagridSortingDemo,
         DatagridStringFilteringDemo,
         DatagridPlaceholderDemo,
+        DatagridScrollingDemo,
+        DatagridColumnSizingDemo,
         ColorFilter,
         Example
     ],
@@ -67,8 +71,10 @@ import {Example} from "./utils/example";
         DatagridSmartIteratorDemo,
         DatagridSortingDemo,
         DatagridStringFilteringDemo,
-        DatagridPlaceholderDemo
+        DatagridPlaceholderDemo,
+        DatagridScrollingDemo,
+        DatagridColumnSizingDemo
     ]
 })
-export default class ModalDemoModule {
+export default class DatagridDemoModule {
 }

--- a/src/app/datagrid/datagrid.demo.routing.ts
+++ b/src/app/datagrid/datagrid.demo.routing.ts
@@ -20,6 +20,8 @@ import {DatagridSmartIteratorDemo} from "./smart-iterator/smart-iterator";
 import {DatagridSortingDemo} from "./sorting/sorting";
 import {DatagridStringFilteringDemo} from "./string-filtering/string-filtering";
 import {DatagridPlaceholderDemo} from "./placeholder/placeholder";
+import {DatagridScrollingDemo} from "./scrolling/scrolling";
+import {DatagridColumnSizingDemo} from "./column-sizing/column-sizing";
 
 const ROUTES: Routes = [
     {
@@ -39,6 +41,8 @@ const ROUTES: Routes = [
             {path: "selection-single", component: DatagridSelectionSingleDemo},
             {path: "server-driven", component: DatagridServerDrivenDemo},
             {path: "placeholder", component: DatagridPlaceholderDemo},
+            {path: "scrolling", component: DatagridScrollingDemo},
+            {path: "column-sizing", component: DatagridColumnSizingDemo},
             {path: "full", component: DatagridFullDemo},
         ]
     }

--- a/src/app/datagrid/datagrid.demo.scss
+++ b/src/app/datagrid/datagrid.demo.scss
@@ -6,7 +6,7 @@
 
 .color-square {
     display: inline-block;
-    vertical-align: text-bottom;
+    vertical-align: bottom;
     height: 14px;
     width: 14px;
     border: 1px solid black;
@@ -29,7 +29,7 @@
 }
 
 .lorem-ipsum {
-    max-width: 300px;
+    width: 300px;
 }
 
 .username-list {
@@ -41,4 +41,8 @@
     .username:last-child::after {
         content: ".";
     }
+}
+
+#vertical-scrolling {
+    height: 500px;
 }

--- a/src/app/datagrid/full/full.html
+++ b/src/app/datagrid/full/full.html
@@ -74,7 +74,7 @@
                 </clr-datagrid-color-filter-demo>
             </clr-dg-filter>
         </clr-dg-column>
-        <clr-dg-column *ngIf="loremIpsumColumn">Multi-line text</clr-dg-column>
+        <clr-dg-column class="lorem-ipsum" *ngIf="loremIpsumColumn">Multi-line text</clr-dg-column>
 
         <clr-dg-placeholder>No users found</clr-dg-placeholder>
         <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
@@ -85,7 +85,7 @@
             <clr-dg-cell>
                 <span class="color-square" [style.backgroundColor]="user.color"></span>
             </clr-dg-cell>
-            <clr-dg-cell class="lorem-ipsum" *ngIf="loremIpsumColumn">
+            <clr-dg-cell *ngIf="loremIpsumColumn">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed tortor tellus,
                 tincidunt eget mauris molestie, ullamcorper facilisis lacus. Vivamus sagittis
                 suscipit libero, et tristique justo consectetur eget.
@@ -112,7 +112,7 @@
                 </clr-datagrid-color-filter-demo>
             </clr-dg-filter>
         </clr-dg-column>
-        <clr-dg-column *ngIf="loremIpsumColumn">Multi-line text</clr-dg-column>
+        <clr-dg-column class="lorem-ipsum" *ngIf="loremIpsumColumn">Multi-line text</clr-dg-column>
 
         <clr-dg-placeholder>No users found</clr-dg-placeholder>
         <clr-dg-row *ngFor="let user of users" [clrDgItem]="user">
@@ -123,7 +123,7 @@
             <clr-dg-cell>
                 <span class="color-square" [style.backgroundColor]="user.color"></span>
             </clr-dg-cell>
-            <clr-dg-cell class="lorem-ipsum" *ngIf="loremIpsumColumn">
+            <clr-dg-cell *ngIf="loremIpsumColumn">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed tortor tellus,
                 tincidunt eget mauris molestie, ullamcorper facilisis lacus. Vivamus sagittis
                 suscipit libero, et tristique justo consectetur eget.

--- a/src/app/datagrid/scrolling/scrolling.html
+++ b/src/app/datagrid/scrolling/scrolling.html
@@ -1,0 +1,57 @@
+<!--
+  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<h2>Vertical scrolling</h2>
+
+<clr-datagrid id="vertical-scrolling">
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
+    <clr-dg-column [clrDgField]="'creation'">Creation date</clr-dg-column>
+    <clr-dg-column [clrDgField]="'pokemon.name'">Pokemon</clr-dg-column>
+    <clr-dg-column [clrDgField]="'color'">Favorite color</clr-dg-column>
+
+    <clr-dg-row *clrDgItems="let user of manyUsers">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>{{user.pokemon.name}}</clr-dg-cell>
+        <clr-dg-cell>
+            <span class="color-square" [style.backgroundColor]="user.color"></span>
+        </clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>{{users.length}} users</clr-dg-footer>
+</clr-datagrid>
+
+
+<h2>Horizontal scrolling</h2>
+
+<div class="card" style="width: 400px">
+    <div class="card-header">
+        For instance when in a narrow card.
+    </div>
+    <div class="card-block">
+        <clr-datagrid>
+            <clr-dg-column>User ID</clr-dg-column>
+            <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
+            <clr-dg-column [clrDgField]="'pokemon.name'">Pokemon</clr-dg-column>
+            <clr-dg-column [clrDgField]="'color'">Favorite color</clr-dg-column>
+            <clr-dg-column class="lorem-ipsum">Filler</clr-dg-column>
+
+            <clr-dg-row *clrDgItems="let user of users">
+                <clr-dg-cell>{{user.id}}</clr-dg-cell>
+                <clr-dg-cell>{{user.name}}</clr-dg-cell>
+                <clr-dg-cell>{{user.pokemon.name}}</clr-dg-cell>
+                <clr-dg-cell>
+                    <span class="color-square" [style.backgroundColor]="user.color"></span>
+                </clr-dg-cell>
+                <clr-dg-cell>This is a very wide column.</clr-dg-cell>
+            </clr-dg-row>
+
+            <clr-dg-footer>{{users.length}} users</clr-dg-footer>
+        </clr-datagrid>
+    </div>
+</div>

--- a/src/app/datagrid/scrolling/scrolling.ts
+++ b/src/app/datagrid/scrolling/scrolling.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component} from "@angular/core";
+
+import {Inventory} from "../inventory/inventory";
+import {User} from "../inventory/user";
+
+@Component({
+    moduleId: module.id,
+    selector: "clr-datagrid-scrolling-demo",
+    providers: [Inventory],
+    templateUrl: "scrolling.html",
+    styleUrls: ["../datagrid.demo.scss"]
+})
+export class DatagridScrollingDemo {
+    manyUsers: User[];
+    users: User[];
+
+    constructor(private inventory: Inventory) {
+        inventory.size = 30;
+        inventory.reset();
+        this.manyUsers = inventory.all;
+        this.users = inventory.all.slice(0, 10);
+    }
+}

--- a/src/clarity-angular/datagrid/_datagrid.clarity.scss
+++ b/src/clarity-angular/datagrid/_datagrid.clarity.scss
@@ -13,36 +13,84 @@
     @include basic-table(".datagrid", ".datagrid-head", ".datagrid-body",
         ".datagrid-row", ".datagrid-column", ".datagrid-cell");
 
-    .datagrid {
-        display: table;
-        max-width: none; // override the basic-table's style of max-width: 100%
+    $clr-datagrid-icon-size: rem(1);
+    $clr-datagrid-action-arrow-size: $clr_baselineRem_0_25;
+    $clr-datagrid-select-column-size: 2*$clr-table-cellpadding + $clr-table-lineheight;
+
+    .datagrid-container {
+        display: flex;
+        flex-flow: column nowrap;
+        width: 100%;
+        overflow-x: auto;
+        overflow-y: hidden;
     }
-    .datagrid-head {
-        display: table-header-group;
+
+    .datagrid {
+        display: flex;
+        flex-flow: column nowrap;
+        align-self: flex-start;
+        min-width: 100%;
+        // Firefox needs this
+        min-height: 0;
+        // IE10 (maybe later versions too) needs this
+        overflow: hidden;
+    }
+    .datagrid-head, .datagrid-body, .datagrid-column, .datagrid-cell {
+        display: block;
+    }
+    .datagrid-table-wrapper {
+        flex: 1 1 auto;
+        display: flex;
+        flex-flow: column nowrap;
+        // Firefox needs this
+        min-height: 0;
+        // IE10 (maybe later versions too) needs this
+        overflow: hidden;
     }
     .datagrid-body {
-        display: table-row-group;
+        flex: 1 1 auto;
+        overflow-y: auto;
     }
-    .datagrid-column {
-        display: table-cell;
+    .datagrid-head {
+        flex: 0 0 auto;
     }
     .datagrid-row {
-        display: table-row;
+        display: flex;
+        flex-flow: row nowrap;
     }
-    .datagrid-cell {
-        display: table-cell;
+    .datagrid-column, .datagrid-cell {
+        flex: 1 1 auto;
+
+        &.datagrid-fixed-width {
+            flex: 0 0 auto;
+        }
+    }
+
+    // Class only applied temporarily when computing columns width
+    .datagrid-computing-columns-width {
+        display: table;
+
+        .datagrid-head {
+            display: table-header-group;
+        }
+        .datagrid-body {
+            display: table-row-group;
+        }
+        .datagrid-row {
+            display: table-row;
+        }
+        .datagrid-column, .datagrid-cell {
+            display: table-cell;
+        }
     }
 
     $clr-datagrid-icon-size: rem(1);
-    $clr-datagrid-action-arrow-size: $clr_baselineRem_0_25;
 
-    .datagrid-content-wrapper {
-        display: block;
-        overflow: auto;
-    }
-
-    .datagrid-wrapper {
+    .datagrid {
         position: relative;
+        flex: 1 1 auto;
+        width: auto; // override the basic table's style of width: 100%
+        max-width: none; // override the basic table's style of max-width: 100%
 
         .datagrid-spinner {
             position: absolute;
@@ -62,13 +110,8 @@
                 margin: auto;
             }
         }
-    }
 
-    .datagrid {
-        // Reset border-radius at the bottom to seamlessly join with the footer
-        border-bottom: 0 none;
-        border-radius: $clr-default-borderradius $clr-default-borderradius 0 0;
-        .datagrid-body:last-child {
+        .datagrid-body {
             .datagrid-row:last-child {
                 .datagrid-cell {
                     &:first-child {
@@ -81,14 +124,20 @@
             }
         }
 
+        .datagrid-head {
+            background-color: $clr-thead-bgcolor;
+            border-bottom: 2px solid $clr-light-midtone-gray;
+        }
+
         .datagrid-column, .datagrid-cell {
             text-align: left;
         }
 
         .datagrid-column {
             position: relative;
-            border-bottom: 2px solid $clr-light-midtone-gray;
             vertical-align: top;
+            background: none;
+            border-bottom: 0;
 
             // Separator between column headers
             &:not(:last-child)::before {
@@ -206,7 +255,9 @@
         }
 
         .datagrid-select {
-            width: 2*$clr-table-cellpadding + $clr-table-lineheight;
+            flex: 0 0 $clr-datagrid-select-column-size;
+            // IE10 needs this
+            max-width: $clr-datagrid-select-column-size;
 
             .checkbox label {
                 display: block;
@@ -222,11 +273,12 @@
         }
 
         .datagrid-row-actions {
-            width: $clr-table-cellpadding + $clr-table-lineheight;
-            cursor: pointer;
+            flex: 0 0 $clr-datagrid-select-column-size;
+            // IE10 needs this
+            max-width: $clr-datagrid-select-column-size;
         }
 
-        .datagrid-row {
+        .datagrid-body .datagrid-row {
             &:hover {
                 background-color: $clr-light-gray;
             }
@@ -238,9 +290,6 @@
 
             .datagrid-action-overflow {
                 position: absolute;
-                left: 100%;
-                transform: translateY(-50%);
-                margin-top: -1 * ($clr-datagrid-icon-size / 2);
                 background: $clr-white;
                 padding: $clr_baselineRem_0_25 $clr_baselineRem_0_25;
                 border: 1px solid $gray-light-midtone;
@@ -331,15 +380,17 @@
 
         .datagrid-cell {
             border-top-color: $clr-lighter-midtone-gray;
-            position: relative;
         }
+    }
+
+    .datagrid-placeholder-container {
+      display: block;
+      flex: 1 1 auto;
     }
 
     .datagrid-placeholder {
         background: $clr-white;
         border-top: 1px solid $clr-lighter-midtone-gray;
-        border-left: $clr-table-borderstyle;
-        border-right: $clr-table-borderstyle;
         padding: $clr_baselineRem_0_5;
 
         &.datagrid-empty {
@@ -364,29 +415,28 @@
     }
 
     .datagrid-action-bar {
+        flex: 0 0 auto;
         padding: $clr_baselineRem_0_125;
         display: flex;
         flex-flow: row nowrap;
         align-items: stretch;
-        width: 100%;
         min-height: $clr_baselineRem_1_75;
         line-height: $clr_baselineRem_1_75 - 3px;
         margin-bottom: -$clr_baselineRem_1;
     }
 
     .datagrid-foot {
+        flex: 0 0 auto;
         display: flex;
         flex-flow: row nowrap;
         justify-content: flex-end;
         align-items: stretch;
-        width: 100%;
         height: $clr_baselineRem_1_5;
         padding: 0 $clr-table-cellpadding;
         // Account for borders
         line-height: $clr_baselineRem_1_5 - 3px;
         font-size: clr-getTypePropertyValueForDomElement(table_header, font-size);
         background-color: $clr-thead-bgcolor;
-        border: $clr-table-borderstyle;
         border-top: 2px solid $clr-light-midtone-gray;
         border-radius: 0 0 $clr-default-borderradius $clr-default-borderradius;
 
@@ -444,5 +494,13 @@
             // FIXME: this should be in the general reboot
             cursor: pointer;
         }
+    }
+
+    // Needed for the hack to test if a cell has a user-defined width
+    .datagrid-cell-width-zero {
+        border: 0 !important;
+        padding: 0 !important;
+        width: 0;
+        flex: 0 0 auto !important;
     }
 }

--- a/src/clarity-angular/datagrid/all.spec.ts
+++ b/src/clarity-angular/datagrid/all.spec.ts
@@ -26,7 +26,16 @@ import DatagridRowSpecs from "./datagrid-row.spec";
 import DatagridPaginationSpecs from "./datagrid-pagination.spec";
 import DatagridFooterSpecs from "./datagrid-footer.spec";
 import DatagridSpecs from "./datagrid.spec";
-import NestedPropertySpec from "./built-in/nested-property.spec";
+import DomAdapterSpecs from "./render/dom-adapter.spec";
+import DatagridRenderOrganizerSpecs from "./render/render-organizer.spec";
+import DatagridCellRendererSpecs from "./render/cell-renderer.spec";
+import DatagridRowRendererSpecs from "./render/row-renderer.spec";
+import DatagridBodyRendererSpecs from "./render/body-renderer.spec";
+import DatagridHeaderRendererSpecs from "./render/header-renderer.spec";
+import DatagridHeadRendererSpecs from "./render/head-renderer.spec";
+import DatagridTableRendererSpecs from "./render/table-renderer.spec";
+import DatagridMainRendererSpecs from "./render/main-renderer.spec";
+import NestedPropertySpecs from "./built-in/nested-property.spec";
 import DatagridPropertyComparatorSpecs from "./built-in/comparators/datagrid-property-comparator.spec";
 import DatagridPropertyStringFilterSpecs from "./built-in/filters/datagrid-property-string-filter.spec";
 import DatagridStringFilterSpecs from "./built-in/filters/datagrid-string-filter.spec";
@@ -55,8 +64,19 @@ describe("Datagrid", function() {
         DatagridPlaceholderSpecs();
         DatagridSpecs();
     });
+    describe("Render", function() {
+        DomAdapterSpecs();
+        DatagridRenderOrganizerSpecs();
+        DatagridCellRendererSpecs();
+        DatagridRowRendererSpecs();
+        DatagridBodyRendererSpecs();
+        DatagridHeaderRendererSpecs();
+        DatagridHeadRendererSpecs();
+        DatagridTableRendererSpecs();
+        DatagridMainRendererSpecs();
+    });
     describe("Built-in", function() {
-        NestedPropertySpec();
+        NestedPropertySpecs();
         DatagridPropertyComparatorSpecs();
         DatagridPropertyStringFilterSpecs();
         DatagridStringFilterSpecs();

--- a/src/clarity-angular/datagrid/datagrid-action-bar.ts
+++ b/src/clarity-angular/datagrid/datagrid-action-bar.ts
@@ -9,10 +9,11 @@ import {Selection} from "./providers/selection";
 @Component({
     selector: "clr-dg-action-bar",
     template: `
-        <div class="datagrid-action-bar">
-            <ng-content *ngIf="selection.current && selection.current.length > 0"></ng-content>
-        </div>
-    `
+        <ng-content *ngIf="selection.current && selection.current.length > 0"></ng-content>
+    `,
+    host: {
+        "[class.datagrid-action-bar]": "true"
+    }
 })
 export class DatagridActionBar {
 

--- a/src/clarity-angular/datagrid/datagrid-action-overflow.spec.ts
+++ b/src/clarity-angular/datagrid/datagrid-action-overflow.spec.ts
@@ -4,10 +4,11 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import {Component} from "@angular/core";
+import {TestBed} from "@angular/core/testing";
 import {TestContext} from "./helpers.spec";
 import {DatagridActionOverflow} from "./datagrid-action-overflow";
 import {RowActionService} from "./providers/row-action-service";
-import {TestBed} from "@angular/core/testing";
+import {DatagridRenderOrganizer} from "./render/render-organizer";
 
 export default function(): void {
     describe("DatagridActionOverflow component", function() {
@@ -16,7 +17,7 @@ export default function(): void {
         let toggle: HTMLElement;
 
         beforeEach(function() {
-            context = this.create(DatagridActionOverflow, SimpleTest, [RowActionService]);
+            context = this.create(DatagridActionOverflow, SimpleTest, [RowActionService, DatagridRenderOrganizer]);
             rowActionServiceProvider = TestBed.get(RowActionService);
             toggle = context.clarityElement.querySelector("clr-icon");
         });

--- a/src/clarity-angular/datagrid/datagrid-cell.spec.ts
+++ b/src/clarity-angular/datagrid/datagrid-cell.spec.ts
@@ -6,13 +6,14 @@
 import {Component} from "@angular/core";
 import {TestContext} from "./helpers.spec";
 import {DatagridCell} from "./datagrid-cell";
+import {DatagridRenderOrganizer} from "./render/render-organizer";
 
 export default function(): void {
     describe("DatagridCell component", function() {
         let context: TestContext<DatagridCell, SimpleTest>;
 
         beforeEach(function() {
-            context = this.create(DatagridCell, SimpleTest);
+            context = this.create(DatagridCell, SimpleTest, [DatagridRenderOrganizer]);
         });
 
         it("projects content", function() {

--- a/src/clarity-angular/datagrid/datagrid-column.spec.ts
+++ b/src/clarity-angular/datagrid/datagrid-column.spec.ts
@@ -15,6 +15,10 @@ import {DatagridPropertyComparator} from "./built-in/comparators/datagrid-proper
 import {StringFilter} from "./interfaces/string-filter";
 import {TestBed} from "@angular/core/testing";
 import {DatagridStringFilter} from "./built-in/filters/datagrid-string-filter";
+import {DatagridRenderOrganizer} from "./render/render-organizer";
+import {DomAdapter} from "./render/dom-adapter";
+
+const PROVIDERS_NEEDED = [Sort, FiltersProvider, DatagridRenderOrganizer, DomAdapter];
 
 export default function (): void {
     describe("DatagridColumn component", function () {
@@ -89,24 +93,24 @@ export default function (): void {
             });
         });
 
-        describe("Template API", function () {
-            it("receives an input for the comparator", function () {
-                this.context = this.create(DatagridColumn, SimpleTest, [Sort, FiltersProvider]);
+        describe("Template API", function() {
+            it("receives an input for the comparator", function() {
+                this.context = this.create(DatagridColumn, SimpleTest, PROVIDERS_NEEDED);
                 this.comparator = new TestComparator();
                 this.context.testComponent.comparator = this.comparator;
                 this.context.detectChanges();
                 expect(this.context.clarityDirective.sortBy).toBe(this.comparator);
             });
 
-            it("receives an input for the property name", function () {
-                this.context = this.create(DatagridColumn, SimpleTest, [Sort, FiltersProvider]);
+            it("receives an input for the property name", function() {
+                this.context = this.create(DatagridColumn, SimpleTest, PROVIDERS_NEEDED);
                 this.context.testComponent.field = "test";
                 this.context.detectChanges();
                 expect(this.context.clarityDirective.field).toBe("test");
             });
 
             it("receives an input for the property filter value", function () {
-                this.context = this.create(DatagridColumn, PreFilterTest, [Sort, FiltersProvider]);
+                this.context = this.create(DatagridColumn, PreFilterTest, PROVIDERS_NEEDED);
                 this.context.testComponent.field = "test";
                 this.context.testComponent.filterValue = "M";
                 this.context.detectChanges();
@@ -114,7 +118,7 @@ export default function (): void {
             });
 
             it("offers two-way binding on the sorted state", function () {
-                this.context = this.create(DatagridColumn, SimpleTest, [Sort, FiltersProvider]);
+                this.context = this.create(DatagridColumn, SimpleTest, PROVIDERS_NEEDED);
                 this.comparator = new TestComparator();
                 this.context.testComponent.comparator = this.comparator;
                 this.context.testComponent.sorted = true;
@@ -126,7 +130,7 @@ export default function (): void {
             });
 
             it("offers two way binding on the filtered state", function () {
-                this.context = this.create(DatagridColumn, PreFilterTest, [Sort, FiltersProvider]);
+                this.context = this.create(DatagridColumn, PreFilterTest, PROVIDERS_NEEDED);
                 this.context.testComponent.field = "test";
                 this.context.testComponent.filterValue = "M";
                 this.context.detectChanges();
@@ -137,12 +141,12 @@ export default function (): void {
             });
 
             it("accepts a custom filter in the projected content", function () {
-                this.context = this.create(DatagridColumn, FilterTest, [Sort, FiltersProvider]);
+                this.context = this.create(DatagridColumn, FilterTest, PROVIDERS_NEEDED);
                 expect(TestBed.get(FiltersProvider).getActiveFilters()).toEqual([this.context.testComponent.filter]);
             });
 
             it("accepts a custom string filter in the projected content", function () {
-                this.context = this.create(DatagridColumn, StringFilterTest, [Sort, FiltersProvider]);
+                this.context = this.create(DatagridColumn, StringFilterTest, PROVIDERS_NEEDED);
                 this.stringFilter = this.context.testComponent.stringFilter.filter;
                 // We make the filter active to see if the FiltersProvider provider knows about it
                 this.stringFilter.value = "hello";
@@ -151,7 +155,7 @@ export default function (): void {
             });
 
             it("prioritizes custom comparators over the default property name one", function () {
-                this.context = this.create(DatagridColumn, SimpleTest, [Sort, FiltersProvider]);
+                this.context = this.create(DatagridColumn, SimpleTest, PROVIDERS_NEEDED);
                 this.comparator = new TestComparator();
                 this.context.testComponent.comparator = this.comparator;
                 this.context.detectChanges();
@@ -161,7 +165,7 @@ export default function (): void {
             });
 
             it("prioritizes custom filters over the default property name one", function () {
-                this.context = this.create(DatagridColumn, FilterTest, [Sort, FiltersProvider]);
+                this.context = this.create(DatagridColumn, FilterTest, PROVIDERS_NEEDED);
                 this.context.testComponent.field = "test";
                 this.context.detectChanges();
                 expect(this.context.clarityElement.querySelectorAll("clr-dg-filter").length).toBe(1);
@@ -169,7 +173,7 @@ export default function (): void {
             });
 
             it("prioritizes custom string filters over the default property name one", function () {
-                this.context = this.create(DatagridColumn, StringFilterTest, [Sort, FiltersProvider]);
+                this.context = this.create(DatagridColumn, StringFilterTest, PROVIDERS_NEEDED);
                 this.context.testComponent.field = "test";
                 this.context.detectChanges();
                 this.stringFilter = this.context.testComponent.stringFilter.filter;
@@ -185,7 +189,7 @@ export default function (): void {
             let context: TestContext<DatagridColumn, SimpleTest>;
 
             beforeEach(function () {
-                context = this.create(DatagridColumn, SimpleTest, [Sort, FiltersProvider]);
+                context = this.create(DatagridColumn, SimpleTest, PROVIDERS_NEEDED);
             });
 
             it("projects content", function () {
@@ -231,33 +235,33 @@ export default function (): void {
 
         describe("View filters", function () {
             it("doesn't display any filter by default", function () {
-                this.context = this.create(DatagridColumn, SimpleTest, [Sort, FiltersProvider]);
+                this.context = this.create(DatagridColumn, SimpleTest, PROVIDERS_NEEDED);
                 expect(this.context.clarityElement.querySelector("clr-dg-filter")).toBeNull();
             });
 
             it("displays a string filter when using a property name", function () {
-                this.context = this.create(DatagridColumn, SimpleTest, [Sort, FiltersProvider]);
+                this.context = this.create(DatagridColumn, SimpleTest, PROVIDERS_NEEDED);
                 this.context.testComponent.field = "test";
                 this.context.detectChanges();
                 expect(this.context.clarityElement.querySelector("clr-dg-string-filter")).not.toBeNull();
             });
 
             it("projects custom filters outside of the title", function () {
-                this.context = this.create(DatagridColumn, FilterTest, [Sort, FiltersProvider]);
+                this.context = this.create(DatagridColumn, FilterTest, PROVIDERS_NEEDED);
                 expect(this.context.clarityElement.querySelector(".my-filter")).not.toBeNull();
                 let title = this.context.clarityElement.querySelector(".datagrid-column-title");
                 expect(title.querySelector(".my-filter")).toBeNull();
             });
 
             it("projects custom string filters outside of the title", function () {
-                this.context = this.create(DatagridColumn, StringFilterTest, [Sort, FiltersProvider]);
+                this.context = this.create(DatagridColumn, StringFilterTest, PROVIDERS_NEEDED);
                 expect(this.context.clarityElement.querySelector(".my-string-filter")).not.toBeNull();
                 let title = this.context.clarityElement.querySelector(".datagrid-column-title");
                 expect(title.querySelector(".my-string-filter")).toBeNull();
             });
 
             it("un-registers the correct filter", function () {
-                this.context = this.create(DatagridColumn, UnregisterTest, [Sort, FiltersProvider]);
+                this.context = this.create(DatagridColumn, UnregisterTest, PROVIDERS_NEEDED);
                 this.context.testComponent.show = true;
                 this.context.clarityDirective.filters.add(new TestFilter());
                 this.context.clarityDirective.filters.add(new TestFilter());

--- a/src/clarity-angular/datagrid/datagrid-pagination.ts
+++ b/src/clarity-angular/datagrid/datagrid-pagination.ts
@@ -35,6 +35,8 @@ import {Subscription} from "rxjs/Subscription";
             </li>
         </ul>
     `,
+    // IE10 comes to pollute even our components declaration
+    styles: [`:host { display: block; }`]
 })
 export class DatagridPagination implements OnDestroy {
     constructor(public page: Page) {

--- a/src/clarity-angular/datagrid/datagrid-placeholder.ts
+++ b/src/clarity-angular/datagrid/datagrid-placeholder.ts
@@ -13,6 +13,8 @@ import {Page} from "./providers/page";
         <!--
             I hate doing this, with these 36px being baselineRem(1.5) hardcoded here,
             but I don't see a better solution right now.
+            
+            TODO: with the new flexbox layout, it might be possible to get rid of this!
         -->
         <div class="datagrid-placeholder" [style.min-height]="(36*nbEmptyRows)+'px'"
             *ngIf="nbEmptyRows > 0" [class.datagrid-empty]="emptyDatagrid">
@@ -20,7 +22,9 @@ import {Page} from "./providers/page";
             <ng-content *ngIf="emptyDatagrid"></ng-content>
         </div>
     `,
-    styles: [`:host { display: block; }`]
+    host: {
+        "[class.datagrid-placeholder-container]": "true"
+    }
 })
 export class DatagridPlaceholder {
     constructor(private items: Items, private page: Page) {}

--- a/src/clarity-angular/datagrid/datagrid-row.spec.ts
+++ b/src/clarity-angular/datagrid/datagrid-row.spec.ts
@@ -13,6 +13,7 @@ import {FiltersProvider} from "./providers/filters";
 import {Sort} from "./providers/sort";
 import {Page} from "./providers/page";
 import {RowActionService} from "./providers/row-action-service";
+import {DatagridRenderOrganizer} from "./render/render-organizer";
 
 export default function(): void {
     describe("DatagridRow component", function() {
@@ -21,8 +22,8 @@ export default function(): void {
         let selectionProvider: Selection;
 
         beforeEach(function () {
-            context = this.create(DatagridRow, FullTest, [Selection, Items, FiltersProvider, Sort, Page,
-                RowActionService]);
+            context = this.create(DatagridRow, FullTest,
+                [Selection, Items, FiltersProvider, Sort, Page, RowActionService, DatagridRenderOrganizer]);
             selectionProvider = TestBed.get(Selection);
         });
 

--- a/src/clarity-angular/datagrid/datagrid-row.ts
+++ b/src/clarity-angular/datagrid/datagrid-row.ts
@@ -16,7 +16,7 @@ import {RowActionService} from "./providers/row-action-service";
         <clr-dg-cell *ngIf="selection.selectionType === SELECTION_TYPE.Single" class="datagrid-select">
             <input type="radio" [name]="selection.id + '-radio'" [value]="item" [(ngModel)]="selection.currentSingle">
         </clr-dg-cell>
-        <clr-dg-cell *ngIf="rowActionService.actionableCount > 0" class="datagrid-single-select">
+        <clr-dg-cell *ngIf="rowActionService.actionableCount > 0" class="datagrid-row-actions">
             <ng-content select="clr-dg-action-overflow"></ng-content>
         </clr-dg-cell>
         <ng-content></ng-content>
@@ -26,8 +26,8 @@ import {RowActionService} from "./providers/row-action-service";
         "[class.datagrid-selected]": "selected"
     }
 })
-export class DatagridRow {
 
+export class DatagridRow {
     /* reference to the enum so that template can access */
     public SELECTION_TYPE = SelectionType;
 
@@ -36,8 +36,7 @@ export class DatagridRow {
      */
     @Input("clrDgItem") item: any;
 
-    constructor (public selection: Selection, public rowActionService: RowActionService) {
-    }
+    constructor(public selection: Selection, public rowActionService: RowActionService) {}
 
     private _selected = false;
     /**

--- a/src/clarity-angular/datagrid/datagrid.html
+++ b/src/clarity-angular/datagrid/datagrid.html
@@ -4,30 +4,29 @@
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
 
-<div class="datagrid-wrapper">
-    <div class="datagrid-content-wrapper">
-        <ng-content select="clr-dg-action-bar"></ng-content>
-        <div class="datagrid">
-            <div class="datagrid-head">
-                <div class="datagrid-row">
-                    <!-- header for datagrid where you can select multiple rows -->
-                    <div class="datagrid-column datagrid-select"
-                         *ngIf="selection.selectionType === SELECTION_TYPE.Multi">
+<ng-content select="clr-dg-action-bar"></ng-content>
+<div class="datagrid">
+    <div clrDgTableWrapper class="datagrid-table-wrapper">
+        <div clrDgHead class="datagrid-head">
+            <div class="datagrid-row">
+                <!-- header for datagrid where you can select multiple rows -->
+                <div class="datagrid-column datagrid-select"
+                     *ngIf="selection.selectionType === SELECTION_TYPE.Multi">
                         <span class="datagrid-column-title">
                             <clr-checkbox [(ngModel)]="allSelected"></clr-checkbox>
                         </span>
-                    </div>
-                    <!-- header for datagrid where you can select one row only -->
-                    <div class="datagrid-column datagrid-select"
-                         *ngIf="selection.selectionType === SELECTION_TYPE.Single">
-                    </div>
-                    <!-- header for single row action; only display if we have at least one actionable row in datagrid -->
-                    <div class="datagrid-column datagrid-row-actions" *ngIf="rowActionService.actionableCount > 0"></div>
-                    <ng-content select="clr-dg-column"></ng-content>
                 </div>
+                <!-- header for datagrid where you can select one row only -->
+                <div class="datagrid-column datagrid-select"
+                     *ngIf="selection.selectionType === SELECTION_TYPE.Single">
+                </div>
+                <!-- header for single row action; only display if we have at least one actionable row in datagrid -->
+                <div class="datagrid-column datagrid-row-actions" *ngIf="rowActionService.actionableCount > 0"></div>
+                <ng-content select="clr-dg-column"></ng-content>
             </div>
+        </div>
 
-        <div class="datagrid-body">
+        <div clrDgBody class="datagrid-body">
             <template *ngIf="iterator"
                       ngFor [ngForOf]="items.displayed" [ngForTrackBy]="iterator.trackBy"
                       [ngForTemplate]="iterator.template"></template>

--- a/src/clarity-angular/datagrid/datagrid.ts
+++ b/src/clarity-angular/datagrid/datagrid.ts
@@ -22,11 +22,15 @@ import {Page} from "./providers/page";
 import {Selection, SelectionType} from "./providers/selection";
 import {Sort} from "./providers/sort";
 import {RowActionService} from "./providers/row-action-service";
+import {DatagridRenderOrganizer} from "./render/render-organizer";
 
 @Component({
     selector: "clr-datagrid",
     templateUrl: "./datagrid.html",
-    providers: [Selection, Sort, FiltersProvider, Page, RowActionService, Items]
+    providers: [Selection, Sort, FiltersProvider, Page, RowActionService, Items, DatagridRenderOrganizer],
+    host: {
+        "[class.datagrid-container]": "true"
+    }
 })
 export class Datagrid implements AfterContentInit, AfterViewInit, OnDestroy {
 
@@ -172,8 +176,11 @@ export class Datagrid implements AfterContentInit, AfterViewInit, OnDestroy {
      * by querying the projected content. This is needed to keep track of the models currently
      * displayed, typically for selection.
      */
-    @ContentChildren(DatagridRow) public rows: QueryList<DatagridRow>;
+    @ContentChildren(DatagridRow) rows: QueryList<DatagridRow>;
+
     ngAfterContentInit() {
+        // TODO: Move all this to ngOnInit() once https://github.com/angular/angular/issues/12818 goes in.
+        // And when we do that, remove the manual step for each one.
         this._subscriptions.push(this.rows.changes.subscribe(() => {
             if (!this.items.smart) {
                 this.items.all = this.rows.map((row: DatagridRow) => row.item);
@@ -201,8 +208,9 @@ export class Datagrid implements AfterContentInit, AfterViewInit, OnDestroy {
             }
         }));
     }
+
     /**
-     * Subscriptions to all the services changes
+     * Subscriptions to all the services and queries changes
      */
     private _subscriptions: Subscription[] = [];
     ngOnDestroy() {

--- a/src/clarity-angular/datagrid/helpers.spec.ts
+++ b/src/clarity-angular/datagrid/helpers.spec.ts
@@ -33,7 +33,7 @@ export class TestContext<D, C> {
             let clarityDirectiveName = (<any>clarityDirectiveType).name;
             throw new Error(`Test component ${componentName} doesn't contain a ${clarityDirectiveName}`);
         }
-        this.clarityDirective = this.clarityDebugElement.componentInstance;
+        this.clarityDirective = this.clarityDebugElement.injector.get(clarityDirectiveType);
         this.clarityElement = this.clarityDebugElement.nativeElement;
     }
 

--- a/src/clarity-angular/datagrid/index.ts
+++ b/src/clarity-angular/datagrid/index.ts
@@ -18,6 +18,14 @@ import {DatagridPagination} from "./datagrid-pagination";
 import {DatagridRow} from "./datagrid-row";
 import {DatagridPlaceholder} from "./datagrid-placeholder";
 
+import {DatagridMainRenderer} from "./render/main-renderer";
+import {DatagridTableRenderer} from "./render/table-renderer";
+import {DatagridHeaderRenderer} from "./render/header-renderer";
+import {DatagridHeadRenderer} from "./render/head-renderer";
+import {DatagridBodyRenderer} from "./render/body-renderer";
+import {DatagridRowRenderer} from "./render/row-renderer";
+import {DatagridCellRenderer} from "./render/cell-renderer";
+
 export * from "./datagrid";
 export * from "./datagrid-action-bar";
 export * from "./datagrid-action-overflow";
@@ -52,6 +60,15 @@ export const DATAGRID_DIRECTIVES: Type<any>[] = [
     DatagridFooter,
     DatagridPagination,
     DatagridPlaceholder,
+
+    // Renderers
+    DatagridMainRenderer,
+    DatagridTableRenderer,
+    DatagridHeadRenderer,
+    DatagridHeaderRenderer,
+    DatagridBodyRenderer,
+    DatagridRowRenderer,
+    DatagridCellRenderer,
 
     // Built-in shortcuts
     DatagridStringFilter

--- a/src/clarity-angular/datagrid/providers/row-action-service.ts
+++ b/src/clarity-angular/datagrid/providers/row-action-service.ts
@@ -4,9 +4,13 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import {Injectable} from "@angular/core";
+import {DatagridRenderOrganizer} from "../render/render-organizer";
 
 @Injectable()
 export class RowActionService {
+
+    constructor(private renderOrganizer: DatagridRenderOrganizer) {}
+
     /**
      * a value of 0 means no rows with action
      */
@@ -23,6 +27,35 @@ export class RowActionService {
         this._actionableCount--;
     }
 
+    /*
+     * Ad-hoc dirty lock, handling only a single pending action
+     */
+    private locked = false;
+    private waiting: () => void;
 
+    public open(fn: () => void) {
+        if (!this.locked) {
+            this.locked = true;
+            fn();
+            // Scrollbar might have disappeared, we need to warn the renderers
+            // TODO: A webkit bug prevents us from simply refreshing the scrollbar. Weird. Needs investigation.
+            // this.renderOrganizer.scrollbar.next();
+            this.renderOrganizer.resize();
+        } else {
+            this.waiting = fn;
+        }
+    }
 
+    public close() {
+        if (this.waiting) {
+            this.waiting();
+            delete this.waiting;
+        } else {
+            this.locked = false;
+            // Scrollbar might have appeared, we need to warn the renderers
+            // TODO: A webkit bug prevents us from simply refreshing the scrollbar. Weird. Needs investigation.
+            // this.renderOrganizer.scrollbar.next();
+            this.renderOrganizer.resize();
+        }
+    }
 }

--- a/src/clarity-angular/datagrid/render/body-renderer.spec.ts
+++ b/src/clarity-angular/datagrid/render/body-renderer.spec.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component} from "@angular/core";
+import {TestContext} from "../helpers.spec";
+import {DatagridBodyRenderer} from "./body-renderer";
+import {DatagridRenderOrganizer} from "./render-organizer";
+import {DomAdapter} from "./dom-adapter";
+import {MockDomAdapter, MOCK_DOM_ADAPTER_PROVIDER} from "./dom-adapter.mock";
+
+export default function(): void {
+    describe("DatagridBodyRenderer directive", function() {
+        let context: TestContext<DatagridBodyRenderer, SimpleTest>;
+
+        beforeEach(function() {
+            context = this.create(DatagridBodyRenderer, SimpleTest,
+                [DatagridRenderOrganizer, MOCK_DOM_ADAPTER_PROVIDER]);
+        });
+
+        it("emits its scrollbar width when notified of a change", function() {
+            let mockDomAdapter: MockDomAdapter = context.getClarityProvider(DomAdapter);
+            let organizer: DatagridRenderOrganizer = context.getClarityProvider(DatagridRenderOrganizer);
+            let scrollbarWidth: number;
+            organizer.scrollbarWidth.subscribe(width => scrollbarWidth = width);
+            expect(scrollbarWidth).toBeUndefined();
+            organizer.scrollbar.next();
+            expect(scrollbarWidth).toBe(0);
+            mockDomAdapter._scrollBarWidth = 42;
+            organizer.scrollbar.next();
+            expect(scrollbarWidth).toBe(42);
+        });
+    });
+}
+
+@Component({
+    template: `<div clrDgBody>Hello world</div>`
+})
+class SimpleTest {
+}

--- a/src/clarity-angular/datagrid/render/body-renderer.ts
+++ b/src/clarity-angular/datagrid/render/body-renderer.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Directive, ElementRef, OnDestroy} from "@angular/core";
+import {Subscription} from "rxjs/Subscription";
+import {DatagridRenderOrganizer} from "./render-organizer";
+import {DomAdapter} from "./dom-adapter";
+
+@Directive({
+    selector: "[clrDgBody]"
+})
+export class DatagridBodyRenderer implements OnDestroy {
+
+    constructor(private el: ElementRef, private organizer: DatagridRenderOrganizer, private domAdapter: DomAdapter) {
+        this.subscription = organizer.scrollbar.subscribe(() => this.computeScrollbarWidth());
+    }
+
+    private subscription: Subscription;
+    ngOnDestroy() {
+        this.subscription.unsubscribe();
+    }
+
+    private computeScrollbarWidth() {
+        this.organizer.scrollbarWidth.next(this.domAdapter.scrollBarWidth(this.el.nativeElement));
+    }
+}

--- a/src/clarity-angular/datagrid/render/cell-renderer.spec.ts
+++ b/src/clarity-angular/datagrid/render/cell-renderer.spec.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component} from "@angular/core";
+import {TestContext} from "../helpers.spec";
+import {DatagridCellRenderer} from "./cell-renderer";
+import {DatagridRenderOrganizer} from "./render-organizer";
+import {MockDatagridRenderOrganizer, MOCK_ORGANIZER_PROVIDER} from "./render-organizer.mock";
+
+export default function(): void {
+    describe("DatagridCellRenderer directive", function() {
+        let context: TestContext<DatagridCellRenderer, SimpleTest>;
+        let organizer: MockDatagridRenderOrganizer;
+
+        beforeEach(function() {
+            context = this.create(DatagridCellRenderer, SimpleTest, [MOCK_ORGANIZER_PROVIDER]);
+            organizer = context.getClarityProvider(DatagridRenderOrganizer);
+        });
+
+        it("allows to set the width of the cell in pixels", function() {
+            expect(context.clarityElement.style.width).toBeFalsy();
+            context.clarityDirective.setWidth(false, 42);
+            expect(context.clarityElement.style.width).toBe("42px");
+        });
+
+        it("makes the cell non-flexible if and only if the width is strict", function() {
+            context.clarityDirective.setWidth(true, 42);
+            expect(context.clarityElement.style.width).toBe("42px");
+            expect(context.clarityElement.classList).toContain("datagrid-fixed-width");
+            context.clarityDirective.setWidth(false, 42);
+            expect(context.clarityElement.classList).not.toContain("datagrid-fixed-width");
+        });
+
+        it("resets the cell to default width when notified", function() {
+            context.clarityDirective.setWidth(true, 42);
+            expect(context.clarityElement.style.width).toBe("42px");
+            expect(context.clarityElement.classList).toContain("datagrid-fixed-width");
+            organizer.clearWidths.next();
+            expect(context.clarityElement.style.width).toBeFalsy();
+            expect(context.clarityElement.classList).not.toContain("datagrid-fixed-width");
+        });
+    });
+}
+
+@Component({
+    template: `<clr-dg-cell>Hello world</clr-dg-cell>`
+})
+class SimpleTest {
+}

--- a/src/clarity-angular/datagrid/render/cell-renderer.ts
+++ b/src/clarity-angular/datagrid/render/cell-renderer.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Directive, ElementRef, Renderer, OnDestroy} from "@angular/core";
+import {Subscription} from "rxjs/Subscription";
+import {STRICT_WIDTH_CLASS} from "./constants";
+import {DatagridRenderOrganizer} from "./render-organizer";
+
+@Directive({
+    selector: "clr-dg-cell"
+})
+export class DatagridCellRenderer implements OnDestroy {
+
+    constructor(private el: ElementRef, private renderer: Renderer, organizer: DatagridRenderOrganizer) {
+        this.subscription = organizer.clearWidths.subscribe(() => this.clearWidth());
+    }
+
+    private subscription: Subscription;
+    ngOnDestroy() {
+        this.subscription.unsubscribe();
+    }
+
+    private clearWidth() {
+        this.renderer.setElementClass(this.el.nativeElement, STRICT_WIDTH_CLASS, false);
+        this.renderer.setElementStyle(this.el.nativeElement, "width", null);
+    }
+
+    public setWidth(strict: boolean, value: number) {
+        this.renderer.setElementClass(this.el.nativeElement, STRICT_WIDTH_CLASS, strict);
+        this.renderer.setElementStyle(this.el.nativeElement, "width", value + "px");
+    }
+}

--- a/src/clarity-angular/datagrid/render/constants.ts
+++ b/src/clarity-angular/datagrid/render/constants.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+export const COMPUTE_WIDTH_CLASS = "datagrid-computing-columns-width";
+export const STRICT_WIDTH_CLASS = "datagrid-fixed-width";

--- a/src/clarity-angular/datagrid/render/dom-adapter.mock.ts
+++ b/src/clarity-angular/datagrid/render/dom-adapter.mock.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import {DomAdapter} from "./dom-adapter";
+
+export class MockDomAdapter extends DomAdapter {
+
+    _userDefinedWidth = 0;
+    userDefinedWidth(element: any): number {
+        return this._userDefinedWidth;
+    }
+
+    _scrollBarWidth = 0;
+    scrollBarWidth(element: any) {
+        return this._scrollBarWidth;
+    }
+
+    _scrollWidth = 0;
+    scrollWidth(element: any) {
+        return this._scrollWidth;
+    }
+}
+
+export const MOCK_DOM_ADAPTER_PROVIDER = {provide: DomAdapter, useClass: MockDomAdapter};

--- a/src/clarity-angular/datagrid/render/dom-adapter.spec.ts
+++ b/src/clarity-angular/datagrid/render/dom-adapter.spec.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {DomAdapter} from "./dom-adapter";
+
+/**
+ * Having a little fun with Typescript just to see how it goes.
+ */
+interface UserContext {
+    domAdapter: DomAdapter;
+    element: HTMLElement;
+}
+
+export default function(): void {
+    describe("DomAdapter", function() {
+        beforeEach(function(this: UserContext) {
+            this.domAdapter = new DomAdapter();
+            this.element = document.createElement("div");
+            this.element.appendChild(document.createTextNode("Hello"));
+            document.body.appendChild(this.element);
+        });
+
+        afterEach(function(this: UserContext) {
+            document.body.removeChild(this.element);
+        });
+
+        it("computes the scrollwidth of an element", function(this: UserContext) {
+            let child = document.createElement("div");
+            child.style.width = "1234px";
+            child.style.height = "10px";
+            this.element.appendChild(child);
+            expect(this.domAdapter.scrollWidth(this.element)).toBe(1234);
+        });
+
+        it("computes the width of the scrollbar on an element", function(this: UserContext) {
+            expect(this.domAdapter.scrollBarWidth(this.element)).toBe(0);
+            this.element.style.overflow = "scroll";
+            // This will actually fail on "good" OSX browsers, even though the behavior is correct.
+            // So it runs only on PhantomJs at the moment.
+            if (/PhantomJS/.test(window.navigator.userAgent)) {
+                expect(this.domAdapter.scrollBarWidth(this.element)).toBeGreaterThan(0);
+            }
+        });
+
+        describe("user-defined width", function() {
+            it("recognizes a width defined on the element", function(this: UserContext) {
+                expect(this.domAdapter.userDefinedWidth(this.element)).toBe(0);
+                this.element.style.width = "42px";
+                expect(this.domAdapter.userDefinedWidth(this.element)).toBe(42);
+            });
+
+            it("recognizes a width defined in a CSS stylesheet", function(this: UserContext) {
+                expect(this.domAdapter.userDefinedWidth(this.element)).toBe(0);
+                let style = document.createElement("style");
+                style.appendChild(document.createTextNode(".my-test { width: 42px; }"));
+                document.body.appendChild(style);
+                this.element.classList.add("my-test");
+                expect(this.domAdapter.userDefinedWidth(this.element)).toBe(42);
+                document.body.removeChild(style);
+            });
+
+            it("ignores padding and border", function(this: UserContext) {
+                this.element.style.padding = "10px";
+                this.element.style.border = "5px solid black";
+                expect(this.domAdapter.userDefinedWidth(this.element)).toBe(0);
+            });
+        });
+
+    });
+};

--- a/src/clarity-angular/datagrid/render/dom-adapter.ts
+++ b/src/clarity-angular/datagrid/render/dom-adapter.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+/*
+ * If we someday want to be able to render the datagrid in a webworker,
+ * this is where we would test if we're in headless mode. Right now it's not testing anything, but any access
+ * to native DOM elements' methods and properties in the Datagrid happens here.
+ */
+
+import {Injectable} from "@angular/core";
+
+@Injectable()
+export class DomAdapter {
+
+    userDefinedWidth(element: any): number {
+        element.classList.add("datagrid-cell-width-zero");
+        let userDefinedWidth = parseInt(getComputedStyle(element).getPropertyValue("width"), 10);
+        element.classList.remove("datagrid-cell-width-zero");
+        return userDefinedWidth;
+    }
+
+    scrollBarWidth(element: any) {
+        return element.offsetWidth - element.clientWidth;
+    }
+
+    scrollWidth(element: any) {
+        return element.scrollWidth || 0;
+    }
+}

--- a/src/clarity-angular/datagrid/render/head-renderer.spec.ts
+++ b/src/clarity-angular/datagrid/render/head-renderer.spec.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component} from "@angular/core";
+import {TestContext} from "../helpers.spec";
+import {DatagridHeadRenderer} from "./head-renderer";
+import {DatagridRenderOrganizer} from "./render-organizer";
+import {MockDatagridRenderOrganizer, MOCK_ORGANIZER_PROVIDER} from "./render-organizer.mock";
+
+export default function(): void {
+    describe("DatagridHeadRenderer directive", function() {
+        let context: TestContext<DatagridHeadRenderer, SimpleTest>;
+        let organizer: MockDatagridRenderOrganizer;
+
+        beforeEach(function() {
+            context = this.create(DatagridHeadRenderer, SimpleTest, [MOCK_ORGANIZER_PROVIDER]);
+            organizer = context.getClarityProvider(DatagridRenderOrganizer);
+        });
+
+        it("adds right padding corresponding to the scrollbar of the body", function() {
+            organizer.scrollbarWidth.next(42);
+            expect(context.clarityElement.style.paddingRight).toBe("42px");
+            organizer.scrollbarWidth.next(0);
+            expect(context.clarityElement.style.paddingRight).toBe("0px");
+        });
+    });
+}
+
+@Component({
+    template: `<div clrDgHead>Hello world</div>`
+})
+class SimpleTest {
+}

--- a/src/clarity-angular/datagrid/render/head-renderer.ts
+++ b/src/clarity-angular/datagrid/render/head-renderer.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Directive, ElementRef, Renderer, OnDestroy} from "@angular/core";
+import {Subscription} from "rxjs/Subscription";
+import {DatagridRenderOrganizer} from "./render-organizer";
+
+@Directive({
+    selector: "[clrDgHead]"
+})
+export class DatagridHeadRenderer implements OnDestroy {
+
+    constructor(private el: ElementRef, private renderer: Renderer, organizer: DatagridRenderOrganizer) {
+        this.subscription = organizer.scrollbarWidth.subscribe(width => this.accountForScrollbar(width));
+    }
+
+    private subscription: Subscription;
+    ngOnDestroy() {
+        this.subscription.unsubscribe();
+    }
+
+    private accountForScrollbar(width: number) {
+        this.renderer.setElementStyle(this.el.nativeElement, "padding-right", width + "px");
+    }
+}

--- a/src/clarity-angular/datagrid/render/header-renderer.spec.ts
+++ b/src/clarity-angular/datagrid/render/header-renderer.spec.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component} from "@angular/core";
+import {TestContext} from "../helpers.spec";
+import {DatagridHeaderRenderer} from "./header-renderer";
+import {DomAdapter} from "./dom-adapter";
+import {DatagridRenderOrganizer} from "./render-organizer";
+import {MockDatagridRenderOrganizer, MOCK_ORGANIZER_PROVIDER} from "./render-organizer.mock";
+import {MockDomAdapter, MOCK_DOM_ADAPTER_PROVIDER} from "./dom-adapter.mock";
+import {Sort} from "../providers/sort";
+import {FiltersProvider} from "../providers/filters";
+
+export default function(): void {
+    describe("DatagridHeaderRenderer directive", function() {
+        let context: TestContext<DatagridHeaderRenderer, SimpleTest>;
+        let domAdapter: MockDomAdapter;
+        let organizer: MockDatagridRenderOrganizer;
+
+        beforeEach(function() {
+            context = this.create(DatagridHeaderRenderer, SimpleTest,
+                [MOCK_ORGANIZER_PROVIDER, MOCK_DOM_ADAPTER_PROVIDER, Sort, FiltersProvider]);
+            domAdapter = context.getClarityProvider(DomAdapter);
+            organizer = context.getClarityProvider(DatagridRenderOrganizer);
+        });
+
+        it("computes and sets the width of a column based on its scrollWidth", function() {
+            domAdapter._scrollWidth = 42;
+            expect(context.clarityDirective.computeWidth()).toBe(42);
+            expect(context.clarityElement.style.width).toBe("42px");
+        });
+
+        it("resets the column to default width when notified", function() {
+            domAdapter._scrollWidth = 42;
+            context.clarityDirective.computeWidth();
+            expect(context.clarityElement.style.width).toBe("42px");
+            organizer.clearWidths.next();
+            expect(context.clarityElement.style.width).toBeFalsy();
+        });
+
+        it("sets a strict column width upon clearing when the user declared one", function() {
+            domAdapter._userDefinedWidth = 42;
+            organizer.clearWidths.next();
+            expect(context.clarityDirective.strictWidth).toBe(42);
+            domAdapter._userDefinedWidth = 0;
+            organizer.clearWidths.next();
+            expect(context.clarityDirective.strictWidth).toBeUndefined();
+        });
+
+        it("does not remove the width defined by the user", function() {
+            context.clarityElement.style.width = "42px";
+            domAdapter._userDefinedWidth = 42;
+            organizer.clearWidths.next();
+            expect(context.clarityElement.style.width).toBe("42px");
+            // One extra cycle to be sure, because clearing widths before computing them
+            // might have a special case handling
+            context.clarityDirective.computeWidth();
+            expect(context.clarityElement.style.width).toBe("42px");
+            organizer.clearWidths.next();
+            expect(context.clarityElement.style.width).toBe("42px");
+        });
+
+        it("does not set the width when the user declared a strict one", function() {
+            domAdapter._scrollWidth = 42;
+            context.clarityDirective.strictWidth = 24;
+            expect(context.clarityDirective.computeWidth()).toBe(24);
+            expect(context.clarityElement.style.width).toBeFalsy();
+            expect(context.clarityElement.classList).toContain("datagrid-fixed-width");
+            delete context.clarityDirective.strictWidth;
+            expect(context.clarityDirective.computeWidth()).toBe(42);
+            expect(context.clarityElement.style.width).toBe("42px");
+            expect(context.clarityElement.classList).not.toContain("datagrid-fixed-width");
+        });
+    });
+}
+
+@Component({
+    template: `<clr-dg-column>Hello world</clr-dg-column>`
+})
+class SimpleTest {
+}

--- a/src/clarity-angular/datagrid/render/header-renderer.ts
+++ b/src/clarity-angular/datagrid/render/header-renderer.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Directive, ElementRef, Renderer, OnDestroy} from "@angular/core";
+import {Subscription} from "rxjs/Subscription";
+import {DomAdapter} from "./dom-adapter";
+import {STRICT_WIDTH_CLASS} from "./constants";
+import {DatagridRenderOrganizer} from "./render-organizer";
+
+@Directive({
+    selector: "clr-dg-column"
+})
+export class DatagridHeaderRenderer implements OnDestroy {
+
+    constructor(private el: ElementRef, private renderer: Renderer, private domAdapter: DomAdapter,
+                organizer: DatagridRenderOrganizer) {
+        this.subscription = organizer.clearWidths.subscribe(() => this.clearWidth());
+    }
+
+    private subscription: Subscription;
+    ngOnDestroy() {
+        this.subscription.unsubscribe();
+    }
+
+    /**
+     * Indicates if the column has a strict width, so it doesn't grow or shrink
+     */
+    public strictWidth: number;
+
+    private widthSet = false;
+
+    private clearWidth() {
+        this.renderer.setElementClass(this.el.nativeElement, STRICT_WIDTH_CLASS, false);
+        // We only clear if we set the width ourselves, otherwise we risk clearing consumer styles.
+        if (this.widthSet) {
+            this.renderer.setElementStyle(this.el.nativeElement, "width", null);
+            this.widthSet = false;
+        }
+        let strictWidth = this.domAdapter.userDefinedWidth(this.el.nativeElement);
+        if (strictWidth) {
+            this.strictWidth = strictWidth;
+        } else {
+            delete this.strictWidth;
+        }
+    }
+
+    public computeWidth(): number {
+        if (this.strictWidth) {
+            // We do NOT set the width here, since we know the user already provided it.
+            this.renderer.setElementClass(this.el.nativeElement, STRICT_WIDTH_CLASS, true);
+            return this.strictWidth;
+        } else {
+            let width = this.domAdapter.scrollWidth(this.el.nativeElement);
+            this.renderer.setElementClass(this.el.nativeElement, STRICT_WIDTH_CLASS, false);
+            this.renderer.setElementStyle(this.el.nativeElement, "width", width + "px");
+            this.widthSet = true;
+            return width;
+        }
+    }
+}

--- a/src/clarity-angular/datagrid/render/main-renderer.spec.ts
+++ b/src/clarity-angular/datagrid/render/main-renderer.spec.ts
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component} from "@angular/core";
+import {TestContext} from "../helpers.spec";
+import {DatagridMainRenderer} from "./main-renderer";
+import {DatagridRenderOrganizer} from "./render-organizer";
+import {DatagridHeaderRenderer} from "./header-renderer";
+
+export default function(): void {
+    describe("DatagridMainRenderer directive", function() {
+        describe("static loading", function() {
+            let context: TestContext<DatagridMainRenderer, StaticTest>;
+            let organizer: DatagridRenderOrganizer;
+            let resizeSpy: jasmine.Spy;
+            let computeWidthSpy: jasmine.Spy;
+
+            beforeEach(function() {
+                resizeSpy = spyOn(DatagridRenderOrganizer.prototype, "resize");
+                context = this.create(DatagridMainRenderer, StaticTest);
+                organizer = context.getClarityProvider(DatagridRenderOrganizer);
+                computeWidthSpy = spyOn(DatagridHeaderRenderer.prototype, "computeWidth");
+            });
+
+            it("triggers the render process on initialization", function() {
+                expect(resizeSpy.calls.count()).toBe(1);
+            });
+
+            it("re-triggers the render process whenever the columns change", function() {
+                resizeSpy.calls.reset();
+                expect(resizeSpy.calls.count()).toBe(0);
+                context.testComponent.secondColumn = false;
+                context.detectChanges();
+                expect(resizeSpy.calls.count()).toBe(1);
+                context.testComponent.secondColumn = true;
+                context.detectChanges();
+                expect(resizeSpy.calls.count()).toBe(2);
+            });
+
+            it("does not re-triggers the render process when the rows change", function() {
+                resizeSpy.calls.reset();
+                expect(resizeSpy.calls.count()).toBe(0);
+                context.testComponent.firstRow = false;
+                context.detectChanges();
+                expect(resizeSpy.calls.count()).toBe(0);
+                context.testComponent.firstRow = true;
+                context.detectChanges();
+                expect(resizeSpy.calls.count()).toBe(0);
+            });
+
+            it("computes the widths of the columns when notified", function() {
+                expect(computeWidthSpy.calls.count()).toBe(0);
+                // Too lazy to do something other than casting right now.
+                (<any>organizer)._computeWidths.next();
+                expect(computeWidthSpy.calls.count()).toBe(context.clarityDirective.headers.length);
+            });
+
+            it("sets the widths of the columns for the other components", function() {
+                expect(organizer.widths.length).toBe(0);
+                // Too lazy to do something other than casting right now.
+                (<any>organizer)._computeWidths.next();
+                expect(organizer.widths.length).toBe(context.clarityDirective.headers.length);
+            });
+        });
+
+        describe("dynamic loading", function() {
+            let context: TestContext<DatagridMainRenderer, DynamicTest>;
+            let resizeSpy: jasmine.Spy;
+
+            beforeEach(function() {
+                resizeSpy = spyOn(DatagridRenderOrganizer.prototype, "resize");
+                context = this.create(DatagridMainRenderer, DynamicTest);
+            });
+
+            it("does not trigger the render process until the rows are loaded", function() {
+                expect(resizeSpy.calls.count()).toBe(0);
+                context.testComponent.rowsReady = true;
+                context.detectChanges();
+                expect(resizeSpy.calls.count()).toBe(1);
+            });
+
+            it("ignores columns changes until the rows are loaded", function() {
+                context.testComponent.secondColumn = false;
+                context.detectChanges();
+                expect(resizeSpy.calls.count()).toBe(0);
+                context.testComponent.rowsReady = true;
+                context.detectChanges();
+                expect(resizeSpy.calls.count()).toBe(1);
+                context.testComponent.secondColumn = true;
+                context.detectChanges();
+                expect(resizeSpy.calls.count()).toBe(2);
+            });
+        });
+
+        describe("smart columns width", function() {
+            let context: TestContext<DatagridMainRenderer, ColumnsWidthTest>;
+            let organizer: DatagridRenderOrganizer;
+
+            beforeEach(function() {
+                context = this.create(DatagridMainRenderer, ColumnsWidthTest);
+                organizer = context.getClarityProvider(DatagridRenderOrganizer);
+            });
+
+            it("gives identical columns the same width", function() {
+                expect(organizer.widths[0].px).toBe(organizer.widths[1].px);
+            });
+
+            it("uses headers content to compute columns width", function() {
+                context.testComponent.firstHeader = "ZZZZZZ";
+                context.detectChanges();
+                organizer.resize();
+                expect(organizer.widths[0].px).toBeGreaterThan(organizer.widths[1].px);
+                context.testComponent.firstHeader = "AAA";
+                context.testComponent.secondHeader = "ZZZZZZ";
+                context.detectChanges();
+                organizer.resize();
+                expect(organizer.widths[0].px).toBeLessThan(organizer.widths[1].px);
+            });
+
+            it("uses cells content to compute columns width", function() {
+                context.testComponent.firstCell = "ZZZZZZ";
+                context.detectChanges();
+                organizer.resize();
+                expect(organizer.widths[0].px).toBeGreaterThan(organizer.widths[1].px);
+                context.testComponent.firstCell = "AAA";
+                context.testComponent.secondCell = "ZZZZZZ";
+                context.detectChanges();
+                organizer.resize();
+                expect(organizer.widths[0].px).toBeLessThan(organizer.widths[1].px);
+            });
+
+
+            it("correctly sets strict widths", function() {
+                context.testComponent.fixedWidth = true;
+                context.detectChanges();
+                expect(organizer.widths[0].strict).toBe(true);
+                expect(organizer.widths[1].strict).toBe(false);
+            });
+        });
+    });
+}
+
+@Component({
+    template: `
+        <clr-datagrid>
+            <clr-dg-column>AAA</clr-dg-column>
+            <clr-dg-column *ngIf="secondColumn">AAA</clr-dg-column>
+            <clr-dg-row *ngIf="firstRow">
+                <clr-dg-cell>BBB</clr-dg-cell>
+                <clr-dg-cell>BBB</clr-dg-cell>
+            </clr-dg-row>
+            <clr-dg-row *ngIf="!firstRow">
+                <clr-dg-cell>CCC</clr-dg-cell>
+                <clr-dg-cell>CCC</clr-dg-cell>
+            </clr-dg-row>
+        </clr-datagrid>
+    `
+})
+class StaticTest {
+    secondColumn = true;
+    firstRow = true;
+}
+
+@Component({
+    template: `
+        <clr-datagrid>
+            <clr-dg-column>AAA</clr-dg-column>
+            <clr-dg-column *ngIf="secondColumn">AAA</clr-dg-column>
+            <clr-dg-row *ngIf="rowsReady">
+                <clr-dg-cell>BBB</clr-dg-cell>
+                <clr-dg-cell>BBB</clr-dg-cell>
+            </clr-dg-row>
+        </clr-datagrid>
+    `
+})
+class DynamicTest {
+    secondColumn = true;
+    rowsReady = false;
+}
+
+@Component({
+    template: `
+        <clr-datagrid>
+            <clr-dg-column *ngIf="fixedWidth" [style.width.px]="42">Fixed width</clr-dg-column>
+            <clr-dg-column>{{firstHeader}}</clr-dg-column>
+            <clr-dg-column>{{secondHeader}}</clr-dg-column>
+            <clr-dg-row>
+                <clr-dg-cell *ngIf="fixedWidth">Fixed width</clr-dg-cell>
+                <clr-dg-cell>{{firstCell}}</clr-dg-cell>
+                <clr-dg-cell>{{secondCell}}</clr-dg-cell>
+            </clr-dg-row>
+        </clr-datagrid>
+    `
+})
+class ColumnsWidthTest {
+    firstHeader = "AAA";
+    secondHeader = "AAA";
+    firstCell = "BBB";
+    secondCell = "BBB";
+
+    fixedWidth = false;
+}

--- a/src/clarity-angular/datagrid/render/main-renderer.ts
+++ b/src/clarity-angular/datagrid/render/main-renderer.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Directive, ContentChildren, QueryList, AfterContentInit, AfterViewInit, OnDestroy} from "@angular/core";
+import {Subscription} from "rxjs/Subscription";
+import {DomAdapter} from "./dom-adapter";
+import {DatagridRenderOrganizer} from "./render-organizer";
+import {DatagridHeaderRenderer} from "./header-renderer";
+import {DatagridRowRenderer} from "./row-renderer";
+
+@Directive({
+    selector: "clr-datagrid",
+    providers: [DomAdapter]
+})
+export class DatagridMainRenderer implements AfterContentInit, AfterViewInit, OnDestroy {
+
+    constructor(private organizer: DatagridRenderOrganizer) {
+        this._subscriptions.push(organizer.computeWidths.subscribe(() => this.computeHeadersWidth()));
+    }
+
+    @ContentChildren(DatagridHeaderRenderer) public headers: QueryList<DatagridHeaderRenderer>;
+    @ContentChildren(DatagridRowRenderer) public rows: QueryList<DatagridRowRenderer>;
+
+    /*
+     * Are directives even allowed to do that?
+     * It works because it's always attached on the same element as a component since they share the same selector,
+     * but it feels like cheating.
+     */
+    ngAfterContentInit() {
+        this._subscriptions.push(this.headers.changes.subscribe(() => {
+            // TODO: only re-stabilize if a column was added or removed. Reordering is fine.
+            this.columnsSizesStable = false;
+            this.stabilizeColumns();
+        }));
+
+        this._subscriptions.push(this.rows.changes.subscribe(() => {
+            this.stabilizeColumns();
+        }));
+    }
+
+    ngAfterViewInit() {
+        this.stabilizeColumns();
+    }
+
+    private _subscriptions: Subscription[] = [];
+    ngOnDestroy() {
+        this._subscriptions.forEach(sub => sub.unsubscribe());
+    }
+
+    /**
+     * Makes each header compute its width.
+     */
+    private computeHeadersWidth() {
+        this.headers.forEach((header, index) => {
+            let width = header.computeWidth();
+            this.organizer.widths[index] = {px: width, strict: !!header.strictWidth};
+        });
+    }
+
+    /**
+     * Indicates if we want to re-compute columns width. This should only happen:
+     * 1) When headers change, with columns being added or removed
+     * 2) When rows are lazily loaded for the first time
+     */
+    private columnsSizesStable = false;
+
+    /**
+     * Triggers a whole re-rendring cycle to set column sizes, if needed.
+     */
+    private stabilizeColumns() {
+        if (this.columnsSizesStable) { return; }
+        // No point resizing if there are no rows, we wait until they are actually loaded.
+        if (this.rows.length > 0) {
+            this.organizer.resize();
+            this.columnsSizesStable = true;
+        }
+    }
+}

--- a/src/clarity-angular/datagrid/render/render-organizer.mock.ts
+++ b/src/clarity-angular/datagrid/render/render-organizer.mock.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import {Injectable} from "@angular/core";
+import {Subject} from "rxjs/Subject";
+import {DatagridRenderOrganizer} from "./render-organizer";
+
+/**
+ * Mock that gives direct access to the subjects, to trigger specific parts of the render cycle.
+ */
+@Injectable()
+export class MockDatagridRenderOrganizer extends DatagridRenderOrganizer {
+
+    public get clearWidths(): Subject<any> {
+        return this._clearWidths;
+    }
+
+    public get tableMode(): Subject<boolean> {
+        return this._tableMode;
+    }
+
+    public get computeWidths(): Subject<any> {
+        return this._computeWidths;
+    }
+
+    public get alignColumns(): Subject<any> {
+        return this._alignColumns;
+    }
+
+}
+
+export const MOCK_ORGANIZER_PROVIDER = {provide: DatagridRenderOrganizer, useClass: MockDatagridRenderOrganizer};

--- a/src/clarity-angular/datagrid/render/render-organizer.spec.ts
+++ b/src/clarity-angular/datagrid/render/render-organizer.spec.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {DatagridRenderOrganizer} from "./render-organizer";
+
+/**
+ * Having a little fun with Typescript just to see how it goes.
+ */
+interface UserContext {
+    organizer: DatagridRenderOrganizer;
+}
+
+export default function(): void {
+    describe("DatagridRenderOrganizer", function() {
+        beforeEach(function(this: UserContext) {
+            this.organizer = new DatagridRenderOrganizer();
+        });
+
+        it("follows the correct rendering order", function(this: UserContext) {
+            let step = 0;
+            this.organizer.clearWidths.subscribe(() => expect(step++).toBe(0));
+            this.organizer.tableMode.subscribe(on => expect(step++).toBe(on ? 1 : 3));
+            this.organizer.computeWidths.subscribe(() => expect(step++).toBe(2));
+            this.organizer.alignColumns.subscribe(() => expect(step++).toBe(4));
+            this.organizer.scrollbar.subscribe(() => expect(step++).toBe(5));
+            this.organizer.resize();
+        });
+
+        it("clears the widths when when resizing", function(this: UserContext) {
+            this.organizer.widths = [{px: 1, strict: false}, {px: 2, strict: true}];
+            this.organizer.resize();
+            expect(this.organizer.widths).toEqual([]);
+        });
+
+    });
+};

--- a/src/clarity-angular/datagrid/render/render-organizer.ts
+++ b/src/clarity-angular/datagrid/render/render-organizer.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import {Injectable} from "@angular/core";
+import {Subject} from "rxjs/Subject";
+import {Observable} from "rxjs";
+
+@Injectable()
+export class DatagridRenderOrganizer {
+
+    public widths: {px: number, strict: boolean}[] = [];
+
+    protected _clearWidths = new Subject<any>();
+    public get clearWidths(): Observable<any> {
+        return this._clearWidths.asObservable();
+    }
+
+    protected _tableMode = new Subject<boolean>();
+    public get tableMode(): Observable<boolean> {
+        return this._tableMode.asObservable();
+    }
+
+    protected _computeWidths = new Subject<any>();
+    public get computeWidths(): Observable<any> {
+        return this._computeWidths.asObservable();
+    }
+
+    protected _alignColumns = new Subject<any>();
+    public get alignColumns(): Observable<any> {
+        return this._alignColumns.asObservable();
+    }
+
+    public scrollbar = new Subject<any>();
+    public scrollbarWidth = new Subject<number>();
+
+    public resize() {
+        this.widths.length = 0;
+        this._clearWidths.next();
+        this._tableMode.next(true);
+        this._computeWidths.next();
+        this._tableMode.next(false);
+        this._alignColumns.next();
+        this.scrollbar.next();
+    }
+
+}

--- a/src/clarity-angular/datagrid/render/row-renderer.ts
+++ b/src/clarity-angular/datagrid/render/row-renderer.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Directive, ContentChildren, QueryList, OnDestroy, AfterViewInit} from "@angular/core";
+import {Subscription} from "rxjs/Subscription";
+import {DatagridRenderOrganizer} from "./render-organizer";
+import {DatagridCellRenderer} from "./cell-renderer";
+
+@Directive({
+    selector: "clr-dg-row"
+})
+export class DatagridRowRenderer implements OnDestroy, AfterViewInit {
+
+    constructor(private organizer: DatagridRenderOrganizer) {
+        this.subscription = organizer.alignColumns.subscribe(() => this.setWidths());
+    }
+
+    private subscription: Subscription;
+    ngOnDestroy() {
+        this.subscription.unsubscribe();
+    }
+
+    @ContentChildren(DatagridCellRenderer) cells: QueryList<DatagridCellRenderer>;
+
+    private setWidths() {
+        if (this.organizer.widths.length === 0) {
+            return;
+        }
+        this.cells.forEach((cell, index) => {
+            let width = this.organizer.widths[index];
+            cell.setWidth(width.strict, width.px);
+        });
+    }
+
+    /*
+     * Are directives even allowed to do that?
+     * It works because it's always attached on the same element as a component since they share the same selector,
+     * but it feels like cheating.
+     */
+    ngAfterViewInit() {
+        this.setWidths();
+    }
+}

--- a/src/clarity-angular/datagrid/render/table-renderer.spec.ts
+++ b/src/clarity-angular/datagrid/render/table-renderer.spec.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component} from "@angular/core";
+import {TestContext} from "../helpers.spec";
+import {DatagridTableRenderer} from "./table-renderer";
+import {DatagridRenderOrganizer} from "./render-organizer";
+import {MockDatagridRenderOrganizer, MOCK_ORGANIZER_PROVIDER} from "./render-organizer.mock";
+
+export default function(): void {
+    describe("DatagridTableRenderer directive", function() {
+        let context: TestContext<DatagridTableRenderer, SimpleTest>;
+        let organizer: MockDatagridRenderOrganizer;
+
+        beforeEach(function() {
+            context = this.create(DatagridTableRenderer, SimpleTest, [MOCK_ORGANIZER_PROVIDER]);
+            organizer = context.getClarityProvider(DatagridRenderOrganizer);
+        });
+
+        it("toggles in and out of table mode when notified", function() {
+            expect(context.clarityElement.classList).not.toContain("datagrid-computing-columns-width");
+            organizer.tableMode.next(true);
+            expect(context.clarityElement.classList).toContain("datagrid-computing-columns-width");
+            organizer.tableMode.next(false);
+            expect(context.clarityElement.classList).not.toContain("datagrid-computing-columns-width");
+        });
+    });
+}
+
+@Component({
+    template: `<div clrDgTableWrapper>Hello World</div>`
+})
+class SimpleTest {
+}

--- a/src/clarity-angular/datagrid/render/table-renderer.ts
+++ b/src/clarity-angular/datagrid/render/table-renderer.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Directive, ElementRef, Renderer, OnDestroy} from "@angular/core";
+import {Subscription} from "rxjs/Subscription";
+import {COMPUTE_WIDTH_CLASS} from "./constants";
+import {DatagridRenderOrganizer} from "./render-organizer";
+
+@Directive({
+    selector: "[clrDgTableWrapper]"
+})
+export class DatagridTableRenderer implements OnDestroy {
+
+    constructor(private el: ElementRef, private renderer: Renderer, organizer: DatagridRenderOrganizer) {
+        this.subscription = organizer.tableMode.subscribe(on => this.tableMode(on));
+    }
+
+    private subscription: Subscription;
+    ngOnDestroy() {
+        this.subscription.unsubscribe();
+    }
+
+    private tableMode(on: boolean) {
+        this.renderer.setElementClass(this.el.nativeElement, COMPUTE_WIDTH_CLASS, on);
+    }
+}

--- a/src/clarity-angular/popover/popover.ts
+++ b/src/clarity-angular/popover/popover.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+/*
+ * Do NOT Angular this up. It assumes we're in the DOM, plays with native elements, ...
+ * It could potentially be used as part of clarity-ui as a vanilla Javascript helper.
+ *
+ * WARNING: This is a quick prototype version, use at your own risks.
+ */
+
+export enum Direction {
+    RIGHT
+}
+
+export interface PopoverOptions {
+    offsetX?: number;
+    offsetY?: number;
+    userAnchorParent?: boolean;
+}
+
+const POSITION_RELATIVE = "relative";
+const POSITION_ABSOLUTE = "absolute";
+const POSITION_FIXED = "fixed";
+
+const OVERFLOW_SCROLL = "scroll";
+const OVERFLOW_AUTO = "auto";
+
+interface InlineOverflow {
+    both: string;
+    x: string;
+    y: string;
+}
+
+const OVERFLOW_HIDDEN: InlineOverflow = {
+    both: "hidden",
+    x: "hidden",
+    y: "hidden"
+};
+
+export class Popover {
+    constructor(private element: any) {
+        // Browsers don't agree with what to do if some of these are not specified, so we set them all to be safe.
+        element.style.position = POSITION_ABSOLUTE;
+        element.style.top = 0;
+        element.style.left = 0;
+    }
+
+    public anchor(anchor: any, direction: Direction,
+                  {offsetX = 0, offsetY = 0, userAnchorParent = false}: PopoverOptions = {}) {
+        // TODO: we are assuming here that the popover is inside or next to the anchor.
+        // We'd need to go up the popover tree too otherwise
+        this.preventScrolling(anchor);
+        if (userAnchorParent) {
+            anchor = anchor.parentNode;
+        }
+        let anchorRect = anchor.getBoundingClientRect();
+        let popoverRect = this.element.getBoundingClientRect();
+        let leftDiff: number;
+        let topDiff: number;
+        // TODO: obviously, handle direction
+        switch (direction) {
+            case Direction.RIGHT:
+                leftDiff = anchorRect.left + anchorRect.width - popoverRect.left + offsetX;
+                topDiff = anchorRect.top + anchorRect.height / 2 - popoverRect.top - popoverRect.height / 2 + offsetY;
+                break;
+            default:
+        }
+        this.element.style.transform = `translateX(${leftDiff}px) translateY(${topDiff}px)`;
+    }
+
+    public destroy() {
+        this.resumeScrolling();
+    }
+
+    private isPositioned(container: any) {
+        let position = getComputedStyle(container).position;
+        return position === POSITION_RELATIVE || position === POSITION_ABSOLUTE || position === POSITION_FIXED;
+    }
+
+    /*
+     * We prevent the containers up to the first positioned one from scrolling
+     */
+
+    private originalOverflows: {e: any, overflow: InlineOverflow}[] = [];
+
+    private preventScrolling(e: any) {
+        let current: any = e;
+        while (current && current !== document) {
+            if (this.scrolls(current)) {
+                this.originalOverflows.push({
+                    e: current,
+                    overflow: this.getInlineOverflow(current)
+                });
+                this.setInlineOverflow(current, OVERFLOW_HIDDEN);
+            }
+            if (this.isPositioned(current)) {
+                break;
+            }
+            current = current.parentNode;
+        }
+    }
+
+    private resumeScrolling() {
+        for (let container of this.originalOverflows) {
+            this.setInlineOverflow(container.e, container.overflow);
+        }
+        this.originalOverflows.length = 0;
+    }
+
+    private getInlineOverflow(container: any): InlineOverflow {
+        return {
+            both: container.style.overflow,
+            x: container.style.overflowX,
+            y: container.style.overflowY
+        };
+    }
+
+    private setInlineOverflow(container: any, overflow: InlineOverflow) {
+        container.style.overflow = overflow.both;
+        container.style.overflowX = overflow.x;
+        container.style.overflowY = overflow.y;
+    }
+
+    private scrolls(container: any): boolean {
+        let computedStyles = getComputedStyle(container);
+        return computedStyles.overflowX === OVERFLOW_SCROLL || computedStyles.overflowX === OVERFLOW_AUTO
+            || computedStyles.overflowY === OVERFLOW_SCROLL || computedStyles.overflowY === OVERFLOW_AUTO;
+    }
+}


### PR DESCRIPTION
## This is ready to go 👍 

We moved from `table-layout: auto`, which was very useful for smartly sizing columns but far too strict to allow all the features we are planning, to a flexbox layout.
    
Because of this, we have to manually handle column sizes, which bleeds quite a lot into our Typescript code. To make sure this is done as cleanly as possible, I wrote all the sizing logic in separate providers and classes.
    
One important pattern to note is the use of the renderer to directly style elements and add classes to them, rather than use more "natural" style and host binding with Angular. The reason is that said bindings introduce watchers and are factored in change detection, which can severely impact the performance of our datagrid. This is why I went with custom event-based size recomputation, to make sure we always did the strict minimum of work, and Angular could simply ignore it during change detection.

This change has been written in a way that does not break existing integration, it only modified our own components' internal template and styles.
    
This refactor allows 2 nice features out of the box:
1. Datagrids can now scroll easily if you restrict them to their container. The header and footer stay fixed, only the body containing the rows scrolls. It's as simple as setting the height of the datagrid to a specific value, or making it 100% to fill its container.
2. Specifying a header width through CSS or `[style.width]` binding locks the corresponding column size and makes it non-flexible. No need to duplicate that information on the cells, just the header is enough.

Tested on Chrome, Firefox, Safari, IE10, IE11 and Edge.

Here is an example of "smart" column sizing, where absolutely no width is specified by the customer:
<img width="1145" alt="smart-columns-size" src="https://cloud.githubusercontent.com/assets/4647197/23175046/3c3a09d2-f82c-11e6-851f-ec6149b00972.png">

And two examples of scrolling datagrids, vertically and horizontally:
![vertical-scrolling](https://cloud.githubusercontent.com/assets/4647197/23175060/4a92fa20-f82c-11e6-8061-48baa6ef74b8.png)
![horizontal-scrolling](https://cloud.githubusercontent.com/assets/4647197/23175063/4caf998a-f82c-11e6-864c-4791c753da8d.png)
