### PR TITLE
[ng] removing const in SortOrder enum so it's not removed during compilation

### DIFF
--- a/src/app/datagrid/sorting/sorting.ts
+++ b/src/app/datagrid/sorting/sorting.ts
@@ -5,8 +5,7 @@
  */
 import { Component } from "@angular/core";
 
-import { SortOrder } from "../../../clarity-angular/datagrid";
-
+import { SortOrder } from "../../../clarity-angular";
 import { Inventory } from "../inventory/inventory";
 import { User } from "../inventory/user";
 import { PokemonComparator } from "../utils/pokemon-comparator";

--- a/src/clarity-angular/datagrid/interfaces/sort-order.ts
+++ b/src/clarity-angular/datagrid/interfaces/sort-order.ts
@@ -11,7 +11,7 @@
  * @export
  * @enum {number}
  */
-export const enum SortOrder {
+export enum SortOrder {
     Unsorted = 0,
     Asc = 1,
     Desc = -1


### PR DESCRIPTION
"Const enums can only use constant enum expressions and unlike regular enums they are completely removed during compilation."

reference: https://www.typescriptlang.org/docs/handbook/enums.html

Signed-off-by: Jeeyun Lim <jeeyun.lim@gmail.com>