### PR TITLE
[NG] Datagrid Selection Clear - DO NOT MERGE

### DIFF
--- a/src/app/datagrid/datagrid.demo.html
+++ b/src/app/datagrid/datagrid.demo.html
@@ -17,6 +17,7 @@
     <li><a [routerLink]="['./pagination']">Pagination</a></li>
     <li><a [routerLink]="['./selection']">Selection</a></li>
     <li><a [routerLink]="['./selection-single']">Selection (Single)</a></li>
+    <li><a [routerLink]="['./preserve-selection']">Preserve Selection</a></li>
     <li><a [routerLink]="['./server-driven']">Server-driven datagrid</a></li>
     <li><a [routerLink]="['./placeholder']">Placeholder</a></li>
     <li><a [routerLink]="['./scrolling']">Scrolling</a></li>

--- a/src/app/datagrid/datagrid.demo.module.ts
+++ b/src/app/datagrid/datagrid.demo.module.ts
@@ -28,6 +28,7 @@ import {DatagridColumnSizingDemo} from "./column-sizing/column-sizing";
 
 import {ColorFilter} from "./utils/color-filter";
 import {Example} from "./utils/example";
+import {DatagridPreserveSelectionDemo} from "./preserve-selection/preserve-selection";
 
 
 @NgModule({
@@ -47,6 +48,7 @@ import {Example} from "./utils/example";
         DatagridPaginationDemo,
         DatagridSelectionDemo,
         DatagridSelectionSingleDemo,
+        DatagridPreserveSelectionDemo,
         DatagridServerDrivenDemo,
         DatagridSmartIteratorDemo,
         DatagridSortingDemo,
@@ -67,6 +69,7 @@ import {Example} from "./utils/example";
         DatagridPaginationDemo,
         DatagridSelectionDemo,
         DatagridSelectionSingleDemo,
+        DatagridPreserveSelectionDemo,
         DatagridServerDrivenDemo,
         DatagridSmartIteratorDemo,
         DatagridSortingDemo,

--- a/src/app/datagrid/datagrid.demo.routing.ts
+++ b/src/app/datagrid/datagrid.demo.routing.ts
@@ -22,6 +22,7 @@ import {DatagridStringFilteringDemo} from "./string-filtering/string-filtering";
 import {DatagridPlaceholderDemo} from "./placeholder/placeholder";
 import {DatagridScrollingDemo} from "./scrolling/scrolling";
 import {DatagridColumnSizingDemo} from "./column-sizing/column-sizing";
+import {DatagridPreserveSelectionDemo} from "./preserve-selection/preserve-selection";
 
 const ROUTES: Routes = [
     {
@@ -39,6 +40,7 @@ const ROUTES: Routes = [
             {path: "pagination", component: DatagridPaginationDemo},
             {path: "selection", component: DatagridSelectionDemo},
             {path: "selection-single", component: DatagridSelectionSingleDemo},
+            {path: "preserve-selection", component: DatagridPreserveSelectionDemo},
             {path: "server-driven", component: DatagridServerDrivenDemo},
             {path: "placeholder", component: DatagridPlaceholderDemo},
             {path: "scrolling", component: DatagridScrollingDemo},

--- a/src/app/datagrid/preserve-selection/preserve-selection.html
+++ b/src/app/datagrid/preserve-selection/preserve-selection.html
@@ -1,0 +1,30 @@
+<clr-datagrid [(clrDgSelected)]="selected">
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column [clrDgField]="'name'" [(clrFilterValue)]="nameFilter">Name</clr-dg-column>
+    <clr-dg-column>Creation date</clr-dg-column>
+    <clr-dg-column>Favorite color</clr-dg-column>
+
+    <clr-dg-row *clrDgItems="let user of users;trackBy:trackByFn" [clrDgItem]="user">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>
+            <span class="color-square" [style.backgroundColor]="user.color"></span>
+        </clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>
+        {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
+        of {{pagination.totalItems}} users
+        <clr-dg-pagination
+            #pagination
+            [clrDgPageSize]="currentPageSize"
+            [clrDgTotalItems]="pagination.totalItems"></clr-dg-pagination>
+    </clr-dg-footer>
+</clr-datagrid>
+
+<div style="margin-top: 24px">
+    <button class="btn" (click)="updateInventorySize()">
+        Update Inventory Size
+    </button>
+</div>

--- a/src/app/datagrid/preserve-selection/preserve-selection.ts
+++ b/src/app/datagrid/preserve-selection/preserve-selection.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component} from "@angular/core";
+
+import {Inventory} from "../inventory/inventory";
+import {User} from "../inventory/user";
+
+@Component({
+    moduleId: module.id,
+    selector: "clr-datagrid-preserve-selection-demo",
+    providers: [Inventory],
+    templateUrl: "preserve-selection.html",
+    styleUrls: ["../datagrid.demo.scss"]
+})
+export class DatagridPreserveSelectionDemo {
+    users: User[];
+    _selected: User[] = [];
+    currentPageSize: number = 10;
+    nameFilter = "";
+
+    get selected() {
+        return this._selected;
+    }
+
+    set selected(selection: User[]) {
+        this._selected = selection;
+    }
+
+    constructor(private inventory: Inventory) {
+        inventory.size = 100;
+        inventory.reset();
+        this.users = inventory.all;
+    }
+
+    backUpUsers: User[] = [];
+
+    updateInventorySize(): void {
+        if (this.users.length === 100) {
+            this.backUpUsers = this.users.slice();
+            this.users = this.backUpUsers.slice(0, 80);
+        } else {
+            this.users = this.backUpUsers;
+            this.backUpUsers = [];
+        }
+    }
+
+    trackByFn(index: number, item: any) {
+        return item.id;
+    }
+}

--- a/src/clarity-angular/datagrid/_datagrid.clarity.scss
+++ b/src/clarity-angular/datagrid/_datagrid.clarity.scss
@@ -269,6 +269,28 @@
             }
         }
 
+        .datagrid-footer-select.checkbox {
+            line-height: inherit;
+            flex: 1 1 100%;
+
+            label {
+                color: unset;
+                cursor: default;
+                opacity: 1;
+            }
+
+            input[type="checkbox"] + label {
+                &::before, &::after {
+                    top: 8px;
+                }
+
+                &::after {
+                    border-left-color: $clr-white;
+                    border-bottom-color: $clr-white;
+                }
+            }
+        }
+
         .datagrid-row-actions {
             flex: 0 0 $clr-datagrid-select-column-size;
             // IE10 needs this

--- a/src/clarity-angular/datagrid/datagrid-footer.spec.ts
+++ b/src/clarity-angular/datagrid/datagrid-footer.spec.ts
@@ -6,13 +6,20 @@
 import {Component} from "@angular/core";
 import {TestContext} from "./helpers.spec";
 import {DatagridFooter} from "./datagrid-footer";
+import {Selection, SelectionType} from "./providers/selection";
+import {FiltersProvider} from "./providers/filters";
+import {Items} from "./providers/items";
+import {Sort} from "./providers/sort";
+import {Page} from "./providers/page";
+
+const PROVIDERS_NEEDED = [Selection, Items, FiltersProvider, Sort, Page];
 
 export default function(): void {
     describe("DatagridFooter component", function() {
         let context: TestContext<DatagridFooter, SimpleTest>;
 
         beforeEach(function() {
-            context = this.create(DatagridFooter, SimpleTest);
+            context = this.create(DatagridFooter, SimpleTest, PROVIDERS_NEEDED);
         });
 
         it("projects content", function() {
@@ -21,6 +28,49 @@ export default function(): void {
 
         it("adds the .datagrid-cell class to the host", function() {
             expect(context.clarityElement.classList.contains("datagrid-foot")).toBeTruthy();
+        });
+
+        it("does not show the selection details when selection type is None", function() {
+            let clarityDirectiveSelection: Selection = context.clarityDirective.selection;
+            clarityDirectiveSelection.selectionType = SelectionType.None;
+
+            context.detectChanges();
+
+            expect(context.clarityElement.querySelector(".datagrid-footer-select")).toBeNull();
+        });
+
+        it("does not show the selection details when selection type is single", function() {
+            let clarityDirectiveSelection: Selection = context.clarityDirective.selection;
+            clarityDirectiveSelection.selectionType = SelectionType.Single;
+            clarityDirectiveSelection.current.push(1);
+
+            context.detectChanges();
+
+            expect(context.clarityElement.querySelector(".datagrid-footer-select")).toBeNull();
+        });
+
+        it("shows the selection details when more than one item is selected", function() {
+            let clarityDirectiveSelection: Selection = context.clarityDirective.selection;
+            clarityDirectiveSelection.selectionType = SelectionType.Multi;
+            clarityDirectiveSelection.current.push(1);
+
+            context.detectChanges();
+
+            expect(context.clarityElement.querySelector(".datagrid-footer-select")).not.toBeNull();
+            expect(context.clarityElement.querySelector(".datagrid-footer-select").textContent).toMatch("1");
+
+
+            clarityDirectiveSelection.current.push(1);
+            context.detectChanges();
+
+            expect(context.clarityElement.querySelector(".datagrid-footer-select")).not.toBeNull();
+            expect(context.clarityElement.querySelector(".datagrid-footer-select").textContent).toMatch("2");
+
+            clarityDirectiveSelection.current = [];
+
+            context.detectChanges();
+
+            expect(context.clarityElement.querySelector(".datagrid-footer-select")).toBeNull();
         });
     });
 }

--- a/src/clarity-angular/datagrid/datagrid-footer.ts
+++ b/src/clarity-angular/datagrid/datagrid-footer.ts
@@ -4,14 +4,27 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import {Component} from "@angular/core";
+import {Selection, SelectionType} from "./providers/selection";
 
 @Component({
     selector: "clr-dg-footer",
     template: `
+        <ng-container 
+            *ngIf="(selection.selectionType === SELECTION_TYPE.Multi) && (selection.current.length > 0)">
+            <clr-checkbox [clrDisabled]="true" [clrChecked]="true" class="datagrid-footer-select">
+                {{selection.current.length}}
+            </clr-checkbox>
+        </ng-container>
         <ng-content></ng-content>
     `,
     host: {
         "[class.datagrid-foot]": "true",
     }
 })
-export class DatagridFooter { }
+export class DatagridFooter {
+
+    constructor(public selection: Selection) {}
+
+    /* reference to the enum so that template can access */
+    public SELECTION_TYPE = SelectionType;
+}

--- a/src/clarity-angular/datagrid/datagrid-items.spec.ts
+++ b/src/clarity-angular/datagrid/datagrid-items.spec.ts
@@ -54,10 +54,10 @@ export default function(): void {
         });
 
         it("receives an input for the trackBy option", function () {
-            expect(this.clarityDirective.trackBy).toBeUndefined();
+            expect(this.itemsProvider.trackBy).toBeUndefined();
             this.testComponent.trackBy = (index: number, item: any) => index;
             this.fixture.detectChanges();
-            expect(this.clarityDirective.trackBy).toBe(this.testComponent.trackBy);
+            expect(this.itemsProvider.trackBy).toBe(this.testComponent.trackBy);
         });
     });
 }

--- a/src/clarity-angular/datagrid/datagrid-items.ts
+++ b/src/clarity-angular/datagrid/datagrid-items.ts
@@ -25,15 +25,15 @@ export class DatagridItems implements OnChanges, DoCheck {
         if ("rawItems" in changes) {
             const currentItems = changes["rawItems"].currentValue;
             if (!this._differ && currentItems) {
-                this._differ = this._differs.find(currentItems).create(this._changeDetector, this.trackBy);
+                this._differ = this._differs.find(currentItems).create(this._changeDetector, this._items.trackBy);
             }
         }
     }
 
-    /**
-     * Tracking function to identify objects. Default is reference equality.
-     */
-    @Input("clrDgItemsTrackBy") public trackBy: TrackByFn = (index: number, item: any) => item;
+    @Input("clrDgItemsTrackBy")
+    set trackBy(value: TrackByFn) {
+        this._items.trackBy = value;
+    }
 
     ngDoCheck() {
         if (this._differ) {

--- a/src/clarity-angular/datagrid/datagrid.html
+++ b/src/clarity-angular/datagrid/datagrid.html
@@ -28,7 +28,7 @@
 
         <div clrDgBody class="datagrid-body">
             <template *ngIf="iterator"
-                      ngFor [ngForOf]="items.displayed" [ngForTrackBy]="iterator.trackBy"
+                      ngFor [ngForOf]="items.displayed" [ngForTrackBy]="items.trackBy"
                       [ngForTemplate]="iterator.template"></template>
             <ng-content *ngIf="!iterator"></ng-content>
         </div>

--- a/src/clarity-angular/datagrid/providers/items.ts
+++ b/src/clarity-angular/datagrid/providers/items.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import {Injectable} from "@angular/core";
+import {Injectable, TrackByFn} from "@angular/core";
 import {Subject} from "rxjs/Subject";
 import {Subscription} from "rxjs/Subscription";
 import {Observable} from "rxjs/Observable";
@@ -20,6 +20,12 @@ export class Items {
      * Indicates if the data is currently loading
      */
     public loading = false;
+
+    //TODO: Verify that trackBy is registered for the *ngFor case too
+    /**
+     * Tracking function to identify objects. Default is reference equality.
+     */
+    public trackBy: TrackByFn = (index: number, item: any) => item;
 
     /**
      * Subscriptions to the other providers changes.
@@ -70,6 +76,7 @@ export class Items {
     public set all(items: any[]) {
         if (this.smart) {
             this._all = items;
+            this.emitAllChanges();
             this._filterItems();
         } else {
             this._displayed = items;
@@ -110,6 +117,17 @@ export class Items {
     // We do not want to expose the Subject itself, but the Observable which is read-only
     public get change(): Observable<any[]> {
         return this._change.asObservable();
+    };
+
+    private _allChanges = new Subject<any[]>();
+    private emitAllChanges(): void {
+        if (this.smart) {
+            this._allChanges.next(this._all);
+        }
+    }
+
+    public get allChanges(): Observable<any[]> {
+        return this._allChanges.asObservable();
     };
 
     /**

--- a/src/clarity-angular/datagrid/providers/selection.spec.ts
+++ b/src/clarity-angular/datagrid/providers/selection.spec.ts
@@ -5,135 +5,231 @@
  */
 import {Selection, SelectionType} from "./selection";
 import {Items} from "./items";
-import {TestBed} from "@angular/core/testing";
 import {Sort} from "./sort";
 import {FiltersProvider} from "./filters";
 import {Page} from "./page";
+import {Filter} from "../interfaces/filter";
+import {Subject} from "rxjs/Subject";
+import {fakeAsync, tick} from "@angular/core/testing";
 
 const numberSort = (a: number, b: number) => a - b;
 
 export default function(): void {
+    let selectionInstance: Selection;
+    let sortInstance: Sort;
+    let pageInstance: Page;
+    let filtersInstance: FiltersProvider;
+    let itemsInstance: Items;
     describe("Selection provider", function() {
         beforeEach(function() {
-            TestBed.configureTestingModule({
-                providers: [Selection, Sort, FiltersProvider, Page, Items]
-            });
+            filtersInstance = new FiltersProvider();
+            sortInstance = new Sort();
+            pageInstance = new Page();
+            itemsInstance = new Items(filtersInstance, sortInstance, pageInstance);
 
-            this.selectionInstance = TestBed.get(Selection);
-            this.itemsInstance = TestBed.get(Items);
-            this.itemsInstance.smartenUp();
-            this.itemsInstance.all = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+            selectionInstance = new Selection(itemsInstance, filtersInstance);
+
+            itemsInstance.smartenUp();
+            itemsInstance.all = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         });
 
         afterEach(function() {
-            this.selectionInstance.destroy();
-            this.itemsInstance.destroy();
+            selectionInstance.destroy();
+            itemsInstance.destroy();
         });
 
         it("starts inactive", function() {
-            expect(this.selectionInstance.selectionType).toBe(SelectionType.None);
-            expect(this.selectionInstance.current).toBeUndefined();
-            this.selectionInstance.setSelected(4, true);
-            expect(this.selectionInstance.current).toBeUndefined();
+            expect(selectionInstance.selectionType).toBe(SelectionType.None);
+            expect(selectionInstance.current).toBeUndefined();
+            selectionInstance.setSelected(4, true);
+            expect(selectionInstance.current).toBeUndefined();
         });
 
         it("can select/deselect items in multi selection type", function() {
-            this.selectionInstance.selectionType = SelectionType.Multi;
-            this.selectionInstance.setSelected(4, true);
-            expect(this.selectionInstance.current).toEqual([4]);
-            this.selectionInstance.setSelected(2, true);
-            expect(this.selectionInstance.current).toEqual([4, 2]);
+            selectionInstance.selectionType = SelectionType.Multi;
+            selectionInstance.setSelected(4, true);
+            expect(selectionInstance.current).toEqual([4]);
+            selectionInstance.setSelected(2, true);
+            expect(selectionInstance.current).toEqual([4, 2]);
         });
 
         it("can select/deselect all items at once in multi selection type", function() {
-            this.selectionInstance.selectionType = SelectionType.Multi;
-            this.selectionInstance.toggleAll();
-            expect(this.selectionInstance.current).toEqual(this.itemsInstance.displayed);
-            this.selectionInstance.toggleAll();
-            expect(this.selectionInstance.current).toEqual([]);
-            this.selectionInstance.setSelected(4, true);
-            expect(this.selectionInstance.current).toEqual([4]);
-            this.selectionInstance.toggleAll();
-            expect(this.selectionInstance.current.sort(numberSort)).toEqual(this.itemsInstance.displayed);
+            selectionInstance.selectionType = SelectionType.Multi;
+            selectionInstance.toggleAll();
+            expect(selectionInstance.current).toEqual(itemsInstance.displayed);
+            selectionInstance.toggleAll();
+            expect(selectionInstance.current).toEqual([]);
+            selectionInstance.setSelected(4, true);
+            expect(selectionInstance.current).toEqual([4]);
+            selectionInstance.toggleAll();
+            expect(selectionInstance.current.sort(numberSort)).toEqual(itemsInstance.displayed);
         });
 
         it("can't select/deselect all items at once in other single selection type", function() {
-            this.selectionInstance.selectionType = SelectionType.Single;
-            this.selectionInstance.toggleAll();
-            expect(this.selectionInstance.currentSingle).toBeUndefined();
-            this.selectionInstance.currentSingle = 4;
-            this.selectionInstance.toggleAll();
-            expect(this.selectionInstance.currentSingle).toEqual(4);
+            selectionInstance.selectionType = SelectionType.Single;
+            selectionInstance.toggleAll();
+            expect(selectionInstance.currentSingle).toBeUndefined();
+            selectionInstance.currentSingle = 4;
+            selectionInstance.toggleAll();
+            expect(selectionInstance.currentSingle).toEqual(4);
         });
 
         it("can detect if an item is selected", function() {
-            this.selectionInstance.selectionType = SelectionType.Multi;
-            expect(this.selectionInstance.isSelected(4)).toBe(false);
-            this.selectionInstance.setSelected(4, true);
-            expect(this.selectionInstance.isSelected(4)).toBe(true);
-            this.selectionInstance.setSelected(4, false);
-            expect(this.selectionInstance.isSelected(4)).toBe(false);
+            selectionInstance.selectionType = SelectionType.Multi;
+            expect(selectionInstance.isSelected(4)).toBe(false);
+            selectionInstance.setSelected(4, true);
+            expect(selectionInstance.isSelected(4)).toBe(true);
+            selectionInstance.setSelected(4, false);
+            expect(selectionInstance.isSelected(4)).toBe(false);
         });
 
         it("can detect if all items are selected in multi selection type", function() {
-            this.selectionInstance.selectionType = SelectionType.Multi;
-            expect(this.selectionInstance.isAllSelected()).toBe(false);
-            this.selectionInstance.setSelected(4, true);
-            expect(this.selectionInstance.isAllSelected()).toBe(false);
-            this.selectionInstance.current = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
-            expect(this.selectionInstance.isAllSelected()).toBe(true);
+            selectionInstance.selectionType = SelectionType.Multi;
+            expect(selectionInstance.isAllSelected()).toBe(false);
+            selectionInstance.setSelected(4, true);
+            expect(selectionInstance.isAllSelected()).toBe(false);
+            selectionInstance.current = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
+            expect(selectionInstance.isAllSelected()).toBe(true);
         });
 
         it("accepts pre-selected items in multi selection type", function() {
-            this.selectionInstance.selectionType = SelectionType.Multi;
-            this.selectionInstance.current = [4, 2];
-            expect(this.selectionInstance.isSelected(1)).toBe(false);
-            expect(this.selectionInstance.isSelected(2)).toBe(true);
-            expect(this.selectionInstance.isSelected(3)).toBe(false);
-            expect(this.selectionInstance.isSelected(4)).toBe(true);
+            selectionInstance.selectionType = SelectionType.Multi;
+            selectionInstance.current = [4, 2];
+            expect(selectionInstance.isSelected(1)).toBe(false);
+            expect(selectionInstance.isSelected(2)).toBe(true);
+            expect(selectionInstance.isSelected(3)).toBe(false);
+            expect(selectionInstance.isSelected(4)).toBe(true);
         });
 
         it("accepts pre-selected item in single selection type", function() {
-            this.selectionInstance.selectionType = SelectionType.Single;
-            this.selectionInstance.currentSingle = 2;
-            expect(this.selectionInstance.isSelected(1)).toBe(false);
-            expect(this.selectionInstance.isSelected(2)).toBe(true);
-            expect(this.selectionInstance.isSelected(3)).toBe(false);
-            expect(this.selectionInstance.isSelected(4)).toBe(false);
+            selectionInstance.selectionType = SelectionType.Single;
+            selectionInstance.currentSingle = 2;
+            expect(selectionInstance.isSelected(1)).toBe(false);
+            expect(selectionInstance.isSelected(2)).toBe(true);
+            expect(selectionInstance.isSelected(3)).toBe(false);
+            expect(selectionInstance.isSelected(4)).toBe(false);
         });
 
         it("exposes an Observable to follow selection changes in multi selection type", function() {
             let nbChanges = 0;
             let currentSelection: any[];
-            this.selectionInstance.change.subscribe((items: any[]) => {
+            selectionInstance.change.subscribe((items: any[]) => {
                 nbChanges++;
                 currentSelection = items;
             });
             expect(currentSelection).toBeUndefined();
-            this.selectionInstance.selectionType = SelectionType.Multi;
+            selectionInstance.selectionType = SelectionType.Multi;
             expect(currentSelection).toEqual([]);
-            this.selectionInstance.setSelected(4, true);
-            expect(this.selectionInstance.current).toEqual([4]);
-            this.selectionInstance.toggleAll();
-            expect(this.selectionInstance.current.sort(numberSort)).toEqual(this.itemsInstance.displayed);
-            this.selectionInstance.toggleAll();
-            expect(this.selectionInstance.current).toEqual([]);
+            selectionInstance.setSelected(4, true);
+            expect(selectionInstance.current).toEqual([4]);
+            selectionInstance.toggleAll();
+            expect(selectionInstance.current.sort(numberSort)).toEqual(itemsInstance.displayed);
+            selectionInstance.toggleAll();
+            expect(selectionInstance.current).toEqual([]);
             expect(nbChanges).toBe(4);
         });
 
         it("exposes an Observable to follow selection changes in single selection type", function() {
             let nbChanges = 0;
             let currentSelection: any;
-            this.selectionInstance.change.subscribe((items: any) => {
+            selectionInstance.change.subscribe((items: any) => {
                 nbChanges++;
                 currentSelection = items;
             });
             expect(currentSelection).toBeUndefined();
-            this.selectionInstance.selectionType = SelectionType.Single;
+            selectionInstance.selectionType = SelectionType.Single;
             expect(currentSelection).toBeUndefined();
-            this.selectionInstance.currentSingle = 4;
-            this.selectionInstance.currentSingle = 2;
+            selectionInstance.currentSingle = 4;
+            selectionInstance.currentSingle = 2;
             expect(nbChanges).toBe(3);
+        });
+
+        it("clears selection when a filter is added", function() {
+            selectionInstance.selectionType = SelectionType.Multi;
+            selectionInstance.current = [4, 2];
+
+            let evenFilter: EvenFilter = new EvenFilter();
+
+            filtersInstance.add(<Filter<any>>evenFilter);
+
+            evenFilter.toggle();
+
+            expect(selectionInstance.current.length).toBe(0);
+        });
+
+        it("keeps only the remaining selection when the items are updated",
+            fakeAsync(function() {
+                selectionInstance.selectionType = SelectionType.Multi;
+                selectionInstance.current = [4, 2];
+
+                itemsInstance.all = [1, 2, 3, 5];
+
+                tick();
+
+                expect(selectionInstance.current.length).toBe(1);
+                expect(selectionInstance.current).toEqual([2]);
+        }));
+
+        it("keeps all the selections when the items are updated " +
+            "and the contain all the previous selection",
+            fakeAsync(function() {
+                selectionInstance.selectionType = SelectionType.Multi;
+                selectionInstance.current = [4, 2];
+
+                itemsInstance.all = [1, 2, 3, 4, 5];
+
+                tick();
+
+                expect(selectionInstance.current.length).toBe(2);
+                expect(selectionInstance.current).toEqual([4, 2]);
+        }));
+
+        it("clears the selections when the items are updated and " +
+            "they do not contain the previous selection",
+            fakeAsync(function() {
+                selectionInstance.selectionType = SelectionType.Multi;
+                selectionInstance.current = [4, 2];
+
+                itemsInstance.all = [1, 3, 5];
+
+                tick();
+
+                expect(selectionInstance.current.length).toBe(0);
+                expect(selectionInstance.current).toEqual([]);
+        }));
+
+        it("maintains the selection when the page is changed", function() {
+            selectionInstance.selectionType = SelectionType.Multi;
+            selectionInstance.current = [4, 2];
+
+            pageInstance.size = 3;
+
+            pageInstance.current = 2;
+
+            expect(selectionInstance.current).toEqual([4, 2]);
         });
     });
 };
+
+abstract class TestFilter implements Filter<number> {
+    private active = false;
+
+    toggle() {
+        this.active = !this.active;
+        this.changes.next(this.active);
+    }
+
+    isActive(): boolean {
+        return this.active;
+    };
+
+    changes = new Subject<boolean>();
+
+    abstract accepts(n: number): boolean;
+}
+
+class EvenFilter extends TestFilter {
+    accepts(n: number): boolean {
+        return n % 2 === 0;
+    };
+}


### PR DESCRIPTION
Before:
User selection was cleared whenever any change to items, filtering or page changes occurred.

After:
1. The selection is cleared when a new filter is applied on the datagrid
2. The selection is preserved when a page is changed
3. When the user uses `clrDgItems` or the smart datagrid, we make use of the trackBy function if provided to preserve selection from the updated items.

Issues:
We still have a `Expression has changed` issue on the demo that @youdz and I have to resolve.

UX Feedback:
@yen and @red have to discuss complex cases when the selection might have to be preserved after a filter has been applied. This PR is blocked until we get more info on which pattern to use.

Tested on Chrome

Signed-off-by: Aditya Bhandari <adityab@vmware.com>