### PR TITLE
[CORE] optional spec helper to log how long it takes our unit tests run

### DIFF
--- a/src/clarity-angular/utils/testing/helpers.spec.ts
+++ b/src/clarity-angular/utils/testing/helpers.spec.ts
@@ -12,7 +12,8 @@ import { Type, DebugElement } from "@angular/core";
 import { TestBed, ComponentFixture } from "@angular/core/testing";
 import { ClarityModule } from "../../clarity.module";
 import { By } from "@angular/platform-browser";
-import {NoopAnimationsModule} from "@angular/platform-browser/animations";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+// import { reportSlowSpecs } from "./slow-specs.spec";
 
 export class TestContext<D, C> {
     fixture: ComponentFixture<C>;
@@ -71,3 +72,11 @@ export function addHelpers(): void {
         }
     });
 }
+
+
+/*
+ * uncomment the line below to show how long it takes specs to run
+ * need to also uncomment the import up top.
+ * would be nice to be able to pass karma/jasmine a flag to turn this off and on.
+ */
+// reportSlowSpecs();

--- a/src/clarity-angular/utils/testing/slow-specs.spec.ts
+++ b/src/clarity-angular/utils/testing/slow-specs.spec.ts
@@ -1,0 +1,31 @@
+// This is a variation of a few similar utils found across the interwebs
+// Saved as a spec so it gets gobbled up and just runs.
+
+export function reportSlowSpecs(): void {
+    const reportSlowerThanMs = 250;
+
+    function now() {
+    return (new Date()).getTime();
+    }
+
+    const slowSpecs = {
+    jasmineStarted() {
+        this._specTimes = [];
+    },
+
+    specStarted() {
+        this._specStartedTime = now();
+    },
+
+    specDone(result: any) {
+        const time = now() - this._specStartedTime;
+
+        this._specTimes.push({ fullName: result.fullName, time: time });
+        if (time >= reportSlowerThanMs) {
+        console.warn(`${result.fullName} took ${time}ms`);
+        }
+    }
+    };
+
+    jasmine.getEnv().addReporter(slowSpecs);
+}


### PR DESCRIPTION
• to use this, all you need to do is uncomment two lines in the helper spec
• I wanted to push this so that it didn't atrophy on my branch
• I'm going to use it in the future to help speed up our unit tests

Signed-off-by: Scott Mathis <smathis@vmware.com>