### PR TITLE
[NG] Align columns with dynamically loaded *clrDgItems

### DIFF
--- a/src/clarity-angular/datagrid/providers/items.spec.ts
+++ b/src/clarity-angular/datagrid/providers/items.spec.ts
@@ -36,7 +36,7 @@ export default function(): void {
 
         it("starts uninitialized", function() {
             expect(this.itemsInstance.smart).toBe(false);
-            expect(this.itemsInstance.displayed).toBeUndefined();
+            expect(this.itemsInstance.displayed.length).toBe(0);
         });
 
         it("doesn't process the items at all if not smart", function() {

--- a/src/clarity-angular/datagrid/providers/items.ts
+++ b/src/clarity-angular/datagrid/providers/items.ts
@@ -101,7 +101,7 @@ export class Items {
     /**
      * List of items currently displayed
      */
-    private _displayed: any[];
+    private _displayed: any[] = [];
     public get displayed(): any[] {
         // Ideally we could return an immutable array, but we don't have it in Clarity yet.
         return this._displayed;

--- a/src/clarity-angular/datagrid/render/main-renderer.spec.ts
+++ b/src/clarity-angular/datagrid/render/main-renderer.spec.ts
@@ -76,7 +76,7 @@ export default function(): void {
 
             it("does not trigger the render process until the rows are loaded", function() {
                 expect(resizeSpy.calls.count()).toBe(0);
-                context.testComponent.rowsReady = true;
+                context.testComponent.projected = true;
                 context.detectChanges();
                 expect(resizeSpy.calls.count()).toBe(1);
             });
@@ -85,12 +85,19 @@ export default function(): void {
                 context.testComponent.secondColumn = false;
                 context.detectChanges();
                 expect(resizeSpy.calls.count()).toBe(0);
-                context.testComponent.rowsReady = true;
+                context.testComponent.projected = true;
                 context.detectChanges();
                 expect(resizeSpy.calls.count()).toBe(1);
                 context.testComponent.secondColumn = true;
                 context.detectChanges();
                 expect(resizeSpy.calls.count()).toBe(2);
+            });
+
+            it("triggers the render process if the rows are given through *clrDgItems", function() {
+                expect(resizeSpy.calls.count()).toBe(0);
+                context.testComponent.clrDgItems = [1];
+                context.detectChanges();
+                expect(resizeSpy.calls.count()).toBe(1);
             });
         });
 
@@ -168,16 +175,23 @@ class StaticTest {
         <clr-datagrid>
             <clr-dg-column>AAA</clr-dg-column>
             <clr-dg-column *ngIf="secondColumn">AAA</clr-dg-column>
-            <clr-dg-row *ngIf="rowsReady">
+            <clr-dg-row *ngIf="projected">
                 <clr-dg-cell>BBB</clr-dg-cell>
                 <clr-dg-cell>BBB</clr-dg-cell>
             </clr-dg-row>
+            <ng-template [ngIf]="clrDgItems.length > 0">
+                <clr-dg-row *clrDgItems="let n of clrDgItems">
+                    <clr-dg-cell>BBB</clr-dg-cell>
+                    <clr-dg-cell>BBB</clr-dg-cell>
+                </clr-dg-row>
+            </ng-template>
         </clr-datagrid>
     `
 })
 class DynamicTest {
     secondColumn = true;
-    rowsReady = false;
+    projected = false;
+    clrDgItems: number[] = [];
 }
 
 @Component({

--- a/src/clarity-angular/datagrid/render/main-renderer.ts
+++ b/src/clarity-angular/datagrid/render/main-renderer.ts
@@ -8,7 +8,7 @@ import {Subscription} from "rxjs/Subscription";
 import {DomAdapter} from "./dom-adapter";
 import {DatagridRenderOrganizer} from "./render-organizer";
 import {DatagridHeaderRenderer} from "./header-renderer";
-import {DatagridRowRenderer} from "./row-renderer";
+import {Items} from "../providers/items";
 
 @Directive({
     selector: "clr-datagrid",
@@ -16,32 +16,26 @@ import {DatagridRowRenderer} from "./row-renderer";
 })
 export class DatagridMainRenderer implements AfterContentInit, AfterViewInit, OnDestroy {
 
-    constructor(private organizer: DatagridRenderOrganizer) {
+    constructor(private organizer: DatagridRenderOrganizer, private items: Items) {
         this._subscriptions.push(organizer.computeWidths.subscribe(() => this.computeHeadersWidth()));
     }
 
     @ContentChildren(DatagridHeaderRenderer) public headers: QueryList<DatagridHeaderRenderer>;
-    @ContentChildren(DatagridRowRenderer) public rows: QueryList<DatagridRowRenderer>;
 
-    /*
-     * Are directives even allowed to do that?
-     * It works because it's always attached on the same element as a component since they share the same selector,
-     * but it feels like cheating.
-     */
     ngAfterContentInit() {
         this._subscriptions.push(this.headers.changes.subscribe(() => {
             // TODO: only re-stabilize if a column was added or removed. Reordering is fine.
             this.columnsSizesStable = false;
             this.stabilizeColumns();
         }));
-
-        this._subscriptions.push(this.rows.changes.subscribe(() => {
-            this.stabilizeColumns();
-        }));
     }
 
     ngAfterViewInit() {
         this.stabilizeColumns();
+
+        this._subscriptions.push(this.items.change.subscribe(() => {
+            this.stabilizeColumns();
+        }));
     }
 
     private _subscriptions: Subscription[] = [];
@@ -72,7 +66,7 @@ export class DatagridMainRenderer implements AfterContentInit, AfterViewInit, On
     private stabilizeColumns() {
         if (this.columnsSizesStable) { return; }
         // No point resizing if there are no rows, we wait until they are actually loaded.
-        if (this.rows.length > 0) {
+        if (this.items.displayed.length > 0) {
             this.organizer.resize();
             this.columnsSizesStable = true;
         }


### PR DESCRIPTION
We were only listening to content children, but `*clrDgItems` render as part of the view.

Fixes #643, #623, #622.

Should be merged in both 0.9.1 and 0.8.16.