### PR TITLE
[NG] Fixes vertical scrolling for fixed height datagrids

### DIFF
--- a/src/clarity-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clarity-angular/data/datagrid/_datagrid.clarity.scss
@@ -18,7 +18,7 @@
     .datagrid-overlay-wrapper {
         display: flex;
         flex-direction: row;
-        flex: 1 0 auto;
+        flex: 0 auto; // Same as flex: initial. It sizes the item based on width/height properties or its content.
         width: 100%;
         overflow-x: auto;
         overflow-y: hidden;


### PR DESCRIPTION
I missed something or changed something in my code and didn't re-check the vertical scrolling with the fix for #847. 
This fix makes fixed height datagrids have vertical scrolling.  

Signed-off-by: Matt Hippely <mhippely@vmware.com>