### PR TITLE
Fix for "Should not show the hint of the Clarity icon #734"

### DIFF
--- a/src/clarity-angular/tooltips/_tooltips.clarity.scss
+++ b/src/clarity-angular/tooltips/_tooltips.clarity.scss
@@ -186,10 +186,7 @@ $clr-tooltip-adjusted-margin: $margin-value + $arrow-width * 2 !default;
     .tooltip {
         & > .clr-icon{
             margin-right: 0;
+            pointer-events: none;
         }
-        clr-icon > svg {
-        pointer-events: none;
-  }
-
     }
 }

--- a/src/clarity-angular/tooltips/_tooltips.clarity.scss
+++ b/src/clarity-angular/tooltips/_tooltips.clarity.scss
@@ -187,5 +187,9 @@ $clr-tooltip-adjusted-margin: $margin-value + $arrow-width * 2 !default;
         & > .clr-icon{
             margin-right: 0;
         }
+      clr-icon > svg {
+      pointer-events: none;
+  }
+
     }
 }

--- a/src/clarity-angular/tooltips/_tooltips.clarity.scss
+++ b/src/clarity-angular/tooltips/_tooltips.clarity.scss
@@ -186,6 +186,7 @@ $clr-tooltip-adjusted-margin: $margin-value + $arrow-width * 2 !default;
     .tooltip {
         & > .clr-icon{
             margin-right: 0;
+            pointer-events: none;
         }
     }
 }

--- a/src/clarity-angular/tooltips/_tooltips.clarity.scss
+++ b/src/clarity-angular/tooltips/_tooltips.clarity.scss
@@ -186,7 +186,6 @@ $clr-tooltip-adjusted-margin: $margin-value + $arrow-width * 2 !default;
     .tooltip {
         & > .clr-icon{
             margin-right: 0;
-            pointer-events: none;
         }
     }
 }

--- a/src/clarity-angular/tooltips/_tooltips.clarity.scss
+++ b/src/clarity-angular/tooltips/_tooltips.clarity.scss
@@ -186,7 +186,10 @@ $clr-tooltip-adjusted-margin: $margin-value + $arrow-width * 2 !default;
     .tooltip {
         & > .clr-icon{
             margin-right: 0;
-            pointer-events: none;
         }
+        clr-icon > svg {
+        pointer-events: none;
+  }
+
     }
 }


### PR DESCRIPTION
Changes made to _tooltips.clarity.scss