### PR TITLE
[NG] Allow reverse order in datagrid 2-way binding sort attribute

### DIFF
--- a/src/app/datagrid/sorting/sorting.html
+++ b/src/app/datagrid/sorting/sorting.html
@@ -7,35 +7,31 @@
 <h2>Custom sort</h2>
 
 <p>
-    Sometimes, the natural sort order for a property is not the relevant one. Sometimes, a column
-    is not even a property on your model but is dynamically generated instead. In these cases,
-    you might want to specify a custom comparator to sort the column according to your needs.
-    This can be done by providing a comparator through the
+    Sometimes, the natural sort order for a property is not the relevant one. Sometimes, a column is not even a property on your
+    model but is dynamically generated instead. In these cases, you might want to specify a custom comparator to sort the
+    column according to your needs. This can be done by providing a comparator through the
     <code class="clr-code">[clrDgSortBy]</code> input, whether or not your column is declared as a
     <code class="clr-code">clrDgField</code>, and will always take precedence over it if it is.
 </p>
 <p>
-    A comparator is just an object that implements a <code class="clr-code">compare</code> method
-    that could be given as parameter to Javascript's native
-    <code class="clr-code">Array.sort()</code> function. In other words, if a and b are two
-    elements being compared, then:
+    A comparator is just an object that implements a <code class="clr-code">compare</code> method that could be given as
+    parameter to Javascript's native
+    <code class="clr-code">Array.sort()</code> function. In other words, if a and b are two elements being compared, then:
 </p>
 <ul>
     <li>
         if compare(a, b) is less than 0, a comes first,
     </li>
     <li>
-        if compare(a, b) returns 0, leave a and b unchanged with respect to each other, but
-        sorted with respect to all other items,
+        if compare(a, b) returns 0, leave a and b unchanged with respect to each other, but sorted with respect to all other items,
     </li>
     <li>
         if compare(a, b) is greater than 0, b comes first.
     </li>
 </ul>
 <p>
-    The safest way to check that your types comply with our API is to have your comparator be an
-    instance of a class that implement the <code class="clr-code">Comparator</code> interface
-    provided by Clarity.
+    The safest way to check that your types comply with our API is to have your comparator be an instance of a class that implement
+    the <code class="clr-code">Comparator</code> interface provided by Clarity.
 </p>
 <div class="alert alert-info">
     <div class="alert-item">
@@ -62,10 +58,49 @@
     </div>
 </div>
 <p>
-    In our example, everyone knows pokemons should not be sorted lexicographically, but according
-    to Pok&eacute;dex number.
+    In our example, everyone knows pokemons should not be sorted lexicographically, but according to Pok&eacute;dex number.
 </p>
 
+<p>
+    The datagrid is currently <b>{{sortOrder !== 0 ? "" : "not"}}</b> sorted<b>{{sortOrder === 1 ? " ascendingly" : sortOrder
+    === -1 ? " descendingly" : ""}}</b>.
+</p>
+<p>
+    <button class="btn btn-secondary" (click)="sortOrder = 1" [disabled]="sortOrder === 1">
+        Sort ascendingly
+    </button>
+    <button class="btn btn-secondary" (click)="sortOrder = -1" [disabled]="sortOrder === -1">
+        Sort descendingly
+    </button>
+    <button class="btn btn-secondary" (click)="sortOrder = 0" [disabled]="sortOrder === 0">
+        Clear sort
+    </button>
+</p>
+<clr-datagrid>
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column>Name</clr-dg-column>
+    <clr-dg-column>Creation date</clr-dg-column>
+    <clr-dg-column [clrDgField]="'pokemon.name'" [clrDgSortBy]="pokemonComparator" [(clrDgSortOrder)]="sortOrder">Pokemon</clr-dg-column>
+    <clr-dg-column>Favorite color</clr-dg-column>
+
+    <clr-dg-row *clrDgItems="let user of users">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>
+            {{user.pokemon.name}} <span class="badge badge-5">#{{user.pokemon.number}}</span>
+        </clr-dg-cell>
+        <clr-dg-cell>
+            <span class="color-square" [style.backgroundColor]="user.color"></span>
+        </clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>{{users.length}} users</clr-dg-footer>
+</clr-datagrid>
+
+<p>
+    The following example is showcasing the deprecated way of sorting pokemons. This will be removed in the next major release.
+</p>
 <p>
     The datagrid is currently {{sorted ? "" : "not"}} sorted.
     <button class="btn btn-secondary" (click)="sorted = !sorted">
@@ -76,12 +111,10 @@
     <clr-dg-column>User ID</clr-dg-column>
     <clr-dg-column>Name</clr-dg-column>
     <clr-dg-column>Creation date</clr-dg-column>
-    <clr-dg-column [clrDgField]="'pokemon.name'"
-                   [clrDgSortBy]="pokemonComparator"
-                   [(clrDgSorted)]="sorted">Pokemon</clr-dg-column>
+    <clr-dg-column [clrDgField]="'pokemon.name'" [clrDgSortBy]="pokemonComparator" [(clrDgSorted)]="sorted">Pokemon</clr-dg-column>
     <clr-dg-column>Favorite color</clr-dg-column>
 
-    <clr-dg-row *clrDgItems="let user of users">
+    <clr-dg-row *clrDgItems="let user of usersDeprecated">
         <clr-dg-cell>{{user.id}}</clr-dg-cell>
         <clr-dg-cell>{{user.name}}</clr-dg-cell>
         <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>

--- a/src/app/datagrid/sorting/sorting.ts
+++ b/src/app/datagrid/sorting/sorting.ts
@@ -3,12 +3,14 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import {Component} from "@angular/core";
+import { Component } from "@angular/core";
 
-import {Inventory} from "../inventory/inventory";
-import {User} from "../inventory/user";
-import {PokemonComparator} from "../utils/pokemon-comparator";
-import {EXAMPLES} from "./examples";
+import { SortOrder } from "../../../clarity-angular/datagrid";
+
+import { Inventory } from "../inventory/inventory";
+import { User } from "../inventory/user";
+import { PokemonComparator } from "../utils/pokemon-comparator";
+import { EXAMPLES } from "./examples";
 
 @Component({
     moduleId: module.id,
@@ -20,7 +22,9 @@ import {EXAMPLES} from "./examples";
 export class DatagridSortingDemo {
     examples = EXAMPLES;
     users: User[];
-    sorted: boolean;
+    usersDeprecated: User[];
+    sortOrder: SortOrder = SortOrder.Unsorted;
+    sorted: boolean = false;
 
     pokemonComparator = new PokemonComparator();
 
@@ -28,5 +32,6 @@ export class DatagridSortingDemo {
         inventory.size = 10;
         inventory.reset();
         this.users = inventory.all;
+        this.usersDeprecated = inventory.all;
     }
 }

--- a/src/clarity-angular/datagrid/index.ts
+++ b/src/clarity-angular/datagrid/index.ts
@@ -3,28 +3,28 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import {Type} from "@angular/core";
+import { Type } from "@angular/core";
 
-import {DatagridStringFilter} from "./built-in/filters/datagrid-string-filter";
-import {Datagrid} from "./datagrid";
-import {DatagridActionBar} from "./datagrid-action-bar";
-import {DatagridActionOverflow} from "./datagrid-action-overflow";
-import {DatagridCell} from "./datagrid-cell";
-import {DatagridColumn} from "./datagrid-column";
-import {DatagridFilter} from "./datagrid-filter";
-import {DatagridFooter} from "./datagrid-footer";
-import {DatagridItems} from "./datagrid-items";
-import {DatagridPagination} from "./datagrid-pagination";
-import {DatagridRow} from "./datagrid-row";
-import {DatagridPlaceholder} from "./datagrid-placeholder";
+import { DatagridStringFilter } from "./built-in/filters/datagrid-string-filter";
+import { Datagrid } from "./datagrid";
+import { DatagridActionBar } from "./datagrid-action-bar";
+import { DatagridActionOverflow } from "./datagrid-action-overflow";
+import { DatagridCell } from "./datagrid-cell";
+import { DatagridColumn } from "./datagrid-column";
+import { DatagridFilter } from "./datagrid-filter";
+import { DatagridFooter } from "./datagrid-footer";
+import { DatagridItems } from "./datagrid-items";
+import { DatagridPagination } from "./datagrid-pagination";
+import { DatagridRow } from "./datagrid-row";
+import { DatagridPlaceholder } from "./datagrid-placeholder";
 
-import {DatagridMainRenderer} from "./render/main-renderer";
-import {DatagridTableRenderer} from "./render/table-renderer";
-import {DatagridHeaderRenderer} from "./render/header-renderer";
-import {DatagridHeadRenderer} from "./render/head-renderer";
-import {DatagridBodyRenderer} from "./render/body-renderer";
-import {DatagridRowRenderer} from "./render/row-renderer";
-import {DatagridCellRenderer} from "./render/cell-renderer";
+import { DatagridMainRenderer } from "./render/main-renderer";
+import { DatagridTableRenderer } from "./render/table-renderer";
+import { DatagridHeaderRenderer } from "./render/header-renderer";
+import { DatagridHeadRenderer } from "./render/head-renderer";
+import { DatagridBodyRenderer } from "./render/body-renderer";
+import { DatagridRowRenderer } from "./render/row-renderer";
+import { DatagridCellRenderer } from "./render/cell-renderer";
 
 export * from "./datagrid";
 export * from "./datagrid-action-bar";
@@ -39,6 +39,7 @@ export * from "./datagrid-pagination";
 export * from "./datagrid-placeholder";
 
 export * from "./interfaces/state";
+export * from "./interfaces/sort-order";
 export * from "./interfaces/filter";
 export * from "./interfaces/string-filter";
 export * from "./interfaces/comparator";

--- a/src/clarity-angular/datagrid/interfaces/sort-order.ts
+++ b/src/clarity-angular/datagrid/interfaces/sort-order.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+/**
+ * Enumeration representing the sorting order of a datagrid column. It is a constant Enum,
+ * i.e. each value needs to be treated as a `number`, starting at index 0.
+ *
+ * @export
+ * @enum {number}
+ */
+export const enum SortOrder {
+    Unsorted = 0,
+    Asc = 1,
+    Desc = -1
+}

--- a/src/clarity-angular/datagrid/interfaces/state.ts
+++ b/src/clarity-angular/datagrid/interfaces/state.ts
@@ -3,8 +3,8 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import {Comparator} from "./comparator";
-import {Filter} from "./filter";
+import { Comparator } from "./comparator";
+import { Filter } from "./filter";
 
 export interface State {
     page?: {
@@ -16,5 +16,5 @@ export interface State {
         by: string | Comparator<any>;
         reverse: boolean;
     };
-    filters?: ({property: string, value: string} | Filter<any>)[];
+    filters?: ({ property: string, value: string } | Filter<any>)[];
 }

--- a/src/clarity-angular/datagrid/providers/sort.spec.ts
+++ b/src/clarity-angular/datagrid/providers/sort.spec.ts
@@ -3,24 +3,24 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import {Sort} from "./sort";
-import {Comparator} from "../interfaces/comparator";
+import { Sort } from "./sort";
+import { Comparator } from "../interfaces/comparator";
 
-export default function(): void {
-    describe("Sort provider", function() {
-        beforeEach(function() {
+export default function (): void {
+    describe("Sort provider", function () {
+        beforeEach(function () {
             this.sortInstance = new Sort();
             this.comparator = new TestComparator();
         });
 
-        it("compares according to the current comparator", function() {
+        it("compares according to the current comparator", function () {
             this.sortInstance.comparator = this.comparator;
             expect(this.sortInstance.compare(1, 10)).toBeLessThan(0);
             expect(this.sortInstance.compare(4, 4)).toBe(0);
             expect(this.sortInstance.compare(42, 3)).toBeGreaterThan(0);
         });
 
-        it("can reverse the order of the current comparator", function() {
+        it("can reverse the order of the current comparator", function () {
             this.sortInstance.comparator = this.comparator;
             this.sortInstance.reverse = true;
             expect(this.sortInstance.compare(1, 10)).toBeGreaterThan(0);
@@ -28,12 +28,14 @@ export default function(): void {
             expect(this.sortInstance.compare(42, 3)).toBeLessThan(0);
         });
 
-        it("exposes a toggle method to set the comparator", function() {
+        it("exposes a toggle method to set the comparator", function () {
             this.sortInstance.toggle(this.comparator);
+            expect(this.sortInstance.comparator).toBe(this.comparator);
+            this.sortInstance.toggle(this.comparator, true);
             expect(this.sortInstance.comparator).toBe(this.comparator);
         });
 
-        it("reverses the order when toggle is called on the same comparator", function() {
+        it("reverses the order when toggle is called on the same comparator", function () {
             // Ascending
             this.sortInstance.toggle(this.comparator);
             expect(this.sortInstance.reverse).toBe(false);
@@ -45,7 +47,22 @@ export default function(): void {
             expect(this.sortInstance.reverse).toBe(false);
         });
 
-        it("always uses ascending order when toggling a new comparator ", function() {
+        it("always uses descending order if forceReverse is set", function () {
+            // Force descending
+            this.sortInstance.toggle(this.comparator, true);
+            expect(this.sortInstance.reverse).toBe(true);
+            // No forcing, so should toggle from previous state
+            this.sortInstance.toggle(this.comparator);
+            expect(this.sortInstance.reverse).toBe(false);
+            // Toggling to descending
+            this.sortInstance.toggle(this.comparator);
+            expect(this.sortInstance.reverse).toBe(true);
+            // Force descending again
+            this.sortInstance.toggle(this.comparator, true);
+            expect(this.sortInstance.reverse).toBe(true);
+        });
+
+        it("always uses ascending order when toggling a new comparator ", function () {
             this.sortInstance.comparator = this.comparator;
             expect(this.sortInstance.reverse).toBe(false);
             this.sortInstance.toggle(new TestComparator());
@@ -57,7 +74,19 @@ export default function(): void {
             expect(this.sortInstance.reverse).toBe(false);
         });
 
-        it("exposes an Observable to follow sort changes", function() {
+        it("always uses descending order if forceReverse is set even when toggling a new comparator ", function () {
+            this.sortInstance.comparator = this.comparator;
+            expect(this.sortInstance.reverse).toBe(false);
+            this.sortInstance.toggle(new TestComparator(), true);
+            expect(this.sortInstance.reverse).toBe(true);
+            this.sortInstance.toggle(this.comparator);
+            this.sortInstance.toggle(this.comparator);
+            expect(this.sortInstance.reverse).toBe(true);
+            this.sortInstance.toggle(new TestComparator());
+            expect(this.sortInstance.reverse).toBe(false);
+        });
+
+        it("exposes an Observable to follow sort changes", function () {
             let nbChanges = 0;
             let latestComparator: Comparator<number>;
             let latestReverse: boolean;

--- a/src/clarity-angular/datagrid/providers/sort.ts
+++ b/src/clarity-angular/datagrid/providers/sort.ts
@@ -3,11 +3,11 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import {Injectable} from "@angular/core";
-import {Subject} from "rxjs/Subject";
-import {Observable} from "rxjs/Observable";
+import { Injectable } from "@angular/core";
+import { Subject } from "rxjs/Subject";
+import { Observable } from "rxjs/Observable";
 
-import {Comparator} from "../interfaces/comparator";
+import { Comparator } from "../interfaces/comparator";
 
 @Injectable()
 export class Sort {
@@ -48,15 +48,24 @@ export class Sort {
     };
 
     /**
-     * Sets a comparator as the current one, or toggles reverse if the comparator is already used.
+     * Sets a comparator as the current one, or toggles reverse if the comparator is already used. The
+     * optional forceReverse input parameter allows to override that toggling behavior by sorting in
+     * reverse order if `true`.
+     *
+     * @param {Comparator<any>} sortBy the comparator to use for sorting
+     * @param {boolean} [forceReverse] `true` to force sorting descendingly
+     *
+     * @memberof Sort
      */
-    public toggle(sortBy: Comparator<any>) {
+    public toggle(sortBy: Comparator<any>, forceReverse?: boolean) {
         // We modify private properties directly, to batch the change event
         if (this.comparator === sortBy) {
-            this._reverse = !this._reverse;
+            this._reverse = typeof forceReverse !== "undefined"
+                ? forceReverse || !this._reverse
+                : !this._reverse;
         } else {
             this._comparator = sortBy;
-            this._reverse = false;
+            this._reverse = typeof forceReverse !== "undefined" ? forceReverse : false;
         }
         this.emitChange();
     }


### PR DESCRIPTION
Changing current datagrid-column implementation to take into account the reverse sorting order. 

Instead of introducing a new 2-way binding as advised in the original issue #586, I replaced the existing  boolean `[(clrDgSorted)]` by a number `[(clrDgSortOrder)]` one. I chose not to go with a `[(clrDgSortedReverse)]` 2-way binding for two main reasons:
 - it would have complexify the usage of the datagrid component, by having to maintain 2 boolean flags for the same concept
 - race conditions would have occurred when the value of each of those 2 flags changes: they are dependent on each other and there's no way to predict the order in which they are updated

Details about the proposed implementation:
- Introduced an exported const Enum `SortOrder` that defines the 3 possible
sorting states for a datagrid column: Unsorted, Asc and Desc.
- Removed `[(clrDgSorted)]`:boolean 2-way binding
- Introduced `[(clrDgSortOrder)]`: SortOrder 2-way binding:
  - replaced the existing logic around the sorted state (2 states: ON or OFF)
  with a tri-state sorting logic (following the 3 `SortOrder` enum values)
  - made sure all existing behaviour is preserved:
    - the `datagrid-column` reacts to the `Sort` provider change events, i.e. when
    sort is cleared or toggled
    - modified the public `sort()` method to allow forcing the reverse sorting
- Modified the `Sort` provider toggle method to allow forcing the reverse sorting. It
is an optional parameter, so it does not break backward compatibility within
clarity-angular implementation
- modified and added some new test cases for the `datagrid-column` component and the
`Sort` provider

I left the original boolean `clrDgSorted` 2-way binding in clr-dg-column to allow
backward compatibility for the component consumption. I added some deprecation
annotations around all code that needs to be removed in the next major release.

/!\ Using both 2-way bindings at the same time will have unpredicted results, so
the using code needs to either use `clrDgSorted` or `clrDgSortOrder`. This needs
be explicitly mentioned in the doc.

This closes #586

Signed-off-by: Clement Cureau <clement.cureau@gmail.com>