### PR TITLE
[CORE] upgrade tslint version

### DIFF
--- a/build/tslint.json
+++ b/build/tslint.json
@@ -1,4 +1,7 @@
 {
+  "linterOptions": {
+      "typeCheck": true
+  },
   "rules": {
     "align": [
       true,
@@ -7,7 +10,9 @@
     ],
     "ban": false,
     "class-name": true,
-    "comment-format": false,
+    "comment-format": [
+      false
+    ],
     "curly": true,
     "eofline": false,
     "forin": true,
@@ -15,7 +20,9 @@
       true,
       "spaces"
     ],
-    "interface-name": false,
+    "interface-name": [
+      false
+    ],
     "jsdoc-format": true,
     "label-position": true,
     "max-line-length": [
@@ -23,13 +30,17 @@
       120
     ],
     "member-access": false,
-    "member-ordering": false,
+    "member-ordering": [
+      false
+    ],
     "no-angle-bracket-type-assertion": false,
     "no-any": false,
     "no-arg": true,
     "no-bitwise": true,
     "no-conditional-assignment": true,
-    "no-consecutive-blank-lines": false,
+    "no-consecutive-blank-lines": [
+      false
+    ],
     "no-console": [
       true,
       "debug",
@@ -39,19 +50,20 @@
       "trace"
     ],
     "no-construct": true,
-    "no-constructor-vars": false,
     "no-debugger": true,
     "no-duplicate-variable": true,
     "no-empty": false,
     "no-eval": true,
-    "no-inferrable-types": false,
+    "no-inferrable-types": [
+      false
+    ],
     "no-internal-module": true,
     "no-null-keyword": false,
     "no-require-imports": true,
     "no-shadowed-variable": true,
     "no-string-literal": false,
     "no-switch-case-fall-through": true,
-    "no-trailing-whitespace": true,
+    "no-trailing-whitespace": false,
     "no-unused-expression": true,
     "no-unused-variable": true,
     "no-use-before-declare": true,
@@ -72,14 +84,18 @@
       "avoid-escape"
     ],
     "radix": true,
-    "semicolon": [true, "always"],
+    "semicolon": [false, "always"],
     "switch-default": true,
-    "trailing-comma": false,
+    "trailing-comma": [
+      false
+    ],
     "triple-equals": [
       true,
       "allow-null-check"
     ],
-    "typedef": false,
+    "typedef": [
+      false
+    ],
     "typedef-whitespace": [
       true,
       {
@@ -97,7 +113,6 @@
         "variable-declaration": "space"
       }
     ],
-    "use-strict": false,
     "variable-name": [
       true,
       "check-format",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "gulp-sass": "^2.2.0",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-stylestats": "^1.2.1",
-    "gulp-tslint": "^7.1.0",
+    "gulp-tslint": "^8.0.0",
     "gulp-typescript": "2.13.0",
     "gulp-util": "^3.0.7",
     "gulp-zip": "^3.1.0",
@@ -70,7 +70,7 @@
     "run-sequence": "^1.1.5",
     "systemjs-builder": "^0.15.13",
     "through2": "^2.0.1",
-    "tslint": "^4.0.0",
+    "tslint": "^5.2.0",
     "typescript": "~2.2.0"
   },
   "scripts": {


### PR DESCRIPTION
please review rules updated especially no-trailing-whitespace/semicolon which are just temporarily set to avoid lots of lint errors.

Signed-off-by: Chris Ha  <chunghha@users.noreply.github.com>