### PR TITLE
[NG] Datagrid: default case-insensitive order

### DIFF
--- a/src/app/datagrid/binding-properties/binding-properties.html
+++ b/src/app/datagrid/binding-properties/binding-properties.html
@@ -10,8 +10,9 @@
     For an easy setup of datagrid column features, you can simply specify the property to bind it to
     in your model. When you do, the column will benefit for all built-in features for this case:
     sorting based on the natural comparison, filtering based on string value, and anything else we
-    might add in the future. You can bind to as deep a property as you want in your model, using
-    a standard dot-separated syntax:
+    might add in the future. Please note that the default sort order for strings will be case-insensitive.
+    If this isn't the desired behavior, you will have to write a custom comparator. You can bind to as deep 
+    a property as you want in your model, using a standard dot-separated syntax:
     <code class="clr-code">[clrDgField]=&quot;'my.deep.property'&quot;</code>
 </p>
 <p>

--- a/src/clarity-angular/datagrid/built-in/comparators/datagrid-property-comparator.spec.ts
+++ b/src/clarity-angular/datagrid/built-in/comparators/datagrid-property-comparator.spec.ts
@@ -12,6 +12,8 @@ export default function(): void {
             expect(this.comparator.compare({a: "aaa"}, {a: "abc"})).toBeLessThan(0);
             expect(this.comparator.compare({a: "aaa"}, {a: "aaa"})).toBe(0);
             expect(this.comparator.compare({a: "bbb"}, {a: "abc"})).toBeGreaterThan(0);
+            expect(this.comparator.compare({a: "AAA"}, {a: "aaa"})).toBe(0);
+            expect(this.comparator.compare({a: "aBc"}, {a: "abc"})).toBe(0);
         });
 
         it("compares integers", function() {
@@ -33,6 +35,8 @@ export default function(): void {
             expect(this.comparator.compare({a: 42}, {a: null})).toBeLessThan(0);
             expect(this.comparator.compare({a: null}, {a: 42})).toBeGreaterThan(0);
             expect(this.comparator.compare({a: null}, {a: null})).toBe(0);
+            expect(this.comparator.compare({a: null}, {a: "aaa"})).toBeGreaterThan(0);
+            expect(this.comparator.compare({a: null}, {a: "AAA"})).toBeGreaterThan(0);
         });
 
         it("supports nested properties", function() {

--- a/src/clarity-angular/datagrid/built-in/comparators/datagrid-property-comparator.ts
+++ b/src/clarity-angular/datagrid/built-in/comparators/datagrid-property-comparator.ts
@@ -17,6 +17,15 @@ export class DatagridPropertyComparator implements Comparator<any> {
     public compare(a: any, b: any): number {
         let propA = this.nestedProp.getPropValue(a);
         let propB = this.nestedProp.getPropValue(b);
+
+        if (typeof propA === "string") {
+            propA = propA.toLowerCase();
+        }
+
+        if (typeof propB === "string") {
+            propB = propB.toLowerCase();
+        }
+
         if (typeof propA === "undefined" || propA === null) {
             if (typeof propB === "undefined" || propB === null) {
                 return 0;


### PR DESCRIPTION
Default sort order for strings should be case-insensitive.

Resolves #491

Signed-off-by: Victor Mejia <victor.a.mejia@gmail.com>