### PR TITLE
[NG] Datagrid Placeholder Fix

### DIFF
--- a/src/app/datagrid/datagrid.demo.html
+++ b/src/app/datagrid/datagrid.demo.html
@@ -15,6 +15,7 @@
     <li><a [routerLink]="['./filtering']">Custom filters</a></li>
     <li><a [routerLink]="['./string-filtering']">Built-in filters</a></li>
     <li><a [routerLink]="['./pagination']">Pagination</a></li>
+    <li><a [routerLink]="['./pagination-scrolling']">Pagination & Scrolling</a></li>
     <li><a [routerLink]="['./selection']">Selection</a></li>
     <li><a [routerLink]="['./selection-single']">Selection (Single)</a></li>
     <li><a [routerLink]="['./preserve-selection']">Preserve Selection</a></li>
@@ -24,6 +25,8 @@
     <li><a [routerLink]="['./column-sizing']">Column sizing</a></li>
     <li><a [routerLink]="['./expandable-rows']">Expandable rows</a></li>
     <li><a [routerLink]="['./full']">Full demo</a></li>
+    <li><a [routerLink]="['./test-cases']">Test Cases</a></li>
+    <li><a [routerLink]="['./test-cases-async']">Asynchronous Test Cases</a></li>
 </ul>
 
 <router-outlet></router-outlet>

--- a/src/app/datagrid/datagrid.demo.module.ts
+++ b/src/app/datagrid/datagrid.demo.module.ts
@@ -32,6 +32,9 @@ import {ColorFilter} from "./utils/color-filter";
 import {Example} from "./utils/example";
 import {FakeLoader} from "./expandable-rows/fake-loader";
 import {DetailWrapper} from "./expandable-rows/detail-wrapper";
+import {DatagridPaginationScrollingDemo} from "./pagination-scrolling/pagination-scrolling";
+import {DatagridTestCasesDemo} from "./test-cases/test-cases";
+import {DatagridTestCasesAsyncDemo} from "./test-cases-async/test-cases-async";
 
 
 @NgModule({
@@ -49,6 +52,7 @@ import {DetailWrapper} from "./expandable-rows/detail-wrapper";
         DatagridFilteringDemo,
         DatagridFullDemo,
         DatagridPaginationDemo,
+        DatagridPaginationScrollingDemo,
         DatagridSelectionDemo,
         DatagridSelectionSingleDemo,
         DatagridPreserveSelectionDemo,
@@ -60,6 +64,8 @@ import {DetailWrapper} from "./expandable-rows/detail-wrapper";
         DatagridScrollingDemo,
         DatagridColumnSizingDemo,
         DatagridExpandableRowsDemo,
+        DatagridTestCasesDemo,
+        DatagridTestCasesAsyncDemo,
         ColorFilter,
         Example,
         FakeLoader,
@@ -73,6 +79,7 @@ import {DetailWrapper} from "./expandable-rows/detail-wrapper";
         DatagridFilteringDemo,
         DatagridFullDemo,
         DatagridPaginationDemo,
+        DatagridPaginationScrollingDemo,
         DatagridSelectionDemo,
         DatagridSelectionSingleDemo,
         DatagridPreserveSelectionDemo,
@@ -83,7 +90,9 @@ import {DetailWrapper} from "./expandable-rows/detail-wrapper";
         DatagridPlaceholderDemo,
         DatagridScrollingDemo,
         DatagridColumnSizingDemo,
-        DatagridExpandableRowsDemo
+        DatagridExpandableRowsDemo,
+        DatagridTestCasesDemo,
+        DatagridTestCasesAsyncDemo
     ]
 })
 export default class DatagridDemoModule {

--- a/src/app/datagrid/datagrid.demo.routing.ts
+++ b/src/app/datagrid/datagrid.demo.routing.ts
@@ -24,6 +24,9 @@ import {DatagridScrollingDemo} from "./scrolling/scrolling";
 import {DatagridColumnSizingDemo} from "./column-sizing/column-sizing";
 import {DatagridPreserveSelectionDemo} from "./preserve-selection/preserve-selection";
 import {DatagridExpandableRowsDemo} from "./expandable-rows/expandable-rows";
+import {DatagridPaginationScrollingDemo} from "./pagination-scrolling/pagination-scrolling";
+import {DatagridTestCasesDemo} from "./test-cases/test-cases";
+import {DatagridTestCasesAsyncDemo} from "./test-cases-async/test-cases-async";
 
 const ROUTES: Routes = [
     {
@@ -39,6 +42,7 @@ const ROUTES: Routes = [
             {path: "filtering", component: DatagridFilteringDemo},
             {path: "string-filtering", component: DatagridStringFilteringDemo},
             {path: "pagination", component: DatagridPaginationDemo},
+            {path: "pagination-scrolling", component: DatagridPaginationScrollingDemo},
             {path: "selection", component: DatagridSelectionDemo},
             {path: "selection-single", component: DatagridSelectionSingleDemo},
             {path: "preserve-selection", component: DatagridPreserveSelectionDemo},
@@ -48,6 +52,8 @@ const ROUTES: Routes = [
             {path: "column-sizing", component: DatagridColumnSizingDemo},
             {path: "expandable-rows", component: DatagridExpandableRowsDemo},
             {path: "full", component: DatagridFullDemo},
+            {path: "test-cases", component: DatagridTestCasesDemo},
+            {path: "test-cases-async", component: DatagridTestCasesAsyncDemo}
         ]
     }
 ];

--- a/src/app/datagrid/pagination-scrolling/pagination-scrolling.html
+++ b/src/app/datagrid/pagination-scrolling/pagination-scrolling.html
@@ -1,0 +1,29 @@
+<!--
+  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<div style="height:500px">
+    <clr-datagrid style="height:100%">
+        <clr-dg-column>User ID</clr-dg-column>
+        <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
+        <clr-dg-column>Creation date</clr-dg-column>
+        <clr-dg-column>Favorite color</clr-dg-column>
+
+        <clr-dg-row *clrDgItems="let user of users">
+            <clr-dg-cell>{{user.id}}</clr-dg-cell>
+            <clr-dg-cell>{{user.name}}</clr-dg-cell>
+            <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+            <clr-dg-cell>
+                <span class="color-square" [style.backgroundColor]="user.color"></span>
+            </clr-dg-cell>
+        </clr-dg-row>
+
+        <clr-dg-footer>
+            {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
+            of {{pagination.totalItems}} users
+            <clr-dg-pagination #pagination [clrDgPageSize]="33"></clr-dg-pagination>
+        </clr-dg-footer>
+    </clr-datagrid>
+</div>

--- a/src/app/datagrid/pagination-scrolling/pagination-scrolling.ts
+++ b/src/app/datagrid/pagination-scrolling/pagination-scrolling.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component} from "@angular/core";
+
+import {Inventory} from "../inventory/inventory";
+import {User} from "../inventory/user";
+
+@Component({
+    moduleId: module.id,
+    selector: "clr-datagrid-pagination-test-demo",
+    providers: [Inventory],
+    templateUrl: "pagination-scrolling.html",
+    styleUrls: ["../datagrid.demo.scss"]
+})
+export class DatagridPaginationScrollingDemo {
+    users: User[];
+
+    constructor(private inventory: Inventory) {
+        inventory.size = 100;
+        inventory.reset();
+        this.users = inventory.all;
+    }
+}

--- a/src/app/datagrid/test-cases-async/test-cases-async.html
+++ b/src/app/datagrid/test-cases-async/test-cases-async.html
@@ -1,0 +1,57 @@
+<!--
+  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<div class="clr-example">
+    <h4>Pagination + Partial data set is loaded asynchronously.</h4>
+    <p>Datagrid height should be fixed irrespective on the number of rows displayed.</p>
+    <clr-datagrid>
+        <clr-dg-column>User ID</clr-dg-column>
+        <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
+        <clr-dg-column>Creation date</clr-dg-column>
+        <clr-dg-column>Favorite color</clr-dg-column>
+
+        <clr-dg-row *clrDgItems="let user of users1">
+            <clr-dg-cell>{{user.id}}</clr-dg-cell>
+            <clr-dg-cell>{{user.name}}</clr-dg-cell>
+            <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+            <clr-dg-cell>
+                <span class="color-square" [style.backgroundColor]="user.color"></span>
+            </clr-dg-cell>
+        </clr-dg-row>
+
+        <clr-dg-footer>
+            {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
+            of {{pagination.totalItems}} users
+            <clr-dg-pagination #pagination [clrDgPageSize]="7"></clr-dg-pagination>
+        </clr-dg-footer>
+    </clr-datagrid>
+</div>
+
+<div class="clr-example">
+    <h4>Pagination + Complete data set is loaded asynchronously.</h4>
+    <p>Datagrid height should be fixed irrespective on the number of rows displayed.</p>
+    <clr-datagrid>
+        <clr-dg-column>User ID</clr-dg-column>
+        <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
+        <clr-dg-column>Creation date</clr-dg-column>
+        <clr-dg-column>Favorite color</clr-dg-column>
+
+        <clr-dg-row *clrDgItems="let user of users">
+            <clr-dg-cell>{{user.id}}</clr-dg-cell>
+            <clr-dg-cell>{{user.name}}</clr-dg-cell>
+            <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+            <clr-dg-cell>
+                <span class="color-square" [style.backgroundColor]="user.color"></span>
+            </clr-dg-cell>
+        </clr-dg-row>
+
+        <clr-dg-footer>
+            {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
+            of {{pagination.totalItems}} users
+            <clr-dg-pagination #pagination [clrDgPageSize]="7"></clr-dg-pagination>
+        </clr-dg-footer>
+    </clr-datagrid>
+</div>

--- a/src/app/datagrid/test-cases-async/test-cases-async.ts
+++ b/src/app/datagrid/test-cases-async/test-cases-async.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component} from "@angular/core";
+
+import {Inventory} from "../inventory/inventory";
+import {User} from "../inventory/user";
+
+@Component({
+    moduleId: module.id,
+    selector: "clr-datagrid-test-cases-async-demo",
+    providers: [Inventory],
+    templateUrl: "test-cases-async.html",
+    styleUrls: ["../datagrid.demo.scss"]
+})
+export class DatagridTestCasesAsyncDemo {
+    users: User[];
+    users1: User[];
+
+    constructor(private inventory: Inventory) {
+        inventory.size = 15;
+        inventory.reset();
+
+        setTimeout(() => {
+            this.users = inventory.all;
+        }, 1000);
+
+        this.users1 = inventory.all.slice(0, 5);
+
+        setTimeout(() => {
+            this.users1 = this.users1.concat(inventory.all.slice(5));
+        }, 1000);
+    }
+}

--- a/src/app/datagrid/test-cases/test-cases.html
+++ b/src/app/datagrid/test-cases/test-cases.html
@@ -1,0 +1,239 @@
+<!--
+  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+<div class="clr-example">
+    <h4>Zero Rows</h4>
+    <p>Datagrid should be high enough to accomodate the placeholder.</p>
+    <clr-datagrid>
+        <clr-dg-column>User ID</clr-dg-column>
+        <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
+        <clr-dg-column>Creation date</clr-dg-column>
+        <clr-dg-column>Favorite color</clr-dg-column>
+
+        <clr-dg-row *clrDgItems="let user of zeroUsers">
+            <clr-dg-cell>{{user.id}}</clr-dg-cell>
+            <clr-dg-cell>{{user.name}}</clr-dg-cell>
+            <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+            <clr-dg-cell>
+                <span class="color-square" [style.backgroundColor]="user.color"></span>
+            </clr-dg-cell>
+        </clr-dg-row>
+
+        <clr-dg-footer>
+            {{zeroUsers.length}} users
+        </clr-dg-footer>
+    </clr-datagrid>
+</div>
+
+<div class="clr-example">
+    <h4>Zero Rows + Fixed Height</h4>
+    <p>Datagrid height should be fixed irrespective on the number of rows displayed.</p>
+    <div style="height: 300px">
+        <clr-datagrid style="height: 100%">
+            <clr-dg-column>User ID</clr-dg-column>
+            <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
+            <clr-dg-column>Creation date</clr-dg-column>
+            <clr-dg-column>Favorite color</clr-dg-column>
+
+            <clr-dg-row *clrDgItems="let user of zeroUsers">
+                <clr-dg-cell>{{user.id}}</clr-dg-cell>
+                <clr-dg-cell>{{user.name}}</clr-dg-cell>
+                <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+                <clr-dg-cell>
+                    <span class="color-square" [style.backgroundColor]="user.color"></span>
+                </clr-dg-cell>
+            </clr-dg-row>
+
+            <clr-dg-footer>
+                {{zeroUsers.length}} users
+            </clr-dg-footer>
+        </clr-datagrid>
+    </div>
+</div>
+
+
+<div class="clr-example">
+    <h4>One Row</h4>
+    <p>Datagrid body height should be atleast 72px.</p>
+    <clr-datagrid>
+        <clr-dg-column>User ID</clr-dg-column>
+        <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
+        <clr-dg-column>Creation date</clr-dg-column>
+        <clr-dg-column>Favorite color</clr-dg-column>
+
+        <clr-dg-row *clrDgItems="let user of oneUser">
+            <clr-dg-cell>{{user.id}}</clr-dg-cell>
+            <clr-dg-cell>{{user.name}}</clr-dg-cell>
+            <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+            <clr-dg-cell>
+                <span class="color-square" [style.backgroundColor]="user.color"></span>
+            </clr-dg-cell>
+        </clr-dg-row>
+
+        <clr-dg-footer>
+            {{oneUser.length}} user
+        </clr-dg-footer>
+    </clr-datagrid>
+</div>
+
+<div class="clr-example">
+    <h4>One Row + Fixed Height</h4>
+    <p>Datagrid height should be fixed irrespective on the number of rows displayed.</p>
+    <div style="height: 300px">
+        <clr-datagrid style="height: 100%">
+            <clr-dg-column>User ID</clr-dg-column>
+            <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
+            <clr-dg-column>Creation date</clr-dg-column>
+            <clr-dg-column>Favorite color</clr-dg-column>
+
+            <clr-dg-row *clrDgItems="let user of oneUser">
+                <clr-dg-cell>{{user.id}}</clr-dg-cell>
+                <clr-dg-cell>{{user.name}}</clr-dg-cell>
+                <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+                <clr-dg-cell>
+                    <span class="color-square" [style.backgroundColor]="user.color"></span>
+                </clr-dg-cell>
+            </clr-dg-row>
+
+            <clr-dg-footer>
+                {{oneUser.length}} user
+            </clr-dg-footer>
+        </clr-datagrid>
+    </div>
+</div>
+
+
+<div class="clr-example">
+    <h4>No Pagination</h4>
+    <p>Datagrid height should be variable depending on the number of rows displayed.</p>
+    <clr-datagrid>
+        <clr-dg-column>User ID</clr-dg-column>
+        <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
+        <clr-dg-column>Creation date</clr-dg-column>
+        <clr-dg-column>Favorite color</clr-dg-column>
+
+        <clr-dg-row *clrDgItems="let user of users">
+            <clr-dg-cell>{{user.id}}</clr-dg-cell>
+            <clr-dg-cell>{{user.name}}</clr-dg-cell>
+            <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+            <clr-dg-cell>
+                <span class="color-square" [style.backgroundColor]="user.color"></span>
+            </clr-dg-cell>
+        </clr-dg-row>
+
+        <clr-dg-footer>
+            {{users.length}} users
+        </clr-dg-footer>
+    </clr-datagrid>
+</div>
+
+<div class="clr-example">
+    <h4>No Pagination + Fixed Height</h4>
+    <p>Datagrid height should be fixed irrespective on the number of rows displayed.</p>
+    <div style="height:300px">
+        <clr-datagrid style="height: 100%">
+            <clr-dg-column>User ID</clr-dg-column>
+            <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
+            <clr-dg-column>Creation date</clr-dg-column>
+            <clr-dg-column>Favorite color</clr-dg-column>
+
+            <clr-dg-row *clrDgItems="let user of users">
+                <clr-dg-cell>{{user.id}}</clr-dg-cell>
+                <clr-dg-cell>{{user.name}}</clr-dg-cell>
+                <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+                <clr-dg-cell>
+                    <span class="color-square" [style.backgroundColor]="user.color"></span>
+                </clr-dg-cell>
+            </clr-dg-row>
+
+            <clr-dg-footer>
+                {{users.length}} users
+            </clr-dg-footer>
+        </clr-datagrid>
+    </div>
+</div>
+
+<div class="clr-example">
+    <h4>Pagination</h4>
+    <p>Datagrid height should be fixed irrespective on the number of rows displayed.</p>
+    <clr-datagrid>
+        <clr-dg-column>User ID</clr-dg-column>
+        <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
+        <clr-dg-column>Creation date</clr-dg-column>
+        <clr-dg-column>Favorite color</clr-dg-column>
+
+        <clr-dg-row *clrDgItems="let user of users">
+            <clr-dg-cell>{{user.id}}</clr-dg-cell>
+            <clr-dg-cell>{{user.name}}</clr-dg-cell>
+            <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+            <clr-dg-cell>
+                <span class="color-square" [style.backgroundColor]="user.color"></span>
+            </clr-dg-cell>
+        </clr-dg-row>
+
+        <clr-dg-footer>
+            {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
+            of {{pagination.totalItems}} users
+            <clr-dg-pagination #pagination [clrDgPageSize]="7"></clr-dg-pagination>
+        </clr-dg-footer>
+    </clr-datagrid>
+</div>
+
+<div class="clr-example" style="margin-bottom: 72px">
+    <h4>Pagination + Fixed Height</h4>
+    <p>Datagrid height should be fixed irrespective on the number of rows displayed.</p>
+    <div style="height:300px">
+        <clr-datagrid style="height:100%">
+            <clr-dg-column>User ID</clr-dg-column>
+            <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
+            <clr-dg-column>Creation date</clr-dg-column>
+            <clr-dg-column>Favorite color</clr-dg-column>
+
+            <clr-dg-row *clrDgItems="let user of users">
+                <clr-dg-cell>{{user.id}}</clr-dg-cell>
+                <clr-dg-cell>{{user.name}}</clr-dg-cell>
+                <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+                <clr-dg-cell>
+                    <span class="color-square" [style.backgroundColor]="user.color"></span>
+                </clr-dg-cell>
+            </clr-dg-row>
+
+            <clr-dg-footer>
+                {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
+                of {{pagination.totalItems}} users
+                <clr-dg-pagination #pagination [clrDgPageSize]="7"></clr-dg-pagination>
+            </clr-dg-footer>
+        </clr-datagrid>
+    </div>
+</div>
+
+<div class="clr-example">
+    <h4>Pagination + Updating Page Size</h4>
+    <p>Datagrid height should be fixed irrespective on the number of rows displayed.</p>
+    <clr-datagrid>
+        <clr-dg-column>User ID</clr-dg-column>
+        <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
+        <clr-dg-column>Creation date</clr-dg-column>
+        <clr-dg-column>Favorite color</clr-dg-column>
+
+        <clr-dg-row *clrDgItems="let user of users">
+            <clr-dg-cell>{{user.id}}</clr-dg-cell>
+            <clr-dg-cell>{{user.name}}</clr-dg-cell>
+            <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+            <clr-dg-cell>
+                <span class="color-square" [style.backgroundColor]="user.color"></span>
+            </clr-dg-cell>
+        </clr-dg-row>
+
+        <clr-dg-footer>
+            {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
+            of {{pagination.totalItems}} users
+            <clr-dg-pagination #pagination [clrDgPageSize]="pageSize"></clr-dg-pagination>
+        </clr-dg-footer>
+    </clr-datagrid>
+    <button class="btn" (click)="updatePageSize()">
+        Update Page Size
+    </button>
+</div>

--- a/src/app/datagrid/test-cases/test-cases.ts
+++ b/src/app/datagrid/test-cases/test-cases.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component} from "@angular/core";
+
+import {Inventory} from "../inventory/inventory";
+import {User} from "../inventory/user";
+
+@Component({
+    moduleId: module.id,
+    selector: "clr-datagrid-test-cases-demo",
+    providers: [Inventory],
+    templateUrl: "test-cases.html",
+    styleUrls: ["../datagrid.demo.scss"]
+})
+export class DatagridTestCasesDemo {
+    users: User[];
+    oneUser: User[];
+    zeroUsers: User[] = [];
+    pageSize: number = 7;
+
+    constructor(private inventory: Inventory) {
+        inventory.size = 15;
+        inventory.reset();
+        this.users = inventory.all;
+
+        this.oneUser = [this.users[0]];
+    }
+
+    updatePageSize(): void {
+        this.pageSize = Math.floor((Math.random() * 10) + 3);
+    }
+}

--- a/src/clarity-angular/datagrid/_datagrid.clarity.scss
+++ b/src/clarity-angular/datagrid/_datagrid.clarity.scss
@@ -23,10 +23,8 @@
         flex-flow: column nowrap;
         align-self: flex-start;
         min-width: 100%;
-        // Firefox needs this
-        min-height: 0;
-        // IE10 (maybe later versions too) needs this
-        overflow: hidden;
+        // IE & Firefox needs this
+        min-height: 1px;
     }
     .datagrid-head, .datagrid-body, .datagrid-row, .datagrid-column, .datagrid-cell {
         display: block;
@@ -35,14 +33,19 @@
         flex: 1 1 auto;
         display: flex;
         flex-flow: column nowrap;
-        // Firefox needs this
-        min-height: 0;
-        // IE10 (maybe later versions too) needs this
-        overflow: hidden;
+        // IE & Firefox needs this
+        min-height: 1px;
     }
     .datagrid-body {
         flex: 1 1 auto;
         overflow-y: auto;
+        -ms-overflow-style: -ms-autohiding-scrollbar;
+
+        display: flex;
+        flex-direction: column;
+
+        //TODO: Use the spinner min height mixin. The mixin needs to be fixed before it can be used.
+        min-height: $clr-baselineRem_3;
     }
     .datagrid-head {
         flex: 0 0 auto;
@@ -87,6 +90,9 @@
             display: table-cell;
         }
         .datagrid-column-separator {
+            display: none;
+        }
+        .datagrid-placeholder-container {
             display: none;
         }
     }
@@ -139,8 +145,6 @@
             background-color: $clr-thead-bgcolor;
             border-bottom: 2*$clr-table-borderwidth solid $clr-light-midtone-gray;
         }
-
-
 
         .datagrid-column, .datagrid-cell {
             text-align: left;
@@ -310,7 +314,6 @@
             }
         }
 
-
         .datagrid-fixed-column {
             flex: 0 0 $clr-datagrid-fixed-column-size;
             // IE10 needs this
@@ -392,6 +395,7 @@
 
         .datagrid-body .datagrid-row {
             border-top: $clr-table-borderwidth solid $clr-lighter-midtone-gray;
+            flex-shrink: 0;
 
             &:first-child {
                 border-top: 0;
@@ -518,17 +522,19 @@
     }
 
     .datagrid-placeholder-container {
-        display: block;
         flex: 1 1 auto;
+        display: flex;
+        justify-content: center;
     }
 
     .datagrid-placeholder {
         background: $clr-white;
         border-top: 1px solid $clr-lighter-midtone-gray;
-        padding: $clr_baselineRem_0_5;
+        width: 100%;
 
         &.datagrid-empty {
             border-top: 0;
+            padding: $clr_baselineRem_0_5;
             display: flex;
             flex-flow: column nowrap;
             align-items: center;

--- a/src/clarity-angular/datagrid/datagrid-placeholder.spec.ts
+++ b/src/clarity-angular/datagrid/datagrid-placeholder.spec.ts
@@ -28,25 +28,6 @@ export default function(): void {
                 this.itemsProvider.all = [];
                 expect(this.component.emptyDatagrid).toBe(true);
             });
-
-            it("counts the numbers of empty rows needed to complete the page", function() {
-                this.pageProvider.size = 10;
-                expect(this.component.nbEmptyRows).toBe(10);
-                this.itemsProvider.all = new Array(3);
-                expect(this.component.nbEmptyRows).toBe(7);
-                this.itemsProvider.all = new Array(10);
-                expect(this.component.nbEmptyRows).toBeLessThanOrEqual(0);
-                this.itemsProvider.all = new Array(42);
-                expect(this.component.nbEmptyRows).toBeLessThanOrEqual(0);
-            });
-
-            it("always leaves space for at least 2 rows", function() {
-                expect(this.component.nbEmptyRows).toBe(2);
-                this.pageProvider.size = 1;
-                expect(this.component.nbEmptyRows).toBe(2);
-                this.itemsProvider.all = new Array(1);
-                expect(this.component.nbEmptyRows).toBe(1);
-            });
         });
 
         describe("View", function() {
@@ -76,20 +57,11 @@ export default function(): void {
                 expect(context.clarityElement.textContent.trim()).toMatch("Hello world");
             });
 
-            it("has height 0 when no empty rows are needed", function() {
+            it("has height 1px (which acts as a bottom border for the last row)" +
+                "when no empty rows are needed", function() {
                 itemsProvider.all = new Array(2);
                 context.detectChanges();
-                expect(context.clarityElement.scrollHeight).toBe(0);
-            });
-
-            // Yuck. But hey, if we're hard-coding a height, we might as well make sure it we don't mess it up.
-            it("adds 36px to its height for each row needed", function() {
-                pageProvider.size = 10;
-                context.detectChanges();
-                expect(context.clarityElement.scrollHeight).toBe(360);
-                itemsProvider.all = new Array(9);
-                context.detectChanges();
-                expect(context.clarityElement.scrollHeight).toBe(36);
+                expect(context.clarityElement.scrollHeight).toBe(1);
             });
         });
     });

--- a/src/clarity-angular/datagrid/datagrid-placeholder.ts
+++ b/src/clarity-angular/datagrid/datagrid-placeholder.ts
@@ -10,16 +10,11 @@ import {Page} from "./providers/page";
 @Component({
     selector: "clr-dg-placeholder",
     template: `
-        <!--
-            I hate doing this, with these 36px being baselineRem(1.5) hardcoded here,
-            but I don't see a better solution right now.
-            
-            TODO: with the new flexbox layout, it might be possible to get rid of this!
-        -->
-        <div class="datagrid-placeholder" [style.min-height]="(36*nbEmptyRows)+'px'"
-            *ngIf="nbEmptyRows > 0" [class.datagrid-empty]="emptyDatagrid">
-            <div class="datagrid-placeholder-image" *ngIf="emptyDatagrid"></div>
-            <ng-content *ngIf="emptyDatagrid"></ng-content>
+        <div
+            class="datagrid-placeholder"
+            [class.datagrid-empty]="emptyDatagrid">
+                <div class="datagrid-placeholder-image" *ngIf="emptyDatagrid"></div>
+                <ng-content *ngIf="emptyDatagrid"></ng-content>
         </div>
     `,
     host: {
@@ -34,18 +29,5 @@ export class DatagridPlaceholder {
      */
     public get emptyDatagrid() {
         return !this.items.loading && (!this.items.displayed || this.items.displayed.length === 0);
-    }
-
-    /**
-     * Number of empty rows to display to ensure we preserve a fixed height on the datagrid,
-     * even if the last page has less items than the previous ones
-     */
-    get nbEmptyRows() {
-        let rowsDisplayed = 0;
-        if (this.items.displayed) {
-            rowsDisplayed = this.items.displayed.length;
-        }
-        // Always leave space for at least 2 rows even if the datagrid isn't paginated
-        return Math.max(this.page.size, 2) - rowsDisplayed;
     }
 }

--- a/src/clarity-angular/datagrid/datagrid.html
+++ b/src/clarity-angular/datagrid/datagrid.html
@@ -41,12 +41,12 @@
                       ngFor [ngForOf]="items.displayed" [ngForTrackBy]="items.trackBy"
                       [ngForTemplate]="iterator.template"></ng-template>
             <ng-content *ngIf="!iterator"></ng-content>
+
+            <!-- Custom placeholder overrides the default empty one -->
+            <ng-content select="clr-dg-placeholder"></ng-content>
+            <clr-dg-placeholder *ngIf="!placeholder"></clr-dg-placeholder>
         </div>
     </div>
-
-    <!-- Custom placeholder overrides the default empty one -->
-    <ng-content select="clr-dg-placeholder"></ng-content>
-    <clr-dg-placeholder *ngIf="!placeholder"></clr-dg-placeholder>
 
     <!--
         This is not inside the table because there is no good way of having a single column span

--- a/src/clarity-angular/datagrid/providers/page.ts
+++ b/src/clarity-angular/datagrid/providers/page.ts
@@ -26,6 +26,7 @@ export class Page {
             // We always emit an event even if the current page index didn't change, because
             // the size changing means the items inside the page are different
             this._change.next(this._current);
+            this._sizeChange.next(this._size);
         }
     }
 
@@ -71,6 +72,12 @@ export class Page {
     public get change(): Observable<number> {
         return this._change.asObservable();
     };
+
+    private _sizeChange = new Subject<number>();
+
+    public get sizeChange(): Observable<number> {
+        return this._sizeChange.asObservable();
+    }
 
     /**
      * Current page

--- a/src/clarity-angular/datagrid/render/dom-adapter.ts
+++ b/src/clarity-angular/datagrid/render/dom-adapter.ts
@@ -30,7 +30,7 @@ export class DomAdapter {
         return element.scrollWidth || 0;
     }
 
-    computedHeight(element: any) {
+    computedHeight(element: any): number {
         return parseInt(getComputedStyle(element).getPropertyValue("height"), 10);
     }
 


### PR DESCRIPTION
Fixes: #631, #583

Changes:
1. Moves the placeholder into the `.datagrid-body`
2. `.datagrid-body` is now `display: flex`. This helps to position to placeholder in the center of the body.
3. `main-renderer` now calculates and sets the height on paginated datagrids. This ensures that the datagrid height is consistent when pages are changed and when the items displayed are less/more that what the page height can support.
4. Removes the datagrid placeholder min height logic and the corresponding tests.

Tested on:
IE11, Edge, Chrome, Safari, Firefox
My VM kept freezing when I ran IE10 so couldn't test on that.

Signed-off-by: Aditya Bhandari <adityab@vmware.com>