### PR TITLE
[NG] wizard provider tests fixed and running

### DIFF
--- a/src/clarity-angular/wizard/all.spec.ts
+++ b/src/clarity-angular/wizard/all.spec.ts
@@ -7,9 +7,9 @@ import WizardHeaderActionSpecs from "./wizard-header-action.spec";
 import WizardPageSpecs from "./wizard-page.spec";
 
 import ButtonHubSpecs from "./providers/button-hub.spec";
-// import WizardNavigationSpecs from "./providers/wizard-navigation.spec";
+import WizardNavigationSpecs from "./providers/wizard-navigation.spec";
 import PageCollectionSpecs from "./providers/page-collection.spec";
-// import HeaderActionsSpecs from "./providers/header-actions.spec";
+import HeaderActionsSpecs from "./providers/header-actions.spec";
 
 describe("New Wizard Tests", () => {
     addHelpers();
@@ -21,7 +21,7 @@ describe("New Wizard Tests", () => {
     WizardPageSpecs();
 
     ButtonHubSpecs();
-    // WizardNavigationSpecs();
+    WizardNavigationSpecs();
     PageCollectionSpecs();
-    // HeaderActionsSpecs();
+    HeaderActionsSpecs();
 });

--- a/src/clarity-angular/wizard/providers/button-hub.spec.ts
+++ b/src/clarity-angular/wizard/providers/button-hub.spec.ts
@@ -27,10 +27,10 @@ export default function(): void {
             context.detectChanges();
         });
 
-        it("'next' calls wizardNavigationService.next", function() {
-            spyOn(wizardNavigationService, "next");
+        it("'next' calls wizardNavigationService.checkAndCommitCurrentPage with next", function() {
+            spyOn(wizardNavigationService, "checkAndCommitCurrentPage");
             buttonHubService.buttonClicked("next");
-            expect(wizardNavigationService.next).toHaveBeenCalled();
+            expect(wizardNavigationService.checkAndCommitCurrentPage).toHaveBeenCalledWith("next");
         });
 
         it("'previous' calls wizardNavigationService.previous", function() {
@@ -41,14 +41,9 @@ export default function(): void {
         });
 
         it("'danger' calls wizardNavigationService.next or wizardNavigationService.finish", function() {
-            spyOn(wizardNavigationService, "next");
+            spyOn(wizardNavigationService, "checkAndCommitCurrentPage");
             buttonHubService.buttonClicked("danger");
-            expect(wizardNavigationService.next).toHaveBeenCalled();
-
-            spyOn(wizardNavigationService, "finish");
-            wizardNavigationService.setCurrentPage(wizardNavigationService.pageCollection.lastPage);
-            buttonHubService.buttonClicked("danger");
-            expect(wizardNavigationService.finish).toHaveBeenCalled();
+            expect(wizardNavigationService.checkAndCommitCurrentPage).toHaveBeenCalledWith("danger");
         });
 
         it("'cancel' calls wizardNavigationService.cancel", function() {
@@ -57,9 +52,7 @@ export default function(): void {
             expect(wizardNavigationService.cancel).toHaveBeenCalled();
         });
 
-        // TODO: this isn't making it all the way up through wizard for some reason
-        // so it is saying the spies aren't getting called...
-        xit("'finish' calls wizard deactivateGhostPages, deactivateGhostPages.close, emit wizardFinished", function() {
+        it("'finish' calls wizard deactivateGhostPages, deactivateGhostPages.close, emit wizardFinished", function() {
             let wizard = context.clarityDirective;
             let finalPage = wizard.pageCollection.lastPage;
 
@@ -68,9 +61,7 @@ export default function(): void {
             spyOn(wizard, "close");
 
             // set up for finish
-            // make last page current
             wizard.navService.setCurrentPage(finalPage);
-            // make ready to complete
             finalPage.nextStepDisabled = false;
             context.detectChanges();
 

--- a/src/clarity-angular/wizard/providers/header-actions.spec.ts
+++ b/src/clarity-angular/wizard/providers/header-actions.spec.ts
@@ -13,7 +13,6 @@ import {WizardNavigationService} from "./wizard-navigation";
 export default function(): void {
 
     describe("Header Actions Service", function() {
-
         let context: TestContext<Wizard, HeaderActionsTest>;
         let headerActionService: HeaderActionService;
         let wizardNavigationService: WizardNavigationService;
@@ -30,7 +29,6 @@ export default function(): void {
         });
 
         it(".currentPageHasHeaderActions indicates if the current page has header actions", function() {
-
             let lastPage = wizardNavigationService.pageCollection.lastPage;
 
             expect(headerActionService.currentPageHasHeaderActions).toBe(true);
@@ -39,7 +37,6 @@ export default function(): void {
         });
 
         it(".showWizardHeaderActions indicates if other pages have the header actions", function() {
-
             let lastPage = wizardNavigationService.pageCollection.lastPage;
             expect(headerActionService.showWizardHeaderActions).toBe(false);
 
@@ -47,9 +44,8 @@ export default function(): void {
             expect(headerActionService.showWizardHeaderActions).toBe(true);
         });
 
-        /*
-        * TODO: investigate displayHeaderActionsWrapper is needed as it seems to always return
-         the same value as wizardHasHeaderActions*/
+        // TODO: investigate if displayHeaderActionsWrapper is needed as it seems to always return
+        // the same value as wizardHasHeaderActions
     });
 
 }

--- a/src/clarity-angular/wizard/providers/wizard-navigation.spec.ts
+++ b/src/clarity-angular/wizard/providers/wizard-navigation.spec.ts
@@ -26,38 +26,39 @@ export default function(): void {
         });
 
         it(".setCurrentPage() should set the current page and emit the event", function() {
-
             wizardNavigationService.setCurrentPage(pageCollectionService.getPageByIndex(1));
             expect(wizardNavigationService.currentPage).toEqual(pageCollectionService.getPageByIndex(1));
             wizardNavigationService.setCurrentPage(pageCollectionService.lastPage);
             expect(wizardNavigationService.currentPage).toEqual(pageCollectionService.lastPage);
         });
 
-        it(".next() should call finish() and throw an error if the current page is the last page.", function() {
-
+        it(".next() should call finish() if the current page is the last page.", function() {
             let testPage = wizardNavigationService.pageCollection.lastPage;
+            let wizard = context.clarityDirective;
+
             wizardNavigationService.setCurrentPage(testPage);
             spyOn(testPage.primaryButtonClicked, "emit");
             spyOn(testPage.onCommit, "emit");
-            spyOn(context.clarityDirective.wizardFinished, "emit");
+            spyOn(wizard.wizardFinished, "emit");
+
             wizardNavigationService.wizardFinished.subscribe(function() {
-                context.clarityDirective.wizardFinished.emit();
+                wizard.wizardFinished.emit();
             });
-            expect(function() {
-                wizardNavigationService.next();
-            }).toThrowError("The wizard has no next page to go to.");
+
+            wizardNavigationService.next();
+
             expect(testPage.primaryButtonClicked.emit).toHaveBeenCalled();
             expect(testPage.onCommit.emit).toHaveBeenCalled();
             expect(testPage.completed).toBe(true);
-            expect(context.clarityDirective.wizardFinished.emit).toHaveBeenCalled();
-
+            expect(wizard.wizardFinished.emit).toHaveBeenCalled();
         });
 
         it(".next() should set the current page to the next page.", function() {
-
             expect(wizardNavigationService.currentPage)
                 .toEqual(wizardNavigationService.pageCollection.getPageByIndex(0));
+
             wizardNavigationService.next();
+
             expect(wizardNavigationService.currentPage)
                 .toEqual(wizardNavigationService.pageCollection.getPageByIndex(1));
         });
@@ -75,19 +76,16 @@ export default function(): void {
          * We should investigate possibilities of stripping down some of these tests on finish() and next() */
 
         it(".finish() should commit the current page and emit the event", function() {
-
             let testPage = wizardNavigationService.pageCollection.getPageByIndex(2);
 
             spyOn(testPage.primaryButtonClicked, "emit");
             spyOn(testPage.onCommit, "emit");
             spyOn(context.clarityDirective.wizardFinished, "emit");
 
-            wizardNavigationService.wizardFinished.subscribe(function() {
-                context.clarityDirective.wizardFinished.emit();
-            });
-
             wizardNavigationService.setCurrentPage(testPage);
+
             wizardNavigationService.finish();
+
             expect(testPage.primaryButtonClicked.emit).toHaveBeenCalled();
             expect(testPage.onCommit.emit).toHaveBeenCalled();
             expect(testPage.completed).toBe(true);
@@ -95,10 +93,10 @@ export default function(): void {
         });
 
         it(".finish() should not commit the current page and emit events if next is disabled", function() {
-
             let testPage = wizardNavigationService.pageCollection.getPageByIndex(2);
 
             testPage.nextStepDisabled = true;
+            context.detectChanges();
 
             spyOn(testPage.primaryButtonClicked, "emit");
             spyOn(testPage.onCommit, "emit");
@@ -106,7 +104,6 @@ export default function(): void {
 
             wizardNavigationService.wizardFinished.subscribe(function() {
                 context.clarityDirective.wizardFinished.emit();
-
             });
 
             wizardNavigationService.setCurrentPage(testPage);

--- a/src/clarity-angular/wizard/providers/wizard-navigation.ts
+++ b/src/clarity-angular/wizard/providers/wizard-navigation.ts
@@ -130,10 +130,11 @@ export class WizardNavigationService implements OnDestroy {
     // the user to the next page.
     public next(): void {
         if (this.currentPageIsLast) {
-            this.finish();
+            this.checkAndCommitCurrentPage("finish");
+            return;
         }
 
-        this.forceNext();
+        this.checkAndCommitCurrentPage("next");
 
         if (!this.wizardHasAltNext) {
             this._movedToNextPage.next(true);
@@ -199,12 +200,15 @@ export class WizardNavigationService implements OnDestroy {
             return;
         }
 
+        if (isFinish || isDangerFinish) {
+            this._wizardFinished.next();
+        }
+
         if (this.wizardHasAltNext) {
-            if (isFinish || isDangerFinish) {
-                this._wizardFinished.next();
-            } else if (isNext || isDangerNext) {
+            if (isNext || isDangerNext) {
                 this._movedToNextPage.next(true);
             }
+            // jump out here, no matter what type we're looking at
             return;
         }
 
@@ -212,17 +216,14 @@ export class WizardNavigationService implements OnDestroy {
         // completed.
         this.pageCollection.commitPage(currentPage);
 
-        if (isFinish || isDangerFinish) {
-            this.finish();
-        } else if (isNext || isDangerNext) {
-            this.next();
+        if (isNext || isDangerNext) {
+            this.forceNext();
         }
         // SPECME
     }
 
     public finish(): void {
-        this._wizardFinished.next();
-        // SPECME
+        this.checkAndCommitCurrentPage("finish");
     }
 
     // When called, the wizard will move to the prev page.

--- a/src/clarity-angular/wizard/wizard.ts
+++ b/src/clarity-angular/wizard/wizard.ts
@@ -66,10 +66,10 @@ export class Wizard implements OnInit, OnDestroy, AfterContentInit, DoCheck {
 
         this.wizardFinishedSubscription = this.navService.wizardFinished.subscribe(() => {
             this.wizardFinished.emit();
+
             if (!this.stopNext) {
                 this.forceFinish();
             }
-            // SPECME
         });
 
         this.differ = differs.find([]).create(null);


### PR DESCRIPTION
• this also uncovered a number of odd issues with the logic around the alt-next changes, yay for unit testing!

Signed-off-by: Scott Mathis <smathis@vmware.com>

[NG] header action service tests fixed and running

• i also fixed some tests that recent changes broke with the button hub service

Signed-off-by: Scott Mathis <smathis@vmware.com>