### PR TITLE
[ng] Add clarity style to clrDgSingleSelected radio input

### DIFF
--- a/src/clarity-angular/datagrid/_datagrid.clarity.scss
+++ b/src/clarity-angular/datagrid/_datagrid.clarity.scss
@@ -259,6 +259,7 @@
             // IE10 needs this
             max-width: $clr-datagrid-select-column-size;
 
+            .radio label,
             .checkbox label {
                 display: block;
                 // These are the properties in default checkbox styles, so we

--- a/src/clarity-angular/datagrid/datagrid-row.ts
+++ b/src/clarity-angular/datagrid/datagrid-row.ts
@@ -7,6 +7,8 @@ import {Component, Input, Output, EventEmitter} from "@angular/core";
 import {Selection, SelectionType} from "./providers/selection";
 import {RowActionService} from "./providers/row-action-service";
 
+let nbRow: number = 0;
+
 @Component({
     selector: "clr-dg-row",
     template: `
@@ -14,7 +16,11 @@ import {RowActionService} from "./providers/row-action-service";
             <clr-checkbox [ngModel]="selected" (ngModelChange)="toggle($event)"></clr-checkbox>
         </clr-dg-cell>
         <clr-dg-cell *ngIf="selection.selectionType === SELECTION_TYPE.Single" class="datagrid-select">
-            <input type="radio" [name]="selection.id + '-radio'" [value]="item" [(ngModel)]="selection.currentSingle">
+            <div class="radio">
+                <input type="radio" [id]="id"  [name]="selection.id + '-radio'" [value]="item" 
+                    [(ngModel)]="selection.currentSingle">    
+                <label for="{{id}}"></label>
+            </div>
         </clr-dg-cell>
         <clr-dg-cell *ngIf="rowActionService.actionableCount > 0" class="datagrid-row-actions">
             <ng-content select="clr-dg-action-overflow"></ng-content>
@@ -26,8 +32,9 @@ import {RowActionService} from "./providers/row-action-service";
         "[class.datagrid-selected]": "selected"
     }
 })
-
 export class DatagridRow {
+    public id: string;
+
     /* reference to the enum so that template can access */
     public SELECTION_TYPE = SelectionType;
 
@@ -36,7 +43,9 @@ export class DatagridRow {
      */
     @Input("clrDgItem") item: any;
 
-    constructor(public selection: Selection, public rowActionService: RowActionService) {}
+    constructor (public selection: Selection, public rowActionService: RowActionService) {
+        this.id = "clr-dg-row" + (nbRow++);
+    }
 
     private _selected = false;
     /**

--- a/src/clarity-angular/forms/_radio.clarity.scss
+++ b/src/clarity-angular/forms/_radio.clarity.scss
@@ -22,6 +22,10 @@
             @include checkbox-radio-label-styles($clr_baselineRem_1, $clr-checkbox-radio-height + $clr_baselineRem_0_25);
         }
 
+        label:empty {
+            padding-left: 0;
+        }
+
         //Radio button base
         input[type="radio"] + label::before {
             @include checkbox-radio-shared-inactive($clr-checkbox-radio-height, $clr-custom-checkbox-radio-top, 0, $clr-form-field-border-color);


### PR DESCRIPTION
Resolves #556.

Note that label inside radio/radio-inline class has a padding-left which is visually noticeable:
<img width="506" alt="screen shot 2017-03-07 at 12 16 23 pm" src="https://cloud.githubusercontent.com/assets/1827742/23676085/5f9a905e-0330-11e7-866b-ca7960cb5289.png">

Should we override this padding for datagrid single select? Or do we want to provide input option for label for the radio buttons? Thoughts?

Signed-off-by: Jeeyun Lim <jeeyun.lim@gmail.com>