### PR TITLE
[NG] Buttons: allow spinner inside of button

### DIFF
--- a/src/app/buttons/button-loading.html
+++ b/src/app/buttons/button-loading.html
@@ -1,0 +1,17 @@
+
+<!--
+  ~ Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<h4>Loading Buttons</h4>
+<button [clrLoading]="validateLoading" class="btn btn-info-outline" (click)="validateDemo()">Validate</button>
+<button [clrLoading]="submitLoading" type="submit" class="btn btn-success-outline" (click)="submitDemo()">Submit</button>
+
+<pre>
+    <code clr-code-highlight="language-html">
+    &lt;button [clrLoading]=&quot;validateLoading&quot; class=&quot;btn btn-info-outline&quot;&gt;Validate&lt;/button&gt;
+    &lt;button [clrLoading]=&quot;submitLoading&quot; type=&quot;submit&quot; class=&quot;btn btn-success-outline&quot;&gt;Success&lt;/button&gt;
+    </code>
+</pre>

--- a/src/app/buttons/button-loading.ts
+++ b/src/app/buttons/button-loading.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component} from "@angular/core";
+
+@Component({
+    moduleId: module.id,
+    selector: "clr-buttons-demo-button-loading",
+    templateUrl: "./button-loading.html",
+    styleUrls: ["./buttons.demo.css"]
+})
+export class ButtonLoadingDemo {
+  private validateLoading: boolean = false;
+  private submitLoading: boolean = false;
+
+  validateDemo() {
+    this.validateLoading = true;
+    setTimeout(() => this.validateLoading = false, 1500);
+  }
+
+  submitDemo() {
+    this.submitLoading = true;
+    setTimeout(() => this.submitLoading = false, 1500);
+  }
+}

--- a/src/app/buttons/buttons.demo.module.ts
+++ b/src/app/buttons/buttons.demo.module.ts
@@ -14,6 +14,7 @@ import {SecondaryButtonDemo} from "./secondary-button";
 import {TertiaryButtonDemo} from "./tertiary-button";
 import {InverseButtonDemo} from "./inverse-button";
 import {ButtonStatesDemo} from "./button-states";
+import {ButtonLoadingDemo} from "./button-loading";
 import {ButtonSizesDemo} from "./button-sizes";
 import {ToggleDemo} from "./toggles";
 import {ButtonsTestDemo} from "./buttons-test";
@@ -33,6 +34,7 @@ import {ButtonsIconsDemo} from "./buttons-icons";
         TertiaryButtonDemo,
         InverseButtonDemo,
         ButtonStatesDemo,
+        ButtonLoadingDemo,
         ButtonSizesDemo,
         ToggleDemo,
         ButtonsTestDemo,
@@ -46,6 +48,7 @@ import {ButtonsIconsDemo} from "./buttons-icons";
         TertiaryButtonDemo,
         InverseButtonDemo,
         ButtonStatesDemo,
+        ButtonLoadingDemo,
         ButtonSizesDemo,
         ToggleDemo,
         ButtonsTestDemo,

--- a/src/app/buttons/buttons.demo.routing.ts
+++ b/src/app/buttons/buttons.demo.routing.ts
@@ -12,6 +12,7 @@ import {SecondaryButtonDemo} from "./secondary-button";
 import {TertiaryButtonDemo} from "./tertiary-button";
 import {InverseButtonDemo} from "./inverse-button";
 import {ButtonStatesDemo} from "./button-states";
+import {ButtonLoadingDemo} from "./button-loading";
 import {ButtonSizesDemo} from "./button-sizes";
 import {ToggleDemo} from "./toggles";
 import {ButtonsTestDemo} from "./buttons-test";
@@ -29,6 +30,7 @@ const ROUTES: Routes = [
             { path: "tertiary-button", component: TertiaryButtonDemo },
             { path: "inverse-button", component: InverseButtonDemo },
             { path: "button-states", component: ButtonStatesDemo },
+            { path: "button-loading", component: ButtonLoadingDemo },
             { path: "button-sizes", component: ButtonSizesDemo },
             { path: "toggles", component: ToggleDemo },
             { path: "buttons-test", component: ButtonsTestDemo },

--- a/src/app/buttons/buttons.demo.ts
+++ b/src/app/buttons/buttons.demo.ts
@@ -19,6 +19,7 @@ import {Component} from "@angular/core";
             <li><a [routerLink]="['./tertiary-button']">Tertiary Buttons</a></li>
             <li><a [routerLink]="['./inverse-button']">Inverse Buttons</a></li>
             <li><a [routerLink]="['./button-states']">Button States</a></li>
+            <li><a [routerLink]="['./button-loading']">Loading Buttons</a></li>
             <li><a [routerLink]="['./button-sizes']">Button Sizes</a></li>
             <li><a [routerLink]="['./toggles']">Toggles</a></li>
             <li><a [routerLink]="['./icons']">Icons in Buttons</a></li>

--- a/src/clarity-angular/button-loading/index.ts
+++ b/src/clarity-angular/button-loading/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import { Type } from "@angular/core";
+import {LoadingButton} from "./loading-button";
+
+export const LOADING_BUTTON_DIRECTIVES: Type<any>[] = [
+    LoadingButton
+];

--- a/src/clarity-angular/button-loading/loading-button.spec.ts
+++ b/src/clarity-angular/button-loading/loading-button.spec.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import {Component, ViewChild} from "@angular/core";
+import {ComponentFixture, TestBed} from "@angular/core/testing";
+import {ClarityModule} from "../clarity.module";
+import {LoadingButton} from "./loading-button";
+
+describe("Loading Buttons", () => {
+    let fixture: ComponentFixture<TestLoadingButtonComponent>;
+    let componentInstance: TestLoadingButtonComponent;
+
+    beforeEach(() => {
+
+        TestBed.configureTestingModule({
+            imports: [
+                ClarityModule.forRoot()
+            ],
+            declarations: [
+                TestLoadingButtonComponent
+            ]
+        });
+
+        fixture = TestBed.createComponent(TestLoadingButtonComponent);
+        componentInstance = fixture.componentInstance;
+
+        fixture.detectChanges();
+    });
+
+    afterEach(() => {
+        fixture.destroy();
+    });
+
+    it("implements LoadingListener", () => {
+        let instance: LoadingButton = fixture.componentInstance.loadingButtonInstance;
+
+        instance.startLoading();
+        expect(instance.loading).toBe(true);
+
+        instance.doneLoading();
+        expect(instance.loading).toBe(false);
+    });
+
+    it("displays spinner when [clrLoading] value is true", () => {
+        fixture.componentInstance.flag = true;
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector(".spinner")).toBeTruthy();
+    });
+
+    it("hides spinner when [clrLoading] value is false", () => {
+        fixture.componentInstance.flag = false;
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector(".spinner")).toBeFalsy();
+    });
+});
+
+@Component({
+    template: `
+        <button [clrLoading]="flag" id="testBtn">Test 1</button>
+    `
+})
+class TestLoadingButtonComponent {
+    @ViewChild(LoadingButton) loadingButtonInstance: LoadingButton;
+
+    flag: boolean = false;
+}

--- a/src/clarity-angular/button-loading/loading-button.ts
+++ b/src/clarity-angular/button-loading/loading-button.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+
+import {Component} from "@angular/core";
+import {LoadingListener} from "../loading/loading-listener";
+
+@Component({
+    selector: "button[clrLoading]",
+    template: `
+        <span class="spinner spinner-inline" *ngIf="loading"></span>
+        <ng-content></ng-content>
+    `,
+    providers: [{provide: LoadingListener, useExisting: LoadingButton}]
+})
+export class LoadingButton implements LoadingListener {
+
+    public loading: Boolean;
+
+    startLoading(): void {
+      this.loading = true;
+    }
+
+    doneLoading(): void {
+      this.loading = false;
+    }
+}
+

--- a/src/clarity-angular/clarity.module.ts
+++ b/src/clarity-angular/clarity.module.ts
@@ -24,6 +24,7 @@ import {OLD_WIZARD_DIRECTIVES} from "./wizard-deprecated/index";
 import {WIZARD_DIRECTIVES} from "./wizard/index";
 import {ICON_DIRECTIVES} from "./iconography/index";
 import {BUTTON_GROUP_DIRECTIVES} from "./button-group/index";
+import {LOADING_BUTTON_DIRECTIVES} from "./button-loading/index";
 import {LOADING_DIRECTIVES} from "./loading/index";
 
 import {ClrResponsiveNavigationService} from "./nav/clrResponsiveNavigationService";
@@ -51,6 +52,7 @@ import {ClrResponsiveNavigationService} from "./nav/clrResponsiveNavigationServi
         WIZARD_DIRECTIVES,
         ICON_DIRECTIVES,
         BUTTON_GROUP_DIRECTIVES,
+        LOADING_BUTTON_DIRECTIVES,
         LOADING_DIRECTIVES
     ],
     exports: [
@@ -70,6 +72,7 @@ import {ClrResponsiveNavigationService} from "./nav/clrResponsiveNavigationServi
         WIZARD_DIRECTIVES,
         ICON_DIRECTIVES,
         BUTTON_GROUP_DIRECTIVES,
+        LOADING_BUTTON_DIRECTIVES,
         LOADING_DIRECTIVES
     ]
 })


### PR DESCRIPTION
Leverages the `[clrLoading]` directive.

Wanted to get some input here. The injected `LoadingListener` in the `Loading` directive seems to be coming in as null: https://github.com/vmware/clarity/blob/master/src/clarity-angular/loading/loading.ts#L16

I'm unsure why, the new `LoadingButton` component here is implementing the `LoadingListener` abstract class. While trying to get it to work, I changed the type from `LoadingListener` to the `LoadingButton` type, and the instance seems to be injected fine. Any thoughts?

Resolves #463

Signed-off-by: Victor Mejia <victor.a.mejia@gmail.com>