### PR TITLE
Updates links to the Clarity Plunkr's:

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -17,9 +17,10 @@ PLEASE FILL OUT THE FOLLOWING. WE MAY CLOSE INCOMPLETE ISSUES.
 
 ### Reproduction of behavior
 <!-- Include a working plunker link reproducing the behavior. -->
-<!-- Clarity Plunker Tempplates -->
-<!-- Clarity Version: [Latest](https://plnkr.co/8TwwdL) -->
-<!-- Clarity Version: [0.7.6](https://plnkr.co/iWrQNL) -->
+<!-- Clarity Plunker Templates -->
+* Include a link to the reproduction scenario you created by forking one of the Clarity Plunker Templates:
+<!-- Clarity Version: [Latest - 0.9.x](https://plnkr.co/uNwwZe) -->
+<!-- Clarity Version: [Legacy - 0.8.15](https://plnkr.co/8TwwdL) -->
 
 ### Environment details
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,8 +120,8 @@ You can submit an issue or a bug to our [GitHub repository](https://github.com/v
 
 * The link to the reproduction scenario you created using one of the Clarity Plunker Templates
 * If possible please provide a minimal demo illustrating the issue by forking one of the Clarity Plunker Templates
-  - Clarity Version: [Latest](https://plnkr.co/8TwwdL)
-  - Clarity Version: [0.7.6](https://plnkr.co/iWrQNL)
+  - Clarity Version: [Latest - 0.9.x](https://plnkr.co/uNwwZe)
+  - Clarity Version: [Legacy - 0.8.15](https://plnkr.co/8TwwdL)
 * The version number of Angular
 * The version number of Clarity
 * The browser name and version number

--- a/README.md
+++ b/README.md
@@ -142,6 +142,6 @@ The Clarity project team welcomes contributions from the community. For more det
 ## Feedback
 
 If you find a bug or want to request a new feature, please open a [GitHub issue](https://github.com/vmware/clarity/issues).
-If possible please provide a minimal demo illustrating the issue by forking one of the Clarity Plunker Templates 
-- Clarity Version: [Latest](https://plnkr.co/8TwwdL)
-- Clarity Version: [0.7.6](https://plnkr.co/iWrQNL)
+* Include a link to the reproduction scenario you created by forking one of the Clarity Plunker Templates:
+  - Clarity Version: [Latest - 0.9.x](https://plnkr.co/uNwwZe)
+  - Clarity Version: [Legacy - 0.8.15](https://plnkr.co/8TwwdL)


### PR DESCRIPTION
- There is now a  -> running ng4 & Clarity 0.9.x
- Changed the legacy plunker to  -> running on ng2

closes #722, closes #721

Signed-off-by: Matt Hippely <mhippely@vmware.com>