### PR TITLE
[NG] Datagrid expandable rows

### DIFF
--- a/src/app/datagrid/basic-structure/basic-structure.html
+++ b/src/app/datagrid/basic-structure/basic-structure.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/basic-structure/basic-structure.ts
+++ b/src/app/datagrid/basic-structure/basic-structure.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/binding-properties/binding-properties.html
+++ b/src/app/datagrid/binding-properties/binding-properties.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/binding-properties/binding-properties.ts
+++ b/src/app/datagrid/binding-properties/binding-properties.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/column-sizing/column-sizing.html
+++ b/src/app/datagrid/column-sizing/column-sizing.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/column-sizing/column-sizing.ts
+++ b/src/app/datagrid/column-sizing/column-sizing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/custom-rendering/custom-rendering.html
+++ b/src/app/datagrid/custom-rendering/custom-rendering.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/custom-rendering/custom-rendering.ts
+++ b/src/app/datagrid/custom-rendering/custom-rendering.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/datagrid.demo.html
+++ b/src/app/datagrid/datagrid.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -22,6 +22,7 @@
     <li><a [routerLink]="['./placeholder']">Placeholder</a></li>
     <li><a [routerLink]="['./scrolling']">Scrolling</a></li>
     <li><a [routerLink]="['./column-sizing']">Column sizing</a></li>
+    <li><a [routerLink]="['./expandable-rows']">Expandable rows</a></li>
     <li><a [routerLink]="['./full']">Full demo</a></li>
 </ul>
 

--- a/src/app/datagrid/datagrid.demo.module.ts
+++ b/src/app/datagrid/datagrid.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -25,10 +25,13 @@ import {DatagridStringFilteringDemo} from "./string-filtering/string-filtering";
 import {DatagridPlaceholderDemo} from "./placeholder/placeholder";
 import {DatagridScrollingDemo} from "./scrolling/scrolling";
 import {DatagridColumnSizingDemo} from "./column-sizing/column-sizing";
+import {DatagridExpandableRowsDemo} from "./expandable-rows/expandable-rows";
+import {DatagridPreserveSelectionDemo} from "./preserve-selection/preserve-selection";
 
 import {ColorFilter} from "./utils/color-filter";
 import {Example} from "./utils/example";
-import {DatagridPreserveSelectionDemo} from "./preserve-selection/preserve-selection";
+import {FakeLoader} from "./expandable-rows/fake-loader";
+import {DetailWrapper} from "./expandable-rows/detail-wrapper";
 
 
 @NgModule({
@@ -56,8 +59,11 @@ import {DatagridPreserveSelectionDemo} from "./preserve-selection/preserve-selec
         DatagridPlaceholderDemo,
         DatagridScrollingDemo,
         DatagridColumnSizingDemo,
+        DatagridExpandableRowsDemo,
         ColorFilter,
-        Example
+        Example,
+        FakeLoader,
+        DetailWrapper
     ],
     exports: [
         DatagridDemo,
@@ -76,7 +82,8 @@ import {DatagridPreserveSelectionDemo} from "./preserve-selection/preserve-selec
         DatagridStringFilteringDemo,
         DatagridPlaceholderDemo,
         DatagridScrollingDemo,
-        DatagridColumnSizingDemo
+        DatagridColumnSizingDemo,
+        DatagridExpandableRowsDemo
     ]
 })
 export default class DatagridDemoModule {

--- a/src/app/datagrid/datagrid.demo.routing.ts
+++ b/src/app/datagrid/datagrid.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -23,6 +23,7 @@ import {DatagridPlaceholderDemo} from "./placeholder/placeholder";
 import {DatagridScrollingDemo} from "./scrolling/scrolling";
 import {DatagridColumnSizingDemo} from "./column-sizing/column-sizing";
 import {DatagridPreserveSelectionDemo} from "./preserve-selection/preserve-selection";
+import {DatagridExpandableRowsDemo} from "./expandable-rows/expandable-rows";
 
 const ROUTES: Routes = [
     {
@@ -45,6 +46,7 @@ const ROUTES: Routes = [
             {path: "placeholder", component: DatagridPlaceholderDemo},
             {path: "scrolling", component: DatagridScrollingDemo},
             {path: "column-sizing", component: DatagridColumnSizingDemo},
+            {path: "expandable-rows", component: DatagridExpandableRowsDemo},
             {path: "full", component: DatagridFullDemo},
         ]
     }

--- a/src/app/datagrid/datagrid.demo.scss
+++ b/src/app/datagrid/datagrid.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/datagrid/datagrid.demo.ts
+++ b/src/app/datagrid/datagrid.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/expandable-rows/detail-wrapper.ts
+++ b/src/app/datagrid/expandable-rows/detail-wrapper.ts
@@ -1,0 +1,17 @@
+import {Component} from "@angular/core";
+
+@Component({
+    selector: "detail-wrapper",
+    template: `
+        <clr-dg-row-detail [clrDgReplace]="true">
+            <clr-dg-cell>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</clr-dg-cell>
+            <clr-dg-cell>Proin in neque in ante placerat mattis id sed quam.</clr-dg-cell>
+            <clr-dg-cell>Proin rhoncus lacus et tempor dignissim.</clr-dg-cell>
+            <clr-dg-cell>Vivamus sem quam, pellentesque aliquet suscipit eget, pellentesque sed arcu.</clr-dg-cell>
+            <clr-dg-cell>Vivamus in dui lectus. Suspendisse cursus est ac nisl imperdiet viverra.</clr-dg-cell>
+        </clr-dg-row-detail>
+    `
+})
+export class DetailWrapper {
+
+}

--- a/src/app/datagrid/expandable-rows/expandable-rows.html
+++ b/src/app/datagrid/expandable-rows/expandable-rows.html
@@ -1,0 +1,87 @@
+<!--
+  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<h2>Expandable rows</h2>
+
+<form>
+    <div class="form-group">
+        <label>Type of detail</label>
+        <div class="radio-inline">
+            <input type="radio" name="detail" id="detail-default" value="default" [(ngModel)]="detail">
+            <label for="detail-default">Default</label>
+        </div>
+        <div class="radio-inline">
+            <input type="radio" name="detail" id="detail-columns" value="columns" [(ngModel)]="detail">
+            <label for="detail-columns">Columns</label>
+        </div>
+    </div>
+    <div class="form-group">
+        <div class="checkbox-inline">
+            <input type="checkbox" name="replace" id="replace" [(ngModel)]="replace">
+            <label for="replace">Replace row</label>
+        </div>
+        <div class="checkbox-inline">
+            <input type="checkbox" name="fixed-height" id="fixed-height" [(ngModel)]="fixedHeight">
+            <label for="fixed-height">Fixed height</label>
+        </div>
+        <div class="checkbox-inline">
+            <input type="checkbox" name="selectable" id="selectable" [(ngModel)]="selectable">
+            <label for="selectable">Selectable</label>
+        </div>
+        <div class="checkbox-inline">
+            <input type="checkbox" name="slow-load" id="slow-load" [(ngModel)]="slowLoad">
+            <label for="slow-load">Slow load</label>
+        </div>
+    </div>
+</form>
+
+<clr-datagrid [style.height.px]="fixedHeight ? 458 : null" [(clrDgSelected)]="selected">
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
+    <clr-dg-column [clrDgField]="'creation'">Creation date</clr-dg-column>
+    <clr-dg-column [clrDgField]="'pokemon.name'">Pokemon</clr-dg-column>
+    <clr-dg-column [clrDgField]="'color'">Favorite color</clr-dg-column>
+
+    <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>{{user.pokemon.name}}</clr-dg-cell>
+        <clr-dg-cell>
+            <span class="color-square" [style.backgroundColor]="user.color"></span>
+        </clr-dg-cell>
+
+        <!-- Example using a wrapper component -->
+        <!--<detail-wrapper *clrIfExpanded ngProjectAs="clr-dg-row-detail" class="datagrid-row-flex"></detail-wrapper>-->
+
+        <clr-dg-row-detail *clrIfExpanded [clrDgReplace]="replace">
+            <template [clrFakeLoader]="slowLoad" clrLoading>
+                <template [ngIf]="detail === 'default'">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin in neque in ante placerat mattis id sed
+                    quam. Proin rhoncus lacus et tempor dignissim. Vivamus sem quam, pellentesque aliquet suscipit eget,
+                    pellentesque sed arcu. Vivamus in dui lectus. Suspendisse cursus est ac nisl imperdiet viverra. Aenean
+                    sagittis nibh lacus, in eleifend urna ultrices et. Mauris porttitor nisi nec velit pharetra porttitor.
+                    Vestibulum vulputate sollicitudin dolor ut tincidunt. Phasellus vitae blandit felis. Nullam posuere
+                    ipsum tincidunt velit pellentesque rhoncus. Morbi faucibus ut ipsum at malesuada. Nam vestibulum felis
+                    sit amet metus finibus hendrerit. Fusce faucibus odio eget ex vulputate rhoncus. Fusce nec aliquam leo,
+                    at suscipit diam.
+                </template>
+
+                <template [ngIf]="detail === 'columns'">
+                    <clr-dg-cell>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</clr-dg-cell>
+                    <clr-dg-cell>Proin in neque in ante placerat mattis id sed quam.</clr-dg-cell>
+                    <clr-dg-cell>Proin rhoncus lacus et tempor dignissim.</clr-dg-cell>
+                    <clr-dg-cell>Vivamus sem quam, pellentesque aliquet suscipit eget, pellentesque sed arcu.</clr-dg-cell>
+                    <clr-dg-cell>Vivamus in dui lectus. Suspendisse cursus est ac nisl imperdiet viverra.</clr-dg-cell>
+                </template>
+            </template>
+        </clr-dg-row-detail>
+    </clr-dg-row>
+
+
+    <clr-dg-footer>{{users.length}} users</clr-dg-footer>
+</clr-datagrid>
+

--- a/src/app/datagrid/expandable-rows/expandable-rows.ts
+++ b/src/app/datagrid/expandable-rows/expandable-rows.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component} from "@angular/core";
+
+import {Inventory} from "../inventory/inventory";
+import {User} from "../inventory/user";
+
+@Component({
+    moduleId: module.id,
+    selector: "clr-datagrid-binding-properties-demo",
+    providers: [Inventory],
+    templateUrl: "expandable-rows.html",
+    styleUrls: ["../datagrid.demo.scss"],
+
+})
+export class DatagridExpandableRowsDemo {
+    constructor(private inventory: Inventory) {
+        inventory.size = 10;
+        inventory.reset();
+        this.users = inventory.all;
+    }
+
+    users: User[];
+    selected: User[];
+
+    detail = "default";
+    replace = false;
+    fixedHeight = false;
+    slowLoad = false;
+
+    get selectable() {
+        return !!this.selected;
+    }
+    set selectable(value: boolean) {
+        if (value) {
+            this.selected = [];
+        } else {
+            delete this.selected;
+        }
+    }
+}

--- a/src/app/datagrid/expandable-rows/fake-loader.ts
+++ b/src/app/datagrid/expandable-rows/fake-loader.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Directive, TemplateRef, ViewContainerRef, Input, OnInit} from "@angular/core";
+import {Loading} from "../../../clarity-angular";
+
+const LATENCY = 2000;
+
+@Directive({
+    selector: "[clrFakeLoader]"
+})
+export class FakeLoader implements OnInit {
+    constructor(private template: TemplateRef<any>, private container: ViewContainerRef, private loading: Loading) {}
+
+    @Input("clrFakeLoader") fake: boolean;
+
+    ngOnInit() {
+        if (this.fake) {
+            this.loading.loading = true;
+            setTimeout(() => {
+                this.load();
+                this.loading.loading = false;
+            }, LATENCY);
+        } else {
+            this.load();
+        }
+    }
+
+    private load() {
+        this.container.createEmbeddedView(this.template);
+    }
+}

--- a/src/app/datagrid/filtering/examples.ts
+++ b/src/app/datagrid/filtering/examples.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/filtering/filtering.html
+++ b/src/app/datagrid/filtering/filtering.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/filtering/filtering.ts
+++ b/src/app/datagrid/filtering/filtering.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/full/full.html
+++ b/src/app/datagrid/full/full.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/full/full.ts
+++ b/src/app/datagrid/full/full.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/inventory/inventory.ts
+++ b/src/app/datagrid/inventory/inventory.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/inventory/pokemon.ts
+++ b/src/app/datagrid/inventory/pokemon.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/inventory/user.ts
+++ b/src/app/datagrid/inventory/user.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/inventory/values.ts
+++ b/src/app/datagrid/inventory/values.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/pagination/pagination.html
+++ b/src/app/datagrid/pagination/pagination.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/pagination/pagination.ts
+++ b/src/app/datagrid/pagination/pagination.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/placeholder/placeholder.html
+++ b/src/app/datagrid/placeholder/placeholder.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/placeholder/placeholder.ts
+++ b/src/app/datagrid/placeholder/placeholder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/preserve-selection/preserve-selection.ts
+++ b/src/app/datagrid/preserve-selection/preserve-selection.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/scrolling/scrolling.html
+++ b/src/app/datagrid/scrolling/scrolling.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/scrolling/scrolling.ts
+++ b/src/app/datagrid/scrolling/scrolling.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/selection-single/selection-single.ts
+++ b/src/app/datagrid/selection-single/selection-single.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/selection/selection.html
+++ b/src/app/datagrid/selection/selection.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/selection/selection.ts
+++ b/src/app/datagrid/selection/selection.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/server-driven/examples.ts
+++ b/src/app/datagrid/server-driven/examples.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/server-driven/server-driven.html
+++ b/src/app/datagrid/server-driven/server-driven.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/server-driven/server-driven.ts
+++ b/src/app/datagrid/server-driven/server-driven.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/smart-iterator/smart-iterator.html
+++ b/src/app/datagrid/smart-iterator/smart-iterator.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/smart-iterator/smart-iterator.ts
+++ b/src/app/datagrid/smart-iterator/smart-iterator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/sorting/examples.ts
+++ b/src/app/datagrid/sorting/examples.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/sorting/sorting.html
+++ b/src/app/datagrid/sorting/sorting.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/sorting/sorting.ts
+++ b/src/app/datagrid/sorting/sorting.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/string-filtering/examples.ts
+++ b/src/app/datagrid/string-filtering/examples.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/string-filtering/string-filtering.html
+++ b/src/app/datagrid/string-filtering/string-filtering.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/string-filtering/string-filtering.ts
+++ b/src/app/datagrid/string-filtering/string-filtering.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/utils/color-filter.ts
+++ b/src/app/datagrid/utils/color-filter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/utils/example.ts
+++ b/src/app/datagrid/utils/example.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/utils/pokemon-comparator.ts
+++ b/src/app/datagrid/utils/pokemon-comparator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/utils/pokemon-filter.ts
+++ b/src/app/datagrid/utils/pokemon-filter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/clarity.module.ts
+++ b/src/clarity-angular/clarity.module.ts
@@ -23,9 +23,10 @@ import {TREE_VIEW_DIRECTIVES} from "./tree-view/index";
 import {OLD_WIZARD_DIRECTIVES} from "./wizard-deprecated/index";
 import {WIZARD_DIRECTIVES} from "./wizard/index";
 import {ICON_DIRECTIVES} from "./iconography/index";
+import {BUTTON_GROUP_DIRECTIVES} from "./button-group/index";
+import {LOADING_DIRECTIVES} from "./loading/index";
 
 import {ClrResponsiveNavigationService} from "./nav/clrResponsiveNavigationService";
-import {BUTTON_GROUP_DIRECTIVES} from "./button-group/index";
 
 @NgModule({
     imports: [
@@ -49,7 +50,8 @@ import {BUTTON_GROUP_DIRECTIVES} from "./button-group/index";
         OLD_WIZARD_DIRECTIVES,
         WIZARD_DIRECTIVES,
         ICON_DIRECTIVES,
-        BUTTON_GROUP_DIRECTIVES
+        BUTTON_GROUP_DIRECTIVES,
+        LOADING_DIRECTIVES
     ],
     exports: [
         ALERT_DIRECTIVES,
@@ -67,7 +69,8 @@ import {BUTTON_GROUP_DIRECTIVES} from "./button-group/index";
         OLD_WIZARD_DIRECTIVES,
         WIZARD_DIRECTIVES,
         ICON_DIRECTIVES,
-        BUTTON_GROUP_DIRECTIVES
+        BUTTON_GROUP_DIRECTIVES,
+        LOADING_DIRECTIVES
     ]
 })
 export class ClarityModule {

--- a/src/clarity-angular/datagrid/_datagrid.clarity.scss
+++ b/src/clarity-angular/datagrid/_datagrid.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -8,9 +8,9 @@
 
     $clr-datagrid-icon-size: rem(1);
     $clr-datagrid-action-arrow-size: $clr_baselineRem_0_25;
-    $clr-datagrid-select-column-size: 2*$clr-table-cellpadding + $clr-table-lineheight;
+    $clr-datagrid-fixed-column-size: 2*$clr-table-cellpadding + $clr-table-lineheight;
 
-    .datagrid-container {
+    .datagrid-host {
         display: flex;
         flex-flow: column nowrap;
         width: 100%;
@@ -28,7 +28,7 @@
         // IE10 (maybe later versions too) needs this
         overflow: hidden;
     }
-    .datagrid-head, .datagrid-body, .datagrid-column, .datagrid-cell {
+    .datagrid-head, .datagrid-body, .datagrid-row, .datagrid-column, .datagrid-cell {
         display: block;
     }
     .datagrid-table-wrapper {
@@ -47,7 +47,8 @@
     .datagrid-head {
         flex: 0 0 auto;
     }
-    .datagrid-row {
+    .datagrid-row-flex {
+        flex: 1 1 auto;
         display: flex;
         flex-flow: row nowrap;
     }
@@ -71,6 +72,9 @@
         }
         .datagrid-row {
             display: table-row;
+        }
+        .datagrid-row-master {
+            display: none;
         }
         .datagrid-column, .datagrid-cell {
             display: table-cell;
@@ -123,7 +127,7 @@
 
         .datagrid-head {
             background-color: $clr-thead-bgcolor;
-            border-bottom: 2px solid $clr-light-midtone-gray;
+            border-bottom: 2*$clr-table-borderwidth solid $clr-light-midtone-gray;
         }
 
         .datagrid-column, .datagrid-cell {
@@ -250,11 +254,13 @@
             }
         }
 
-        .datagrid-select {
-            flex: 0 0 $clr-datagrid-select-column-size;
+        .datagrid-fixed-column {
+            flex: 0 0 $clr-datagrid-fixed-column-size;
             // IE10 needs this
-            max-width: $clr-datagrid-select-column-size;
+            max-width: $clr-datagrid-fixed-column-size;
+        }
 
+        .datagrid-select {
             .radio label,
             .checkbox label {
                 display: block;
@@ -291,13 +297,42 @@
             }
         }
 
-        .datagrid-row-actions {
-            flex: 0 0 $clr-datagrid-select-column-size;
-            // IE10 needs this
-            max-width: $clr-datagrid-select-column-size;
+        .datagrid-row-actions clr-icon {
+            height: $clr-table-lineheight;
+            vertical-align: bottom;
+        }
+
+        .datagrid-expandable-caret {
+            $horizontalPadding: ($clr-datagrid-fixed-column-size - $clr_baselineRem_1_25) / 2;
+            padding: ($clr_baselineRem_0_125 - 1) $horizontalPadding $clr_baselineRem_0_125;
+            text-align: center;
+
+            button {
+                @include clr-no-styles-button();
+                cursor: pointer;
+                height: $clr_baselineRem_1_25;
+                width: $clr_baselineRem_1_25;
+            }
+
+            clr-icon {
+                color: $gray-dark;
+                svg {
+                    transition: transform 0.2s ease-in-out;
+                }
+            }
+
+            .spinner {
+                margin-top: $clr_baselineRem_0_25;
+            }
         }
 
         .datagrid-body .datagrid-row {
+            border-top: $clr-table-borderwidth solid $clr-lighter-midtone-gray;
+
+            &:first-child {
+                border-top: 0;
+            }
+
             &:hover {
                 background-color: $clr-light-gray;
             }
@@ -396,10 +431,25 @@
             .datagrid-action-toggle {
                 cursor: pointer;
             }
+
+            .datagrid-row-detail {
+                &.datagrid-container {
+                    padding-top: 0;
+                }
+
+                .datagrid-cell  {
+                    padding-top: 0;
+                }
+            }
         }
 
         .datagrid-cell {
-            border-top-color: $clr-lighter-midtone-gray;
+            border-top: 0;
+        }
+
+        .datagrid-container {
+            font-size: $clr-table-fontsize;
+            padding: $clr-table-topcellpadding $clr-table-cellpadding $clr-table-bottomcellpadding;
         }
     }
 

--- a/src/clarity-angular/datagrid/all.spec.ts
+++ b/src/clarity-angular/datagrid/all.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -16,6 +16,7 @@ import FiltersProviderSpecs from "./providers/filters.spec";
 import PageProviderSpecs from "./providers/page.spec";
 import ItemsProviderSpecs from "./providers/items.spec";
 import SelectionProviderSpecs from "./providers/selection.spec";
+import RowExpandProviderSpecs from "./providers/row-expand.spec";
 import DatagridActionBarSpecs from "./datagrid-action-bar.spec";
 import DatagridActionOverflowSpecs from "./datagrid-action-overflow.spec";
 import DatagridCellSpecs from "./datagrid-cell.spec";
@@ -23,6 +24,8 @@ import DatagridFilterSpecs from "./datagrid-filter.spec";
 import DatagridColumnSpecs from "./datagrid-column.spec";
 import DatagridItemsSpecs from "./datagrid-items.spec";
 import DatagridRowSpecs from "./datagrid-row.spec";
+import DatagridRowDetailSpecs from "./datagrid-row-detail.spec";
+import DatagridIfExpandedSpecs from "./datagrid-if-expanded.spec";
 import DatagridPaginationSpecs from "./datagrid-pagination.spec";
 import DatagridFooterSpecs from "./datagrid-footer.spec";
 import DatagridSpecs from "./datagrid.spec";
@@ -30,11 +33,13 @@ import DomAdapterSpecs from "./render/dom-adapter.spec";
 import DatagridRenderOrganizerSpecs from "./render/render-organizer.spec";
 import DatagridCellRendererSpecs from "./render/cell-renderer.spec";
 import DatagridRowRendererSpecs from "./render/row-renderer.spec";
+import DatagridRowMasterRendererSpecs from "./render/row-master-renderer.spec";
 import DatagridBodyRendererSpecs from "./render/body-renderer.spec";
 import DatagridHeaderRendererSpecs from "./render/header-renderer.spec";
 import DatagridHeadRendererSpecs from "./render/head-renderer.spec";
 import DatagridTableRendererSpecs from "./render/table-renderer.spec";
 import DatagridMainRendererSpecs from "./render/main-renderer.spec";
+import DatagridRowExpandAnimationSpecs from "./animation-hack/row-expand-animation.spec";
 import NestedPropertySpecs from "./built-in/nested-property.spec";
 import DatagridPropertyComparatorSpecs from "./built-in/comparators/datagrid-property-comparator.spec";
 import DatagridPropertyStringFilterSpecs from "./built-in/filters/datagrid-property-string-filter.spec";
@@ -50,6 +55,7 @@ describe("Datagrid", function() {
         PageProviderSpecs();
         ItemsProviderSpecs();
         SelectionProviderSpecs();
+        RowExpandProviderSpecs();
     });
     describe("Components", function() {
         DatagridActionBarSpecs();
@@ -59,6 +65,8 @@ describe("Datagrid", function() {
         DatagridColumnSpecs();
         DatagridItemsSpecs();
         DatagridRowSpecs();
+        DatagridRowDetailSpecs();
+        DatagridIfExpandedSpecs();
         DatagridPaginationSpecs();
         DatagridFooterSpecs();
         DatagridPlaceholderSpecs();
@@ -69,11 +77,13 @@ describe("Datagrid", function() {
         DatagridRenderOrganizerSpecs();
         DatagridCellRendererSpecs();
         DatagridRowRendererSpecs();
+        DatagridRowMasterRendererSpecs();
         DatagridBodyRendererSpecs();
         DatagridHeaderRendererSpecs();
         DatagridHeadRendererSpecs();
         DatagridTableRendererSpecs();
         DatagridMainRendererSpecs();
+        DatagridRowExpandAnimationSpecs();
     });
     describe("Built-in", function() {
         NestedPropertySpecs();

--- a/src/clarity-angular/datagrid/animation-hack/row-expand-animation.spec.ts
+++ b/src/clarity-angular/datagrid/animation-hack/row-expand-animation.spec.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component} from "@angular/core";
+import {TestBed} from "@angular/core/testing";
+import {By} from "@angular/platform-browser";
+import {DatagridRowExpandAnimation} from "./row-expand-animation";
+import {RowExpand} from "../providers/row-expand";
+import {DatagridRenderOrganizer} from "../render/render-organizer";
+import {MOCK_DOM_ADAPTER_PROVIDER} from "../render/dom-adapter.mock";
+
+/*
+ * TODO: web animations testing doesn't play nicely with PhantomJS. Pushing this to later.
+ */
+export default function(): void {
+    // Commenting this out because PhantomJS is being uncooperative.
+    // I lost too much time trying to get it to pass, but this should just go away anyway once the
+    // new cool features of Angular 4.1 animations come in.
+    xdescribe("DatagridRowExpandAnimation directive", function() {
+        beforeEach(function () {
+            // We do not use the TestContext on purpose, because we want to test this directive in isolation,
+            // without all other components and directives on the same selector.
+            // TODO: improve the TestContext to allow this.
+            TestBed.configureTestingModule({
+                declarations: [DatagridRowExpandAnimation, SimpleTest],
+                providers: [RowExpand, DatagridRenderOrganizer, MOCK_DOM_ADAPTER_PROVIDER]
+            });
+            this.fixture = TestBed.createComponent(SimpleTest);
+            this.fixture.detectChanges();
+            this.testComponent = this.fixture.componentInstance;
+            this.clarityElement =
+                this.fixture.debugElement.query(By.directive(DatagridRowExpandAnimation)).nativeElement;
+            this.expand = TestBed.get(RowExpand);
+        });
+
+        afterEach(function() {
+            this.fixture.destroy();
+        });
+
+        it("immediately sets the height of the row before animating", function() {
+            expect(this.clarityElement.style.height).toBeFalsy();
+            this.expand.expanded = true;
+            expect(this.clarityElement.style.height).toBeTruthy();
+        });
+    });
+}
+
+@Component({
+    template: `<clr-dg-row>Hello world</clr-dg-row>`
+})
+class SimpleTest {
+}

--- a/src/clarity-angular/datagrid/animation-hack/row-expand-animation.ts
+++ b/src/clarity-angular/datagrid/animation-hack/row-expand-animation.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+/*
+ * This is a hack that we have to write for now because of bugs and limitations in Angular,
+ * please do not use this as an example.
+ */
+
+import {Directive, ElementRef, Renderer} from "@angular/core";
+
+import {DomAdapter} from "../render/dom-adapter";
+import {RowExpand} from "../providers/row-expand";
+import {DatagridRenderOrganizer} from "../render/render-organizer";
+
+@Directive({
+    selector: "clr-dg-row"
+})
+export class DatagridRowExpandAnimation {
+
+    constructor(private el: ElementRef, private domAdapter: DomAdapter, private renderer: Renderer,
+                private expand: RowExpand, private renderOrganizer: DatagridRenderOrganizer) {
+        expand.animate.subscribe(() => {
+            // We already had an animation waiting, so we just have to run in, not prepare again
+            if (this.oldHeight) {
+                setTimeout(() => this.run());
+            } else {
+                this.animate();
+            }
+        });
+    }
+
+    private running: any;
+    private oldHeight: number;
+
+    /*
+     * Dirty manual animation handling, but we have no way to use dynamic heights in Angular's current API.
+     * They're working on it, but have no ETA.
+     */
+    private animate() {
+        // Check if we do have web-animations available. If not, just skip the animation.
+        if (!this.el.nativeElement.animate) {
+            return;
+        }
+
+        // We had an animation running, we skip to the end
+        if (this.running) {
+            this.running.finish();
+        }
+
+        this.oldHeight = this.domAdapter.computedHeight(this.el.nativeElement);
+        // We set the height of the element immediately to avoid a flicker before the animation starts.
+        this.renderer.setElementStyle(this.el.nativeElement, "height", this.oldHeight + "px");
+        this.renderer.setElementStyle(this.el.nativeElement, "overflow-y", "hidden");
+        setTimeout(() => {
+            if (this.expand.loading) { return; }
+            this.run();
+        });
+    }
+
+    private run() {
+        this.renderer.setElementStyle(this.el.nativeElement, "height", null);
+        // I don't like realigning the columns before the animation, since the scrollbar could appear or disappear
+        // halfway, but that's a compromise we have to make for now. We can look into a smarter fix later.
+        this.renderOrganizer.scrollbar.next();
+        let newHeight = this.domAdapter.computedHeight(this.el.nativeElement);
+        this.running = this.el.nativeElement.animate({
+            height: [this.oldHeight + "px", newHeight + "px"],
+            overflowY: ["hidden", "hidden"],
+            easing: "ease-in-out"
+        }, {
+            duration: 200
+        });
+        this.running.onfinish = () => {
+            this.renderer.setElementStyle(this.el.nativeElement, "overflow-y", null);
+            delete this.running;
+        };
+        delete this.oldHeight;
+    }
+}

--- a/src/clarity-angular/datagrid/built-in/comparators/datagrid-property-comparator.spec.ts
+++ b/src/clarity-angular/datagrid/built-in/comparators/datagrid-property-comparator.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/built-in/comparators/datagrid-property-comparator.ts
+++ b/src/clarity-angular/datagrid/built-in/comparators/datagrid-property-comparator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/built-in/filters/datagrid-property-string-filter.spec.ts
+++ b/src/clarity-angular/datagrid/built-in/filters/datagrid-property-string-filter.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/built-in/filters/datagrid-property-string-filter.ts
+++ b/src/clarity-angular/datagrid/built-in/filters/datagrid-property-string-filter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/built-in/filters/datagrid-string-filter-impl.spec.ts
+++ b/src/clarity-angular/datagrid/built-in/filters/datagrid-string-filter-impl.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/built-in/filters/datagrid-string-filter.spec.ts
+++ b/src/clarity-angular/datagrid/built-in/filters/datagrid-string-filter.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/built-in/filters/datagrid-string-filter.ts
+++ b/src/clarity-angular/datagrid/built-in/filters/datagrid-string-filter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/built-in/nested-property.spec.ts
+++ b/src/clarity-angular/datagrid/built-in/nested-property.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/built-in/nested-property.ts
+++ b/src/clarity-angular/datagrid/built-in/nested-property.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/datagrid-action-bar.spec.ts
+++ b/src/clarity-angular/datagrid/datagrid-action-bar.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/datagrid-action-bar.ts
+++ b/src/clarity-angular/datagrid/datagrid-action-bar.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/datagrid-action-overflow.spec.ts
+++ b/src/clarity-angular/datagrid/datagrid-action-overflow.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/datagrid-action-overflow.ts
+++ b/src/clarity-angular/datagrid/datagrid-action-overflow.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/datagrid-cell.spec.ts
+++ b/src/clarity-angular/datagrid/datagrid-cell.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/datagrid-cell.ts
+++ b/src/clarity-angular/datagrid/datagrid-cell.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/datagrid-column.spec.ts
+++ b/src/clarity-angular/datagrid/datagrid-column.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/datagrid-column.ts
+++ b/src/clarity-angular/datagrid/datagrid-column.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/datagrid-filter.spec.ts
+++ b/src/clarity-angular/datagrid/datagrid-filter.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/datagrid-filter.ts
+++ b/src/clarity-angular/datagrid/datagrid-filter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/datagrid-footer.spec.ts
+++ b/src/clarity-angular/datagrid/datagrid-footer.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/datagrid-footer.ts
+++ b/src/clarity-angular/datagrid/datagrid-footer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/datagrid-if-expanded.spec.ts
+++ b/src/clarity-angular/datagrid/datagrid-if-expanded.spec.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component, ViewChild, Inject} from "@angular/core";
+import {DatagridIfExpanded} from "./datagrid-if-expanded";
+import {RowExpand} from "./providers/row-expand";
+import {TestBed} from "@angular/core/testing";
+
+export default function(): void {
+    describe("DatagridIfExpanded directive", function() {
+        describe("View", function() {
+            beforeEach(function () {
+                /*
+                 * Since DatagridIfExpanded is a structural directive that isn't rendered in the DOM immediately,
+                 * we can't use our usual shortcut, we need to rely on @ViewChild.
+                 * A quick investigation didn't reveal a better solution yet, we might want to look into it more.
+                 */
+                TestBed.configureTestingModule({
+                    declarations: [DatagridIfExpanded, SimpleTest, TestCounter],
+                    providers: [RowExpand]
+                });
+                this.fixture = TestBed.createComponent(SimpleTest);
+                this.fixture.detectChanges();
+                this.testComponent = this.fixture.componentInstance;
+                this.testElement = this.fixture.nativeElement;
+                this.clarityDirective = this.fixture.componentInstance.ifExpanded;
+                this.rowExpand = TestBed.get(RowExpand);
+            });
+
+            afterEach(function() {
+                this.fixture.destroy();
+            });
+
+            it("doesn't display anything by default", function () {
+                expect(this.testElement.textContent.trim()).toBe("");
+            });
+
+            it("displays the content when the row becomes expanded", function () {
+                this.rowExpand.expanded = true;
+                this.fixture.detectChanges();
+                expect(this.testElement.textContent.trim()).toBe("1");
+            });
+
+            it("removes the content when the row becomes collapsed again", function () {
+                this.rowExpand.expanded = true;
+                this.fixture.detectChanges();
+                this.rowExpand.expanded = false;
+                this.fixture.detectChanges();
+                expect(this.testElement.textContent.trim()).toBe("");
+            });
+
+            it("doesn't instantiate until the content is actually needed", function () {
+                expect(this.testComponent.counter.total).toBe(0);
+            });
+
+            it("re-instantiates the content every time it is displayed", function () {
+                this.rowExpand.expanded = true;
+                this.fixture.detectChanges();
+                expect(this.testElement.textContent.trim()).toBe("1");
+                this.rowExpand.expanded = false;
+                this.fixture.detectChanges();
+                this.rowExpand.expanded = true;
+                this.fixture.detectChanges();
+                expect(this.testElement.textContent.trim()).toBe("2");
+            });
+        });
+
+        describe("Row interaction", function() {
+            beforeEach(function () {
+                /*
+                 * Since DatagridIfExpanded is a structural directive that isn't rendered in the DOM immediately,
+                 * we can't use our usual shortcut, we need to rely on @ViewChild.
+                 * A quick investigation didn't reveal a better solution yet, we might want to look into it more.
+                 */
+                TestBed.configureTestingModule({
+                    declarations: [DatagridIfExpanded, NgIfTest],
+                    providers: [RowExpand]
+                });
+                this.fixture = TestBed.createComponent(NgIfTest);
+                this.fixture.detectChanges();
+                this.testComponent = this.fixture.componentInstance;
+                this.rowExpand = TestBed.get(RowExpand);
+            });
+
+            afterEach(function() {
+                this.fixture.destroy();
+            });
+
+            it("sets the row as expandable", function () {
+                expect(this.rowExpand.expandable).toBe(true);
+            });
+
+            it("sets the row as not expandable when destroyed", function () {
+                this.testComponent.expandable = false;
+                this.fixture.detectChanges();
+                expect(this.rowExpand.expandable).toBe(false);
+            });
+        });
+    });
+}
+
+
+@Component({
+    template: `<test-counter *clrIfExpanded></test-counter>`,
+    providers: [{provide: "counter", useValue: {total: 0}}]
+})
+class SimpleTest {
+    @ViewChild(DatagridIfExpanded) ifExpanded: DatagridIfExpanded;
+
+    constructor(@Inject("counter") public counter: {total: number}) {}
+}
+
+@Component({
+    selector: "test-counter",
+    template: `{{count}}`
+})
+class TestCounter {
+    public count: number;
+
+    constructor(@Inject("counter") counter: {total: number}) {
+        this.count = ++counter.total;
+    }
+}
+
+
+@Component({
+    template: `
+        <ng-container *ngIf="expandable">
+            <div *clrIfExpanded>Hello World</div>
+        </ng-container>`
+})
+class NgIfTest {
+    expandable = true;
+}

--- a/src/clarity-angular/datagrid/datagrid-if-expanded.ts
+++ b/src/clarity-angular/datagrid/datagrid-if-expanded.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Directive, TemplateRef, ViewContainerRef, OnInit, OnDestroy} from "@angular/core";
+
+import {RowExpand} from "./providers/row-expand";
+
+/**
+ * TODO: make this a reusable directive outside of Datagrid, like [clrLoading].
+ */
+@Directive({
+    selector: "[clrIfExpanded]"
+})
+export class DatagridIfExpanded implements OnInit, OnDestroy {
+
+    constructor(private template: TemplateRef<any>, private container: ViewContainerRef, private expand: RowExpand) {
+        expand.expandable = true;
+        expand.expandChange.subscribe(() => this.updateView());
+    }
+
+    private updateView() {
+        if (this.expand.expanded) {
+            // Should we pass a context? I don't see anything useful to pass right now,
+            // but we can come back to it in the future as a solution for additional features.
+            this.container.createEmbeddedView(this.template);
+        } else {
+            // We clear before the animation is over. Not ideal, but doing better would involve a much heavier
+            // process for very little gain. Once Angular animations are dynamic enough, we should be able to
+            // get the optimal behavior.
+            this.container.clear();
+        }
+    }
+
+    ngOnInit() {
+        this.updateView();
+    }
+
+    ngOnDestroy() {
+        this.expand.expandable = false;
+    }
+}

--- a/src/clarity-angular/datagrid/datagrid-items.spec.ts
+++ b/src/clarity-angular/datagrid/datagrid-items.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/datagrid-items.ts
+++ b/src/clarity-angular/datagrid/datagrid-items.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/datagrid-pagination.spec.ts
+++ b/src/clarity-angular/datagrid/datagrid-pagination.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/datagrid-pagination.ts
+++ b/src/clarity-angular/datagrid/datagrid-pagination.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/datagrid-placeholder.spec.ts
+++ b/src/clarity-angular/datagrid/datagrid-placeholder.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/datagrid-placeholder.ts
+++ b/src/clarity-angular/datagrid/datagrid-placeholder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/datagrid-row-detail.spec.ts
+++ b/src/clarity-angular/datagrid/datagrid-row-detail.spec.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component} from "@angular/core";
+import {TestContext} from "./helpers.spec";
+import {DatagridRowDetail} from "./datagrid-row-detail";
+import {Selection, SelectionType} from "./providers/selection";
+import {Items} from "./providers/items";
+import {FiltersProvider} from "./providers/filters";
+import {Sort} from "./providers/sort";
+import {Page} from "./providers/page";
+import {RowActionService} from "./providers/row-action-service";
+import {RowExpand} from "./providers/row-expand";
+import {DatagridRenderOrganizer} from "./render/render-organizer";
+
+export default function(): void {
+    describe("DatagridRowDetail component", function() {
+        let context: TestContext<DatagridRowDetail, FullTest>;
+
+        beforeEach(function() {
+            context = this.create(DatagridRowDetail, FullTest,
+                [Selection, Items, FiltersProvider, Sort, Page, RowActionService, RowExpand, DatagridRenderOrganizer]);
+        });
+
+        it("projects content", function() {
+            expect(context.clarityElement.textContent.trim()).toMatch("Hello world");
+        });
+
+        it("adds the .datagrid-row-flex class to the host", function() {
+            expect(context.clarityElement.classList.contains("datagrid-row-flex")).toBe(true);
+        });
+
+        it("adds the .datagrid-row-detail class to the host if not replacing the row itself", function() {
+            expect(context.clarityElement.classList.contains("datagrid-row-detail")).toBe(true);
+            context.testComponent.replace = true;
+            context.detectChanges();
+            expect(context.clarityElement.classList.contains("datagrid-row-detail")).toBe(false);
+        });
+
+        it("adds the .datagrid-container class to the host if it doesn't contain cells", function() {
+            expect(context.clarityElement.classList.contains("datagrid-container")).toBe(true);
+            context.testComponent.cell = true;
+            context.detectChanges();
+            expect(context.clarityElement.classList.contains("datagrid-container")).toBe(false);
+        });
+
+        it("updates the RowExpand provider with the [clrDgReplace] input", function() {
+            let expand: RowExpand = context.getClarityProvider(RowExpand);
+            expect(expand.replace).toBe(false);
+            context.testComponent.replace = true;
+            context.detectChanges();
+            expect(expand.replace).toBe(true);
+        });
+
+        it("displays an empty cell in place of the caret", function() {
+            expect(context.clarityElement.querySelectorAll(".datagrid-fixed-column").length).toBe(1);
+        });
+
+        it("displays an extra empty cell when the datagrid is selectable", function() {
+            let selection: Selection = context.getClarityProvider(Selection);
+            selection.selectionType = SelectionType.Multi;
+            context.detectChanges();
+            expect(context.clarityElement.querySelectorAll(".datagrid-fixed-column").length).toBe(2);
+            selection.selectionType = SelectionType.Single;
+            context.detectChanges();
+            expect(context.clarityElement.querySelectorAll(".datagrid-fixed-column").length).toBe(2);
+        });
+
+        it("displays an extra empty cell when the datagrid has an actionable row", function() {
+            context.getClarityProvider(RowActionService).hasActionableRow = true;
+            context.detectChanges();
+            expect(context.clarityElement.querySelectorAll(".datagrid-fixed-column").length).toBe(2);
+        });
+
+        it("displays as many extra empty cells as needed", function() {
+            let selection: Selection = context.getClarityProvider(Selection);
+            selection.selectionType = SelectionType.Multi;
+            context.getClarityProvider(RowActionService).hasActionableRow = true;
+            context.detectChanges();
+            expect(context.clarityElement.querySelectorAll(".datagrid-fixed-column").length).toBe(3);
+        });
+
+        it("doesn't display any empty cell when replacing", function() {
+            context.testComponent.replace = true;
+            context.detectChanges();
+            expect(context.clarityElement.querySelectorAll(".datagrid-fixed-column").length).toBe(0);
+            let selection: Selection = context.getClarityProvider(Selection);
+            selection.selectionType = SelectionType.Multi;
+            context.getClarityProvider(RowActionService).hasActionableRow = true;
+            context.detectChanges();
+            expect(context.clarityElement.querySelectorAll(".datagrid-fixed-column").length).toBe(0);
+        });
+    });
+}
+
+@Component({
+    template: `
+        <clr-dg-row-detail [clrDgReplace]="replace">
+            <ng-container *ngIf="!cell">Hello world</ng-container>
+            <clr-dg-cell *ngIf="cell">This is a cell</clr-dg-cell>
+        </clr-dg-row-detail>
+    `
+})
+class FullTest {
+    public replace = false;
+    public cell = false;
+}

--- a/src/clarity-angular/datagrid/datagrid-row-detail.ts
+++ b/src/clarity-angular/datagrid/datagrid-row-detail.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component, Input, ContentChildren, QueryList} from "@angular/core";
+import {RowExpand} from "./providers/row-expand";
+import {Selection, SelectionType} from "./providers/selection";
+import {RowActionService} from "./providers/row-action-service";
+import {DatagridCell} from "./datagrid-cell";
+
+/**
+ * Generic bland container serving various purposes for Datagrid.
+ * For instance, it can help span a text over multiple rows in detail view.
+ */
+@Component({
+    selector: "clr-dg-row-detail",
+    template: `
+        <ng-container *ngIf="!replace">
+            <clr-dg-cell class="datagrid-fixed-column"
+                *ngIf="selection.selectionType === SELECTION_TYPE.Multi 
+                    || selection.selectionType === SELECTION_TYPE.Single"></clr-dg-cell>
+            <clr-dg-cell *ngIf="rowActionService.hasActionableRow" class="datagrid-fixed-column"></clr-dg-cell>
+            <clr-dg-cell class="datagrid-fixed-column"></clr-dg-cell>
+        </ng-container>
+        <ng-content></ng-content>
+    `,
+    host: {
+        "[class.datagrid-row-flex]": "true",
+        "[class.datagrid-row-detail]": "!replace",
+        "[class.datagrid-container]": "cells.length === 0",
+    }
+})
+export class DatagridRowDetail {
+    /* reference to the enum so that template can access it */
+    public SELECTION_TYPE = SelectionType;
+
+    constructor(public selection: Selection, public rowActionService: RowActionService,
+                public expand: RowExpand) {}
+
+    @ContentChildren(DatagridCell) cells: QueryList<DatagridCell>;
+
+    get replace() {
+        return this.expand.replace;
+    }
+
+    @Input("clrDgReplace") set replace(value: boolean) {
+        this.expand.replace = !!value;
+    }
+}

--- a/src/clarity-angular/datagrid/datagrid-row.spec.ts
+++ b/src/clarity-angular/datagrid/datagrid-row.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -14,122 +14,234 @@ import {FiltersProvider} from "./providers/filters";
 import {Sort} from "./providers/sort";
 import {Page} from "./providers/page";
 import {RowActionService} from "./providers/row-action-service";
+import {GlobalExpandableRows} from "./providers/global-expandable-rows";
 import {DatagridRenderOrganizer} from "./render/render-organizer";
+import {DomAdapter} from "./render/dom-adapter";
+import {RowExpand} from "./providers/row-expand";
+import {LoadingListener} from "../loading/loading-listener";
+
+const PROVIDERS = [Selection, Items, FiltersProvider, Sort, Page, RowActionService,
+    GlobalExpandableRows, DatagridRenderOrganizer, DomAdapter];
 
 export default function(): void {
     describe("DatagridRow component", function() {
 
-        // Until we can properly type "this"
-        let context: TestContext<DatagridRow, FullTest>;
-        let selectionProvider: Selection;
+        describe("View", function() {
+            // Until we can properly type "this"
+            let context: TestContext<DatagridRow, FullTest>;
 
-        beforeEach(function () {
-            context = this.create(DatagridRow, FullTest,
-                [Selection, Items, FiltersProvider, Sort, Page, RowActionService, DatagridRenderOrganizer]);
+            beforeEach(function () {
+                context = this.create(DatagridRow, FullTest, PROVIDERS);
+            });
 
-            selectionProvider = TestBed.get(Selection);
+            it("projects content", function () {
+                expect(context.clarityElement.textContent.trim()).toMatch("Hello world");
+            });
+
+            it("adds the .datagrid-row class to the host", function () {
+                expect(context.clarityElement.classList.contains("datagrid-row")).toBeTruthy();
+            });
+
+            it("receives an input for the row's modal", function () {
+                context.testComponent.item = { id: 1 };
+                context.detectChanges();
+                expect(context.clarityDirective.item).toBe(context.testComponent.item);
+            });
+
+            it("displays an empty cell when one of the rows is expandable", function () {
+                expect(context.clarityElement.querySelector(".datagrid-fixed-column")).toBeNull();
+                context.getClarityProvider(GlobalExpandableRows).hasExpandableRow = true;
+                context.detectChanges();
+                expect(context.clarityElement.querySelector(".datagrid-fixed-column")).not.toBeNull();
+            });
         });
 
-        it("projects content", function () {
-            expect(context.clarityElement.textContent.trim()).toMatch("Hello world");
+        describe("Selection", function() {
+            // Until we can properly type "this"
+            let context: TestContext<DatagridRow, FullTest>;
+            let selectionProvider: Selection;
+
+            beforeEach(function () {
+                context = this.create(DatagridRow, FullTest, PROVIDERS);
+                selectionProvider = TestBed.get(Selection);
+            });
+
+            it("doesn't display a checkbox unless selection type is multi", function () {
+                selectionProvider.selectionType = SelectionType.None;
+                context.detectChanges();
+                expect(context.clarityElement.querySelector("input[type='checkbox']")).toBeNull();
+
+                selectionProvider.selectionType = SelectionType.Single;
+                context.detectChanges();
+                expect(context.clarityElement.querySelector("input[type='checkbox']")).toBeNull();
+            });
+
+            it("doesn't display a radio button unless selection type is single", function () {
+                selectionProvider.selectionType = SelectionType.None;
+                context.detectChanges();
+                expect(context.clarityElement.querySelector("input[type='radio']")).toBeNull();
+
+                selectionProvider.selectionType = SelectionType.Multi;
+                context.detectChanges();
+                expect(context.clarityElement.querySelector("input[type='radio']")).toBeNull();
+            });
+
+            it("selects the model when the checkbox is clicked", function () {
+                selectionProvider.selectionType = SelectionType.Multi;
+                context.testComponent.item = {id: 1};
+                context.detectChanges();
+                let checkbox = context.clarityElement.querySelector("input[type='checkbox']");
+                expect(selectionProvider.current).toEqual([]);
+                checkbox.click();
+                context.detectChanges();
+                expect(selectionProvider.current).toEqual([context.testComponent.item]);
+                checkbox.click();
+                context.detectChanges();
+                expect(selectionProvider.current).toEqual([]);
+            });
+
+            it("selects the model when the radio button is clicked", function () {
+                selectionProvider.selectionType = SelectionType.Single;
+                context.testComponent.item = {id: 1};
+                context.detectChanges();
+                let radio = context.clarityElement.querySelector("input[type='radio']");
+                expect(selectionProvider.currentSingle).toBeUndefined();
+                radio.click();
+                context.detectChanges();
+                expect(selectionProvider.currentSingle).toEqual(context.testComponent.item);
+            });
+
+            it("adds the .datagrid-selected class to the host when the row is selected", function () {
+                selectionProvider.selectionType = SelectionType.Multi;
+                context.testComponent.item = {id: 1};
+                context.detectChanges();
+                context.clarityDirective.selected = true;
+                context.detectChanges();
+                expect(context.clarityElement.classList.contains("datagrid-selected")).toBeTruthy();
+            });
+
+            it("offers two-way binding on the selected state of the row", fakeAsync(function () {
+                selectionProvider.selectionType = SelectionType.Multi;
+                context.testComponent.item = {id: 1};
+                flushAndAssertSelected(false);
+                // Input
+                context.testComponent.selected = true;
+                flushAndAssertSelected(true);
+                // Output
+                context.clarityElement.querySelector("input[type='checkbox']").click();
+                flushAndAssertSelected(false);
+            }));
+
+            it("supports selected rows even if the datagrid isn't selectable", fakeAsync(function () {
+                selectionProvider.selectionType = SelectionType.None;
+                expect(context.testComponent.item).toBeUndefined();
+                expect(context.clarityDirective.selected).toBe(false);
+                context.testComponent.selected = true;
+                context.detectChanges();
+                expect(context.clarityDirective.selected).toBe(true);
+                context.testComponent.selected = false;
+                context.detectChanges();
+                expect(context.clarityDirective.selected).toBe(false);
+            }));
+
+            function flushAndAssertSelected(selected: boolean) {
+                context.detectChanges();
+                // ngModel is asynchronous, we need an extra change detection
+                tick();
+                context.detectChanges();
+                expect(context.testComponent.selected).toBe(selected);
+                expect(context.clarityDirective.selected).toBe(selected);
+            }
         });
 
-        it("adds the .datagrid-row class to the host", function () {
-            expect(context.clarityElement.classList.contains("datagrid-row")).toBeTruthy();
+        describe("Expand/Collapse", function() {
+            // Until we can properly type "this"
+            let context: TestContext<DatagridRow, ExpandTest>;
+            let expand: RowExpand;
+
+            beforeEach(function () {
+                context = this.create(DatagridRow, ExpandTest, PROVIDERS);
+                // This is the datagrid's job, so we handle it manually for the tests.
+                context.getClarityProvider(GlobalExpandableRows).hasExpandableRow = true;
+                context.detectChanges();
+                expand = context.getClarityProvider(RowExpand);
+            });
+
+            it("registers a LoadingListener", function () {
+                expect(context.getClarityProvider(LoadingListener)).toBeTruthy();
+            });
+
+            it("displays a clickable caret when the row is expandable", function () {
+                expect(context.clarityElement.querySelector("button clr-icon[shape^=caret]")).not.toBeNull();
+            });
+
+            it("displays a spinner instead of the caret when the details are loading", function () {
+                expect(context.clarityElement.querySelector(".spinner")).toBeNull();
+                expand.loading = true;
+                context.detectChanges();
+                expect(context.clarityElement.querySelector(".spinner")).not.toBeNull();
+            });
+
+            it("doesn't display the details when collapsed", function() {
+                expect(context.clarityElement.textContent).toMatch("Hello world");
+                expect(context.clarityElement.textContent).not.toMatch("Detail");
+                expand.replace = true;
+                context.detectChanges();
+                expect(context.clarityElement.textContent).toMatch("Hello world");
+                expect(context.clarityElement.textContent).not.toMatch("Detail");
+            });
+
+            // FIXME: PhantomJS being a d***
+            xit("displays both the row and the details when expanded and not replacing", fakeAsync(function () {
+                expand.expanded = true;
+                tick();
+                context.detectChanges();
+                expect(context.clarityElement.textContent).toMatch("Hello world");
+                expect(context.clarityElement.textContent).toMatch("Detail");
+            }));
+
+            xit("displays only the details when expanded and replacing", fakeAsync(function () {
+                expand.replace = true;
+                expand.expanded = true;
+                tick();
+                context.detectChanges();
+                expect(context.clarityElement.textContent).not.toMatch("Hello world");
+                expect(context.clarityElement.textContent).toMatch("Detail");
+            }));
+
+            it("doesn't display the details while loading", fakeAsync(function() {
+                expand.expanded = true;
+                expand.loading = true;
+                tick();
+                context.detectChanges();
+                expect(context.clarityElement.textContent).not.toMatch("Detail");
+            }));
+
+            xit("expands and collapses when the caret is clicked", fakeAsync(function () {
+                let caret = context.clarityElement.querySelector(".datagrid-expandable-caret button");
+                caret.click();
+                flushAnimations();
+                expect(expand.expanded).toBe(true);
+                caret.click();
+                flushAnimations();
+                expect(expand.expanded).toBe(false);
+            }));
+
+            xit("offers 2-way binding on the expanded state of the row", fakeAsync(function () {
+                context.testComponent.expanded = true;
+                flushAnimations();
+                expect(context.clarityDirective.expanded).toBe(true);
+                context.clarityElement.querySelector(".datagrid-expandable-caret button").click();
+                flushAnimations();
+                expect(context.testComponent.expanded).toBe(false);
+            }));
+
+            function flushAnimations() {
+                context.detectChanges();
+                tick();
+                context.detectChanges();
+            }
         });
-
-        it("receives an input for the row's modal", function () {
-            context.testComponent.item = { id: 1 };
-            context.detectChanges();
-            expect(context.clarityDirective.item).toBe(context.testComponent.item);
-        });
-
-        it("doesn't display a checkbox unless selection type is multi", function () {
-            selectionProvider.selectionType = SelectionType.None;
-            context.detectChanges();
-            expect(context.clarityElement.querySelector("input[type='checkbox']")).toBeNull();
-
-            selectionProvider.selectionType = SelectionType.Single;
-            context.detectChanges();
-            expect(context.clarityElement.querySelector("input[type='checkbox']")).toBeNull();
-        });
-
-        it("doesn't display a radio button unless selection type is single", function () {
-            selectionProvider.selectionType = SelectionType.None;
-            context.detectChanges();
-            expect(context.clarityElement.querySelector("input[type='radio']")).toBeNull();
-
-            selectionProvider.selectionType = SelectionType.Multi;
-            context.detectChanges();
-            expect(context.clarityElement.querySelector("input[type='radio']")).toBeNull();
-        });
-
-        it("selects the model when the checkbox is clicked", function () {
-            selectionProvider.selectionType = SelectionType.Multi;
-            context.testComponent.item = { id: 1 };
-            context.detectChanges();
-            let checkbox = context.clarityElement.querySelector("input[type='checkbox']");
-            expect(selectionProvider.current).toEqual([]);
-            checkbox.click();
-            context.detectChanges();
-            expect(selectionProvider.current).toEqual([ context.testComponent.item ]);
-            checkbox.click();
-            context.detectChanges();
-            expect(selectionProvider.current).toEqual([]);
-        });
-
-        it("selects the model when the radio button is clicked", function () {
-            selectionProvider.selectionType = SelectionType.Single;
-            context.testComponent.item = { id: 1 };
-            context.detectChanges();
-            let radio = context.clarityElement.querySelector("input[type='radio']");
-            expect(selectionProvider.currentSingle).toBeUndefined();
-            radio.click();
-            context.detectChanges();
-            expect(selectionProvider.currentSingle).toEqual(context.testComponent.item);
-        });
-
-        it("adds the .datagrid-selected class to the host when the row is selected", function () {
-            selectionProvider.selectionType = SelectionType.Multi;
-            context.testComponent.item = { id: 1 };
-            context.detectChanges();
-            context.clarityDirective.selected = true;
-            context.detectChanges();
-            expect(context.clarityElement.classList.contains("datagrid-selected")).toBeTruthy();
-        });
-
-        it("offers two-way binding on the selected state of the row", fakeAsync(function () {
-            selectionProvider.selectionType = SelectionType.Multi;
-            context.testComponent.item = { id: 1 };
-            flushAndAssertSelected(false);
-            // Input
-            context.testComponent.selected = true;
-            flushAndAssertSelected(true);
-            // Output
-            context.clarityElement.querySelector("input[type='checkbox']").click();
-            flushAndAssertSelected(false);
-        }));
-
-        it("supports selected rows even if the datagrid isn't selectable", fakeAsync(function () {
-            selectionProvider.selectionType = SelectionType.None;
-            expect(context.testComponent.item).toBeUndefined();
-            expect(context.clarityDirective.selected).toBe(false);
-            context.testComponent.selected = true;
-            context.detectChanges();
-            expect(context.clarityDirective.selected).toBe(true);
-            context.testComponent.selected = false;
-            context.detectChanges();
-            expect(context.clarityDirective.selected).toBe(false);
-        }));
-
-        function flushAndAssertSelected(selected: boolean) {
-            context.detectChanges();
-            // ngModel is asynchronous, we need an extra change detection
-            tick();
-            context.detectChanges();
-            expect(context.testComponent.selected).toBe(selected);
-            expect(context.clarityDirective.selected).toBe(selected);
-        }
     });
 }
 
@@ -139,4 +251,17 @@ export default function(): void {
 class FullTest {
     item: any;
     selected = false;
+}
+
+@Component({
+    template: `
+        <clr-dg-row [(clrDgExpanded)]="expanded">
+            Hello world
+            <clr-dg-row-detail *clrIfExpanded>
+                Detail
+            </clr-dg-row-detail>
+        </clr-dg-row>`
+})
+class ExpandTest {
+    expanded = false;
 }

--- a/src/clarity-angular/datagrid/datagrid-row.ts
+++ b/src/clarity-angular/datagrid/datagrid-row.ts
@@ -1,36 +1,69 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { Component, Input, Output, EventEmitter } from "@angular/core";
+import {Component, Input, Output, EventEmitter} from "@angular/core";
 import { Selection, SelectionType } from "./providers/selection";
 import { RowActionService } from "./providers/row-action-service";
+import {GlobalExpandableRows} from "./providers/global-expandable-rows";
+import {RowExpand} from "./providers/row-expand";
+import {LoadingListener} from "../loading/loading-listener";
+
 
 let nbRow: number = 0;
 
 @Component({
     selector: "clr-dg-row",
     template: `
-        <clr-dg-cell *ngIf="selection.selectionType === SELECTION_TYPE.Multi" class="datagrid-select">
-            <clr-checkbox [ngModel]="selected" (ngModelChange)="toggle($event)"></clr-checkbox>
-        </clr-dg-cell>
-        <clr-dg-cell *ngIf="selection.selectionType === SELECTION_TYPE.Single" class="datagrid-select">
-            <div class="radio">
-                <input type="radio" [id]="id"  [name]="selection.id + '-radio'" [value]="item" 
-                    [(ngModel)]="selection.currentSingle">    
-                <label for="{{id}}"></label>
-            </div>
-        </clr-dg-cell>
-        <clr-dg-cell *ngIf="rowActionService.hasActionableRow" class="datagrid-row-actions">
-            <ng-content select="clr-dg-action-overflow"></ng-content>
-        </clr-dg-cell>
-        <ng-content></ng-content>
+        <clr-dg-row-master class="datagrid-row-flex">
+            <clr-dg-cell *ngIf="selection.selectionType === SELECTION_TYPE.Multi" 
+                class="datagrid-select datagrid-fixed-column">
+                <clr-checkbox [ngModel]="selected" (ngModelChange)="toggle($event)"></clr-checkbox>
+            </clr-dg-cell>
+            <clr-dg-cell *ngIf="selection.selectionType === SELECTION_TYPE.Single" 
+                class="datagrid-select datagrid-fixed-column">
+                <div class="radio">
+                    <input type="radio" [id]="id"  [name]="selection.id + '-radio'" [value]="item" 
+                        [(ngModel)]="selection.currentSingle">    
+                    <label for="{{id}}"></label>
+                </div>
+            </clr-dg-cell>
+            <clr-dg-cell *ngIf="rowActionService.hasActionableRow" 
+                class="datagrid-row-actions datagrid-fixed-column">
+                <ng-content select="clr-dg-action-overflow"></ng-content>
+            </clr-dg-cell>
+            <clr-dg-cell *ngIf="globalExpandable.hasExpandableRow" 
+                class="datagrid-expandable-caret datagrid-fixed-column">
+                <ng-container *ngIf="expand.expandable">
+                    <button (click)="toggleExpand()" *ngIf="!expand.loading">
+                        <clr-icon shape="caret" [dir]="expand.expanded?'down':'right'"></clr-icon>
+                    </button>
+                    <div class="spinner spinner-sm" *ngIf="expand.loading"></div>
+                </ng-container>
+            </clr-dg-cell>
+            <ng-content  *ngIf="!expand.replace || !expand.expanded || expand.loading"></ng-content>
+            
+            <template *ngIf="expand.replace && expand.expanded && !expand.loading" 
+                [ngTemplateOutlet]="detail"></template>
+        </clr-dg-row-master>
+        
+        <template *ngIf="!expand.replace && expand.expanded && !expand.loading"
+            [ngTemplateOutlet]="detail"></template>
+        
+        <!-- 
+            We need the "project into template" hack because we need this in 2 different places
+            depending on whether the details replace the row or not.
+        -->
+        <template #detail>
+            <ng-content select="clr-dg-row-detail"></ng-content>
+        </template>
     `,
     host: {
         "[class.datagrid-row]": "true",
         "[class.datagrid-selected]": "selected"
-    }
+    },
+    providers: [RowExpand, {provide: LoadingListener, useExisting: RowExpand}]
 })
 export class DatagridRow {
     public id: string;
@@ -43,7 +76,8 @@ export class DatagridRow {
      */
     @Input("clrDgItem") item: any;
 
-    constructor (public selection: Selection, public rowActionService: RowActionService) {
+    constructor(public selection: Selection, public rowActionService: RowActionService,
+                public globalExpandable: GlobalExpandableRows, public expand: RowExpand) {
         this.id = "clr-dg-row" + (nbRow++);
     }
 
@@ -74,6 +108,21 @@ export class DatagridRow {
         if (selected !== this.selected) {
             this.selected = selected;
             this.selectedChanged.emit(selected);
+        }
+    }
+
+    public get expanded() {
+        return this.expand.expanded;
+    }
+    @Input("clrDgExpanded") public set expanded(value: boolean) {
+        this.expand.expanded = value;
+    }
+    @Output("clrDgExpandedChange") expandedChange = new EventEmitter<boolean>(false);
+
+    public toggleExpand() {
+        if (this.expand.expandable) {
+            this.expanded = !this.expanded;
+            this.expandedChange.emit(this.expanded);
         }
     }
 }

--- a/src/clarity-angular/datagrid/datagrid.html
+++ b/src/clarity-angular/datagrid/datagrid.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -8,20 +8,24 @@
 <div class="datagrid" [class.loading]="loading">
     <div clrDgTableWrapper class="datagrid-table-wrapper">
         <div clrDgHead class="datagrid-head">
-            <div class="datagrid-row">
+            <div class="datagrid-row datagrid-row-flex">
                 <!-- header for datagrid where you can select multiple rows -->
-                <div class="datagrid-column datagrid-select"
+                <div class="datagrid-column datagrid-select datagrid-fixed-column"
                      *ngIf="selection.selectionType === SELECTION_TYPE.Multi">
                         <span class="datagrid-column-title">
                             <clr-checkbox [(ngModel)]="allSelected"></clr-checkbox>
                         </span>
                 </div>
                 <!-- header for datagrid where you can select one row only -->
-                <div class="datagrid-column datagrid-select"
+                <div class="datagrid-column datagrid-select datagrid-fixed-column"
                      *ngIf="selection.selectionType === SELECTION_TYPE.Single">
                 </div>
                 <!-- header for single row action; only display if we have at least one actionable row in datagrid -->
-                <div class="datagrid-column datagrid-row-actions" *ngIf="rowActionService.hasActionableRow"></div>
+                <div class="datagrid-column datagrid-row-actions datagrid-fixed-column"
+                     *ngIf="rowActionService.hasActionableRow"></div>
+                <!-- header for carets; only display if we have at least one expandable row in datagrid -->
+                <div class="datagrid-column datagrid-expandable-caret datagrid-fixed-column"
+                     *ngIf="expandableRows.hasExpandableRow"></div>
                 <ng-content select="clr-dg-column"></ng-content>
             </div>
         </div>

--- a/src/clarity-angular/datagrid/helpers.spec.ts
+++ b/src/clarity-angular/datagrid/helpers.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -59,6 +59,15 @@ export function addHelpers(): void {
             TestBed.configureTestingModule({
                 imports: [ClarityModule.forRoot()],
                 declarations: [testComponent],
+                providers: providers
+            });
+            return this._context = new TestContext<D, C>(clarityDirective, testComponent);
+        };
+
+        this.createOnly = <D, C>(clarityDirective: Type<D>, testComponent: Type<C>,
+                                 providers: any[] = [], extraDirectives: Type<any>[] = []) => {
+            TestBed.configureTestingModule({
+                declarations: [clarityDirective, testComponent, ...extraDirectives],
                 providers: providers
             });
             return this._context = new TestContext<D, C>(clarityDirective, testComponent);

--- a/src/clarity-angular/datagrid/index.ts
+++ b/src/clarity-angular/datagrid/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -16,6 +16,8 @@ import { DatagridFooter } from "./datagrid-footer";
 import { DatagridItems } from "./datagrid-items";
 import { DatagridPagination } from "./datagrid-pagination";
 import { DatagridRow } from "./datagrid-row";
+import {DatagridIfExpanded} from "./datagrid-if-expanded";
+import {DatagridRowDetail} from "./datagrid-row-detail";
 import { DatagridPlaceholder } from "./datagrid-placeholder";
 
 import { DatagridMainRenderer } from "./render/main-renderer";
@@ -24,7 +26,10 @@ import { DatagridHeaderRenderer } from "./render/header-renderer";
 import { DatagridHeadRenderer } from "./render/head-renderer";
 import { DatagridBodyRenderer } from "./render/body-renderer";
 import { DatagridRowRenderer } from "./render/row-renderer";
+import {DatagridRowMasterRenderer} from "./render/row-master-renderer";
 import { DatagridCellRenderer } from "./render/cell-renderer";
+
+import {DatagridRowExpandAnimation} from "./animation-hack/row-expand-animation";
 
 export * from "./datagrid";
 export * from "./datagrid-action-bar";
@@ -33,6 +38,8 @@ export * from "./datagrid-column";
 export * from "./datagrid-filter";
 export * from "./datagrid-items";
 export * from "./datagrid-row";
+export * from "./datagrid-if-expanded";
+export * from "./datagrid-row-detail";
 export * from "./datagrid-cell";
 export * from "./datagrid-footer";
 export * from "./datagrid-pagination";
@@ -57,6 +64,8 @@ export const DATAGRID_DIRECTIVES: Type<any>[] = [
     DatagridFilter,
     DatagridItems,
     DatagridRow,
+    DatagridIfExpanded,
+    DatagridRowDetail,
     DatagridCell,
     DatagridFooter,
     DatagridPagination,
@@ -69,7 +78,11 @@ export const DATAGRID_DIRECTIVES: Type<any>[] = [
     DatagridHeaderRenderer,
     DatagridBodyRenderer,
     DatagridRowRenderer,
+    DatagridRowMasterRenderer,
     DatagridCellRenderer,
+
+    // Animation hack
+    DatagridRowExpandAnimation,
 
     // Built-in shortcuts
     DatagridStringFilter

--- a/src/clarity-angular/datagrid/interfaces/comparator.ts
+++ b/src/clarity-angular/datagrid/interfaces/comparator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/interfaces/filter.ts
+++ b/src/clarity-angular/datagrid/interfaces/filter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/interfaces/sort-order.ts
+++ b/src/clarity-angular/datagrid/interfaces/sort-order.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/interfaces/state.ts
+++ b/src/clarity-angular/datagrid/interfaces/state.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/interfaces/string-filter.ts
+++ b/src/clarity-angular/datagrid/interfaces/string-filter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/providers/custom-filter.ts
+++ b/src/clarity-angular/datagrid/providers/custom-filter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/providers/filters.spec.ts
+++ b/src/clarity-angular/datagrid/providers/filters.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/providers/filters.ts
+++ b/src/clarity-angular/datagrid/providers/filters.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/providers/global-expandable-rows.ts
+++ b/src/clarity-angular/datagrid/providers/global-expandable-rows.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Injectable} from "@angular/core";
+
+@Injectable()
+export class GlobalExpandableRows {
+
+    public hasExpandableRow = false;
+
+}

--- a/src/clarity-angular/datagrid/providers/items.spec.ts
+++ b/src/clarity-angular/datagrid/providers/items.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/providers/items.ts
+++ b/src/clarity-angular/datagrid/providers/items.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/providers/page.spec.ts
+++ b/src/clarity-angular/datagrid/providers/page.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/providers/page.ts
+++ b/src/clarity-angular/datagrid/providers/page.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/providers/row-action-service.ts
+++ b/src/clarity-angular/datagrid/providers/row-action-service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/providers/row-expand.spec.ts
+++ b/src/clarity-angular/datagrid/providers/row-expand.spec.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {RowExpand} from "./row-expand";
+
+export default function(): void {
+    describe("RowExpand provider", function() {
+        beforeEach(function() {
+            this.expand = new RowExpand();
+        });
+
+        it("starts with the correct default settings", function() {
+            expect(this.expand.expandable).toBe(false, "not expandable");
+            expect(this.expand.replace).toBe(false, "not replacing the row");
+            expect(this.expand.loading).toBe(false, "already loaded");
+            expect(this.expand.expanded).toBe(false, "collapsed");
+        });
+
+        it("implements LoadingListener", function() {
+            this.expand.startLoading();
+            expect(this.expand.loading).toBe(true);
+            this.expand.doneLoading();
+            expect(this.expand.loading).toBe(false);
+        });
+
+        it("prepares the animation before requesting to expand", function() {
+            let listeners: string[] = [];
+            this.expand.animate.subscribe(() => listeners.push("animate"));
+            this.expand.expandChange.subscribe(() => listeners.push("expand"));
+            this.expand.expanded = true;
+            expect(listeners).toEqual(["animate", "expand"]);
+        });
+
+        it("re-triggers animation when done loading", function() {
+            let animates = 0;
+            this.expand.animate.subscribe(() => animates++);
+            this.expand.startLoading();
+            this.expand.expanded = true;
+            expect(animates).toBe(1);
+            this.expand.doneLoading();
+            expect(animates).toBe(2);
+        });
+    });
+};

--- a/src/clarity-angular/datagrid/providers/row-expand.ts
+++ b/src/clarity-angular/datagrid/providers/row-expand.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Injectable} from "@angular/core";
+import {Observable} from "rxjs/Observable";
+import {Subject} from "rxjs/Subject";
+import {LoadingListener} from "../../loading/loading-listener";
+
+@Injectable()
+export class RowExpand implements LoadingListener {
+
+    public expandable = false;
+    public replace = false;
+
+    private _loading = false;
+    get loading(): boolean {
+        return this._loading;
+    }
+    set loading(value: boolean) {
+        value = !!value;
+        if (value !== this._loading) {
+            this._loading = value;
+        }
+    }
+
+    private _expanded = false;
+    get expanded(): boolean {
+        return this._expanded;
+    }
+    set expanded(value: boolean) {
+        value = !!value;
+        if (value !== this._expanded) {
+            this._expanded = value;
+            this._animate.next();
+            this._expandChange.next(value);
+        }
+    }
+
+    private _animate = new Subject<any>();
+    public get animate(): Observable<boolean> {
+        return this._animate.asObservable();
+    }
+
+    private _expandChange = new Subject<boolean>();
+    public get expandChange(): Observable<boolean> {
+        return this._expandChange.asObservable();
+    }
+
+
+    startLoading() {
+        this.loading = true;
+    }
+
+    doneLoading() {
+        this.loading = false;
+        this._animate.next();
+    }
+}

--- a/src/clarity-angular/datagrid/providers/selection.spec.ts
+++ b/src/clarity-angular/datagrid/providers/selection.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/providers/selection.ts
+++ b/src/clarity-angular/datagrid/providers/selection.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/providers/sort.spec.ts
+++ b/src/clarity-angular/datagrid/providers/sort.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/providers/sort.ts
+++ b/src/clarity-angular/datagrid/providers/sort.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/render/body-renderer.spec.ts
+++ b/src/clarity-angular/datagrid/render/body-renderer.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/render/body-renderer.ts
+++ b/src/clarity-angular/datagrid/render/body-renderer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/render/cell-renderer.spec.ts
+++ b/src/clarity-angular/datagrid/render/cell-renderer.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/render/cell-renderer.ts
+++ b/src/clarity-angular/datagrid/render/cell-renderer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/render/constants.ts
+++ b/src/clarity-angular/datagrid/render/constants.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/render/dom-adapter.mock.ts
+++ b/src/clarity-angular/datagrid/render/dom-adapter.mock.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -21,6 +21,11 @@ export class MockDomAdapter extends DomAdapter {
     _scrollWidth = 0;
     scrollWidth(element: any) {
         return this._scrollWidth;
+    }
+
+    _computedHeight = 0;
+    computedHeight(element: any) {
+        return this._computedHeight;
     }
 }
 

--- a/src/clarity-angular/datagrid/render/dom-adapter.spec.ts
+++ b/src/clarity-angular/datagrid/render/dom-adapter.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -42,6 +42,14 @@ export default function(): void {
             if (/PhantomJS/.test(window.navigator.userAgent)) {
                 expect(this.domAdapter.scrollBarWidth(this.element)).toBeGreaterThan(0);
             }
+        });
+
+        it("computes the height of an element", function(this: UserContext) {
+            let child = document.createElement("div");
+            child.style.width = "10px";
+            child.style.height = "1234px";
+            this.element.replaceChild(child, this.element.firstChild);
+            expect(this.domAdapter.computedHeight(this.element)).toBe(1234);
         });
 
         describe("user-defined width", function() {

--- a/src/clarity-angular/datagrid/render/dom-adapter.ts
+++ b/src/clarity-angular/datagrid/render/dom-adapter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -28,5 +28,9 @@ export class DomAdapter {
 
     scrollWidth(element: any) {
         return element.scrollWidth || 0;
+    }
+
+    computedHeight(element: any) {
+        return parseInt(getComputedStyle(element).getPropertyValue("height"), 10);
     }
 }

--- a/src/clarity-angular/datagrid/render/head-renderer.spec.ts
+++ b/src/clarity-angular/datagrid/render/head-renderer.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/render/head-renderer.ts
+++ b/src/clarity-angular/datagrid/render/head-renderer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/render/header-renderer.spec.ts
+++ b/src/clarity-angular/datagrid/render/header-renderer.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/render/header-renderer.ts
+++ b/src/clarity-angular/datagrid/render/header-renderer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/render/main-renderer.spec.ts
+++ b/src/clarity-angular/datagrid/render/main-renderer.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/render/main-renderer.ts
+++ b/src/clarity-angular/datagrid/render/main-renderer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/render/render-organizer.mock.ts
+++ b/src/clarity-angular/datagrid/render/render-organizer.mock.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/render/render-organizer.spec.ts
+++ b/src/clarity-angular/datagrid/render/render-organizer.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/render/render-organizer.ts
+++ b/src/clarity-angular/datagrid/render/render-organizer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/render/row-master-renderer.spec.ts
+++ b/src/clarity-angular/datagrid/render/row-master-renderer.spec.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component, Directive, Inject} from "@angular/core";
+import {TestContext} from "../helpers.spec";
+import {DatagridRowMasterRenderer} from "./row-master-renderer";
+import {DatagridRenderOrganizer} from "./render-organizer";
+import {MockDatagridRenderOrganizer, MOCK_ORGANIZER_PROVIDER} from "./render-organizer.mock";
+
+export default function(): void {
+    describe("DatagridRowMasterRenderer directive", function() {
+        let context: TestContext<DatagridRowMasterRenderer, FullTest>;
+        let organizer: MockDatagridRenderOrganizer;
+
+        beforeEach(function() {
+            context = this.createOnly(DatagridRowMasterRenderer, FullTest, [MOCK_ORGANIZER_PROVIDER], [TestCounter]);
+            organizer = context.getClarityProvider(DatagridRenderOrganizer);
+        });
+
+        it("adds the .datagrid-row-master class to the host", function() {
+            expect(context.clarityElement.classList.contains("datagrid-row-master")).toBeTruthy();
+        });
+
+        it("projects content by default", function() {
+            expect(context.clarityElement.textContent.trim()).toBe("Hello World");
+        });
+
+        it("projects outside of the host when in table mode", function() {
+            organizer.tableMode.next(true);
+            expect(context.clarityElement.textContent.trim()).toBe("");
+            expect(context.testElement.textContent.trim()).toBe("Hello World");
+            organizer.tableMode.next(false);
+            expect(context.clarityElement.textContent.trim()).toBe("Hello World");
+            expect(context.testElement.textContent.trim()).toBe("Hello World");
+        });
+
+        it("instantiates the content a single time, on initialization", function() {
+            expect(context.testComponent.counter.total).toBe(1);
+            organizer.tableMode.next(true);
+            expect(context.testComponent.counter.total).toBe(1);
+            organizer.tableMode.next(false);
+            expect(context.testComponent.counter.total).toBe(1);
+        });
+    });
+}
+
+@Component({
+    template: `
+        <clr-dg-row-master>
+            <span testCounter>Hello World</span>
+        </clr-dg-row-master>`,
+    providers: [{provide: "counter", useValue: {total: 0}}]
+})
+class FullTest {
+    constructor(@Inject("counter") public counter: {total: number}) {}
+}
+
+@Directive({
+    selector: "[testCounter]"
+})
+class TestCounter {
+    constructor(@Inject("counter") counter: {total: number}) {
+        counter.total++;
+    }
+}

--- a/src/clarity-angular/datagrid/render/row-master-renderer.ts
+++ b/src/clarity-angular/datagrid/render/row-master-renderer.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {
+    Component, OnDestroy, ViewContainerRef, AfterViewInit, ViewChild, TemplateRef
+} from "@angular/core";
+import {Subscription} from "rxjs/Subscription";
+import {DatagridRenderOrganizer} from "./render-organizer";
+
+/**
+ * This component serves as a conditional wrapper.
+ * When in table mode, it puts its content next to itself rather than inside.
+ */
+@Component({
+    selector: "clr-dg-row-master",
+    template: `
+        <template #projected><ng-content></ng-content></template>
+        <ng-container #inside></ng-container>
+    `,
+    host: {
+        "[class.datagrid-row-master]": "true"
+    }
+})
+export class DatagridRowMasterRenderer implements AfterViewInit, OnDestroy {
+
+    constructor(private outsideContainer: ViewContainerRef, private organizer: DatagridRenderOrganizer) {}
+
+    private subscription: Subscription;
+    ngOnDestroy() {
+        this.subscription.unsubscribe();
+    }
+
+    @ViewChild("inside", {read: ViewContainerRef}) insideContainer: ViewContainerRef;
+    @ViewChild("projected") projected: TemplateRef<any>;
+
+    private outside = false;
+
+    ngAfterViewInit() {
+        this.insideContainer.createEmbeddedView(this.projected);
+        this.subscription = this.organizer.tableMode.subscribe(on => this.projectOutside(on));
+    }
+
+    projectOutside(outside: boolean) {
+        // We know the datagrid row's master container is always the first element in it,
+        // so hard-coding a zero index here is fine.
+        if (outside && !this.outside) {
+            this.outsideContainer.insert(this.insideContainer.detach(0), 0);
+        } else if (!outside && this.outside) {
+            this.insideContainer.insert(this.outsideContainer.detach(0), 0);
+        }
+        this.outside = outside;
+    }
+
+}

--- a/src/clarity-angular/datagrid/render/row-renderer.ts
+++ b/src/clarity-angular/datagrid/render/row-renderer.ts
@@ -1,17 +1,17 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import {Directive, ContentChildren, QueryList, OnDestroy, AfterViewInit} from "@angular/core";
+import {Directive, ContentChildren, QueryList, OnDestroy, AfterViewInit, AfterContentInit} from "@angular/core";
 import {Subscription} from "rxjs/Subscription";
 import {DatagridRenderOrganizer} from "./render-organizer";
 import {DatagridCellRenderer} from "./cell-renderer";
 
 @Directive({
-    selector: "clr-dg-row"
+    selector: "clr-dg-row, clr-dg-row-detail"
 })
-export class DatagridRowRenderer implements OnDestroy, AfterViewInit {
+export class DatagridRowRenderer implements OnDestroy, AfterContentInit, AfterViewInit {
 
     constructor(private organizer: DatagridRenderOrganizer) {
         this.subscription = organizer.alignColumns.subscribe(() => this.setWidths());
@@ -25,7 +25,7 @@ export class DatagridRowRenderer implements OnDestroy, AfterViewInit {
     @ContentChildren(DatagridCellRenderer) cells: QueryList<DatagridCellRenderer>;
 
     private setWidths() {
-        if (this.organizer.widths.length === 0) {
+        if (this.organizer.widths.length !== this.cells.length) {
             return;
         }
         this.cells.forEach((cell, index) => {
@@ -34,11 +34,12 @@ export class DatagridRowRenderer implements OnDestroy, AfterViewInit {
         });
     }
 
-    /*
-     * Are directives even allowed to do that?
-     * It works because it's always attached on the same element as a component since they share the same selector,
-     * but it feels like cheating.
-     */
+    ngAfterContentInit() {
+        this.cells.changes.subscribe(() => {
+            this.setWidths();
+        });
+    }
+
     ngAfterViewInit() {
         this.setWidths();
     }

--- a/src/clarity-angular/datagrid/render/table-renderer.spec.ts
+++ b/src/clarity-angular/datagrid/render/table-renderer.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/datagrid/render/table-renderer.ts
+++ b/src/clarity-angular/datagrid/render/table-renderer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clarity-angular/index.ts
+++ b/src/clarity-angular/index.ts
@@ -23,3 +23,4 @@ export * from "./animations/collapse/index";
 export * from "./animations/fade/index";
 export * from "./animations/fade-slide/index";
 export * from "./animations/slide/index";
+export * from "./loading/index";

--- a/src/clarity-angular/loading/index.ts
+++ b/src/clarity-angular/loading/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import { Type } from "@angular/core";
+import {Loading} from "./loading";
+
+export * from "./loading";
+export * from "./loading-listener";
+
+export const LOADING_DIRECTIVES: Type<any>[] = [
+    Loading
+];

--- a/src/clarity-angular/loading/loading-listener.ts
+++ b/src/clarity-angular/loading/loading-listener.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+/**
+ * This is an abstract class because we need it to still be a valid token for dependency injection after transpiling.
+ * This does not mean you should extend it, simply implementing it is fine.
+ */
+export abstract class LoadingListener {
+
+    abstract startLoading(): void;
+
+    abstract doneLoading(): void;
+}

--- a/src/clarity-angular/loading/loading.spec.ts
+++ b/src/clarity-angular/loading/loading.spec.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component, ViewChild, Injectable} from "@angular/core";
+import {TestBed} from "@angular/core/testing";
+import {Loading} from "./loading";
+import {LoadingListener} from "./loading-listener";
+
+describe("Loading directive", function() {
+    beforeEach(function () {
+        TestBed.configureTestingModule({
+            declarations: [Loading, FullTest],
+            providers: [{provide: LoadingListener, useClass: DummyListener}]
+        });
+        this.fixture = TestBed.createComponent(FullTest);
+        this.fixture.detectChanges();
+        this.testComponent = this.fixture.componentInstance;
+        this.clarityDirective = this.fixture.componentInstance.loadingDirective;
+        this.listener = TestBed.get(LoadingListener);
+    });
+
+    afterEach(function() {
+        this.fixture.destroy();
+    });
+
+    it("notifies the listener when the [clrLoading] input changes", function () {
+        expect(this.listener.loading).toBe(false);
+        this.testComponent.loading = true;
+        this.fixture.detectChanges();
+        expect(this.listener.loading).toBe(true);
+        this.testComponent.loading = false;
+        this.fixture.detectChanges();
+        expect(this.listener.loading).toBe(false);
+    });
+
+    it("ignores successive inputs with the same value", function () {
+        spyOn(this.listener, "startLoading");
+        spyOn(this.listener, "doneLoading");
+        this.testComponent.loading = false;
+        this.fixture.detectChanges();
+        this.testComponent.loading = null;
+        this.fixture.detectChanges();
+        expect(this.listener.doneLoading).toHaveBeenCalledTimes(0);
+        this.testComponent.loading = true;
+        this.fixture.detectChanges();
+        this.testComponent.loading = 42;
+        this.fixture.detectChanges();
+        expect(this.listener.startLoading).toHaveBeenCalledTimes(1);
+    });
+
+    it("stops loading when destroyed", function () {
+        this.testComponent.loading = true;
+        this.fixture.detectChanges();
+        expect(this.listener.loading).toBe(true);
+        this.testComponent.displayed = false;
+        this.fixture.detectChanges();
+        expect(this.listener.loading).toBe(false);
+    });
+});
+
+
+@Component({
+    template: `<div *ngIf="displayed" [clrLoading]="loading"></div>`
+})
+class FullTest {
+    @ViewChild(Loading) loadingDirective: Loading;
+
+    public displayed = true;
+    public loading = false;
+}
+
+@Injectable()
+class DummyListener implements LoadingListener {
+    public loading = false;
+
+    startLoading(): void {
+        this.loading = true;
+    }
+
+    doneLoading(): void {
+        this.loading = false;
+    }
+}

--- a/src/clarity-angular/loading/loading.ts
+++ b/src/clarity-angular/loading/loading.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Directive, Input, OnDestroy, Optional} from "@angular/core";
+
+import {LoadingListener} from "./loading-listener";
+
+@Directive({
+    selector: "[clrLoading]"
+})
+export class Loading implements OnDestroy {
+
+    // We find the first parent that handles something loading
+    constructor(@Optional() private listener: LoadingListener) {}
+
+    private _loading = false;
+    public get loading() {
+        return this._loading;
+    }
+    @Input("clrLoading") public set loading(value: boolean) {
+        value = !!value;
+        if (value === this._loading) { return; }
+        this._loading = value;
+        if (this.listener) {
+            if (value) {
+                this.listener.startLoading();
+            } else {
+                this.listener.doneLoading();
+            }
+        }
+    }
+
+    ngOnDestroy() {
+        this.loading = false;
+    }
+
+}


### PR DESCRIPTION
Expandable rows as a solution to the master/detail pattern.

This PR also introduces a new pattern for "loading listeners". If it works well, we will use it everywhere we have a spinner for lazy loading: treeview, stackview, tabs, ...

Several future improvements already noted:
1. We will be able to move to full Angular animations once 4.1 is out. Until then, we have to use this manual web-animations hack.
2. Many animation tests are not passing in PhantomJS, I had to comment them out for now. Some of these are important, we need to fix them ASAP. I'm expecting Angular 4.1 to help a lot.
3. The detail container should not be cleared immediately when collapsing, it should wait for the animation to be over.
4. The headers re-align immediately if a scrollbar is supposed to appear during the animation, rather than when the scrollbar actually appears.