### PR TITLE
[CORE] obsolete jsnext:main by pkg.module

### DIFF
--- a/build/npm/clarity-angular.json
+++ b/build/npm/clarity-angular.json
@@ -4,7 +4,7 @@
     "description": "Angular 2 components for Clarity",
     "homepage": "https://vmware.github.io/clarity/",
     "main": "clarity-angular.umd.js",
-    "jsnext:main": "index.js",
+    "module": "index.js",
     "repository" : {
         "type" : "git",
         "url" : "git@github.com:vmware/clarity.git"


### PR DESCRIPTION
See its wiki page - https://github.com/rollup/rollup/wiki/jsnext:main