### PR TITLE
[UI] Input Fields Padding Fix

### DIFF
--- a/src/clarity-angular/forms/_forms.clarity.scss
+++ b/src/clarity-angular/forms/_forms.clarity.scss
@@ -220,10 +220,6 @@
                     margin: $clr_baselineRem_0_5 $clr_baselineRem_0_5 0 0;
                 }
 
-                #{$styledInputs} {
-                    padding: 0 $clr_baselineRem_0_5;
-                }
-
                 .tooltip-validation {
                     input {
                         margin: 0;


### PR DESCRIPTION
Removed incorrect padding styles for input fields on Small screens

Before: 12px
![image](https://cloud.githubusercontent.com/assets/1426805/23526607/8bbe69f4-ff47-11e6-88a1-9583aa82d73e.png)


After: 6px
![image](https://cloud.githubusercontent.com/assets/1426805/23526625/977d102e-ff47-11e6-92ac-0c3fb5dbd057.png)

Tested on Chrome


Signed-off-by: Aditya Bhandari <adityab@vmware.com>