### PR TITLE
[UI] Progress bars: Fix reset animation

### DIFF
--- a/src/clarity-angular/progress-bars/_progress-bars.clarity.scss
+++ b/src/clarity-angular/progress-bars/_progress-bars.clarity.scss
@@ -73,6 +73,11 @@ $clr-progress-bgColor: $clr-light-gray !default;
                 background-image: none;
             }
 
+            &[value="0"]::-webkit-progress-value  {
+                // Prevent transition when resetting back to zero.
+                transition: none;
+            }
+
             &::-webkit-progress-bar {
                 background-color: $clr-progress-bgColor;
                 border-radius: 0;
@@ -156,6 +161,11 @@ $clr-progress-bgColor: $clr-light-gray !default;
 
         &::-webkit-progress-value {
             transition: $clr-progress-transition;
+        }
+
+        &[value="0"]::-webkit-progress-value  {
+            // Prevent transition when resetting back to zero.
+            transition: none;
         }
 
         &::-moz-progress-bar {


### PR DESCRIPTION
We can simply disable animation for when value=“0” to prevent the “negative” progress feel.

## Before:

![screen recording 2017-04-12 at 12 47 pm](https://cloud.githubusercontent.com/assets/2253132/24976457/5caf72be-1f7e-11e7-962f-9a4896979588.gif)

#### Animations:
---
![screen recording 2017-04-12 at 12 48 pm](https://cloud.githubusercontent.com/assets/2253132/24976485/741651de-1f7e-11e7-95d2-7f30b1da1259.gif)


## After:

![screen recording 2017-04-12 at 12 18 pm](https://cloud.githubusercontent.com/assets/2253132/24976348/ef4418ce-1f7d-11e7-9cde-a6789ae05606.gif)

#### Animations:
---
![screen recording 2017-04-12 at 12 23 pm](https://cloud.githubusercontent.com/assets/2253132/24976358/fdc18ada-1f7d-11e7-931c-364736661dee.gif)

Resolves #380

Signed-off-by: Victor Mejia <victor.a.mejia@gmail.com>