### PR TITLE
[WEB] Adjusting right edge of the NG/CSS/HTML bugs

### DIFF
--- a/src/styles/components.scss
+++ b/src/styles/components.scss
@@ -16,7 +16,7 @@
 .component-workstream-bugs {
     position: absolute;
     top: $bl-1_0;
-    right: 0;
+    right: $bl-1_0;
     width: 86px;
     .bug {
         &.hidden {


### PR DESCRIPTION
Something in the layout changed that caused the NG/CSS/HTML logos to creep over into the margin. This change adjusts their positioning so they no longer creep over.

Signed-off-by: Scott Mathis <smathis@vmware.com>