### PR TITLE
[NG] Fixes datagrid error when loading active

### DIFF
--- a/src/app/datagrid/test-cases-async/test-cases-async.html
+++ b/src/app/datagrid/test-cases-async/test-cases-async.html
@@ -7,7 +7,8 @@
 <div class="clr-example">
     <h4>Pagination + Partial data set is loaded asynchronously.</h4>
     <p>Datagrid height should be fixed irrespective on the number of rows displayed.</p>
-    <clr-datagrid>
+    <button class="btn btn-outline-primary" (click)="toggle()">Toggle Spinner</button>
+    <clr-datagrid [clrDgLoading]="loading">
         <clr-dg-column>User ID</clr-dg-column>
         <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
         <clr-dg-column>Creation date</clr-dg-column>
@@ -33,7 +34,8 @@
 <div class="clr-example">
     <h4>Pagination + Complete data set is loaded asynchronously.</h4>
     <p>Datagrid height should be fixed irrespective on the number of rows displayed.</p>
-    <clr-datagrid>
+    <button class="btn btn-outline-primary" (click)="toggle()">Toggle Spinner</button>
+    <clr-datagrid [clrDgLoading]="loading">
         <clr-dg-column>User ID</clr-dg-column>
         <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
         <clr-dg-column>Creation date</clr-dg-column>

--- a/src/app/datagrid/test-cases-async/test-cases-async.ts
+++ b/src/app/datagrid/test-cases-async/test-cases-async.ts
@@ -19,6 +19,12 @@ export class DatagridTestCasesAsyncDemo {
     users: User[];
     users1: User[];
 
+    loading: boolean = false;
+
+    toggle() {
+        this.loading = !this.loading;
+    }
+
     constructor(private inventory: Inventory) {
         inventory.size = 15;
         inventory.reset();
@@ -31,6 +37,6 @@ export class DatagridTestCasesAsyncDemo {
 
         setTimeout(() => {
             this.users1 = this.users1.concat(inventory.all.slice(5));
-        }, 1000);
+        }, 3000);
     }
 }

--- a/src/app/datagrid/test-cases/test-cases.html
+++ b/src/app/datagrid/test-cases/test-cases.html
@@ -3,10 +3,12 @@
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
+
 <div class="clr-example">
     <h4>Zero Rows</h4>
     <p>Datagrid should be high enough to accomodate the placeholder.</p>
-    <clr-datagrid>
+    <button class="btn btn-outline-primary" (click)="toggle()">Toggle Spinner</button>
+    <clr-datagrid [clrDgLoading]="loading">
         <clr-dg-column>User ID</clr-dg-column>
         <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
         <clr-dg-column>Creation date</clr-dg-column>
@@ -30,8 +32,9 @@
 <div class="clr-example">
     <h4>Zero Rows + Fixed Height</h4>
     <p>Datagrid height should be fixed irrespective on the number of rows displayed.</p>
+    <button class="btn btn-outline-primary" (click)="toggle()">Toggle Spinner</button>
     <div style="height: 300px">
-        <clr-datagrid style="height: 100%">
+        <clr-datagrid style="height: 100%" [clrDgLoading]="loading">
             <clr-dg-column>User ID</clr-dg-column>
             <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
             <clr-dg-column>Creation date</clr-dg-column>
@@ -53,11 +56,11 @@
     </div>
 </div>
 
-
 <div class="clr-example">
     <h4>One Row</h4>
     <p>Datagrid body height should be atleast 72px.</p>
-    <clr-datagrid>
+    <button class="btn btn-outline-primary" (click)="toggle()">Toggle Spinner</button>
+    <clr-datagrid [clrDgLoading]="loading">
         <clr-dg-column>User ID</clr-dg-column>
         <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
         <clr-dg-column>Creation date</clr-dg-column>
@@ -81,8 +84,9 @@
 <div class="clr-example">
     <h4>One Row + Fixed Height</h4>
     <p>Datagrid height should be fixed irrespective on the number of rows displayed.</p>
+    <button class="btn btn-outline-primary" (click)="toggle()">Toggle Spinner</button>
     <div style="height: 300px">
-        <clr-datagrid style="height: 100%">
+        <clr-datagrid style="height: 100%" [clrDgLoading]="loading">
             <clr-dg-column>User ID</clr-dg-column>
             <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
             <clr-dg-column>Creation date</clr-dg-column>
@@ -104,11 +108,11 @@
     </div>
 </div>
 
-
 <div class="clr-example">
     <h4>No Pagination</h4>
     <p>Datagrid height should be variable depending on the number of rows displayed.</p>
-    <clr-datagrid>
+    <button class="btn btn-outline-primary" (click)="toggle()">Toggle Spinner</button>
+    <clr-datagrid [clrDgLoading]="loading">
         <clr-dg-column>User ID</clr-dg-column>
         <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
         <clr-dg-column>Creation date</clr-dg-column>
@@ -132,8 +136,9 @@
 <div class="clr-example">
     <h4>No Pagination + Fixed Height</h4>
     <p>Datagrid height should be fixed irrespective on the number of rows displayed.</p>
+    <button class="btn btn-outline-primary" (click)="toggle()">Toggle Spinner</button>
     <div style="height:300px">
-        <clr-datagrid style="height: 100%">
+        <clr-datagrid style="height: 100%" [clrDgLoading]="loading">
             <clr-dg-column>User ID</clr-dg-column>
             <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
             <clr-dg-column>Creation date</clr-dg-column>
@@ -158,7 +163,8 @@
 <div class="clr-example">
     <h4>Pagination</h4>
     <p>Datagrid height should be fixed irrespective on the number of rows displayed.</p>
-    <clr-datagrid>
+    <button class="btn btn-outline-primary" (click)="toggle()">Toggle Spinner</button>
+    <clr-datagrid [clrDgLoading]="loading">
         <clr-dg-column>User ID</clr-dg-column>
         <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
         <clr-dg-column>Creation date</clr-dg-column>
@@ -184,8 +190,9 @@
 <div class="clr-example" style="margin-bottom: 72px">
     <h4>Pagination + Fixed Height</h4>
     <p>Datagrid height should be fixed irrespective on the number of rows displayed.</p>
+    <button class="btn btn-outline-primary" (click)="toggle()">Toggle Spinner</button>
     <div style="height:300px">
-        <clr-datagrid style="height:100%">
+        <clr-datagrid style="height:100%" [clrDgLoading]="loading">
             <clr-dg-column>User ID</clr-dg-column>
             <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
             <clr-dg-column>Creation date</clr-dg-column>
@@ -212,7 +219,8 @@
 <div class="clr-example">
     <h4>Pagination + Updating Page Size</h4>
     <p>Datagrid height should be fixed irrespective on the number of rows displayed.</p>
-    <clr-datagrid>
+    <button class="btn btn-outline-primary" (click)="toggle()">Toggle Spinner</button>
+    <clr-datagrid [clrDgLoading]="loading">
         <clr-dg-column>User ID</clr-dg-column>
         <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
         <clr-dg-column>Creation date</clr-dg-column>

--- a/src/app/datagrid/test-cases/test-cases.ts
+++ b/src/app/datagrid/test-cases/test-cases.ts
@@ -21,6 +21,8 @@ export class DatagridTestCasesDemo {
     zeroUsers: User[] = [];
     pageSize: number = 7;
 
+    loading: boolean = false;
+
     constructor(private inventory: Inventory) {
         inventory.size = 15;
         inventory.reset();
@@ -31,5 +33,9 @@ export class DatagridTestCasesDemo {
 
     updatePageSize(): void {
         this.pageSize = Math.floor((Math.random() * 10) + 3);
+    }
+
+    toggle() {
+        this.loading = !this.loading;
     }
 }

--- a/src/clarity-angular/datagrid/_datagrid.clarity.scss
+++ b/src/clarity-angular/datagrid/_datagrid.clarity.scss
@@ -13,16 +13,34 @@
     .datagrid-host {
         display: flex;
         flex-flow: column nowrap;
+    }
+
+    .datagrid-overlay-wrapper {
+        display: flex;
+        flex-direction: row;
+        flex: 1 0 auto;
         width: 100%;
         overflow-x: auto;
         overflow-y: hidden;
-    }
 
+        .datagrid-spinner {
+            flex: 0 0 100%;
+            margin-left: -100%;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            background: rgba($clr-white, 0.6);
+        }
+
+    }
+    .datagrid-scroll-wrapper {
+        display: flex;
+        flex-direction: row;
+        min-width: 100%;
+    }
     .datagrid {
         display: flex;
         flex-flow: column nowrap;
-        align-self: flex-start;
-        min-width: 100%;
         // IE & Firefox needs this
         min-height: 1px;
     }
@@ -111,29 +129,6 @@
         flex: 1 1 auto;
         width: auto; // override the basic table's style of width: 100%
         max-width: none; // override the basic table's style of max-width: 100%
-
-        .datagrid-spinner-wrapper {
-            position: relative;
-
-            .datagrid-spinner {
-                position: absolute;
-                top: 0;
-                bottom: 0;
-                left: 0;
-                right: 0;
-                background: rgba($clr-white, 0.6);
-
-                .spinner {
-                    // We center the spinner in the datagrid
-                    position: absolute;
-                    top: 0;
-                    bottom: 0;
-                    left: 0;
-                    right: 0;
-                    margin: auto;
-                }
-            }
-        }
 
         .datagrid-body {
             .datagrid-row:last-child {

--- a/src/clarity-angular/datagrid/datagrid.html
+++ b/src/clarity-angular/datagrid/datagrid.html
@@ -5,59 +5,59 @@
   -->
 
 <ng-content select="clr-dg-action-bar"></ng-content>
-<div class="datagrid" #datagrid>
-    <div class="datagrid-spinner-wrapper" *ngIf="loading">
-        <!--we are using the offsetHeight here to set the height of spinner which is brittle;
-            re-evaluate later to see if there is a better fix for this-->
-        <div class="datagrid-spinner" [style.height.px]="datagrid.offsetHeight">
-            <div class="spinner">Loading...</div>
-        </div>
-    </div>
-    <div clrDgTableWrapper class="datagrid-table-wrapper">
-        <div clrDgHead class="datagrid-head">
-            <div class="datagrid-row datagrid-row-flex">
-                <!-- header for datagrid where you can select multiple rows -->
-                <div class="datagrid-column datagrid-select datagrid-fixed-column"
-                     *ngIf="selection.selectionType === SELECTION_TYPE.Multi">
+<div class="datagrid-overlay-wrapper">
+    <div class="datagrid-scroll-wrapper">
+        <div class="datagrid" #datagrid>
+            <div clrDgTableWrapper class="datagrid-table-wrapper">
+                <div clrDgHead class="datagrid-head">
+                    <div class="datagrid-row datagrid-row-flex">
+                        <!-- header for datagrid where you can select multiple rows -->
+                        <div class="datagrid-column datagrid-select datagrid-fixed-column"
+                             *ngIf="selection.selectionType === SELECTION_TYPE.Multi">
                         <span class="datagrid-column-title">
                             <clr-checkbox [(ngModel)]="allSelected"></clr-checkbox>
                         </span>
-                        <div class="datagrid-column-separator"></div>
+                            <div class="datagrid-column-separator"></div>
+                        </div>
+                        <!-- header for datagrid where you can select one row only -->
+                        <div class="datagrid-column datagrid-select datagrid-fixed-column"
+                             *ngIf="selection.selectionType === SELECTION_TYPE.Single">
+                            <div class="datagrid-column-separator"></div>
+                        </div>
+                        <!-- header for single row action; only display if we have at least one actionable row in datagrid -->
+                        <div class="datagrid-column datagrid-row-actions datagrid-fixed-column"
+                             *ngIf="rowActionService.hasActionableRow">
+                            <div class="datagrid-column-separator"></div>
+                        </div>
+                        <!-- header for carets; only display if we have at least one expandable row in datagrid -->
+                        <div class="datagrid-column datagrid-expandable-caret datagrid-fixed-column"
+                             *ngIf="expandableRows.hasExpandableRow">
+                            <div class="datagrid-column-separator"></div>
+                        </div>
+                        <ng-content select="clr-dg-column"></ng-content>
+                    </div>
                 </div>
-                <!-- header for datagrid where you can select one row only -->
-                <div class="datagrid-column datagrid-select datagrid-fixed-column"
-                     *ngIf="selection.selectionType === SELECTION_TYPE.Single">
-                    <div class="datagrid-column-separator"></div>
+
+                <div clrDgBody class="datagrid-body">
+                    <ng-template *ngIf="iterator"
+                                 ngFor [ngForOf]="items.displayed" [ngForTrackBy]="items.trackBy"
+                                 [ngForTemplate]="iterator.template"></ng-template>
+                    <ng-content *ngIf="!iterator"></ng-content>
+
+                    <!-- Custom placeholder overrides the default empty one -->
+                    <ng-content select="clr-dg-placeholder"></ng-content>
+                    <clr-dg-placeholder *ngIf="!placeholder"></clr-dg-placeholder>
                 </div>
-                <!-- header for single row action; only display if we have at least one actionable row in datagrid -->
-                <div class="datagrid-column datagrid-row-actions datagrid-fixed-column"
-                     *ngIf="rowActionService.hasActionableRow">
-                    <div class="datagrid-column-separator"></div>
-                </div>
-                <!-- header for carets; only display if we have at least one expandable row in datagrid -->
-                <div class="datagrid-column datagrid-expandable-caret datagrid-fixed-column"
-                     *ngIf="expandableRows.hasExpandableRow">
-                    <div class="datagrid-column-separator"></div>
-                </div>
-                <ng-content select="clr-dg-column"></ng-content>
             </div>
-        </div>
 
-        <div clrDgBody class="datagrid-body">
-            <ng-template *ngIf="iterator"
-                      ngFor [ngForOf]="items.displayed" [ngForTrackBy]="items.trackBy"
-                      [ngForTemplate]="iterator.template"></ng-template>
-            <ng-content *ngIf="!iterator"></ng-content>
-
-            <!-- Custom placeholder overrides the default empty one -->
-            <ng-content select="clr-dg-placeholder"></ng-content>
-            <clr-dg-placeholder *ngIf="!placeholder"></clr-dg-placeholder>
+            <!--
+                This is not inside the table because there is no good way of having a single column span
+                everything when using custom elements with display:table-cell.
+            -->
+            <ng-content select="clr-dg-footer"></ng-content>
         </div>
     </div>
-
-    <!--
-        This is not inside the table because there is no good way of having a single column span
-        everything when using custom elements with display:table-cell.
-    -->
-    <ng-content select="clr-dg-footer"></ng-content>
+    <div class="datagrid-spinner" *ngIf="loading">
+        <div class="spinner">Loading...</div>
+    </div>
 </div>


### PR DESCRIPTION
CSS fix to the datagrid placeholder for loading indications. 
Also included are changes to the test cases, test cases async for testing _loading spinner_  in a variety of conditions. Thanks @adityarb88 for those pages.

- closes #847

Signed-off-by: Matt Hippely <mhippely@vmware.com>