### PR TITLE
[UI] Remove position: relative from forms in grid only

### DIFF
--- a/src/app/forms/form-grid-validation/form-grid-validation.demo.html
+++ b/src/app/forms/form-grid-validation/form-grid-validation.demo.html
@@ -1,0 +1,137 @@
+<!--
+  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<p>
+    Try it live:
+    <button class="btn btn-primary" (click)="basic = true">Show modal</button>
+</p>
+<clr-modal [(clrModalOpen)]="basic" [clrModalSize]="'lg'">
+    <h3 class="modal-title">Modal</h3>
+    <div class="modal-body">
+        <form>
+            <section class="form-block">
+                <label>Form Inside a Grid</label>
+                <div class="form-group row">
+                    <div class="col-lg-2 col-md-12 col-sm-12 col-xs-12">
+                        <label for="gForm_1">Input field</label>
+                    </div>
+                    <div class="col-lg-4 col-md-4 col-sm-12 col-xs-12">
+                        <input class="form-control" type="text" id="gForm_1" placeholder="Enter value here" size="45">
+                    </div>
+                    <clr-tooltip
+                        [clrTooltipDirection]="'top-right'"
+                        [clrTooltipSize]="'lg'">
+                        <clr-icon shape="info-circle" class="info-tips-icon" size="24"></clr-icon>
+                        <clr-tooltip-content class="tooltip-content">
+                            This should be a long text here.This should be a long text here.
+                            This should be a long text here.This should be a long text here.
+                            This should be a long text here.This should be a long text here.
+                        </clr-tooltip-content>
+                    </clr-tooltip>
+                </div>
+                <div class="form-group row">
+                    <div class="col-lg-2 col-md-12 col-sm-12 col-xs-12">
+                        <label for="gForm_3">Select box</label>
+                    </div>
+                    <div class="col-lg-4 col-md-8 col-sm-12 col-xs-12">
+                        <div class="select form-control">
+                            <select id="gForm_3">
+                                <option>Option 1</option>
+                                <option>Option 2</option>
+                                <option>Option 3</option>
+                                <option>Option 4</option>
+                            </select>
+                        </div>
+                    </div>
+                </div>
+                <div class="form-group row">
+                    <div class="col-lg-2 col-md-12 col-sm-12 col-xs-12">
+                        <label for="gForm_4">Text area</label>
+                    </div>
+                    <div class="col-lg-10 col-md-12 col-sm-12 col-xs-12">
+                        <textarea id="gForm_4" rows="5" class="form-control"></textarea>
+                    </div>
+                </div>
+                <div class="form-group row">
+                    <div class="col-lg-2 col-md-12 col-sm-12 col-xs-12">
+                        <label>This label has a lot of content in it. This tests that labels in forms wrap correctly.</label>
+                    </div>
+                    <div class="col-lg-4 col-md-5 col-sm-12 col-xs-12">
+                        <div class="select form-control">
+                            <select id="exampleSelect1">
+                                <option>1</option>
+                                <option>2</option>
+                                <option>3</option>
+                                <option>4</option>
+                                <option>5</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="col-lg-3 col-md-5 col-sm-12 col-xs-12">
+                        <span>Sockets: 1</span>
+                    </div>
+                </div>
+                <div class="form-group row">
+                    <div class="col-lg-2 col-md-12 col-sm-12 col-xs-12">
+                        <label>Multiple select box</label>
+                    </div>
+                    <div class="col-lg-10 col-md-12 col-sm-12 col-xs-12">
+                        <div class="select multiple form-control">
+                            <select multiple id="exampleSelect2">
+                                <option>1</option>
+                                <option>2</option>
+                                <option>3</option>
+                                <option>4</option>
+                                <option>5</option>
+                            </select>
+                        </div>
+                    </div>
+                </div>
+                <div class="form-group row">
+                    <div class="col-lg-2 col-md-12 col-sm-12 col-xs-12">
+                        <label>Select box with a size of 5 rows</label>
+                    </div>
+                    <div class="col-lg-10 col-md-12 col-sm-12 col-xs-12">
+                        <div class="select multiple form-control">
+                            <select id="exampleSelect3" size="5">
+                                <option>1</option>
+                                <option>2</option>
+                                <option>3</option>
+                                <option>4</option>
+                                <option>5</option>
+                                <option>6</option>
+                                <option>7</option>
+                                <option>8</option>
+                            </select>
+                        </div>
+                    </div>
+                </div>
+                <div class="form-group row">
+                    <div class="col-lg-2 col-md-12 col-sm-12 col-xs-12">
+                        <label for="gForm_3">Other form fields</label>
+                    </div>
+                    <div class="col-lg-2 col-md-3 col-sm-12 col-xs-12">
+                        <div class="toggle-switch">
+                            <input type="checkbox" id="othertoggle">
+                            <label for="othertoggle">Toggle</label>
+                        </div>
+                    </div>
+                    <div class="col-lg-3 col-md-3 col-sm-12 col-xs-12">
+                        <div class="checkbox-inline">
+                            <input type="checkbox" id="othercheckbox" checked>
+                            <label for="othercheckbox">Inline Checkbox</label>
+                        </div>
+                    </div>
+                </div>
+                <button type="submit" class="btn btn-primary">Button</button>
+            </section>
+        </form>
+    </div>
+    <div class="modal-footer">
+        <button type="button" class="btn btn-outline" (click)="basic = false">Cancel</button>
+        <button type="button" class="btn btn-primary" (click)="basic = false">Ok</button>
+    </div>
+</clr-modal>

--- a/src/app/forms/form-grid-validation/form-grid-validation.demo.scss
+++ b/src/app/forms/form-grid-validation/form-grid-validation.demo.scss
@@ -1,0 +1,5 @@
+// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
+
+@import "../../_utils/code";

--- a/src/app/forms/form-grid-validation/form-grid-validation.ts
+++ b/src/app/forms/form-grid-validation/form-grid-validation.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component} from "@angular/core";
+
+@Component({
+    moduleId: module.id,
+    selector: "clr-forms-demo-grid-validation",
+    // Note the .css extension here, not .scss. That's the best we can have at the moment.
+    styleUrls: ["./form-grid-validation.demo.css"],
+    templateUrl: "./form-grid-validation.demo.html"
+})
+export class FormGridValidationDemo {
+    // Booleans to open each example modal
+    public basic: boolean = false;
+}

--- a/src/app/forms/forms.demo.module.ts
+++ b/src/app/forms/forms.demo.module.ts
@@ -18,6 +18,7 @@ import {FormGridDemo} from "./form-grid/form-grid";
 import {TemplateDrivenFormsDemo} from "./template-driven-forms/template-driven-forms";
 import {ReactiveFormsDemo} from "./reactive-forms/reactive-forms";
 import {Example} from "./utils/example";
+import {FormGridValidationDemo} from "./form-grid-validation/form-grid-validation";
 
 @NgModule({
     imports: [
@@ -33,6 +34,7 @@ import {Example} from "./utils/example";
         FormGridDemo,
         FormTestDemo,
         FormValidationDemo,
+        FormGridValidationDemo,
         FormCompactDemo,
         TemplateDrivenFormsDemo,
         ReactiveFormsDemo,
@@ -44,6 +46,7 @@ import {Example} from "./utils/example";
         FormGridDemo,
         FormTestDemo,
         FormValidationDemo,
+        FormGridValidationDemo,
         FormCompactDemo,
         TemplateDrivenFormsDemo,
         ReactiveFormsDemo

--- a/src/app/forms/forms.demo.routing.ts
+++ b/src/app/forms/forms.demo.routing.ts
@@ -14,6 +14,7 @@ import {FormGridDemo} from "./form-grid/form-grid";
 
 import {TemplateDrivenFormsDemo} from "./template-driven-forms/template-driven-forms";
 import {ReactiveFormsDemo} from "./reactive-forms/reactive-forms";
+import {FormGridValidationDemo} from "./form-grid-validation/form-grid-validation";
 
 const ROUTES: Routes = [
     {
@@ -26,6 +27,7 @@ const ROUTES: Routes = [
             { path: "form-validation", component: FormValidationDemo },
             { path: "form-compact", component: FormCompactDemo },
             { path: "form-grid", component: FormGridDemo },
+            { path: "form-grid-validation", component: FormGridValidationDemo },
             { path: "form-template-driven", component: TemplateDrivenFormsDemo },
             { path: "form-reactive", component: ReactiveFormsDemo }
         ]

--- a/src/app/forms/forms.demo.ts
+++ b/src/app/forms/forms.demo.ts
@@ -16,6 +16,7 @@ import {Component} from "@angular/core";
             <li><a [routerLink]="['./form-validation']">Form Validation</a></li>
             <li><a [routerLink]="['./form-compact']">Compact Form</a></li>
             <li><a [routerLink]="['./form-grid']">Forms in a Grid</a></li>
+            <li><a [routerLink]="['./form-grid-validation']">Forms Validation in a Grid</a></li>
             <li><a [routerLink]="['./form-template-driven']">Template-Driven Forms</a></li>
             <li><a [routerLink]="['./form-reactive']">Reactive Forms</a></li>
         </ul>

--- a/src/clarity-angular/forms/_forms.clarity.scss
+++ b/src/clarity-angular/forms/_forms.clarity.scss
@@ -70,6 +70,7 @@
 
             &.row {
                 padding-left: 0;
+                position: static;
             }
 
             //The first label in a form-group always appears on the left hand side for large screens
@@ -84,7 +85,7 @@
 
             &.row > [class*='col-']:first-child > label,
             &.row > [class*='col-']:first-child > span {
-                position: relative;
+                position: static;
             }
 
             & > label:first-child,


### PR DESCRIPTION
Remove `position: relative` from `.form-group` and the first `label` inside of forms in grids only.
This PR fixes clipping issues when you use tooltips inside of forms in grids.

Note:
1. Regular forms don't fix this problem yet. Fixing clipping issues with regular forms might be a breaking change. More info here #932
2. I am not sure if we have the tooltip angular component working for validation. So as of now I believe that validation messages clip inside of forms in an overflowing container. We need to check whether our angular tooltips support validation and if not then file an issue for adding that feature.

1. No clipping
![image](https://cloud.githubusercontent.com/assets/1426805/26406684/dd136d44-404d-11e7-965d-5c76bf265251.png)

2. Wrapping
![image](https://cloud.githubusercontent.com/assets/1426805/26406693/e420b592-404d-11e7-8f9e-f9e5b5899724.png)


Tested on:
Chrome, Firefox, Safari, IE 11, Edge

Signed-off-by: Aditya Bhandari <adityab@vmware.com>