### PR TITLE
[NG] default wizard page id

### DIFF
--- a/src/clarity-angular/wizard/wizard-page.spec.ts
+++ b/src/clarity-angular/wizard/wizard-page.spec.ts
@@ -263,6 +263,19 @@ class TestComponent {
     }
 }
 
+@Component({
+    template: `
+        <ng-container *ngFor="let page of [0, 1, 2, 3]">
+            <clr-wizard-page [id]="3 === page ? 'lastpage' : page">
+                Content for page {{ page }}
+            </clr-wizard-page>
+        </ng-container>
+    `
+})
+class IdTestComponent {
+    @ViewChildren(WizardPage) pages: QueryList<WizardPage>;
+}
+
 export default function(): void {
     describe("WizardPage", () => {
         let fixture: ComponentFixture<any>;
@@ -272,6 +285,84 @@ export default function(): void {
         let otherWizardPage: WizardPage;
         let pageCollection = new MyPageCollectionMock();
         let navService: WizardNavigationService;
+
+        describe("Numeric id bug", () => {
+            let firstPage: WizardPage;
+            let secondPage: WizardPage;
+            let thirdPage: WizardPage;
+            let fourthPage: WizardPage;
+            let myTestComponent: IdTestComponent;
+
+            beforeEach(() => {
+                TestBed.configureTestingModule({
+                    imports: [ ClarityModule.forRoot(), NoopAnimationsModule ],
+                    declarations: [ IdTestComponent ],
+                    providers: [
+                        WizardNavigationService,
+                        { provide: PageCollectionService, useValue: pageCollection },
+                        ButtonHubService
+                    ]
+                });
+                fixture = TestBed.createComponent(IdTestComponent);
+                fixture.detectChanges();
+                debugEl = fixture.debugElement;
+                myTestComponent = fixture.componentInstance;
+                firstPage = myTestComponent.pages.toArray()[0];
+                secondPage = myTestComponent.pages.toArray()[1];
+                thirdPage = myTestComponent.pages.toArray()[2];
+                fourthPage = myTestComponent.pages.toArray()[3];
+            });
+
+            afterEach(() => {
+                fixture.destroy();
+            });
+
+            it("should not auto-assign an id of zero", () => {
+                let myId = firstPage.id;
+                let myMungedId: string[];
+                let generatedId: string;
+
+                myMungedId = myId.split("-").reverse();
+                generatedId = myMungedId[0];
+                expect(generatedId).toBe("0", "should pass 0 as id if specified");
+            });
+
+            it("should match numeric ids if passed", () => {
+                // had an issue here because ppl were using indexes as ids and our logic
+                // was not awesome for that
+                let myId = firstPage.id;
+                let myMungedId: string[];
+                let generatedId: string;
+
+                myMungedId = myId.split("-").reverse();
+                generatedId = myMungedId[0];
+                expect(generatedId).toBe("0", "first page id should be 0");
+
+                myId = secondPage.id;
+                myMungedId = myId.split("-").reverse();
+                generatedId = myMungedId[0];
+
+                myMungedId = myId.split("-").reverse();
+                generatedId = myMungedId[0];
+                expect(generatedId).toBe("1", "should pass 1 as id if specified");
+
+                myId = thirdPage.id;
+                myMungedId = myId.split("-").reverse();
+                generatedId = myMungedId[0];
+
+                myMungedId = myId.split("-").reverse();
+                generatedId = myMungedId[0];
+                expect(generatedId).toBe("2", "should pass 2 as id if specified");
+
+                myId = fourthPage.id;
+                myMungedId = myId.split("-").reverse();
+                generatedId = myMungedId[0];
+
+                myMungedId = myId.split("-").reverse();
+                generatedId = myMungedId[0];
+                expect(generatedId).toBe("lastpage", "should pass string label as id");
+            });
+        });
 
         describe("Typescript API", () => {
             beforeEach(() => {

--- a/src/clarity-angular/wizard/wizard-page.ts
+++ b/src/clarity-angular/wizard/wizard-page.ts
@@ -170,15 +170,13 @@ export class WizardPage implements OnInit {
         new EventEmitter();
 
     // If our host has an ID attribute, we use this instead of our index.
-    // sometimes people are using array indices here. that's why it's "any".
-    // most often a string or a number.
     @Input("id")
-    _id: any = (wizardPageIndex++).toString();
+    _id: string = `${wizardPageIndex++}`;
 
     public get id() {
-        if (!this._id && this._id !== 0) {
+        if (this._id == null) {
             // guard here in the event that input becomes undefined or null by accident
-            this._id = (wizardPageIndex++).toString();
+            this._id = `${wizardPageIndex}`;
         }
         return `clr-wizard-page-${this._id}`;
     }

--- a/src/clarity-angular/wizard/wizard-page.ts
+++ b/src/clarity-angular/wizard/wizard-page.ts
@@ -170,11 +170,13 @@ export class WizardPage implements OnInit {
         new EventEmitter();
 
     // If our host has an ID attribute, we use this instead of our index.
+    // sometimes people are using array indices here. that's why it's "any".
+    // most often a string or a number.
     @Input("id")
-    _id: string = (wizardPageIndex++).toString();
+    _id: any = (wizardPageIndex++).toString();
 
     public get id() {
-        if (!this._id) {
+        if (!this._id && this._id !== 0) {
             // guard here in the event that input becomes undefined or null by accident
             this._id = (wizardPageIndex++).toString();
         }


### PR DESCRIPTION
Default page `id` should only taken place by absence (~~not~~ `undefined`) of `@Input("id")`.

Fixes #783