### PR TITLE
[NG] Fix datagrid pagination page values when datagrid is empty

### DIFF
--- a/src/clarity-angular/datagrid/providers/page.spec.ts
+++ b/src/clarity-angular/datagrid/providers/page.spec.ts
@@ -25,6 +25,13 @@ export default function(): void {
             expect(this.pageInstance.last).toBe(5);
         });
 
+        it("has firstItem and lastItem -1 when totalItems are 0", function() {
+            this.pageInstance.size = 10;
+            this.pageInstance.totalItems = 0;
+            expect(this.pageInstance.firstItem).toBe(-1);
+            expect(this.pageInstance.firstItem).toBe(-1);
+        });
+
         it("computes the indexes of the first and last displayed items", function() {
             this.pageInstance.size = 10;
             this.pageInstance.totalItems = 42;

--- a/src/clarity-angular/datagrid/providers/page.ts
+++ b/src/clarity-angular/datagrid/providers/page.ts
@@ -108,6 +108,9 @@ export class Page {
      * Index of the first item displayed on the current page, starting at 0
      */
     public get firstItem(): number {
+        if (this.totalItems === 0) {
+            return -1;
+        }
         if (this.size === 0) {
             return 0;
         }
@@ -118,6 +121,9 @@ export class Page {
      * Index of the last item displayed on the current page, starting at 0
      */
     public get lastItem(): number {
+        if (this.totalItems === 0) {
+            return -1;
+        }
         if (this.size === 0) {
             return this.totalItems - 1;
         }


### PR DESCRIPTION
When there are 0 items in the datagrid, and paging is active, firstItem is reported as 1, and lastItem -as the page size. This could lead to footers like "1 - 10 of 0 items". It is correct to return -1 in this case, as these values are indices, and 0 would be a valid index of a non-existing 1st element (thus footers like "1 - 1 of 0" will be produced).

Fixes #518

Signed-off-by: Ivan Donchev <idonchev@vmware.com>