### PR TITLE
[CORE] Fix Import Order [Do Not Review or Merge]

### DIFF
--- a/src/clarity-angular/custom-forms/_custom-forms.clarity.scss
+++ b/src/clarity-angular/custom-forms/_custom-forms.clarity.scss
@@ -2,6 +2,4 @@
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
-@import "../utils/variables.clarity";
-@import "../utils/mixins.clarity";
 @import "node_modules/bootstrap/scss/custom-forms";

--- a/src/clarity-angular/list-group/_list-group.clarity.scss
+++ b/src/clarity-angular/list-group/_list-group.clarity.scss
@@ -2,6 +2,4 @@
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
-@import "../utils/variables.clarity";
-@import "../utils/mixins.clarity";
 @import "node_modules/bootstrap/scss/list-group";

--- a/src/clarity-angular/main.scss
+++ b/src/clarity-angular/main.scss
@@ -7,50 +7,79 @@
 
 /* @echo VERSION */
 
-@import "./utils/mixins.clarity";
-@import "./utils/normalize.clarity";
-@import "./utils/reboot.clarity";
-@import "./utils/helpers.clarity";
-@import "./utils/layers.clarity";
+/** Order of imports is important **/
+@import "./utils/layers.clarity"; // no dependencies on other clarity scss
+@import "./utils/helpers.clarity"; // no dependencies on other clarity scss
+@import "./color/color.clarity"; // depends on colors.clarity, helpers.clarity, contrast-cache.clarity
+@import "./utils/mixins.clarity"; // depends on color.clarity
+@import "./utils/variables.clarity"; // depends on helpers.clarity, color.clarity
+@import "./utils/reboot.clarity"; // depends on variables.clarity, mixins.clarity, color.clarity, helpers.clarity
+
+@import "./typography/fonts.clarity"; // no dependencies on other clarity scss
+
+@import "./utils/normalize.clarity"; // no dependencies on other clarity scss
 @import "./media/media.clarity"; //depends on variables.clarity
 @import "./images/icons.clarity"; // depeonds on variables.clarity
 @import "./utils/utilities.clarity"; // depends on variables.clarity, mixins.clarity
-@import "./color/color.clarity"; // depends on colors.clarity, helper.clarity, contrast-cache.clarity
-@import "./utils/variables.clarity"; // depends on helpers.clarity, color.clarity
 @import "./images/images.clarity"; // depends on variables.clarity, mixins.clarity, icons.clarity
 @import "./typography/typography.clarity"; // depends on colors.clarity, color.clarity, variables.clarity, utilities.clarity
+
+/** Start BS4 **/
+@import "./responsive-embed/responsive-embed.clarity"; // no dependencies on other clarity scss
+@import "./list-group/list-group.clarity"; // no dependencies on other clarity scss
+@import "./navbar/navbar.clarity"; // no dependencies on other clarity scss
+@import "./custom-forms/custom-forms.clarity"; // depends on variables.clarity, mixins.clarity
+@import "./grid/grid.clarity"; // depends on variables.clarity, mixins.clarity
+/** End BS4 **/
+
+@import "./animations/animations.clarity"; // no dependencies on other clarity scss
+
 @import "./buttons/buttons.clarity"; // depends on variables.clarity, mixins.clarity, color.clarity
 @import "./button-group/button-group.clarity"; // depends on variables.clarity, mixins.clarity
+
 @import "./alert/alert.clarity"; // depends on variables.clarity, mixins.clarity, color.clarity, icons.clarity, buttons.clarity
-@import "./buttons/toggles.clarity"; // depends on variables.clarity, mixins.clarity, color.clarity, helpers.clarity
-@import "./list-group/list-group.clarity"; // depends on variables.clarity, mixins.clarity
+
 @import "./card/card.clarity"; // depends on variables.clarity, mixins.clarity, color.clarity, helpers.clarity, list-group.clarity
+
 @import "./close/close.clarity"; // depends on variables.clarity, mixins.clarity
+
 @import "./code/code.clarity"; // depends on variables.clarity, mixins.clarity, helpers.clarity, code.scss
-@import "./custom-forms/custom-forms.clarity"; // depends on variables.clarity, mixins.clarity
+
 @import "./dropdown/dropdown.clarity"; // depends on variables.clarity, mixins.clarity, color.clarity, helpers.clarity, layers.clarity
+
 @import "./labels/labels.clarity"; // depends on variables.clarity, mixins.clarity, color.clarity, helpers.clarity
-@import "./grid/grid.clarity"; // depends on variables.clarity, mixins.clarity
+
 @import "./lists/lists.clarity"; // depends on variables.clarity, mixins.clarity, helpers.clarity, typograph.clarity
+
 @import "./login/login.clarity"; // depends on variables.clarity, mixins.clarity, helpers.clarity, color.clarity, icons.clarity
+
 @import "./layout/layout.clarity"; // depends on variables.clarity, mixins.clarity, helpers.clarity, color.clarity, layers.clarity
+
 @import "./modal/modal.clarity"; // depends on variables.clarity, mixins.clarity, helpers.clarity, color.clarity, layers.clarity
-@import "./navbar/navbar.clarity"; // depends on variables.clarity, mixins.clarity
+
 @import "./nav/header.clarity"; // depends on variables.clarity, mixins.clarity, helpers.clarity, color.clarity, layers.clarity
 @import "./nav/nav.clarity"; // depends on variables.clarity, mixins.clarity, helpers.clarity, color.clarity, layers.clarity
 @import "./nav/subnav.clarity"; // depends on variables.clarity, mixins.clarity, helpers.clarity, color.clarity, layers.clarity
 @import "./nav/sidenav.clarity"; // depends on variables.clarity, mixins.clarity, helpers.clarity, color.clarity
 @import "./nav/responsive-nav.clarity"; // depends on variables.clarity, mixins.clarity, helpers.clarity, color.clarity, layers.clarity
+
 @import "./progress-bars/progress-bars.clarity"; // depends on variables.clarity, helpers.clarity, color.clarity
+
 @import "./spinners/spinner.clarity"; // depends on variables.clarity, mixins.clarity, color.clarity, helpers.clarity, icons.clarity
+
 @import "./stack-view/stack-view.clarity"; // depends on variables.clarity, mixins.clarity, color.clarity, helpers.clarity, forms.clarity
+
 @import "./tables/tables.clarity"; // depends on variables.clarity, mixins.clarity, helpers.clarity, typography.clarity
+
 @import "./tree-view/tree-view.clarity"; // depends on variables.clarity, mixins.clarity, helpers.clarity, forms.clarity
+
 @import "./tooltips/tooltips.clarity"; // depends on variables.clarity, mixins.clarity, color.clarity, helpers.clarity, layers.clarity
+
+@import "./buttons/toggles.clarity"; // depends on variables.clarity, mixins.clarity, color.clarity, helpers.clarity
 @import "./forms/forms.clarity"; // depends on variables.clarity, mixins.clarity, color.clarity, helpers.clarity, layers.clarity, icons.clarity
+
 @import "./datagrid/datagrid.clarity"; // depends on variables.clarity, mixins.clarity, helpers.clarity, layers, icons.clarity, tables.clarity
-@import "./animations/animations.clarity"; // no dependencies on other clarity scss
+
 @import "./tabs/tabs.clarity"; // no dependencies on other clarity scss
+
 @import "./wizard/wizard.clarity"; // depends on variables.clarity, mixins.clarity, helpers.clarity, color.clarity, layers.clarity
-@import "./responsive-embed/responsive-embed.clarity"; // no dependencies on other clarity scss
-@import "./typography/fonts.clarity"; // no dependencies on other clarity scss

--- a/src/clarity-angular/main.scss
+++ b/src/clarity-angular/main.scss
@@ -17,20 +17,21 @@
 
 @import "./typography/fonts.clarity"; // no dependencies on other clarity scss
 
-@import "./utils/normalize.clarity"; // no dependencies on other clarity scss
-@import "./media/media.clarity"; //depends on variables.clarity
 @import "./images/icons.clarity"; // depeonds on variables.clarity
-@import "./utils/utilities.clarity"; // depends on variables.clarity, mixins.clarity
-@import "./images/images.clarity"; // depends on variables.clarity, mixins.clarity, icons.clarity
-@import "./typography/typography.clarity"; // depends on colors.clarity, color.clarity, variables.clarity, utilities.clarity
 
 /** Start BS4 **/
+@import "./utils/utilities.clarity"; // no dependencies on other clarity scss
+@import "./images/images.clarity"; // depends on variables.clarity, mixins.clarity, icons.clarity
+@import "./utils/normalize.clarity"; // no dependencies on other clarity scss
+@import "./media/media.clarity"; //no dependencies on other clarity scss
 @import "./responsive-embed/responsive-embed.clarity"; // no dependencies on other clarity scss
 @import "./list-group/list-group.clarity"; // no dependencies on other clarity scss
 @import "./navbar/navbar.clarity"; // no dependencies on other clarity scss
 @import "./custom-forms/custom-forms.clarity"; // depends on variables.clarity, mixins.clarity
 @import "./grid/grid.clarity"; // depends on variables.clarity, mixins.clarity
 /** End BS4 **/
+
+@import "./typography/typography.clarity"; // depends on colors.clarity, color.clarity, variables.clarity, utilities.clarity
 
 @import "./animations/animations.clarity"; // no dependencies on other clarity scss
 

--- a/src/clarity-angular/media/_media.clarity.scss
+++ b/src/clarity-angular/media/_media.clarity.scss
@@ -2,5 +2,4 @@
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
-@import "../utils/variables.clarity";
 @import "node_modules/bootstrap/scss/media";

--- a/src/clarity-angular/modal/_modal.clarity.scss
+++ b/src/clarity-angular/modal/_modal.clarity.scss
@@ -14,119 +14,122 @@ $clr-modal-md-width: baselineRem(24) !default;
 $clr-modal-lg-width: baselineRem(36) !default;
 $clr-modal-xl-width: baselineRem(48) !default;
 
-.modal {
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    right: 0;
-    left: 0;
-    z-index: map-get($clr-layers, modal);
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    padding: $clr_baselineRem_2;
 
-    @media screen and (max-width: map-get($clr-breakpoints, small)) {
-        padding: $clr_baselineRem_0_5;
-    }
-}
+@include exports("modal.clarity") {
+    .modal {
+        position: fixed;
+        top: 0;
+        bottom: 0;
+        right: 0;
+        left: 0;
+        z-index: map-get($clr-layers, modal);
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        padding: $clr_baselineRem_2;
 
-.modal-dialog {
-    position: relative;
-    z-index: map-get($clr-layers, modal);
-    width: $clr-modal-md-width;
-    max-width: 100%;
-
-    &.modal-sm {
-        width: $clr-modal-sm-width;
+        @media screen and (max-width: map-get($clr-breakpoints, small)) {
+            padding: $clr_baselineRem_0_5;
+        }
     }
 
-    &.modal-lg {
-        width: $clr-modal-lg-width;
-    }
+    .modal-dialog {
+        position: relative;
+        z-index: map-get($clr-layers, modal);
+        width: $clr-modal-md-width;
+        max-width: 100%;
 
-    &.modal-xl {
-        width: $clr-modal-xl-width;
-    }
+        &.modal-sm {
+            width: $clr-modal-sm-width;
+        }
 
-    $modal-boxshadow-y: 1px;
-    $modal-boxshadow-spread: 2px;
+        &.modal-lg {
+            width: $clr-modal-lg-width;
+        }
 
-    .modal-content {
-        padding: $clr-modal-content-padding-top $clr-modal-content-padding-right $clr-modal-content-padding-bottom $clr-modal-content-padding-left;
-        background-color: clr-getColor(lightest);
-        border-radius: $clr-default-borderradius;
-        box-shadow: 0 $modal-boxshadow-y $modal-boxshadow-spread $modal-boxshadow-spread rgba(0, 0, 0, 0.2);
+        &.modal-xl {
+            width: $clr-modal-xl-width;
+        }
 
-        .modal-header {
-            border-bottom: none;
-            padding: 0 0 $clr_baselineRem_1 0;
+        $modal-boxshadow-y: 1px;
+        $modal-boxshadow-spread: 2px;
 
-            .modal-title {
-                @include clr-getTypePropertiesForDomElement(modal_header, (color, font-size, font-family, font-weight, line-height, letter-spacing));
-                margin: 0;
-                padding: 0;
+        .modal-content {
+            padding: $clr-modal-content-padding-top $clr-modal-content-padding-right $clr-modal-content-padding-bottom $clr-modal-content-padding-left;
+            background-color: clr-getColor(lightest);
+            border-radius: $clr-default-borderradius;
+            box-shadow: 0 $modal-boxshadow-y $modal-boxshadow-spread $modal-boxshadow-spread rgba(0, 0, 0, 0.2);
+
+            .modal-header {
+                border-bottom: none;
+                padding: 0 0 $clr_baselineRem_1 0;
+
+                .modal-title {
+                    @include clr-getTypePropertiesForDomElement(modal_header, (color, font-size, font-family, font-weight, line-height, letter-spacing));
+                    margin: 0;
+                    padding: 0;
+                }
+
+                .close {
+                    margin-top: 0;
+                    font-size: rem(26/$clr-rem-denominator);
+                    line-height: $clr_baselineRem_1;
+
+                    clr-icon {
+                        // per measurement, this results in an icon that is 16x16...
+                        width: $clr_baselineRem_1;
+                        height: $clr_baselineRem_1;
+                    }
+                }
             }
 
-            .close {
-                margin-top: 0;
-                font-size: rem(26/$clr-rem-denominator);
-                line-height: $clr_baselineRem_1;
+            .modal-body {
+                // This doesn't do much, but at least with several paragraphs in the content
+                // it doesn't mess up the modal's proportions.
+                max-height: 55vh;
+                overflow-y: auto;
+                overflow-x: hidden;
 
-                clr-icon {
-                    // per measurement, this results in an icon that is 16x16...
-                    width: $clr_baselineRem_1;
-                    height: $clr_baselineRem_1;
+                @extend %clr-container;
+            }
+
+            .modal-footer {
+                display: flex;
+                justify-content: flex-end;
+                padding: $clr_baselineRem_1 0 0 0;
+
+                .btn {
+                    //switched right margin to left because footer is right aligned
+                    margin: 0 0 0 $clr_baselineRem_0_5;
                 }
             }
         }
 
-        .modal-body {
-            // This doesn't do much, but at least with several paragraphs in the content
-            // it doesn't mess up the modal's proportions.
-            max-height: 55vh;
-            overflow-y: auto;
-            overflow-x: hidden;
+        @media screen and (max-width: map-get($clr-breakpoints, small)) {
+            .modal-content {
+                padding: $clr_baselineRem_0_5 0 $clr_baselineRem_0_5 $clr_baselineRem_1;
 
-            @extend %clr-container;
-        }
+                .modal-header {
+                    padding: 0 $clr_baselineRem_1 $clr_baselineRem_0_5 0;
+                }
 
-        .modal-footer {
-            display: flex;
-            justify-content: flex-end;
-            padding: $clr_baselineRem_1 0 0 0;
-
-            .btn {
-                //switched right margin to left because footer is right aligned
-                margin: 0 0 0 $clr_baselineRem_0_5;
+                .modal-footer {
+                    padding: $clr_baselineRem_0_5 $clr_baselineRem_1 0 0;
+                }
             }
         }
     }
 
-    @media screen and (max-width: map-get($clr-breakpoints, small)) {
-        .modal-content {
-            padding: $clr_baselineRem_0_5 0 $clr_baselineRem_0_5 $clr_baselineRem_1;
-
-            .modal-header {
-                padding: 0 $clr_baselineRem_1 $clr_baselineRem_0_5 0;
-            }
-
-            .modal-footer {
-                padding: $clr_baselineRem_0_5 $clr_baselineRem_1 0 0;
-            }
-        }
+    .modal-backdrop {
+        $clr-backdrop-opacity: 0.85;
+        position: fixed;
+        top: 0;
+        bottom: 0;
+        right: 0;
+        left: 0;
+        background-color: clr-getColor(darkest);
+        opacity: $clr-backdrop-opacity;
+        z-index: map-get($clr-layers, modal-bg);
     }
-}
-
-.modal-backdrop {
-    $clr-backdrop-opacity: 0.85;
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    right: 0;
-    left: 0;
-    background-color: clr-getColor(darkest);
-    opacity: $clr-backdrop-opacity;
-    z-index: map-get($clr-layers, modal-bg);
 }

--- a/src/clarity-angular/navbar/_navbar.clarity.scss
+++ b/src/clarity-angular/navbar/_navbar.clarity.scss
@@ -2,6 +2,5 @@
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
-@import "../utils/variables.clarity";
-@import "../utils/mixins.clarity";
+
 @import "node_modules/bootstrap/scss/navbar";

--- a/src/clarity-angular/tree-view/_tree-view.clarity.scss
+++ b/src/clarity-angular/tree-view/_tree-view.clarity.scss
@@ -83,164 +83,166 @@ $clr-tree-node-children-margin-small: $clr-tree-node-touch-target-small - $clr-t
     }
 }
 
-//TreeNode
-clr-tree-node {
-    //Positioning
-    position: relative;
+@include exports("tree-view.clarity") {
+    //TreeNode
+    clr-tree-node {
+        //Positioning
+        position: relative;
 
-    //Display
-    display: block;
+        //Display
+        display: block;
 
-    //Not sure why Firefox doesn't add this by default using the collapse
-    //animation directive.
-    @include fixForFirefox() {
-        overflow-y: hidden;
+        //Not sure why Firefox doesn't add this by default using the collapse
+        //animation directive.
+        @include fixForFirefox() {
+            overflow-y: hidden;
+        }
+
+        & > clr-checkbox,
+        & > .checkbox {
+            //Positioning
+            position: absolute;
+
+            //Display
+            display: inline-block;
+        }
+
+        @include positionCheckBoxInTree();
     }
 
-    & > clr-checkbox,
-    & > .checkbox {
+    //Caret in Tree Nodes
+    .clr-treenode-caret {
         //Positioning
         position: absolute;
+        left: 0;
+        top: 0;
 
         //Display
         display: inline-block;
-    }
+        margin: 0;
+        padding: 0;
+        @include caret-touch-target();
 
-    @include positionCheckBoxInTree();
-}
-
-//Caret in Tree Nodes
-.clr-treenode-caret {
-    //Positioning
-    position: absolute;
-    left: 0;
-    top: 0;
-
-    //Display
-    display: inline-block;
-    margin: 0;
-    padding: 0;
-    @include caret-touch-target();
-
-    //Others
-    border: 1px solid transparent;
-    background: transparent;
-    color: $gray-dark-midtone;
-    cursor: pointer;
-    outline-offset: -5px;
-
-    clr-icon {
-        vertical-align: middle;
-        height: $clr-tree-caret-size;
-        width: $clr-tree-caret-size;
-    }
-
-    &:hover {
-        color: $clr-black;
-    }
-}
-
-//Spinners in Tree Nodes
-.clr-treenode-spinner {
-
-    //Positioning
-    position: absolute;
-    @include spinner-positioning();
-
-    //display
-    min-height: $clr-tree-spinner-size;
-    min-width: $clr-tree-spinner-size;
-    height: $clr-tree-spinner-size;
-    width: $clr-tree-spinner-size;
-}
-
-//Tree Node Content
-@include generate-tree-content();
-
-
-//Tree Nodes containing TreeNodes are wrapped with this class
-.clr-treenode-children {
-    margin-left: $clr-tree-node-children-margin;
-}
-
-.clr-tree--compact.clr-treenode,
-.clr-tree--compact clr-tree-node {
-    @include positionCheckBoxInTree($clr-tree-node-touch-target-small);
-
-    .clr-treenode-caret {
-        @include caret-touch-target($clr-tree-node-touch-target-small);
+        //Others
+        border: 1px solid transparent;
+        background: transparent;
+        color: $gray-dark-midtone;
+        cursor: pointer;
+        outline-offset: -5px;
 
         clr-icon {
-            vertical-align: text-top;
+            vertical-align: middle;
+            height: $clr-tree-caret-size;
+            width: $clr-tree-caret-size;
+        }
+
+        &:hover {
+            color: $clr-black;
         }
     }
 
+    //Spinners in Tree Nodes
     .clr-treenode-spinner {
-        @include spinner-positioning($clr-tree-node-touch-target-small);
+
+        //Positioning
+        position: absolute;
+        @include spinner-positioning();
+
+        //display
+        min-height: $clr-tree-spinner-size;
+        min-width: $clr-tree-spinner-size;
+        height: $clr-tree-spinner-size;
+        width: $clr-tree-spinner-size;
     }
 
-    @include generate-tree-content($clr-tree-node-touch-target-small);
+    //Tree Node Content
+    @include generate-tree-content();
 
+
+    //Tree Nodes containing TreeNodes are wrapped with this class
     .clr-treenode-children {
-        margin-left: $clr-tree-node-children-margin-small;
-    }
-}
-
-.clr-treenode-link {
-    //Display
-    display: inline-block;
-    line-height: inherit;
-    height: 100%;
-    width: 100%;
-    padding: 0 0 0 4px;
-    margin: 0;
-
-    //Others
-    background: transparent;
-    border-radius: 3px 0 0 3px;
-    border-color: transparent;
-    color: clr-getTextColor();
-    cursor: pointer;
-    text-align: left;
-
-    &:link,
-    &:visited,
-    &:active,
-    &:hover {
-        color: inherit;
+        margin-left: $clr-tree-node-children-margin;
     }
 
-    &:hover,
-    &:focus {
-        text-decoration: none;
-        background: #EEEEEE;
+    .clr-tree--compact.clr-treenode,
+    .clr-tree--compact clr-tree-node {
+        @include positionCheckBoxInTree($clr-tree-node-touch-target-small);
+
+        .clr-treenode-caret {
+            @include caret-touch-target($clr-tree-node-touch-target-small);
+
+            clr-icon {
+                vertical-align: text-top;
+            }
+        }
+
+        .clr-treenode-spinner {
+            @include spinner-positioning($clr-tree-node-touch-target-small);
+        }
+
+        @include generate-tree-content($clr-tree-node-touch-target-small);
+
+        .clr-treenode-children {
+            margin-left: $clr-tree-node-children-margin-small;
+        }
     }
 
-    &:focus {
-        outline: 0;
-    }
-
-    &.active {
-        background: $clr-selection-color;
-        color: $clr-black;
-    }
-}
-
-.clr-treenode-content {
-
-    //Going to create problems with clipping but no other option right now
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-
-    clr-icon {
-
+    .clr-treenode-link {
         //Display
-        height: 16px;
-        width: 16px;
-        margin-right: $clr_baselineRem_0_25;
-        vertical-align: middle;
+        display: inline-block;
+        line-height: inherit;
+        height: 100%;
+        width: 100%;
+        padding: 0 0 0 4px;
+        margin: 0;
 
+        //Others
+        background: transparent;
+        border-radius: 3px 0 0 3px;
+        border-color: transparent;
+        color: clr-getTextColor();
+        cursor: pointer;
+        text-align: left;
+
+        &:link,
+        &:visited,
+        &:active,
+        &:hover {
+            color: inherit;
+        }
+
+        &:hover,
+        &:focus {
+            text-decoration: none;
+            background: #EEEEEE;
+        }
+
+        &:focus {
+            outline: 0;
+        }
+
+        &.active {
+            background: $clr-selection-color;
+            color: $clr-black;
+        }
     }
 
+    .clr-treenode-content {
+
+        //Going to create problems with clipping but no other option right now
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+
+        clr-icon {
+
+            //Display
+            height: 16px;
+            width: 16px;
+            margin-right: $clr_baselineRem_0_25;
+            vertical-align: middle;
+
+        }
+
+    }
 }

--- a/src/clarity-angular/utils/_mixins.clarity.scss
+++ b/src/clarity-angular/utils/_mixins.clarity.scss
@@ -3,6 +3,7 @@
 // The full license information can be found in LICENSE in the root directory of this project.
 
 @import "node_modules/bootstrap/scss/mixins";
+@import "../color/color.clarity";
 
 //Generates styles for elements with different styles in different cases from its corresponding map
 @mixin clr-getStylesFromMap($element-map,$element) {

--- a/src/clarity-angular/utils/_utilities.clarity.scss
+++ b/src/clarity-angular/utils/_utilities.clarity.scss
@@ -2,6 +2,5 @@
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
-@import "./variables.clarity";
-@import "./mixins.clarity";
+
 @import "node_modules/bootstrap/scss/utilities";


### PR DESCRIPTION
The order of imports in `main.scss` was definitely incorrect. There were some files which were importing `variables.clarity.scss` but `variables.clarity.scss` itself was being imported after those files. I have rearranged the imports to get these issues fixed.

CSS Regression Tests Pass https://travis-ci.org/adityarb88/clarity/builds/204293171

Tested on: Chrome

Signed-off-by: Aditya Bhandari <adityab@vmware.com>