### PR TITLE
[NG] Add a resize method on Datagrid

### DIFF
--- a/src/clarity-angular/datagrid/datagrid.spec.ts
+++ b/src/clarity-angular/datagrid/datagrid.spec.ts
@@ -20,6 +20,7 @@ import { StringFilter } from "./interfaces/string-filter";
 import { DatagridStringFilterImpl } from "./built-in/filters/datagrid-string-filter-impl";
 import {DatagridPropertyStringFilter} from "./built-in/filters/datagrid-property-string-filter";
 import {GlobalExpandableRows} from "./providers/global-expandable-rows";
+import {DatagridRenderOrganizer} from "./render/render-organizer";
 
 export default function (): void {
     describe("Datagrid component", function () {
@@ -37,6 +38,17 @@ export default function (): void {
                 expect(refreshed).toBe(false);
                 context.clarityDirective.dataChanged();
                 expect(refreshed).toBe(true);
+            });
+
+            it("allows to manually resize the datagrid", function() {
+                let organizer: DatagridRenderOrganizer = context.getClarityProvider(DatagridRenderOrganizer);
+                let resizeDone: boolean = false;
+                organizer.done.subscribe(() => {
+                    resizeDone = true;
+                });
+                expect(resizeDone).toBe(false);
+                context.clarityDirective.resize();
+                expect(resizeDone).toBe(true);
             });
 
         });

--- a/src/clarity-angular/datagrid/datagrid.ts
+++ b/src/clarity-angular/datagrid/datagrid.ts
@@ -40,7 +40,7 @@ export class Datagrid implements AfterContentInit, AfterViewInit, OnDestroy {
 
     constructor(public selection: Selection, private sort: Sort, private filters: FiltersProvider,
                 private page: Page, public items: Items, public rowActionService: RowActionService,
-                public expandableRows: GlobalExpandableRows) {}
+                public expandableRows: GlobalExpandableRows, private organizer: DatagridRenderOrganizer) {}
 
     /* reference to the enum so that template can access */
     public SELECTION_TYPE = SelectionType;
@@ -250,5 +250,9 @@ export class Datagrid implements AfterContentInit, AfterViewInit, OnDestroy {
 
     ngOnDestroy() {
         this._subscriptions.forEach((sub: Subscription) => sub.unsubscribe());
+    }
+
+    resize(): void {
+        this.organizer.resize();
     }
 }

--- a/src/clarity-angular/datagrid/render/render-organizer.ts
+++ b/src/clarity-angular/datagrid/render/render-organizer.ts
@@ -36,6 +36,11 @@ export class DatagridRenderOrganizer {
     public scrollbar = new Subject<any>();
     public scrollbarWidth = new Subject<number>();
 
+    protected _done = new Subject<any>();
+    public get done(): Observable<any> {
+        return this._done.asObservable();
+    }
+
     public resize() {
         this.widths.length = 0;
         this._clearWidths.next();
@@ -44,6 +49,7 @@ export class DatagridRenderOrganizer {
         this._tableMode.next(false);
         this._alignColumns.next();
         this.scrollbar.next();
+        this._done.next();
     }
 
 }


### PR DESCRIPTION
Adds a `resize` method on the datagrid component for users to be able to manually trigger the resizing the datagrid.

Note that I am using the `done` Observable. It wasn't just added for the test. Its coming with the datagrid placeholder fix anyway :-)

Tested on Chrome.

Signed-off-by: Aditya Bhandari <adityab@vmware.com>