### PR TITLE
[NG] Input tab trap directive

### DIFF
--- a/src/app/modal/modal-trap.demo.html
+++ b/src/app/modal/modal-trap.demo.html
@@ -1,0 +1,63 @@
+<!--
+  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<p>For accessiblity purposes, you may want to trap user input tabbing to within the modal.
+You can use the <code>clrInputTrap</code> directive. Both <code>SHIFT</code> and <code>SHIFT+TAB</code>
+will keep the user tabbing from within the modal.
+</p>
+
+<div class="clr-example">
+    <div class="backdrop-example-container">
+        <div class="modal static">
+            <div class="modal-dialog" role="dialog" aria-hidden="true">
+                <div clrInputTrap class="modal-content">
+                    <div class="modal-header">
+                        <button aria-label="Close" class="close" type="button">
+                            <clr-icon aria-hidden="true" shape="close"></clr-icon>
+                        </button>
+                        <h3 class="modal-title">Enter password:</h3>
+                    </div>
+                    <div class="modal-body">
+                        <input type="password">
+                    </div>
+                    <div class="modal-footer">
+                        <button class="btn btn-outline" type="button">Cancel</button>
+                        <button class="btn btn-primary" type="button">Ok</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="modal-backdrop static" aria-hidden="true"></div>
+    </div>
+</div>
+
+<pre><code clr-code-highlight="language-html">
+&lt;div class=&quot;clr-example&quot;&gt;
+    &lt;div class=&quot;backdrop-example-container&quot;&gt;
+        &lt;div class=&quot;modal static&quot;&gt;
+            &lt;div class=&quot;modal-dialog&quot; role=&quot;dialog&quot; aria-hidden=&quot;true&quot;&gt;
+                &lt;div class=&quot;modal-content&quot;&gt;
+                    &lt;div class=&quot;modal-header&quot;&gt;
+                        &lt;button aria-label=&quot;Close&quot; class=&quot;close&quot; type=&quot;button&quot;&gt;
+                            &lt;clr-icon aria-hidden=&quot;true&quot; shape=&quot;close&quot;&gt;&lt;/clr-icon&gt;
+                        &lt;/button&gt;
+                        &lt;h3 class=&quot;modal-title&quot;&gt;Enter password:&lt;/h3&gt;
+                    &lt;/div&gt;
+                    &lt;div class=&quot;modal-body&quot;&gt;
+                        &lt;input type=&quot;password&quot;&gt;
+                    &lt;/div&gt;
+                    &lt;div class=&quot;modal-footer&quot;&gt;
+                        &lt;button class=&quot;btn btn-outline&quot; type=&quot;button&quot;&gt;Cancel&lt;/button&gt;
+                        &lt;button class=&quot;btn btn-primary&quot; type=&quot;button&quot;&gt;Ok&lt;/button&gt;
+                    &lt;/div&gt;
+                &lt;/div&gt;
+            &lt;/div&gt;
+        &lt;/div&gt;
+        &lt;div class=&quot;modal-backdrop static&quot; aria-hidden=&quot;true&quot;&gt;&lt;/div&gt;
+    &lt;/div&gt;
+&lt;/div&gt;
+</code>
+</pre>

--- a/src/app/modal/modal-trap.ts
+++ b/src/app/modal/modal-trap.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component} from "@angular/core";
+
+@Component({
+    moduleId: module.id,
+    selector: "clr-modal-trap-demo",
+    styleUrls: ["./modal.demo.css"],
+    templateUrl: "./modal-trap.demo.html"
+})
+export class ModalTrapDemo {
+}

--- a/src/app/modal/modal.demo.module.ts
+++ b/src/app/modal/modal.demo.module.ts
@@ -18,6 +18,7 @@ import {ModalAngularStaticBackdropDemo} from "./modal-angular-static-backdrop";
 import {ModalAnimationDemo} from "./modal-animation";
 import {ModalBackdropDemo} from "./modal-backdrop";
 import {ModalSizesDemo} from "./modal-sizes";
+import {ModalTrapDemo} from "./modal-trap";
 
 
 @NgModule({
@@ -36,7 +37,8 @@ import {ModalSizesDemo} from "./modal-sizes";
         ModalAngularStaticBackdropDemo,
         ModalAnimationDemo,
         ModalBackdropDemo,
-        ModalSizesDemo
+        ModalSizesDemo,
+        ModalTrapDemo
     ],
     exports: [
         ModalDemo,
@@ -48,7 +50,8 @@ import {ModalSizesDemo} from "./modal-sizes";
         ModalAngularStaticBackdropDemo,
         ModalAnimationDemo,
         ModalBackdropDemo,
-        ModalSizesDemo
+        ModalSizesDemo,
+        ModalTrapDemo
     ]
 })
 export default class ModalDemoModule {

--- a/src/app/modal/modal.demo.routing.ts
+++ b/src/app/modal/modal.demo.routing.ts
@@ -16,6 +16,7 @@ import {ModalAngularStaticBackdropDemo} from "./modal-angular-static-backdrop";
 import {ModalAnimationDemo} from "./modal-animation";
 import {ModalBackdropDemo} from "./modal-backdrop";
 import {ModalSizesDemo} from "./modal-sizes";
+import {ModalTrapDemo} from "./modal-trap";
 
 const ROUTES: Routes = [
     {
@@ -31,7 +32,8 @@ const ROUTES: Routes = [
             { path: "not-closable", component: ModalAngularNotClosableDemo },
             { path: "animation", component: ModalAnimationDemo },
             { path: "backdrop", component: ModalBackdropDemo },
-            { path: "sizes", component: ModalSizesDemo }
+            { path: "sizes", component: ModalSizesDemo },
+            { path: "input-trap", component: ModalTrapDemo}
         ]
     }
 ];

--- a/src/app/modal/modal.demo.ts
+++ b/src/app/modal/modal.demo.ts
@@ -22,6 +22,7 @@ import {Component} from "@angular/core";
             <li><a [routerLink]="['./dynamic-sizing']">Dynamically Change Sizes</a></li>
             <li><a [routerLink]="['./static-backdrop']">Keep Open When Clicking Backdrop</a></li>
             <li><a [routerLink]="['./not-closable']">Force User Action</a></li>
+            <li><a [routerLink]="['./input-trap']">Trap User Input</a></li>
         </ul>
 
         <router-outlet></router-outlet>

--- a/src/clarity-angular/clarity.module.ts
+++ b/src/clarity-angular/clarity.module.ts
@@ -26,6 +26,7 @@ import {ICON_DIRECTIVES} from "./iconography/index";
 import {BUTTON_GROUP_DIRECTIVES} from "./button-group/index";
 import {LOADING_BUTTON_DIRECTIVES} from "./button-loading/index";
 import {LOADING_DIRECTIVES} from "./loading/index";
+import {INPUT_TRAP_DIRECTIVES} from "./input-trap/index";
 
 import {ClrResponsiveNavigationService} from "./nav/clrResponsiveNavigationService";
 
@@ -53,7 +54,8 @@ import {ClrResponsiveNavigationService} from "./nav/clrResponsiveNavigationServi
         ICON_DIRECTIVES,
         BUTTON_GROUP_DIRECTIVES,
         LOADING_BUTTON_DIRECTIVES,
-        LOADING_DIRECTIVES
+        LOADING_DIRECTIVES,
+        INPUT_TRAP_DIRECTIVES
     ],
     exports: [
         ALERT_DIRECTIVES,
@@ -73,7 +75,8 @@ import {ClrResponsiveNavigationService} from "./nav/clrResponsiveNavigationServi
         ICON_DIRECTIVES,
         BUTTON_GROUP_DIRECTIVES,
         LOADING_BUTTON_DIRECTIVES,
-        LOADING_DIRECTIVES
+        LOADING_DIRECTIVES,
+        INPUT_TRAP_DIRECTIVES
     ]
 })
 export class ClarityModule {

--- a/src/clarity-angular/input-trap/index.ts
+++ b/src/clarity-angular/input-trap/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import { Type } from "@angular/core";
+import {InputTrapDirective} from "./input-trap.directive";
+
+export const INPUT_TRAP_DIRECTIVES: Type<any>[] = [
+    InputTrapDirective
+];

--- a/src/clarity-angular/input-trap/input-trap.directive.spec.ts
+++ b/src/clarity-angular/input-trap/input-trap.directive.spec.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {ComponentFixture, TestBed} from "@angular/core/testing";
+import {Component} from "@angular/core";
+import {ClarityModule} from "../clarity.module";
+import {InputTrapDirective} from "./input-trap.directive";
+import {By} from "@angular/platform-browser/";
+
+
+describe("InputTrap", () => {
+    let fixture: ComponentFixture<any>;
+    let compiled: any;
+    let directive: InputTrapDirective;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [ClarityModule.forRoot()],
+            declarations: [TestComponent]
+        });
+
+        fixture = TestBed.createComponent(TestComponent);
+        fixture.detectChanges();
+
+        compiled = fixture.nativeElement;
+
+        directive = fixture.debugElement
+                        .query(By.directive(InputTrapDirective))
+                        .injector.get(InputTrapDirective);
+    });
+
+    afterEach(() => {
+        fixture.destroy();
+    });
+
+    it("should create directive", () => {
+        expect(directive).toBeTruthy();
+    });
+
+    describe("on directive init", () => {
+        it("should contain the first input", () => {
+            expect(directive.firstInput).toBeTruthy();
+            expect(directive.firstInput.id).toEqual("first");
+        });
+
+        it("should contain the last input", () => {
+            expect(directive.lastInput).toBeTruthy();
+            expect(directive.lastInput.id).toEqual("last");
+        });
+    });
+
+    describe("on keydown", () => {
+        it(`should focus last input when shift+tab key
+            is pressed and first input is active`, () => {
+
+            directive.firstInput.focus();
+
+            let keydownEvent = <KeyboardEvent>{
+                shiftKey: true,
+                keyCode: InputTrapDirective.TAB_KEY,
+                preventDefault: () => {}
+            };
+
+            directive.onkeydown(keydownEvent);
+
+            expect(document.activeElement).toEqual(directive.lastInput);
+        });
+
+        it(`should focus first input when tab key
+            is pressed and last input is active`, () => {
+            directive.lastInput.focus();
+
+            let keydownEvent = <KeyboardEvent>{
+                shiftKey: false,
+                keyCode: InputTrapDirective.TAB_KEY,
+                preventDefault: () => {}
+            };
+
+            directive.onkeydown(keydownEvent);
+
+            expect(document.activeElement).toEqual(directive.firstInput);
+        });
+    });
+});
+
+@Component({
+    template: `
+        <form clrInputTrap>
+            <button id="first">
+                Button to test first input
+            </button>
+            <input type="text" />
+            <select>
+              <option value="1">1</option>
+              <option value="2">2</option>
+            </select>
+            <button id="last">
+              Last Input
+            </button>
+        </form>
+   `
+})
+class TestComponent {
+
+}

--- a/src/clarity-angular/input-trap/input-trap.directive.ts
+++ b/src/clarity-angular/input-trap/input-trap.directive.ts
@@ -1,0 +1,47 @@
+import { Directive, HostListener, ElementRef, OnInit } from "@angular/core";
+
+@Directive({
+    selector: "[clrInputTrap]"
+})
+export class InputTrapDirective implements OnInit {
+
+    static TAB_KEY = 9;
+
+    // tslint:disable-next-line:max-line-length
+    // reference: https://github.com/jkup/focusable
+    static FOCUSABLE_INPUTS = "a[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled])";
+
+    firstInput: HTMLElement;
+    lastInput: HTMLElement;
+
+    constructor(public elementRef: ElementRef) { }
+
+    @HostListener("document:keydown", ["$event"])
+    onkeydown(event: any) {
+        const isShiftKey = !!event.shiftKey;
+
+        if (event.keyCode === InputTrapDirective.TAB_KEY) {
+            if (isShiftKey) {
+                if (document.activeElement === this.firstInput) {
+                    event.preventDefault();
+                    this.lastInput.focus();
+                }
+            }  else if (document.activeElement === this.lastInput) {
+                event.preventDefault();
+                this.firstInput.focus();
+          }
+        }
+    }
+
+    ngOnInit() {
+        const element = this.elementRef.nativeElement;
+
+        const focusableInputs = Array.from(
+            element.querySelectorAll(InputTrapDirective.FOCUSABLE_INPUTS)
+        ) as HTMLElement[];
+
+        this.firstInput = focusableInputs[0];
+        this.lastInput = focusableInputs[focusableInputs.length - 1];
+    }
+
+}


### PR DESCRIPTION
New `clrInputTrap` directive to trap the user tabbing to the inputs within the container.

Would love some input here, as not entirely sure how exhaustive the `focusableInputs` list should be. Thanks!

![screen recording 2017-05-08 at 03 15 pm](https://cloud.githubusercontent.com/assets/2253132/25829030/9c20454c-3408-11e7-8686-29a6b885a1c1.gif)

Resolves #767

Signed-off-by: Victor Mejia <victor.a.mejia@gmail.com>