### PR TITLE
[NG] Fixes height of datagrid when it has a fixed height

### DIFF
--- a/src/clarity-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clarity-angular/data/datagrid/_datagrid.clarity.scss
@@ -20,6 +20,7 @@
         flex-direction: row;
         flex: 0 auto; // Same as flex: initial. It sizes the item based on width/height properties or its content.
         width: 100%;
+        min-height: 100%; // Must be min to fix Safari bug: height: 100% won't fill flex parent. http://bit.ly/2qAPkha
         overflow-x: auto;
         overflow-y: hidden;
 


### PR DESCRIPTION
## Before
<img width="587" alt="screen shot 2017-05-12 at 9 25 58 am" src="https://cloud.githubusercontent.com/assets/433692/26007405/31d3705c-36f5-11e7-94d8-08663aa2fed1.png">

## After
<img width="1162" alt="screen shot 2017-05-12 at 9 26 11 am" src="https://cloud.githubusercontent.com/assets/433692/26007396/2b940fb2-36f5-11e7-8b57-0b391adfac1d.png">

Tested on Chrome, FF, Safari, IE11, Edge
(Safari has issues with `flex: 0 auto` and `height: 100%` hence the `min-height` and bitly link)

Signed-off-by: Matt Hippely <mhippely@vmware.com>