### PR TITLE
[ng] allow multiple filters to be open

### DIFF
--- a/src/clarity-angular/datagrid/_datagrid.clarity.scss
+++ b/src/clarity-angular/datagrid/_datagrid.clarity.scss
@@ -112,27 +112,26 @@
         width: auto; // override the basic table's style of width: 100%
         max-width: none; // override the basic table's style of max-width: 100%
 
-        &.loading {
-            // this allows for the spinner to be centered relative to .datagrid-container
+        .datagrid-spinner-wrapper {
             position: relative;
-        }
 
-        .datagrid-spinner {
-            position: absolute;
-            top: 0;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            background: rgba($clr-white, 0.6);
-
-            .spinner {
-                // We center the spinner in the datagrid
+            .datagrid-spinner {
                 position: absolute;
                 top: 0;
                 bottom: 0;
                 left: 0;
                 right: 0;
-                margin: auto;
+                background: rgba($clr-white, 0.6);
+
+                .spinner {
+                    // We center the spinner in the datagrid
+                    position: absolute;
+                    top: 0;
+                    bottom: 0;
+                    left: 0;
+                    right: 0;
+                    margin: auto;
+                }
             }
         }
 

--- a/src/clarity-angular/datagrid/datagrid-action-overflow.ts
+++ b/src/clarity-angular/datagrid/datagrid-action-overflow.ts
@@ -4,20 +4,20 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import {
-    Component, EventEmitter, HostListener, Input, Output, ElementRef, ViewChild
+    Component, EventEmitter, HostListener, Input, Output, ElementRef
 } from "@angular/core";
 import {Point} from "../popover/popover";
-import {DatagridRenderOrganizer} from "./render/render-organizer";
-
 
 @Component({
     selector: "clr-dg-action-overflow",
     template: `
         <clr-icon #anchor shape="ellipsis-vertical" class="datagrid-action-toggle" (click)="toggle()"></clr-icon>
-        <div #menu class="datagrid-action-overflow" *clrPopover="open; anchor: anchor; anchorPoint: anchorPoint; 
-            popoverPoint: popoverPoint;">
-            <ng-content></ng-content>
-        </div>
+        <ng-template [(clrPopover)]="open" [clrPopoverAnchor]="anchor" [clrPopoverAnchorPoint]="anchorPoint"
+             [clrPopoverPopoverPoint]="popoverPoint">
+            <div #menu class="datagrid-action-overflow">
+                <ng-content></ng-content>
+            </div>
+        </ng-template>
     `
 })
 
@@ -26,18 +26,7 @@ export class DatagridActionOverflow {
     public anchorPoint: Point = Point.RIGHT_CENTER;
     public popoverPoint: Point = Point.LEFT_CENTER;
 
-    constructor(private elementRef: ElementRef, private datagridRenderOrganizer: DatagridRenderOrganizer) {
-    }
-
-    // after change detection cycle settles, refresh the scrollbar
-    // NOTE: this might break if angular decides to change when @ViewChild's setter is called in its lifecycle
-    @ViewChild("menu") set menu(child: any) {
-        // Scrollbar might have disappeared, we need to warn the renderers
-        if (child) {
-            // TODO: A webkit bug prevents us from simply refreshing the scrollbar. Weird. Needs investigation.
-            // this.renderOrganizer.scrollbar.next();
-            this.datagridRenderOrganizer.resize();
-        }
+    constructor(private elementRef: ElementRef) {
     }
 
     /**

--- a/src/clarity-angular/datagrid/datagrid-filter.ts
+++ b/src/clarity-angular/datagrid/datagrid-filter.ts
@@ -9,7 +9,7 @@ import {Filter} from "./interfaces/filter";
 import {CustomFilter} from "./providers/custom-filter";
 import {FiltersProvider, RegisteredFilter} from "./providers/filters";
 import {DatagridFilterRegistrar} from "./utils/datagrid-filter-registrar";
-import {Point} from "../popover/popover";
+import {Point, PopoverOptions} from "../popover/popover";
 
 
 /**
@@ -25,17 +25,19 @@ import {Point} from "../popover/popover";
         <button #anchor class="datagrid-filter-toggle" (click)="toggle()"
            [class.datagrid-filter-open]="open" [class.datagrid-filtered]="active"></button>
 
-        <div class="datagrid-filter" *clrPopover="open; anchor: anchor; anchorPoint: anchorPoint; 
-            popoverPoint: popoverPoint">
-            <!-- FIXME: this whole filter part needs a final design before we can try to have a cleaner DOM -->
-            <div class="datagrid-filter-close-wrapper">
-                <button type="button" class="close" aria-label="Close" (click)="open = false">
-                    <clr-icon aria-hidden="true" shape="close"></clr-icon>
-                </button>
+        <ng-template [(clrPopover)]="open" [clrPopoverAnchor]="anchor" [clrPopoverAnchorPoint]="anchorPoint"
+             [clrPopoverPopoverPoint]="popoverPoint" [clrPopoverOptions]="popoverOptions">
+            <div class="datagrid-filter">
+                <!-- FIXME: this whole filter part needs a final design before we can try to have a cleaner DOM -->
+                <div class="datagrid-filter-close-wrapper">
+                    <button type="button" class="close" aria-label="Close" (click)="open = false">
+                        <clr-icon aria-hidden="true" shape="close"></clr-icon>
+                    </button>
+                </div>
+    
+                <ng-content></ng-content>
             </div>
-
-            <ng-content></ng-content>
-        </div>
+        </ng-template>
     `
 })
 export class DatagridFilter extends DatagridFilterRegistrar<Filter<any>> implements CustomFilter {
@@ -45,6 +47,7 @@ export class DatagridFilter extends DatagridFilterRegistrar<Filter<any>> impleme
 
     public anchorPoint: Point = Point.RIGHT_BOTTOM;
     public popoverPoint: Point = Point.RIGHT_TOP;
+    public popoverOptions: PopoverOptions = { allowMultipleOpen: true };
     /**
      * Tracks whether the filter dropdown is open or not
      */

--- a/src/clarity-angular/datagrid/datagrid.html
+++ b/src/clarity-angular/datagrid/datagrid.html
@@ -5,7 +5,14 @@
   -->
 
 <ng-content select="clr-dg-action-bar"></ng-content>
-<div class="datagrid" [class.loading]="loading">
+<div class="datagrid" #datagrid>
+    <div class="datagrid-spinner-wrapper" *ngIf="loading">
+        <!--we are using the offsetHeight here to set the height of spinner which is brittle;
+            re-evaluate later to see if there is a better fix for this-->
+        <div class="datagrid-spinner" [style.height.px]="datagrid.offsetHeight">
+            <div class="spinner">Loading...</div>
+        </div>
+    </div>
     <div clrDgTableWrapper class="datagrid-table-wrapper">
         <div clrDgHead class="datagrid-head">
             <div class="datagrid-row datagrid-row-flex">
@@ -44,7 +51,8 @@
 
             <!-- Custom placeholder overrides the default empty one -->
             <ng-content select="clr-dg-placeholder"></ng-content>
-            <clr-dg-placeholder *ngIf="!placeholder"></clr-dg-placeholder></div>
+            <clr-dg-placeholder *ngIf="!placeholder"></clr-dg-placeholder>
+        </div>
     </div>
 
     <!--
@@ -52,8 +60,4 @@
         everything when using custom elements with display:table-cell.
     -->
     <ng-content select="clr-dg-footer"></ng-content>
-
-    <div class="datagrid-spinner" *ngIf="loading">
-        <div class="spinner">Loading...</div>
-    </div>
 </div>

--- a/src/clarity-angular/dropdown/dropdown.ts
+++ b/src/clarity-angular/dropdown/dropdown.ts
@@ -21,10 +21,12 @@ import {menuPositions} from "./menu-positions";
     selector: "clr-dropdown",
     template: `
         <ng-content select="[clrDropdownToggle]"></ng-content>
-        <div class="dropdown-menu" *clrPopover="open; anchor: anchor; anchorPoint: anchorPoint;
-            popoverPoint: popoverPoint;">
-            <ng-content select="[clr-dropdown-menu, .dropdown-menu]"></ng-content>
-        </div>
+        <ng-template [(clrPopover)]="open" [clrPopoverAnchor]="anchor" [clrPopoverAnchorPoint]="anchorPoint"
+                     [clrPopoverPopoverPoint]="popoverPoint">
+            <div class="dropdown-menu">
+                <ng-content select="[clr-dropdown-menu, .dropdown-menu]"></ng-content>
+            </div>
+        </ng-template>
     `,
     host: {
         "[class.dropdown]" : "true",

--- a/src/clarity-angular/popover/popover.directive.spec.ts
+++ b/src/clarity-angular/popover/popover.directive.spec.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import {Component} from "@angular/core";
+import {Component, ViewChildren, QueryList} from "@angular/core";
 import {ComponentFixture, TestBed} from "@angular/core/testing";
 import {PopoverDirective} from "./popover.directive";
 
@@ -15,25 +15,26 @@ describe("Popover directive", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            declarations: [TestComponent, PopoverDirective]
+            declarations: [TestComponent, DesugaredSyntaxComponent, PopoverDirective]
         });
-
-        fixture = TestBed.createComponent(TestComponent);
-        fixture.detectChanges();
-        compiled = fixture.nativeElement;
     });
 
     afterEach(() => {
         fixture.destroy();
     });
 
-
     it("projects content", function () {
+        fixture = TestBed.createComponent(TestComponent);
+        compiled = fixture.nativeElement;
+
         expect(compiled.textContent).toMatch(/anchor1/);
         expect(compiled.textContent).toMatch(/anchor2/);
     });
 
     it("shows popover content if open", function () {
+        fixture = TestBed.createComponent(TestComponent);
+        compiled = fixture.nativeElement;
+
         fixture.componentInstance.open1 = true;
         fixture.detectChanges();
         expect(compiled.textContent).toMatch(/popover1/);
@@ -41,6 +42,9 @@ describe("Popover directive", () => {
     });
 
     it("queues up opening of subsequent popovers if one is already open", function () {
+        fixture = TestBed.createComponent(TestComponent);
+        compiled = fixture.nativeElement;
+
         fixture.componentInstance.open1 = true;
         fixture.componentInstance.open2 = true;
         fixture.componentInstance.open3 = true;
@@ -67,6 +71,16 @@ describe("Popover directive", () => {
         expect(compiled.textContent).not.toMatch(/popover2/);
         expect(compiled.textContent).toMatch(/popover3/);
     });
+
+    it("shows popover content when using desugared syntax", function () {
+        fixture = TestBed.createComponent(DesugaredSyntaxComponent);
+        compiled = fixture.nativeElement;
+
+        fixture.componentInstance.open1 = true;
+        fixture.detectChanges();
+        expect(compiled.textContent).toMatch(/popover1/);
+        expect(compiled.textContent).not.toMatch(/popover2/);
+    });
 });
 
 @Component({
@@ -89,4 +103,23 @@ class TestComponent {
     open1: boolean = false;
     open2: boolean = false;
     open3: boolean = false;
+}
+
+@Component({
+    template: `
+        <span #anchor1>anchor1</span>
+        <ng-template [(clrPopover)]="open1" [clrPopoverAnchor]="anchor1">
+            <span>popover1</span>
+        </ng-template>
+        <span #anchor2>anchor2</span>
+        <ng-template [(clrPopover)]="open2" [clrPopoverAnchor]="anchor2">
+            <span>popover2</span>
+        </ng-template>
+    `
+})
+class DesugaredSyntaxComponent {
+    @ViewChildren(PopoverDirective) popoverDirectives: QueryList<PopoverDirective>;
+
+    open1: boolean = false;
+    open2: boolean = false;
 }

--- a/src/clarity-angular/popover/popover.spec.ts
+++ b/src/clarity-angular/popover/popover.spec.ts
@@ -44,19 +44,17 @@ describe("Popover", function () {
         popoverInstance = new Popover(popover);
     });
 
-    xit("prevents scrolling of its first positioned container", function () {
+    it("adds a scroll event handler to its first positioned container", function () {
         popoverInstance.anchor(anchor, null, null);
-        expect(container.style.overflow).toEqual("hidden");
+        expect(container.onscroll).toBeDefined();
     });
 
-    xit("resumes scrolling of its first positioned container when destroyed", function () {
+    it("removes scroll event handler of its first positioned container when destroyed", function () {
         popoverInstance.anchor(anchor, null, null);
         popoverInstance.destroy();
-        expect(container.style.overflow).toEqual("scroll");
+        expect(container.onscroll).toBeNull();
     });
 
-    // TODO: when time permits, calculate expected values based on values for the elements
-    // rather than hard code as we have here; then use string interpolation for the expected value
     it("positions the popover according to align points specified", function () {
         let x: number;
         let y: number;

--- a/src/clarity-angular/tooltips/tooltip.ts
+++ b/src/clarity-angular/tooltips/tooltip.ts
@@ -27,11 +27,13 @@ const tooltipSizes: string[] = [
     template: `
        <a #anchor href="javascript://" role="tooltip" aria-haspopup="true" class="tooltip" 
                 [ngClass]="'tooltip-' + direction + ' tooltip-' + size">
-            <ng-content></ng-content>
-            <span class="tooltip-content" *clrPopover="visible; anchor: anchor; anchorPoint: anchorPoint; 
-                popoverPoint: popoverPoint;">
-                <ng-content select="clr-tooltip-content"></ng-content>
-            </span>
+           <ng-content></ng-content>
+           <ng-template [(clrPopover)]="visible" [clrPopoverAnchor]="anchor" [clrPopoverAnchorPoint]="anchorPoint"
+                        [clrPopoverPopoverPoint]="popoverPoint">
+                <span class="tooltip-content">
+                    <ng-content select="clr-tooltip-content"></ng-content>
+                </span>
+           </ng-template>
         </a>
     `,
     host: {


### PR DESCRIPTION
Addressed in this commit are:
- change in popover to allow multiple to be open (thru options)
- ui/ng change to prevent filter popovers from shifting when the loading spinner is on (i.e. refactor loading spinner to not rely on datagrid class having `position:relative`)
- changing popover implementation to close on scroll (as per discussion with @reddolan)

Fixes #668 and #706.

Signed-off-by: Jeeyun Lim <jeeyun.lim@gmail.com>