### PR TITLE
[NG] Fixing alt cancel issue in new wizard

### DIFF
--- a/src/app/wizard/wizard-alt-cancel.demo.html
+++ b/src/app/wizard/wizard-alt-cancel.demo.html
@@ -6,8 +6,6 @@
 
 <button class="btn btn-primary" (click)="wizard.open()">Alt-Cancel Wizard</button>
 
-<p>TODO: STILL NEEDS WORK. KNOWN ISSUE - ALT CANCEL ROUTINE FIRING TWICE.</p>
-
 <clr-wizard #wizard
     [(clrWizardOpen)]="open"
     [clrWizardSize]="'md'"

--- a/src/app/wizard/wizard-alt-cancel.demo.ts
+++ b/src/app/wizard/wizard-alt-cancel.demo.ts
@@ -19,24 +19,18 @@ export class WizardAltCancelDemo {
 
     public showCancelConfirm: boolean = false;
 
-    private alreadyCancelled: boolean = false;
-
     public pageCustomCancel(): void {
         this.showCancelConfirm = true;
     }
 
     public doPageCancel() {
-        // catches cancel when it falls through to wizard
-        this.alreadyCancelled = true;
+        this.showCancelConfirm = false;
         this.wizard.close();
     }
 
     public doCancel() {
-        if (this.alreadyCancelled) {
-            // resets for next trip through
-            this.alreadyCancelled = false;
-        } else if (confirm("Do you really, really want to close the wizard?")) {
-            this.alreadyCancelled = true;
+        if (confirm("Do you really, really want to close the wizard?")) {
+            this.showCancelConfirm = false;
             this.wizard.close();
         }
     }
@@ -50,35 +44,29 @@ import { Wizard } from "../../clarity-angular/wizard/wizard";
 })
 export class WizardAltCancelDemo {
     @ViewChild("wizard") wizard: Wizard;
-    @ViewChild(CodeHighlight) codeHighlight: CodeHighlight;
 
     public showCancelConfirm: boolean = false;
-
-    private alreadyCancelled: boolea false;
 
     public pageCustomCancel(): void {
         this.showCancelConfirm = true;
     }
 
     public doPageCancel() {
-        // catches cancel when it falls through to wizard
-        this.alreadyCancelled = true;
+        this.showCancelConfirm = false;
         this.wizard.close();
     }
 
     public doCancel() {
-        if (this.alreadyCancelled) {
-            // resets for next trip through
-            this.alreadyCancelled = false;
-        } else if (confirm("Do you really, really want to close the wizard?")) {
-            this.alreadyCancelled = true;
+        if (confirm("Do you really, really want to close the wizard?")) {
+            this.showCancelConfirm = false;
             this.wizard.close();
         }
     }
+}
 `;
 
     html: string = `
-<clr-wizard #wizard (clrWizardOnCancel)="doCancel()" [clrWizardPreventDefaultCancel]="true">
+<clr-wizard #wizard [(clrWizardOpen)]="open" (clrWizardOnCancel)="doCancel()" [clrWizardPreventDefaultCancel]="true">
     <clr-wizard-title>Wizard with alternate cancel</clr-wizard-title>
 
     <clr-wizard-button [type]="'cancel'">Cancel</clr-wizard-button>
@@ -90,9 +78,7 @@ export class WizardAltCancelDemo {
         ...
     </clr-wizard-page>
 
-    <clr-wizard-page (clrWizardPageOnCancel)="pageCustomCancel()"
-        [clrWizardPagePreventDefaultCancel]="true">
-        <template clrPageTitle>Page level alt-cancel</template>
+    <clr-wizard-page (clrWizardPageOnCancel)="pageCustomCancel()" [clrWizardPagePreventDefaultCancel]="true">
         ...
     </clr-wizard-page>
 </clr-wizard>

--- a/src/app/wizard/wizard-async-validation.demo.html
+++ b/src/app/wizard/wizard-async-validation.demo.html
@@ -14,7 +14,10 @@
     <clr-wizard-button [type]="'next'">Next</clr-wizard-button>
     <clr-wizard-button [type]="'finish'">Finish</clr-wizard-button>
 
-    <clr-wizard-page [clrWizardPagePreventDefault]="true" (clrWizardPageOnCommit)="onCommit()">
+    <clr-wizard-page
+        clrWizardPagePreventDefault="true"
+        (clrWizardPageOnCommit)="onCommit()"
+        (clrWizardPageOnCancel)="doCancel()">
         <template clrPageTitle>Form with async validation</template> <!-- mandatory -->
 
         <div class="spinner" *ngIf="loadingFlag">

--- a/src/app/wizard/wizard-async-validation.demo.ts
+++ b/src/app/wizard/wizard-async-validation.demo.ts
@@ -21,6 +21,13 @@ export class WizardAsyncValidation {
     loadingFlag: boolean = false;
     errorFlag: boolean = false;
 
+    // have to define doCancel because page will prevent doCancel from working
+    // if the page had a previous button, you would need to call 
+    // this.wizard.previous() manually as well...
+    doCancel(): void {
+        this.wizard.close();
+    }
+
     onCommit(): void {
         let value: any = this.formData.value;
         this.loadingFlag = true;
@@ -50,6 +57,13 @@ export class WizardAsyncValidation {
     loadingFlag: boolean = false;
     errorFlag: boolean = false;
 
+    // have to define doCancel because page will prevent doCancel from working
+    // if the page had a previous button, you would need to call 
+    // this.wizard.previous() manually as well...
+    doCancel(): void {
+        this.wizard.close();
+    }
+
     onCommit(): void {
         let value: any = this.formData.value;
         this.loadingFlag = true;
@@ -76,8 +90,12 @@ export class WizardAsyncValidation {
     <clr-wizard-button [type]="'next'">Next</clr-wizard-button>
     <clr-wizard-button [type]="'finish'">Finish</clr-wizard-button>
 
-    <clr-wizard-page [clrWizardPagePreventDefault]="true" (clrWizardPageOnCommit)="onCommit()">
+    <clr-wizard-page
+        clrWizardPagePreventDefault="true"
+        (clrWizardPageOnCommit)="onCommit()"
+        (clrWizardPageOnCancel)="doCancel()">
         <template clrPageTitle>Form with async validation</template>
+
         <div class="spinner" *ngIf="loadingFlag">
             Loading...
         </div>
@@ -103,7 +121,6 @@ export class WizardAsyncValidation {
         </form>
     </clr-wizard-page>
     <clr-wizard-page>
-        <template clrPageTitle>Wizard complete</template>
         ...
     </clr-wizard-page>
 </clr-wizard>

--- a/src/clarity-angular/modal/modal.ts
+++ b/src/clarity-angular/modal/modal.ts
@@ -118,11 +118,13 @@ export class Modal implements OnChanges, OnDestroy {
     @Input("clrModalClosable") closable: boolean = true;
     @Input("clrModalSize") size: string;
     @Input("clrModalStaticBackdrop") staticBackdrop: boolean = false;
-    @Input("clrModalSkipAnimation") skipAnimation: boolean = false;
+    @Input("clrModalSkipAnimation") skipAnimation: string = "false";
 
     // presently this is only used by wizards
     @Input("clrModalGhostPageState") ghostPageState: string = "hidden";
     @Input("clrModalOverrideScrollService") bypassScrollService: boolean = false;
+    @Input("clrModalPreventClose") stopClose: boolean = false;
+    @Output("clrModalAlternateClose") altClose: EventEmitter<boolean> = new EventEmitter<boolean>(false);
 
     constructor(private _scrollingService: ScrollingService) {
     }
@@ -151,7 +153,7 @@ export class Modal implements OnChanges, OnDestroy {
     }
 
     open(): void {
-        if (this._open) {
+        if (this._open === true) {
             return;
         }
         this._open = true;
@@ -160,10 +162,15 @@ export class Modal implements OnChanges, OnDestroy {
 
     @HostListener("body:keyup.escape")
     close(): void {
+        if (this.stopClose) {
+            this.altClose.emit(false);
+            return;
+        }
         if (!this.closable || this._open === false) {
             return;
         }
         this._open = false;
+        // SPECME
     }
 
     fadeDone(e: AnimationTransitionEvent) {

--- a/src/clarity-angular/wizard/providers/wizard-navigation.ts
+++ b/src/clarity-angular/wizard/providers/wizard-navigation.ts
@@ -92,9 +92,12 @@ export class WizardNavigationService implements OnDestroy {
         });
 
         this.cancelButtonSubscription = this.buttonService.cancelBtnClicked.subscribe(() => {
-            if (!this.currentPage.preventDefault) {
+            if (this.currentPage.preventDefault) {
+                this.currentPage.pageOnCancel.emit(this.currentPage);
+            } else {
                 this.cancel();
             }
+            // SPECME
         });
 
         this.pagesResetSubscription = this.pageCollection.pagesReset.subscribe(() => {

--- a/src/clarity-angular/wizard/wizard.html
+++ b/src/clarity-angular/wizard/wizard.html
@@ -9,10 +9,11 @@
     [clrModalSize]="size"
     [clrModalClosable]="closable"
     [clrModalStaticBackdrop]="true"
-    (clrModalOpenChange)="cancel()"
     [clrModalSkipAnimation]="stopModalAnimations"
     [clrModalGhostPageState]="ghostPageState"
-    [clrModalOverrideScrollService]="isStatic">
+    [clrModalOverrideScrollService]="isStatic"
+    clrModalPreventClose="true"
+    (clrModalAlternateClose)="modalCancel()">
 
     <nav class="modal-nav clr-wizard-stepnav-wrapper">
         <h3 class="clr-wizard-title"><ng-content select="clr-wizard-title"></ng-content></h3>

--- a/src/clarity-angular/wizard/wizard.ts
+++ b/src/clarity-angular/wizard/wizard.ts
@@ -61,15 +61,7 @@ export class Wizard implements OnInit, OnDestroy, AfterContentInit, DoCheck {
         });
 
         this.cancelSubscription = this.navService.notifyWizardCancel.subscribe(() => {
-            let currentPage = this.navService.currentPage;
-
-            currentPage.pageOnCancel.emit();
-            this.onCancel.emit();
-
-            if (!this.stopCancel && !currentPage.preventDefault && !currentPage.stopCancel) {
-                this.close();
-                // SPECME
-            }
+            this.checkAndCancel();
         });
 
         this.wizardFinishedSubscription = this.navService.wizardFinished.subscribe(() => {
@@ -212,7 +204,6 @@ export class Wizard implements OnInit, OnDestroy, AfterContentInit, DoCheck {
     // LEGACY: Naming convention matches old wizard
     public open(): void {
         let navService = this.navService;
-
         this._open = true;
         if (!this.currentPage) {
             navService.setFirstPageCurrent();
@@ -266,6 +257,29 @@ export class Wizard implements OnInit, OnDestroy, AfterContentInit, DoCheck {
 
     public cancel(): void {
         this.navService.cancel();
+    }
+
+    // need to bust out some logic here because the modal openChange event is 
+    // messing up alt-cancel routines
+    public modalCancel(): void {
+        this.checkAndCancel();
+        // SPECME
+    }
+
+    public checkAndCancel(): void {
+        let currentPage = this.currentPage;
+        let currentPageHasOverrides = currentPage.stopCancel || currentPage.preventDefault;
+
+        currentPage.pageOnCancel.emit();
+        if (!currentPageHasOverrides) {
+            this.onCancel.emit();
+        }
+        // SPECME
+
+        if (!this.stopCancel && !currentPageHasOverrides) {
+            this.close();
+        }
+        // SPECME
     }
 
     public goTo(pageId: string): void {


### PR DESCRIPTION
These changes Address the following issues with the 0.9.0 wizard:

• an issue where and alt cancel routine was fired twice at the wizard level
• an issue where a page level alt cancel routine fired and was followed by a wizard level alt cancel
• an issue with enter and leave animations in the modal

To resolve this issue, I gave precedence to page level alt cancel routines. If the current page has defined either and preventDefault or stopCancel, it will prevent comparable events at the wizard level from firing. This was already the case for finish, previous, next, and danger buttons. The logic was not implemented for cancel buttons, however.

Tested in:
✔︎ Chrome

Signed-off-by: Scott Mathis <smathis@vmware.com>