### PR TITLE
[NG] wizard force forward feature and nav fixes

### DIFF
--- a/src/app/wizard/wizard-alt-next.demo.ts
+++ b/src/app/wizard/wizard-alt-next.demo.ts
@@ -45,7 +45,7 @@ export class WizardAltNextDemo implements OnInit {
         let allAreCorrect = sequenceOneIsCorrect && sequenceTwoIsCorrect && sequenceThreeIsCorrect;
 
         if (allAreCorrect) {
-            this.wizard.forceFinish();
+            this.wizard.finish();
             // resetting for another pass through
             this.model.allowNext = false;
             this.model.sequenceOne = "";
@@ -109,7 +109,7 @@ export class WizardAltNextDemo implements OnInit {
         let allAreCorrect = sequenceOneIsCorrect && sequenceTwoIsCorrect && sequenceThreeIsCorrect;
 
         if (allAreCorrect) {
-            this.wizard.forceFinish();
+            this.wizard.finish();
             // resetting for another pass through
             this.model.allowNext = false;
             this.model.sequenceOne = "";

--- a/src/app/wizard/wizard-async-validation.demo.ts
+++ b/src/app/wizard/wizard-async-validation.demo.ts
@@ -35,7 +35,7 @@ export class WizardAsyncValidation {
 
         setTimeout(() => {
             if (value.answer === "42") {
-                this.wizard.next();
+                this.wizard.forceNext();
             } else {
                 this.errorFlag = true;
             }

--- a/src/app/wizard/wizard-custom-buttons.demo.ts
+++ b/src/app/wizard/wizard-custom-buttons.demo.ts
@@ -18,14 +18,14 @@ export class WizardCustomButtonsDemo {
     @ViewChild(CodeHighlight) codeHighlight: CodeHighlight;
 
     public handleDangerClick(): void {
-        this.wizard.finish();
+        this.wizard.finish(false);
     }
 
     public showWarning = false;
 
     public doCustomClick(buttonType: string): void {
         if ("custom-next" === buttonType) {
-            this.wizard.next();
+            this.wizard.next(false);
         }
 
         if ("custom-previous" === buttonType) {
@@ -48,14 +48,14 @@ export class WizardCustomButtonsDemo {
     @ViewChild("wizard") wizard: Wizard;
 
     public handleDangerClick(): void {
-        this.wizard.finish();
+        this.wizard.finish(false);
     }
 
     public showWarning = false;
 
     public doCustomClick(buttonType: string): void {
         if ("custom-next" === buttonType) {
-            this.wizard.next();
+            this.wizard.next(false);
         }
 
         if ("custom-previous" === buttonType) {

--- a/src/app/wizard/wizard-force-forward.demo.html
+++ b/src/app/wizard/wizard-force-forward.demo.html
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<button class="btn btn-primary" (click)="wizard.open()">Force Forward Wizard</button>
+
+<clr-wizard #wizard [(clrWizardOpen)]="_open" [clrWizardForceForwardNavigation]="true">
+    <clr-wizard-title>Wizard, Only Forward Navigation</clr-wizard-title>
+
+    <clr-wizard-button [type]="'cancel'">Cancel</clr-wizard-button>
+    <clr-wizard-button [type]="'previous'">Back</clr-wizard-button>
+    <clr-wizard-button [type]="'next'">Next</clr-wizard-button>
+    <clr-wizard-button [type]="'finish'">Finish</clr-wizard-button>
+
+    <clr-wizard-page *ngFor="let page of [1, 2, 3, 4]">
+        <ng-template clrPageTitle>Title for page {{ page }}</ng-template>
+        <p>Content for page {{ page }}.</p>
+    </clr-wizard-page>
+</clr-wizard>
+
+<clr-example [clrLanguage]="'typescript'" [clrCode]="code"></clr-example>
+<clr-example [clrLanguage]="'html'" [clrCode]="html"></clr-example>

--- a/src/app/wizard/wizard-force-forward.demo.ts
+++ b/src/app/wizard/wizard-force-forward.demo.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component, ViewChild } from "@angular/core";
+import { Wizard } from "../../clarity-angular/wizard/wizard";
+
+@Component({
+    moduleId: module.id,
+    selector: "clr-wizard-force-forward",
+    templateUrl: "./wizard-force-forward.demo.html"
+})
+export class WizardForceForwardDemo {
+    @ViewChild("wizard") wizard: Wizard;
+    _open: boolean = false;
+
+    open() {
+        this._open = !this.open;
+    }
+
+    code: string = `
+@Component({
+    ...
+})
+export class WizardForceForwardDemo {
+    @ViewChild("wizard") wizard: Wizard;
+    _open: boolean = false;
+
+    open() {
+        this._open = !this.open;
+    }
+}
+    `;
+
+    html: string = `
+<clr-wizard #wizard [(clrWizardOpen)]="_open" [clrWizardForceForwardNavigation]="true">
+    <clr-wizard-title>Wizard, Only Forward Navigation</clr-wizard-title>
+
+    <clr-wizard-button [type]="'cancel'">Cancel</clr-wizard-button>
+    <clr-wizard-button [type]="'previous'">Back</clr-wizard-button>
+    <clr-wizard-button [type]="'next'">Next</clr-wizard-button>
+    <clr-wizard-button [type]="'finish'">Finish</clr-wizard-button>
+
+    <clr-wizard-page *ngFor="let page of [1, 2, 3, 4]">
+        <ng-template clrPageTitle>Title for page {{ page }}</ng-template>
+        <p>Content for page {{ page }}.</p>
+    </clr-wizard-page>
+</clr-wizard>
+`;
+}

--- a/src/app/wizard/wizard-options.demo.ts
+++ b/src/app/wizard/wizard-options.demo.ts
@@ -110,7 +110,7 @@ export class WizardSimple {
     public doCustomClick(buttonType: string): void {
         if ("custom-next" === buttonType) {
             if (this.model.okToClick) {
-                this.wizardMedium.next();
+                this.wizardMedium.next(false);
             } else {
                 console.log("hi, i am the demo. i can't move to the next page...");
             }

--- a/src/app/wizard/wizard-reset.demo.ts
+++ b/src/app/wizard/wizard-reset.demo.ts
@@ -36,11 +36,11 @@ export class WizardResetDemo implements OnInit {
 
     public doReset(): void {
         if (this.model.forceReset) {
-            this.wizard.reset();
             this.model.forceReset = false;
             this.model.favoriteColor = "";
             this.model.luckyNumber = "";
             this.model.flavorOfIceCream = "";
+            this.wizard.reset();
         }
     }
 

--- a/src/app/wizard/wizard.demo.module.ts
+++ b/src/app/wizard/wizard.demo.module.ts
@@ -24,6 +24,7 @@ import { WizardAltCancelDemo } from "./wizard-alt-cancel.demo";
 import { WizardInlineDemo } from "./wizard-inline.demo";
 import { WizardJumpToDemo } from "./wizard-jump-to.demo";
 import { WizardAltNextDemo } from "./wizard-alt-next.demo";
+import { WizardForceForwardDemo } from "./wizard-force-forward.demo";
 
 @NgModule({
     imports: [
@@ -47,7 +48,8 @@ import { WizardAltNextDemo } from "./wizard-alt-next.demo";
         WizardInlineDemo,
         WizardJumpToDemo,
         CodeExample,
-        WizardAltNextDemo
+        WizardAltNextDemo,
+        WizardForceForwardDemo
     ],
     exports: [
         WizardBasicDemo,
@@ -64,7 +66,8 @@ import { WizardAltNextDemo } from "./wizard-alt-next.demo";
         WizardResetDemo,
         WizardJumpToDemo,
         CodeExample,
-        WizardAltNextDemo
+        WizardAltNextDemo,
+        WizardForceForwardDemo
     ]
 })
 export default class WizardDemoModule {

--- a/src/app/wizard/wizard.demo.routing.ts
+++ b/src/app/wizard/wizard.demo.routing.ts
@@ -19,6 +19,7 @@ import { WizardAltCancelDemo } from "./wizard-alt-cancel.demo";
 import { WizardInlineDemo } from "./wizard-inline.demo";
 import { WizardJumpToDemo } from "./wizard-jump-to.demo";
 import { WizardAltNextDemo } from "./wizard-alt-next.demo";
+import { WizardForceForwardDemo } from "./wizard-force-forward.demo";
 
 const ROUTES: Routes = [
     {
@@ -38,7 +39,8 @@ const ROUTES: Routes = [
             { path: "inline", component: WizardInlineDemo },
             { path: "jump-to", component: WizardJumpToDemo },
             { path: "reset", component: WizardResetDemo },
-            { path: "alt-next", component: WizardAltNextDemo }
+            { path: "alt-next", component: WizardAltNextDemo },
+            { path: "force-forward", component: WizardForceForwardDemo }
         ]
     }
 ];

--- a/src/app/wizard/wizard.demo.ts
+++ b/src/app/wizard/wizard.demo.ts
@@ -32,6 +32,7 @@ import {Component, ViewEncapsulation} from "@angular/core";
                 <li><a [routerLink]="['./alt-next']">Alt next</a></li>
                 <li><a [routerLink]="['./inline']">Inline/static wizard</a></li>
                 <li><a [routerLink]="['./jump-to']">Jump-to page</a></li>
+                <li><a [routerLink]="['./force-forward']">Force forward</a></li>
             </ul>
         </div>
       </div>

--- a/src/clarity-angular/wizard/_wizard.clarity.scss
+++ b/src/clarity-angular/wizard/_wizard.clarity.scss
@@ -154,12 +154,9 @@ $clr-wizard-box-shadow: 0 1px 2px 2px rgba(0, 0, 0, 0.2);
         display: block; 
         font-size: 14px;
         color: $clr-wizard-sidenav-text;
-        // TODO: ??? - THIS IS THE CURRENT WHITESPACE
-        // padding-top: 36px;
         width: 100%;
     }
 
-    // TODO: PUT IN STYLES FOR NAV-LINKS, THEN REMOVE DEPENDENCY ON NAV STYLES
     .clr-wizard-stepnav-list {
         display: block;
         box-shadow: none;
@@ -193,6 +190,10 @@ $clr-wizard-box-shadow: 0 1px 2px 2px rgba(0, 0, 0, 0.2);
         &.complete {
             box-shadow: $clr-wizard-stepnav-border-size 0 0 $clr-wizard-stepnav-border-color--active inset;
             transition: box-shadow 0.2s ease-in;
+        }
+
+        &.no-click button {
+            pointer-events: none;
         }
     }
 

--- a/src/clarity-angular/wizard/providers/page-collection.mock.ts
+++ b/src/clarity-angular/wizard/providers/page-collection.mock.ts
@@ -22,4 +22,8 @@ export class PageCollectionMock {
     public get stepItemIdWasCalled(): boolean {
         return this._stepItemIdWasCalled;
     }
+
+    public previousPageIsCompleted(): boolean {
+        return true;
+    }
 }

--- a/src/clarity-angular/wizard/providers/page-collection.spec.ts
+++ b/src/clarity-angular/wizard/providers/page-collection.spec.ts
@@ -12,7 +12,6 @@ import { TestContext } from "../../utils/testing/helpers.spec";
 export default function(): void {
 
     describe("Page Collection Service", function() {
-
         describe("With pages", function() {
             let context: TestContext<Wizard, PageCollectionTest>;
             let pageCollectionService: PageCollectionService;
@@ -41,7 +40,6 @@ export default function(): void {
 
 
             it(".getPageById() should return the wizard page with a matching id", function() {
-
                 // checkResults() method is tested here as well
                 let firstPageId = context.clarityDirective.pages.first.id;
                 let firstPageIdNumber = firstPageId.match(/\d+/)[0];
@@ -171,9 +169,19 @@ export default function(): void {
                 expect(secondPage.completed).toBe(true);
             });
 
+            xit(".commitPage() should only fire page.onCommit once", function() {
+
+            });
+
+            xit(".commitPage() should only fire page.onCommit once -- even if there are page overrides", function() {
+
+            });
+
+            xit(".commitPage() should only fire page.onCommit once -- even if there are wizard overrides", function() {
+
+            });
 
             it(".reset() should set the completed properties back to false.", function() {
-
                 pageCollectionService.firstPage.completed = true;
                 pageCollectionService.lastPage.completed = true;
 
@@ -181,8 +189,35 @@ export default function(): void {
 
                 expect(pageCollectionService.firstPage.completed).toBe(false);
                 expect(pageCollectionService.lastPage.completed).toBe(false);
+            });
+
+            xit(".previousPageComplete() should return true if previous page is completed", function() {
 
             });
+
+            xit(".previousPageComplete() should return true if there is no previous page", function() {
+
+            });
+
+            xit(".previousPageComplete() should return false if previous page is not complete", function() {
+
+            });
+
+            xit("updateCompletedStates() shouldn't update completed state if all pages completed", function() {
+
+            });
+
+            xit("updateCompletedStates() should mark pages after first incomplete page as incomplete", function() {
+
+            });
+
+            xit("findFirstIncompletePageIndex() should return index of first incomplete page", function() {
+                // mixing up complete/incomplete states...
+            });
+
+            xit("findFirstIncompletePageIndex() should return last index if all pages complete", function() {
+            });
+
         });
     });
 }
@@ -230,26 +265,5 @@ export default function(): void {
     `
 })
 class PageCollectionTest {
-    open: boolean = true;
-    headerActionClicked = function() {
-        // console.log("header action clicked!");
-    };
-}
-
-@Component({
-    template: `
-            <clr-wizard #wizard [(clrWizardOpen)]="open" [clrWizardSize]="'lg'">
-                <clr-wizard-title>My Wizard Title</clr-wizard-title>
-                <clr-wizard-button [type]="'cancel'">Cancel</clr-wizard-button>
-                <clr-wizard-button [type]="'previous'">Back</clr-wizard-button>
-                <clr-wizard-button [type]="'next'">Next</clr-wizard-button>
-                <clr-wizard-button [type]="'finish'">Fait Accompli</clr-wizard-button>
-                <clr-wizard-header-action (actionClicked)="headerActionClicked($event)">
-                    <clr-icon shape="cloud" class="is-solid"></clr-icon>
-                </clr-wizard-header-action>
-            </clr-wizard>
-    `
-})
-class PageCollectionNoPagesTest {
     open: boolean = true;
 }

--- a/src/clarity-angular/wizard/providers/page-collection.ts
+++ b/src/clarity-angular/wizard/providers/page-collection.ts
@@ -153,6 +153,23 @@ export class PageCollectionService {
         return this.getPageByIndex(previousPageIndex);
     }
 
+    public previousPageIsCompleted(page: WizardPage) {
+        let previousPage: WizardPage;
+
+        if (!page) {
+            return false;
+        }
+
+        previousPage = this.getPreviousPage(page);
+
+        if (null === previousPage) {
+            // page is the first page. no previous page.
+            return true;
+        }
+
+        return previousPage.completed;
+    }
+
     public getNextPage(page: WizardPage) {
         let myPageIndex = this.getPageIndex(page);
         let nextPageIndex = myPageIndex + 1;
@@ -180,7 +197,6 @@ export class PageCollectionService {
             // of event emitters this is how they break that cycle.
             page.onCommit.emit(page.id);
         }
-        //SPECME
     }
 
     // used by the navService to navigate back to first possible step after
@@ -203,16 +219,13 @@ export class PageCollectionService {
         if (firstIncompleteIndex === this.pagesAsArray.length - 1) {
             // all complete no need to do anything
             return;
-            // SPECME
         }
 
         this.pagesAsArray.forEach((page: WizardPage, index: number) => {
             if (index > firstIncompleteIndex) {
                 page.completed = false;
             }
-            // SPECME
         });
-        // SPECME
     }
 
     public findFirstIncompletePageIndex(): number {
@@ -221,15 +234,12 @@ export class PageCollectionService {
             if (null === returnIndex && false === page.completed) {
                 returnIndex = index;
             }
-            // SPECME
         });
-        // SPECME
 
         // fallthrough, all completed, return last page
         if (null === returnIndex) {
             returnIndex = this.pagesCount - 1;
         }
-        // SPECME
 
         return returnIndex;
     }
@@ -237,6 +247,5 @@ export class PageCollectionService {
     public findFirstIncompletePage(): WizardPage {
         let myIncompleteIndex = this.findFirstIncompletePageIndex();
         return this.pagesAsArray[myIncompleteIndex];
-        // SPECME
     }
 }

--- a/src/clarity-angular/wizard/providers/wizard-navigation.spec.ts
+++ b/src/clarity-angular/wizard/providers/wizard-navigation.spec.ts
@@ -4,11 +4,12 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import {WizardNavigationService} from "./wizard-navigation";
-import {PageCollectionService} from "./page-collection";
-import {Component} from "@angular/core";
-import {Wizard} from "../wizard";
-import {TestContext} from "../../utils/testing/helpers.spec";
+import { WizardNavigationService } from "./wizard-navigation";
+import { PageCollectionService } from "./page-collection";
+import { Component, ViewChild } from "@angular/core";
+import { Wizard } from "../wizard";
+import { WizardPage } from "../wizard-page";
+import { TestContext } from "../../utils/testing/helpers.spec";
 
 export default function(): void {
 
@@ -76,7 +77,7 @@ export default function(): void {
          * We should investigate possibilities of stripping down some of these tests on finish() and next() */
 
         it(".finish() should commit the current page and emit the event", function() {
-            let testPage = wizardNavigationService.pageCollection.getPageByIndex(2);
+            let testPage = wizardNavigationService.pageCollection.getPageByIndex(3);
 
             spyOn(testPage.primaryButtonClicked, "emit");
             spyOn(testPage.onCommit, "emit");
@@ -129,20 +130,160 @@ export default function(): void {
 
         });
 
+        it(".previous() set current page to incomplete if set to forceForward navigation", function() {
+            let testPage = wizardNavigationService.pageCollection.getPageByIndex(2);
+            let previousPage = wizardNavigationService.pageCollection.getPageByIndex(1);
+
+            wizardNavigationService.setCurrentPage(testPage);
+            testPage.completed = true;
+
+            wizardNavigationService.forceForwardNavigation = true;
+            wizardNavigationService.previous();
+
+            expect(wizardNavigationService.currentPage).toEqual(previousPage);
+            expect(testPage.completed).toBe(false, "forceForward should set old current page to incomplete");
+        });
+
         it(".goTo() should return undefined if the given page is equal to the current page", function() {
+            let startPage = wizardNavigationService.pageCollection.getPageByIndex(0);
             let testPage = wizardNavigationService.pageCollection.getPageByIndex(1);
             let goToPage = wizardNavigationService.pageCollection.getPageByIndex(1);
+
+            startPage.completed = true;
             wizardNavigationService.setCurrentPage(testPage);
+
             expect(wizardNavigationService.goTo(goToPage)).toBeUndefined();
             expect(wizardNavigationService.goTo(goToPage.id)).toBeUndefined();
         });
 
         it(".goTo() should set the current page as the given page", function() {
+            let startPage = wizardNavigationService.pageCollection.getPageByIndex(0);
             let testPage = wizardNavigationService.pageCollection.getPageByIndex(1);
             let goToPage = wizardNavigationService.pageCollection.getPageByIndex(2);
-            wizardNavigationService.setCurrentPage(testPage);
-            wizardNavigationService.setCurrentPage(goToPage);
+            let pageAsExpected: boolean;
+
+            // goTo checks completed states
+            startPage.completed = true;
+            testPage.completed = true;
+
+            wizardNavigationService.goTo(goToPage);
+            context.detectChanges();
+
+            pageAsExpected = (wizardNavigationService.currentPage === goToPage);
+
+            expect(pageAsExpected).toBe(true);
+        });
+
+        it(".goTo() should not mark pages incomplete if moving forward and wizard is set to forceForward", function() {
+            let startPage = wizardNavigationService.pageCollection.getPageByIndex(0);
+            let testPage = wizardNavigationService.pageCollection.getPageByIndex(1);
+            let goToPage = wizardNavigationService.pageCollection.getPageByIndex(2);
+
+            // goTo checks completed states
+            startPage.completed = true;
+            testPage.completed = true;
+            wizardNavigationService.forceForwardNavigation = true;
+
+            wizardNavigationService.goTo(goToPage);
+
             expect(wizardNavigationService.currentPage).toEqual(goToPage);
+            expect(startPage.completed).toBe(true);
+            expect(testPage.completed).toBe(true);
+        });
+
+        it(".goTo() should mark pages incomplete if moving backward and wizard is set to forceForward", function() {
+            let startPage = wizardNavigationService.pageCollection.getPageByIndex(0);
+            let secondPage = wizardNavigationService.pageCollection.getPageByIndex(1);
+            let thirdPage = wizardNavigationService.pageCollection.getPageByIndex(2);
+            let fourthPage = wizardNavigationService.pageCollection.getPageByIndex(3);
+
+            // goTo checks completed states
+            startPage.completed = true;
+            secondPage.completed = true;
+            thirdPage.completed = true;
+            wizardNavigationService.forceForwardNavigation = true;
+
+            wizardNavigationService.goTo(fourthPage);
+            context.detectChanges();
+
+            expect(wizardNavigationService.currentPage).toEqual(fourthPage, "move forward as expected");
+            expect(startPage.completed).toBe(true, "validate startPage.completed is true as expected");
+            expect(secondPage.completed).toBe(true, "validate secondPage.completed is true as expected");
+            expect(thirdPage.completed).toBe(true, "validate thirdPage.completed is true as expected");
+            expect(fourthPage.completed).toBe(false, "validate fourthPage.completed is false as expected");
+
+            wizardNavigationService.goTo(secondPage);
+            context.detectChanges();
+
+            expect(wizardNavigationService.currentPage).toEqual(secondPage, "now move backward");
+            expect(startPage.completed).toBe(true, "startPage.completed should still be true");
+            expect(secondPage.completed).toBe(false, "secondPage.completed should be set to false");
+            expect(thirdPage.completed).toBe(false, "thirdPage.completed should be set to false");
+            expect(fourthPage.completed).toBe(false, "fourthPage.completed should remain false");
+        });
+
+        it(".goTo() should mark pages complete if moving forward and told to lazyComplete", function() {
+            let startPage = wizardNavigationService.pageCollection.getPageByIndex(0);
+            let secondPage = wizardNavigationService.pageCollection.getPageByIndex(1);
+            let thirdPage = wizardNavigationService.pageCollection.getPageByIndex(2);
+            let fourthPage = wizardNavigationService.pageCollection.getPageByIndex(3);
+
+            expect(startPage.completed).toBe(false, "validate startPage.completed is false as expected");
+            expect(secondPage.completed).toBe(false, "validate secondPage.completed is false as expected");
+            expect(thirdPage.completed).toBe(false, "validate thirdPage.completed is false as expected");
+            expect(fourthPage.completed).toBe(false, "validate fourthPage.completed is false as expected");
+
+            // lazyComplete (second parameter as true) ignores completed states
+            wizardNavigationService.goTo(fourthPage, true);
+            context.detectChanges();
+
+            expect(wizardNavigationService.currentPage).toEqual(fourthPage, "move forward as expected");
+            expect(startPage.completed).toBe(true, "validate startPage.completed is true as expected");
+            expect(secondPage.completed).toBe(true, "validate secondPage.completed is true as expected");
+            expect(thirdPage.completed).toBe(true, "validate thirdPage.completed is true as expected");
+            expect(fourthPage.completed).toBe(false, "validate fourthPage.completed is false as expected");
+        });
+
+        it(".goTo() should not allow lazyComplete by default", function() {
+            let startPage = wizardNavigationService.pageCollection.getPageByIndex(0);
+            let secondPage = wizardNavigationService.pageCollection.getPageByIndex(1);
+            let thirdPage = wizardNavigationService.pageCollection.getPageByIndex(2);
+            let fourthPage = wizardNavigationService.pageCollection.getPageByIndex(3);
+
+            expect(startPage.completed).toBe(false, "validate startPage.completed is false as expected");
+            expect(secondPage.completed).toBe(false, "validate secondPage.completed is false as expected");
+            expect(thirdPage.completed).toBe(false, "validate thirdPage.completed is false as expected");
+            expect(fourthPage.completed).toBe(false, "validate fourthPage.completed is false as expected");
+
+            wizardNavigationService.goTo(fourthPage);
+            context.detectChanges();
+
+            expect(wizardNavigationService.currentPage).toEqual(startPage, "wizard did not move forward");
+            expect(startPage.completed).toBe(false, "validate startPage.completed is still false as expected");
+            expect(secondPage.completed).toBe(false, "validate secondPage.completed is still false as expected");
+            expect(thirdPage.completed).toBe(false, "validate thirdPage.completed is still false as expected");
+            expect(fourthPage.completed).toBe(false, "validate fourthPage.completed is still false as expected");
+        });
+
+        it(".goTo() should not mark last page complete if moving forward with lazy complete", function() {
+            let startPage = wizardNavigationService.pageCollection.getPageByIndex(0);
+            let secondPage = wizardNavigationService.pageCollection.getPageByIndex(1);
+            let thirdPage = wizardNavigationService.pageCollection.getPageByIndex(2);
+            let fourthPage = wizardNavigationService.pageCollection.getPageByIndex(3);
+
+            expect(startPage.completed).toBe(false, "validate startPage.completed is false as expected");
+            expect(secondPage.completed).toBe(false, "validate secondPage.completed is false as expected");
+            expect(thirdPage.completed).toBe(false, "validate thirdPage.completed is false as expected");
+            expect(fourthPage.completed).toBe(false, "validate fourthPage.completed is false as expected");
+
+            wizardNavigationService.goTo(thirdPage, true);
+            context.detectChanges();
+
+            expect(wizardNavigationService.currentPage).toEqual(thirdPage, "wizard moved forward");
+            expect(startPage.completed).toBe(true, "validate startPage.completed was turned true as expected");
+            expect(secondPage.completed).toBe(true, "validate secondPage.completed was turned true as expected");
+            expect(thirdPage.completed).toBe(false, "validate thirdPage.completed is still false as expected");
+            expect(fourthPage.completed).toBe(false, "validate fourthPage.completed is still false as expected");
         });
 
         it(".setFirstPageCurrent() should set the first page as the current page", function() {
@@ -156,12 +297,425 @@ export default function(): void {
             expect(pageCollectionBeforeReset).toEqual(pageCollectionAfterReset);
         });
 
+        it(".forceNext() should throw an error if there's no next page to go to", function() {
+            let testPage = wizardNavigationService.pageCollection.getPageByIndex(3);
+            wizardNavigationService.setCurrentPage(testPage);
+            expect(wizardNavigationService.currentPage).toEqual(testPage);
+            expect(() => { wizardNavigationService.forceNext(); }).toThrowError();
+        });
 
+        it(".forceNext() set next page to be current and commit old current page if incomplete", function() {
+            let firstPage = wizardNavigationService.pageCollection.getPageByIndex(0);
+            let testPage = wizardNavigationService.pageCollection.getPageByIndex(1);
+
+            spyOn(wizardNavigationService.pageCollection, "commitPage").and.callThrough();
+
+            expect(wizardNavigationService.currentPage).toBe(firstPage, "initialized to first page");
+
+            wizardNavigationService.forceNext();
+            context.detectChanges();
+
+            expect(wizardNavigationService.currentPage).toBe(testPage, "moved to next page");
+            expect(wizardNavigationService.pageCollection.commitPage).toHaveBeenCalledTimes(1);
+            expect(wizardNavigationService.pageCollection.commitPage).toHaveBeenCalledWith(firstPage);
+        });
+
+        describe(".checkAndCommitCurrentPage() -- ", function() {
+            it("should do nothing if the current page is not ready to complete", function() {
+                let currentPage = wizardNavigationService.currentPage;
+                currentPage.nextStepDisabled = true;
+
+                // whole lotta spies!
+                spyOn(currentPage.primaryButtonClicked, "emit");
+                spyOn(currentPage.nextButtonClicked, "emit");
+                spyOn(wizardNavigationService.pageCollection, "commitPage");
+                spyOn(wizardNavigationService, "forceNext");
+
+                context.detectChanges();
+                expect(currentPage.readyToComplete).toBe(false, "validate page is not ready to complete");
+                wizardNavigationService.checkAndCommitCurrentPage("next");
+
+                expect(currentPage.primaryButtonClicked.emit).not.toHaveBeenCalled();
+                expect(currentPage.nextButtonClicked.emit).not.toHaveBeenCalled();
+                expect(wizardNavigationService.pageCollection.commitPage).not.toHaveBeenCalled();
+                expect(wizardNavigationService.forceNext).not.toHaveBeenCalled();
+            });
+
+            it("should do nothing if the action type is finish and current page is not the last page", function() {
+                let lastPage = wizardNavigationService.pageCollection.getPageByIndex(3);
+                let currentPage = wizardNavigationService.currentPage;
+                let lastPageIsNotCurrent = (wizardNavigationService.currentPage !== lastPage);
+
+                // whole lotta spies!
+                spyOn(currentPage.primaryButtonClicked, "emit");
+                spyOn(currentPage.nextButtonClicked, "emit");
+                spyOn(wizardNavigationService.pageCollection, "commitPage");
+                spyOn(wizardNavigationService, "forceNext");
+
+                expect(lastPageIsNotCurrent).toBe(true, "verify last page is not the current page");
+
+                wizardNavigationService.checkAndCommitCurrentPage("finish");
+
+                expect(currentPage.primaryButtonClicked.emit).not.toHaveBeenCalled();
+                expect(currentPage.nextButtonClicked.emit).not.toHaveBeenCalled();
+                expect(wizardNavigationService.pageCollection.commitPage).not.toHaveBeenCalled();
+                expect(wizardNavigationService.forceNext).not.toHaveBeenCalled();
+            });
+
+            it("should emit that a primary button was clicked", function() {
+                let currentPage = wizardNavigationService.currentPage;
+                spyOn(currentPage.primaryButtonClicked, "emit");
+                wizardNavigationService.checkAndCommitCurrentPage("next");
+                expect(currentPage.primaryButtonClicked.emit).toHaveBeenCalledTimes(1);
+            });
+
+            it("should emit finish button was clicked", function() {
+                let lastPage = wizardNavigationService.pageCollection.getPageByIndex(3);
+                let currentPage: WizardPage;
+                let lastPageIsCurrent: boolean;
+
+                wizardNavigationService.setCurrentPage(lastPage);
+                context.detectChanges();
+                currentPage = wizardNavigationService.currentPage;
+
+                lastPageIsCurrent = (currentPage === lastPage);
+                expect(lastPageIsCurrent).toBe(true, "verify last page is the current page");
+
+                spyOn(currentPage.primaryButtonClicked, "emit");
+                spyOn(currentPage.finishButtonClicked, "emit");
+
+                wizardNavigationService.checkAndCommitCurrentPage("finish");
+
+                expect(currentPage.primaryButtonClicked.emit).toHaveBeenCalledTimes(1);
+                expect(currentPage.finishButtonClicked.emit).toHaveBeenCalledTimes(1);
+            });
+
+            it("should emit danger button was clicked", function() {
+                let lastPage = wizardNavigationService.pageCollection.getPageByIndex(3);
+                let currentPage: WizardPage;
+                let lastPageIsCurrent: boolean;
+
+                wizardNavigationService.setCurrentPage(lastPage);
+                context.detectChanges();
+
+                currentPage = wizardNavigationService.currentPage;
+                lastPageIsCurrent = (currentPage === lastPage);
+                expect(lastPageIsCurrent).toBe(true, "verify last page is the current page");
+
+                spyOn(currentPage.primaryButtonClicked, "emit");
+                spyOn(currentPage.nextButtonClicked, "emit");
+                spyOn(currentPage.finishButtonClicked, "emit");
+                spyOn(wizardNavigationService, "forceNext");
+
+                wizardNavigationService.checkAndCommitCurrentPage("danger");
+
+                expect(currentPage.primaryButtonClicked.emit).toHaveBeenCalledTimes(1);
+                expect(currentPage.finishButtonClicked.emit).toHaveBeenCalledTimes(1);
+                expect(currentPage.nextButtonClicked.emit).not.toHaveBeenCalled();
+                expect(wizardNavigationService.forceNext).not.toHaveBeenCalled();
+            });
+
+            it("should emit next button was clicked", function() {
+                let currentPage = wizardNavigationService.currentPage;
+
+                spyOn(currentPage.primaryButtonClicked, "emit");
+                spyOn(currentPage.nextButtonClicked, "emit");
+                spyOn(currentPage.finishButtonClicked, "emit");
+                spyOn(wizardNavigationService, "forceNext");
+
+                wizardNavigationService.checkAndCommitCurrentPage("next");
+
+                expect(currentPage.primaryButtonClicked.emit).toHaveBeenCalledTimes(1);
+                expect(currentPage.finishButtonClicked.emit).not.toHaveBeenCalledTimes(1);
+                expect(currentPage.nextButtonClicked.emit).toHaveBeenCalled();
+                expect(wizardNavigationService.forceNext).toHaveBeenCalled();
+            });
+
+            it("should commit the current page -- but only once", function() {
+                let currentPage = wizardNavigationService.currentPage;
+                spyOn(currentPage.onCommit, "emit");
+                wizardNavigationService.checkAndCommitCurrentPage("next");
+                expect(currentPage.onCommit.emit).toHaveBeenCalledTimes(1);
+            });
+
+            it("should notify wizardFinished if finish", function() {
+                let calledAsExpected = false;
+                let checkMe = wizardNavigationService.wizardFinished.subscribe(() => {
+                    calledAsExpected = true;
+                });
+                let lastPage = wizardNavigationService.pageCollection.getPageByIndex(3);
+                let currentPage: WizardPage;
+                let lastPageIsCurrent: boolean;
+
+                wizardNavigationService.setCurrentPage(lastPage);
+                context.detectChanges();
+                currentPage = wizardNavigationService.currentPage;
+
+                lastPageIsCurrent = (currentPage === lastPage);
+                expect(lastPageIsCurrent).toBe(true, "verify last page is the current page");
+
+                wizardNavigationService.checkAndCommitCurrentPage("finish");
+
+                expect(calledAsExpected).toBe(true, "wizard notification sent");
+
+                checkMe.unsubscribe();
+            });
+
+            it("should notify wizardFinished if danger button on last page", function() {
+                let calledAsExpected = false;
+                let checkMe = wizardNavigationService.wizardFinished.subscribe(() => {
+                    calledAsExpected = true;
+                });
+                let lastPage = wizardNavigationService.pageCollection.getPageByIndex(3);
+                let currentPage: WizardPage;
+                let lastPageIsCurrent: boolean;
+
+                wizardNavigationService.setCurrentPage(lastPage);
+                context.detectChanges();
+                currentPage = wizardNavigationService.currentPage;
+
+                lastPageIsCurrent = (currentPage === lastPage);
+                expect(lastPageIsCurrent).toBe(true, "verify last page is the current page");
+
+                wizardNavigationService.checkAndCommitCurrentPage("danger");
+
+                expect(calledAsExpected).toBe(true, "wizard notification sent");
+
+                checkMe.unsubscribe();
+            });
+
+            it("should notify movedToNextPage if wizard has alt-next and next clicked", function() {
+                let calledAsExpected = false;
+                let checkMe = wizardNavigationService.movedToNextPage.subscribe(() => {
+                    calledAsExpected = true;
+                });
+
+                wizardNavigationService.wizardHasAltNext = true;
+                context.detectChanges();
+
+                wizardNavigationService.checkAndCommitCurrentPage("next");
+
+                expect(calledAsExpected).toBe(true, "next page notification sent to wizard");
+
+                checkMe.unsubscribe();
+            });
+
+            it("should notify movedToNextPage if wizard has alt-next and danger-next clicked", function() {
+                let calledAsExpected = false;
+                let checkMe = wizardNavigationService.movedToNextPage.subscribe(() => {
+                    calledAsExpected = true;
+                });
+
+                wizardNavigationService.wizardHasAltNext = true;
+                context.detectChanges();
+
+                wizardNavigationService.checkAndCommitCurrentPage("danger");
+
+                expect(calledAsExpected).toBe(true, "next page notification sent to wizard");
+
+                checkMe.unsubscribe();
+            });
+
+            it("should emit onCommit if next overridden at page level", function() {
+                let currentPage = wizardNavigationService.currentPage;
+                spyOn(currentPage.onCommit, "emit");
+
+                currentPage.stopNext = true;
+                context.detectChanges();
+
+                wizardNavigationService.checkAndCommitCurrentPage("next");
+
+                expect(currentPage.onCommit.emit).toHaveBeenCalledTimes(1);
+            });
+
+            it("should emit onCommit if next overridden at wizard level", function() {
+                let currentPage = wizardNavigationService.currentPage;
+                spyOn(currentPage.onCommit, "emit");
+
+                wizardNavigationService.wizardHasAltNext = true;
+                wizardNavigationService.checkAndCommitCurrentPage("next");
+
+                expect(currentPage.onCommit.emit).toHaveBeenCalledTimes(1);
+            });
+
+            it("should not commit page, fire events, or navigate if next overridden at wizard level", function() {
+                let currentPage = wizardNavigationService.currentPage;
+                let expectedPage = wizardNavigationService.pageCollection.getPageByIndex(0);
+                let currentAsExpected: boolean;
+
+                spyOn(currentPage.primaryButtonClicked, "emit");
+                spyOn(currentPage.nextButtonClicked, "emit");
+                spyOn(currentPage.onCommit, "emit");
+                spyOn(wizardNavigationService.pageCollection, "commitPage");
+                spyOn(wizardNavigationService, "forceNext");
+
+                wizardNavigationService.wizardHasAltNext = true;
+                wizardNavigationService.checkAndCommitCurrentPage("next");
+                currentAsExpected = (currentPage === expectedPage);
+
+                // still need some events fired
+                expect(currentPage.primaryButtonClicked.emit).toHaveBeenCalled();
+                expect(currentPage.nextButtonClicked.emit).toHaveBeenCalled();
+                expect(wizardNavigationService.pageCollection.commitPage).toHaveBeenCalled();
+
+                expect(currentPage.onCommit.emit).not.toHaveBeenCalled();
+                expect(wizardNavigationService.forceNext).not.toHaveBeenCalled();
+                expect(currentAsExpected).toBe(true, "wizard did not navigate");
+            });
+
+            it("should not commit page, fire events, or navigate if next overridden at page level", function() {
+                let currentPage = wizardNavigationService.currentPage;
+                let expectedPage = wizardNavigationService.pageCollection.getPageByIndex(0);
+                let currentAsExpected: boolean;
+
+                spyOn(currentPage.primaryButtonClicked, "emit");
+                spyOn(currentPage.nextButtonClicked, "emit");
+                spyOn(currentPage.onCommit, "emit");
+                spyOn(wizardNavigationService.pageCollection, "commitPage");
+                spyOn(wizardNavigationService, "forceNext");
+
+                currentPage.stopNext = true;
+                context.detectChanges();
+
+                wizardNavigationService.checkAndCommitCurrentPage("next");
+                currentAsExpected = (currentPage === expectedPage);
+
+                // still need some events fired
+                expect(currentPage.primaryButtonClicked.emit).toHaveBeenCalled();
+                expect(currentPage.nextButtonClicked.emit).toHaveBeenCalled();
+                expect(currentPage.onCommit.emit).toHaveBeenCalled();
+
+                expect(wizardNavigationService.pageCollection.commitPage).not.toHaveBeenCalled();
+                expect(wizardNavigationService.forceNext).not.toHaveBeenCalled();
+                expect(currentAsExpected).toBe(true, "wizard did not navigate");
+            });
+
+            it("should navigate if not overridden and next clicked", function() {
+                let currentPage = wizardNavigationService.currentPage;
+                let expectedPage = wizardNavigationService.pageCollection.getPageByIndex(1);
+                let currentAsExpected: boolean;
+
+                spyOn(currentPage.primaryButtonClicked, "emit");
+                spyOn(currentPage.nextButtonClicked, "emit");
+                spyOn(currentPage.onCommit, "emit");
+                spyOn(wizardNavigationService.pageCollection, "commitPage");
+                spyOn(wizardNavigationService, "forceNext").and.callThrough();
+
+                expect(wizardNavigationService.wizardHasAltNext).toBe(false, "wizard alt-next false by default");
+                expect(currentPage.stopNext).toBe(false, "page alt-next false by default");
+                expect(currentPage.preventDefault).toBe(false, "page prevent default false by default");
+
+                wizardNavigationService.checkAndCommitCurrentPage("next");
+                currentAsExpected = (wizardNavigationService.currentPage === expectedPage);
+
+                // still need some events fired
+                expect(currentPage.primaryButtonClicked.emit).toHaveBeenCalledTimes(1);
+                expect(currentPage.nextButtonClicked.emit).toHaveBeenCalledTimes(1);
+                // expect(currentPage.onCommit.emit).toHaveBeenCalledTimes(1);
+                expect(wizardNavigationService.pageCollection.commitPage).toHaveBeenCalledTimes(1);
+                expect(wizardNavigationService.forceNext).toHaveBeenCalledTimes(1);
+
+                expect(currentAsExpected).toBe(true, "wizard navigated");
+            });
+
+            it("should navigate if not overridden and danger-next clicked", function() {
+                let currentPage = wizardNavigationService.currentPage;
+                let expectedPage = wizardNavigationService.pageCollection.getPageByIndex(1);
+                let currentAsExpected: boolean;
+
+                spyOn(currentPage.primaryButtonClicked, "emit");
+                spyOn(currentPage.dangerButtonClicked, "emit");
+                spyOn(currentPage.onCommit, "emit");
+                spyOn(wizardNavigationService.pageCollection, "commitPage");
+                spyOn(wizardNavigationService, "forceNext").and.callThrough();
+
+                expect(wizardNavigationService.wizardHasAltNext).toBe(false, "wizard alt-next false by default");
+                expect(currentPage.stopNext).toBe(false, "page alt-next false by default");
+                expect(currentPage.preventDefault).toBe(false, "page prevent default false by default");
+
+                wizardNavigationService.checkAndCommitCurrentPage("danger");
+                currentAsExpected = (wizardNavigationService.currentPage === expectedPage);
+
+                // these get called in routines outside of checkAndCommit by default. simplify in the future?
+                expect(currentPage.onCommit.emit).not.toHaveBeenCalled();
+
+                // still need some events fired
+                expect(wizardNavigationService.pageCollection.commitPage).toHaveBeenCalledTimes(1);
+                expect(currentPage.primaryButtonClicked.emit).toHaveBeenCalledTimes(1);
+                expect(currentPage.dangerButtonClicked.emit).toHaveBeenCalledTimes(1);
+                expect(wizardNavigationService.forceNext).toHaveBeenCalledTimes(1);
+
+                expect(currentAsExpected).toBe(true, "wizard navigated");
+            });
+        });
+
+        describe(".canGoTo() -- ", function() {
+            it("should return false if pages parameter is falsy", function() {
+                expect(wizardNavigationService.canGoTo(null)).toBe(false, "null returns false");
+            });
+
+            it("should return false if pages parameter is empty array", function() {
+                expect(wizardNavigationService.canGoTo([])).toBe(false, "empty array returns false");
+            });
+
+            it("should return true if all pages passed to it are completed", function() {
+                let firstPage = wizardNavigationService.pageCollection.getPageByIndex(0);
+                let secondPage = wizardNavigationService.pageCollection.getPageByIndex(1);
+                let thirdPage = wizardNavigationService.pageCollection.getPageByIndex(2);
+                let pagesToTest: WizardPage[];
+
+                firstPage.completed = true;
+                secondPage.completed = true;
+                thirdPage.completed = true;
+                pagesToTest = [ firstPage, secondPage, thirdPage ];
+
+                expect(wizardNavigationService.canGoTo(pagesToTest)).toBe(true);
+            });
+
+            it("should return true if last page is incomplete but page before it is complete", function() {
+                let firstPage = wizardNavigationService.pageCollection.getPageByIndex(0);
+                let secondPage = wizardNavigationService.pageCollection.getPageByIndex(1);
+                let thirdPage = wizardNavigationService.pageCollection.getPageByIndex(2);
+                let pagesToTest: WizardPage[];
+
+                firstPage.completed = true;
+                secondPage.completed = true;
+                thirdPage.completed = false;
+                pagesToTest = [ firstPage, secondPage, thirdPage ];
+
+                expect(wizardNavigationService.canGoTo(pagesToTest)).toBe(true);
+            });
+
+            it("should return true if last page is incomplete but current page", function() {
+                let firstPage = wizardNavigationService.pageCollection.getPageByIndex(0);
+                let secondPage = wizardNavigationService.pageCollection.getPageByIndex(1);
+                let pagesToTest: WizardPage[];
+
+                firstPage.completed = true;
+                secondPage.completed = false;
+                wizardNavigationService.setCurrentPage(secondPage);
+
+                pagesToTest = [ firstPage, secondPage ];
+
+                expect(wizardNavigationService.canGoTo(pagesToTest)).toBe(true);
+            });
+
+            it("should return false if last page is incomplete and page before it is also incomplete", function() {
+                let firstPage = wizardNavigationService.pageCollection.getPageByIndex(0);
+                let secondPage = wizardNavigationService.pageCollection.getPageByIndex(1);
+                let thirdPage = wizardNavigationService.pageCollection.getPageByIndex(2);
+                let pagesToTest: WizardPage[];
+
+                firstPage.completed = true;
+                secondPage.completed = false;
+                thirdPage.completed = false;
+                pagesToTest = [ firstPage, secondPage, thirdPage ];
+
+                expect(wizardNavigationService.canGoTo(pagesToTest)).toBe(false);
+            });
+        });
     });
-
 }
-
-
 
 @Component({
     template: `
@@ -171,38 +725,30 @@ export default function(): void {
                 <clr-wizard-button [type]="'previous'">Back</clr-wizard-button>
                 <clr-wizard-button [type]="'next'">Next</clr-wizard-button>
                 <clr-wizard-button [type]="'finish'">Fait Accompli</clr-wizard-button>
-                <clr-wizard-header-action (actionClicked)="headerActionClicked($event)">
-                    <clr-icon shape="cloud" class="is-solid"></clr-icon>
-                </clr-wizard-header-action>
+
                 <clr-wizard-page>
                     <ng-template clrPageTitle>Longer Title for Page 1</ng-template>
                     <p>Content for step 1</p>
-                    <!-- CUSTOME HDR ACTIONS GO HERE -->
-                    <ng-template clrPageHeaderActions>
-                        <clr-wizard-header-action (actionClicked)="headerActionClicked($event)" id="bell">
-                            <clr-icon shape="bell" class="has-badge"></clr-icon>
-                        </clr-wizard-header-action>
-                        <clr-wizard-header-action (actionClicked)="headerActionClicked($event)" id="warning">
-                            <clr-icon shape="warning"></clr-icon>
-                        </clr-wizard-header-action>
-                    </ng-template>
                 </clr-wizard-page>
+
                 <clr-wizard-page>
                     <ng-template clrPageTitle>Title for Page 2</ng-template>
                     <p>Content for step 2</p>
                 </clr-wizard-page>
+
                 <clr-wizard-page>
                     <ng-template clrPageTitle>Title for Page 3</ng-template>
                     <p>Content for step 3</p>
+                </clr-wizard-page>
+
+                <clr-wizard-page>
+                    <ng-template clrPageTitle>Title for Last Page</ng-template>
+                    <p>Content for step 4</p>
                 </clr-wizard-page>
             </clr-wizard>
     `
 })
 class NavigationTest {
+    @ViewChild("wizard") wizard: Wizard;
     open: boolean = true;
-
-    headerActionClicked = function(){
-        // console.log("header action clicked!");
-    };
-
 }

--- a/src/clarity-angular/wizard/wizard-header-action.ts
+++ b/src/clarity-angular/wizard/wizard-header-action.ts
@@ -32,7 +32,6 @@ export class WizardHeaderAction {
     // title is explanatory text added to the header action
     @Input("title")
     title: string = "";
-    // SPECME
 
     // If our host has an ID attribute, we use this instead of our index.
     @Input("id")

--- a/src/clarity-angular/wizard/wizard-page.spec.ts
+++ b/src/clarity-angular/wizard/wizard-page.spec.ts
@@ -938,24 +938,19 @@ export default function(): void {
 
             // TODO: BUILD THESE TESTS OUT AT THE WIZARD LEVEL. ONLY WIZARD HANDLES CANCEL/CLOSE
             // BECAUSE IT NEEDS TO COMMUNICATE WITH MODAL PROPERTIES
-            // describe("pageOnCancel", () => {
-            //     it("should pass page id when emitted", () => {
-            //     });
+            xdescribe("pageOnCancel", () => {
+                it("should pass page id when emitted", () => {
+                });
 
-            //     it("should emit when page is current and wizard is cancelled", () => {
-            //     });
+                it("should only emit once by default", () => {
+                });
 
-            //     it("should not emit when another page is current and wizard is cancelled", () => {
-            //     });
+                it("should only emit once if overridden at page level", () => {
+                });
 
-            //     it("should emit when page is current and wizard is closed", () => {
-            //     });
-
-            //     it("should not emit when another page is current and wizard is closed", () => {
-            //     });
-            // });
-
-            // TODO: TEST BUTTON OUTPUTS IN PAGE COLLECTION
+                it("should only emit once if overridden at wizard level", () => {
+                });
+            });
 
             describe("id", () => {
                 it("should use custom id when defined in input", () => {

--- a/src/clarity-angular/wizard/wizard-stepnav-item.spec.ts
+++ b/src/clarity-angular/wizard/wizard-stepnav-item.spec.ts
@@ -20,6 +20,7 @@ import { PageCollectionService } from "./providers/page-collection";
 import { ButtonHubService } from "./providers/button-hub";
 import { WizardPageNavTitleDirective } from "./directives/page-navtitle";
 import { MockPage } from "./wizard-page.mock";
+import { PageCollectionMock } from "./providers/page-collection.mock";
 
 let pageIndex = 0;
 let fakeOutPage = new MockPage(pageIndex);
@@ -51,12 +52,16 @@ export default function(): void {
         let testItemComponent: WizardStepnavItem;
         let debugEl: DebugElement;
         let myStepnavItem: HTMLElement;
+        let pageCollection = new PageCollectionMock();
 
         beforeEach(() => {
             TestBed.configureTestingModule({
                 imports: [ ClarityModule.forRoot() ],
                 declarations: [ TestComponent ],
-                providers: [ WizardNavigationService, PageCollectionService, ButtonHubService ]
+                providers: [
+                    WizardNavigationService,
+                    ButtonHubService,
+                    { provide: PageCollectionService, useValue: pageCollection } ]
             });
             fixture = TestBed.createComponent(TestComponent);
             fixture.detectChanges();
@@ -78,12 +83,6 @@ export default function(): void {
                     testItemComponent.page._id = "try-a-different-id";
                     fixture.detectChanges();
                     expect(pageCollectionSpy).toHaveBeenCalledWith(testItemComponent.page);
-                });
-
-                it("should receive expected id from page collection", () => {
-                    const expectedId = "this-is-my-page-step-0";
-                    fixture.detectChanges();
-                    expect(testItemComponent.id).toBe(expectedId);
                 });
 
                 it("should throw an error if page is not present", () => {
@@ -169,6 +168,30 @@ export default function(): void {
                     fakeOutPage.reset();
                     fixture.detectChanges();
                     expect(testItemComponent.isComplete).toBe(false, "resets when page is reset");
+                });
+
+                it("should throw an error if page is not present", () => {
+                    testItemComponent.page = null;
+                    expect(() => { testItemComponent.click(); }).toThrow();
+                });
+            });
+
+            describe("canNavigate", () => {
+                xit("should update false/true when previous page is updated", () => {
+                    // mock inits/resets with all false
+                    expect(testItemComponent.isComplete).toBe(false, "inits as false");
+                    fakeOutPage.completed = true;
+                    fixture.detectChanges();
+                    expect(testItemComponent.isComplete).toBe(true, "updates when page is updated");
+                    fakeOutPage.reset();
+                    fixture.detectChanges();
+                    expect(testItemComponent.isComplete).toBe(false, "resets when page is reset");
+                });
+
+                xit("should return true if previousPage is completed", () => {
+                });
+
+                xit("should return false if previousPage is not completed", () => {
                 });
 
                 it("should throw an error if page is not present", () => {

--- a/src/clarity-angular/wizard/wizard-stepnav-item.ts
+++ b/src/clarity-angular/wizard/wizard-stepnav-item.ts
@@ -25,6 +25,7 @@ import { PageCollectionService } from "./providers/page-collection";
         "[class.nav-item]": "true",
         "[class.active]": "isCurrent",
         "[class.disabled]": "isDisabled",
+        "[class.no-click]": "!canNavigate",
         "[class.complete]": "isComplete"
     }
 })
@@ -59,6 +60,11 @@ export class WizardStepnavItem {
     public get isComplete(): boolean {
         this.pageGuard();
         return this.page.completed;
+    }
+
+    public get canNavigate(): boolean {
+        this.pageGuard();
+        return this.pageCollection.previousPageIsCompleted(this.page);
     }
 
     click(): void {


### PR DESCRIPTION
• adds a forceForward input to the wizard that marks pages incomplete when navigating backwards. useful for when you need to do validation on the primary button click of every page.

• fixes an issue where step-nav items that could not be navigated to but could still get focus

• fixes an issue where reset was happening before the last page was committed, meaning the final page would show up completed even after reset

• fixes an issue where users could not click not the step nav item to navigate to the next step

Closes: #610, #784

Signed-off-by: Scott Mathis <smathis@vmware.com>

[NG] wizard bifurcating next/finish from wizard calls

• adding ability to pass a boolean to wizard.next() and wizard.finish() to avoid running event emissions and checks. this can cause an event loop if fired from an onNext or onFinish event handler

• can also explicitly call wizard.forceNext() or wizard.forceFinish(). These likewise bypass page checking and event emission

• by default, wizard.next() and wizard.finish() bypass state checks and event emission because 80% of the time that is what people seem to want to do

• the only time you might want to do wizard.next(false) or wizard.finish(false) to force state checks and event emission is with custom buttons that you want to duplicate existing functionality with. pretty sure those aren’t being used to a large extent.

Signed-off-by: Scott Mathis <smathis@vmware.com>

[NG] unit tests

Signed-off-by: Scott Mathis <smathis@vmware.com>

[NG] unit tests

Signed-off-by: Scott Mathis <smathis@vmware.com>

[NG] unit tests

Signed-off-by: Scott Mathis <smathis@vmware.com>

[NG] unit tests

Signed-off-by: Scott Mathis <smathis@vmware.com>