### PR TITLE
[NG] Datagrid Filter + Placeholder Fix

### DIFF
--- a/src/clarity-angular/datagrid/_datagrid.clarity.scss
+++ b/src/clarity-angular/datagrid/_datagrid.clarity.scss
@@ -9,6 +9,8 @@
     $clr-datagrid-icon-size: rem(1);
     $clr-datagrid-action-arrow-size: $clr_baselineRem_0_25;
     $clr-datagrid-select-column-size: 2*$clr-table-cellpadding + $clr-table-lineheight;
+    $clr-datagrid-filter-padding: $clr_baselineRem_0_75;
+    $clr-datagrid-filter-top-margin: $clr_baselineRem_0_2;
 
     .datagrid-container {
         display: flex;
@@ -39,6 +41,11 @@
         min-height: 0;
         // IE10 (maybe later versions too) needs this
         overflow: hidden;
+
+        &.has-filter {
+            // space for (filter padding + 2 * 24 (close button + input field) + margin top + Header height + 1px for vertical rhythm)
+            min-height: $clr-datagrid-filter-padding * 2 + $clr_baselineRem_2 + $clr-datagrid-filter-top-margin + $clr_baselineRem_1_5 + 1;
+        }
     }
     .datagrid-body {
         flex: 1 1 auto;
@@ -223,9 +230,9 @@
                 position: absolute;
                 top: 100%;
                 right: 0;
-                margin-top: $clr_baselineRem_0_2;
+                margin-top: $clr-datagrid-filter-top-margin;
                 background: $clr-white;
-                padding: $clr_baselineRem_0_75;
+                padding: $clr-datagrid-filter-padding;
                 border: 1px solid $gray-light-midtone;
                 box-shadow: 0 1px 3px rgba($gray-dark, 0.25);
                 border-radius: $clr-default-borderradius;
@@ -234,6 +241,7 @@
 
                 .datagrid-filter-close-wrapper {
                     text-align: right;
+                    height: $clr_baselineRem_1;
 
                     .close {
                         float: none;

--- a/src/clarity-angular/datagrid/datagrid.html
+++ b/src/clarity-angular/datagrid/datagrid.html
@@ -6,7 +6,7 @@
 
 <ng-content select="clr-dg-action-bar"></ng-content>
 <div class="datagrid">
-    <div clrDgTableWrapper class="datagrid-table-wrapper">
+    <div clrDgTableWrapper class="datagrid-table-wrapper" [class.has-filter]="hasFilters()">
         <div clrDgHead class="datagrid-head">
             <div class="datagrid-row">
                 <!-- header for datagrid where you can select multiple rows -->
@@ -36,7 +36,7 @@
 
     <!-- Custom placeholder overrides the default empty one -->
     <ng-content select="clr-dg-placeholder"></ng-content>
-    <clr-dg-placeholder *ngIf="!placeholder"></clr-dg-placeholder>
+    <clr-dg-placeholder *ngIf="!placeholder && items.displayed.length == 0"></clr-dg-placeholder>
 
     <!--
         This is not inside the table because there is no good way of having a single column span

--- a/src/clarity-angular/datagrid/datagrid.ts
+++ b/src/clarity-angular/datagrid/datagrid.ts
@@ -116,6 +116,10 @@ export class Datagrid implements AfterContentInit, AfterViewInit, OnDestroy {
         this.refresh.emit(state);
     }
 
+    public hasFilters(): boolean {
+        return this.filters.getActiveFilters().length > 0 ? true : false;
+    }
+
     /**
      * Public method to re-trigger the computation of displayed items manually
      */


### PR DESCRIPTION
Fixes: #631, #583 

1. Added a minimum height (equal to the height of the header + the height of the filter popover) to `.datagrid-table-wrapper` to make space for the filter popover to appear without clipping.

**Before:**
1. When no rows are displayed
![image](https://cloud.githubusercontent.com/assets/1426805/24225416/9289f146-0f1d-11e7-9e3c-2c38d5e1d57d.png)

2. When only one row is displayed
![image](https://cloud.githubusercontent.com/assets/1426805/24225436/af28af04-0f1d-11e7-9817-140c5fa08de2.png)

3. When two rows are displayed
![image](https://cloud.githubusercontent.com/assets/1426805/24225450/c7367aa4-0f1d-11e7-83cd-d120ea15eb3b.png)


**After:**
1. When no rows are displayed
![image](https://cloud.githubusercontent.com/assets/1426805/24225467/e151ac4c-0f1d-11e7-9ccf-b04676459525.png)

2. When only 1 row is displayed
![image](https://cloud.githubusercontent.com/assets/1426805/24225476/e9e212a2-0f1d-11e7-8a4f-cb9731d3ed34.png)

3. When 2 rows are displayed
![image](https://cloud.githubusercontent.com/assets/1426805/24225480/f8e81184-0f1d-11e7-8e42-a85f42aed318.png)


Custom placeholders work as expected
![image](https://cloud.githubusercontent.com/assets/1426805/24225521/30f28a78-0f1e-11e7-9a5f-7d7940a73a96.png)

Custom placeholders when filtering is present:
![image](https://cloud.githubusercontent.com/assets/1426805/24225602/a06bcf0e-0f1e-11e7-97e1-5afe426adc33.png)

Tested on Chrome

Signed-off-by: Aditya Bhandari <adityab@vmware.com>