### PR TITLE
[ICONS,UI] getting rid of icon hints in tooltip hovers

### DIFF
--- a/src/clarity-angular/tooltips/_tooltips.clarity.scss
+++ b/src/clarity-angular/tooltips/_tooltips.clarity.scss
@@ -187,5 +187,9 @@ $clr-tooltip-adjusted-margin: $margin-value + $arrow-width * 2 !default;
         & > .clr-icon{
             margin-right: 0;
         }
+
+        clr-icon > svg {
+            pointer-events: none;
+        }
     }
 }


### PR DESCRIPTION
• this was only affecting some browsers, not all

Tested in:
✔︎ Chrome
✔︎ Firefox

Closes: #734

Signed-off-by: Scott Mathis <smathis@vmware.com>