### PR TITLE
Fix the Event name for Wizard Open state change

### DIFF
--- a/src/app/wizard/wizard-options.demo.html
+++ b/src/app/wizard/wizard-options.demo.html
@@ -24,7 +24,7 @@
         </td>
     </tr>
     <tr>
-        <td class="left">(clrWizardOpenChanged)</td>
+        <td class="left">(clrWizardOpenChange)</td>
         <td>true, false</td>
         <td>N/A</td>
         <td class="left">

--- a/src/clarity-angular/wizard/wizard.ts
+++ b/src/clarity-angular/wizard/wizard.ts
@@ -47,7 +47,7 @@ export class Wizard extends Tabs {
     @Input("clrWizardClosable") closable: boolean = true;
 
     // EventEmitter which is emitted on open/close of the wizard.
-    @Output("clrWizardOpenChanged") _openChanged: EventEmitter<boolean> =
+    @Output("clrWizardOpenChange") _openChange: EventEmitter<boolean> =
         new EventEmitter<boolean>(false);
 
     // User can bind his event handler for onCancel of the main content
@@ -119,7 +119,7 @@ export class Wizard extends Tabs {
     // wizard.
     open(): void {
         this._open = true;
-        this._openChanged.emit(true);
+        this._openChange.emit(true);
     }
 
     // close --
@@ -129,7 +129,7 @@ export class Wizard extends Tabs {
     close(): void {
         this._open = false;
         this.onCancel.emit(null);
-        this._openChanged.emit(false);
+        this._openChange.emit(false);
     }
 
     // _close --


### PR DESCRIPTION
Angular 2 adds 'Change', not 'Changed' when performing a two-way binding. 