### PR TITLE
[WEB] Updated the documentation on loading Clarity Icons in Typescript

### DIFF
--- a/src/pages/documentation/iconography.html
+++ b/src/pages/documentation/iconography.html
@@ -247,7 +247,7 @@
         The ClarityIcons API enables you to add your own icons to the publically available ClarityIcons architecture. Use the following call to add your icon to our library in your application:
     </p>
     <pre><code clr-code-highlight="language-typescript">
-ClarityIcons.add({{'{'}}"shapeNameGoesHere": &quot;&lt;svg ... &gt;[your SVG code goes here]&lt;/svg&gt;&quot;{{'}'}});
+ClarityIcons.add(&#123;"shapeNameGoesHere": &quot;&lt;svg ... &gt;[your SVG code goes here]&lt;/svg&gt;&quot;&#125;);
 </code></pre>
     <p>
         This API method will assign your SVG markup to the named shape it is sent. The icon can then be retrieved like in your application like any other icon in the ClarityIcons library.
@@ -261,7 +261,7 @@ ClarityIcons.add({{'{'}}"shapeNameGoesHere": &quot;&lt;svg ... &gt;[your SVG cod
         The Clarity Icons API can create aliases for the icons in your application with a single API call:
     </p>
     <pre><code clr-code-highlight="language-typescript">
-ClarityIcons.alias({{'{'}}"bell": ["alarm", "oh-noehz"]{{'}'}});
+ClarityIcons.alias(&#123;"bell": ["alarm", "oh-noehz"]&#125;);
 </code></pre>
     <p>
         The above method call will assign "alarm" and "oh-noehz" names to the existing "bell" icon shape. Now you can use the "bell" icon with any of the new names you have assigned it.

--- a/src/pages/get-started.html
+++ b/src/pages/get-started.html
@@ -113,6 +113,18 @@ npm install mutationobserver-shim@0.3.2 --save
 ]
 </code></pre>
     </li>
+    <li>
+        (Optional) If you load Clarity Icons by importing it in Typescript, you can load the shape sets modularly:
+        <pre><code clr-code-highlight="language-typescript">
+import 'clarity-icons';
+</code></pre> Unlike loading <code class="clr-code">clarity-icons.min.js</code> in a <code class="clr-code">script</code> tag, the pattern above won't load all shape sets, but only Core Shapes. Thus, you can load additional sets on demand when you need shapes from those sets. For example, if I need to use
+        <code class="clr-code">play</code> icon, which happens to be in the set of Essential Shapes, I would want to import <code class="clr-code">essential-shapes</code> as well:
+        <pre><code clr-code-highlight="language-typescript">
+import 'clarity-icons';
+import 'clarity-icons/shapes/essential-shapes';
+</code></pre>
+
+    </li>
 </ol>
 
 <h5 id="step-2b-install-clarity-ui">Step 2b: Install Clarity UI</h5>


### PR DESCRIPTION
- fixed interpolation issue on the Iconography page

Resolves https://github.com/vmware/clarity/issues/725

Signed-off-by: stsogoo <stsogoo@vmware.com>