### PR TITLE
[NG] Add change detector ref to footer

### DIFF
--- a/src/app/datagrid/selection/selection.html
+++ b/src/app/datagrid/selection/selection.html
@@ -70,9 +70,7 @@
     <clr-dg-column>Name</clr-dg-column>
     <clr-dg-column>Creation date</clr-dg-column>
     <clr-dg-column>
-        <ng-container *clrDgHideableColumn>
-            Favorite color
-        </ng-container>
+        Favorite color
     </clr-dg-column>
 
     <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">

--- a/src/clarity-angular/data/datagrid/datagrid-column-toggle.spec.ts
+++ b/src/clarity-angular/data/datagrid/datagrid-column-toggle.spec.ts
@@ -43,10 +43,6 @@ export default function (): void {
                 component = new DatagridColumnToggle(hideableColumnService);
             });
 
-            afterEach(function () {
-                component.ngOnDestroy();
-            });
-
             it("gets a list of hideable columns from the HideableColumnService", function () {
                 // inits to empty array.
                 expect(component.columns).toEqual([]);

--- a/src/clarity-angular/data/datagrid/datagrid-column-toggle.ts
+++ b/src/clarity-angular/data/datagrid/datagrid-column-toggle.ts
@@ -75,7 +75,6 @@ export class DatagridColumnToggle implements OnInit, OnDestroy {
      * @type {Array}
      */
     public columns: DatagridHideableColumn[] = [];
-    // public lastColumnshowing: boolean = false;
 
     public get allColumnsVisible(): boolean {
         return this._allColumnsVisible;
@@ -102,11 +101,11 @@ export class DatagridColumnToggle implements OnInit, OnDestroy {
                     this.columns.push(col);
                 }
             });
-        });
+            });
     }
 
     ngOnDestroy() {
-        // this._hideableColumnChangeSubscription.unsubscribe();
+        this._hideableColumnChangeSubscription.unsubscribe();
     }
 
     selectAll() {

--- a/src/clarity-angular/data/datagrid/datagrid-footer.spec.ts
+++ b/src/clarity-angular/data/datagrid/datagrid-footer.spec.ts
@@ -55,6 +55,7 @@ export default function(): void {
             clarityDirectiveSelection.selectionType = SelectionType.Multi;
             clarityDirectiveSelection.current.push(1);
 
+            context.clarityDirective.cdr.markForCheck();
             context.detectChanges();
 
             expect(context.clarityElement.querySelector(".datagrid-foot-select")).not.toBeNull();
@@ -62,6 +63,7 @@ export default function(): void {
 
 
             clarityDirectiveSelection.current.push(1);
+            context.clarityDirective.cdr.markForCheck();
             context.detectChanges();
 
             expect(context.clarityElement.querySelector(".datagrid-foot-select")).not.toBeNull();
@@ -69,6 +71,7 @@ export default function(): void {
 
             clarityDirectiveSelection.current = [];
 
+            context.clarityDirective.cdr.markForCheck();
             context.detectChanges();
 
             expect(context.clarityElement.querySelector(".datagrid-foot-select")).toBeNull();

--- a/src/clarity-angular/data/datagrid/datagrid.ts
+++ b/src/clarity-angular/data/datagrid/datagrid.ts
@@ -255,6 +255,7 @@ export class Datagrid implements AfterContentInit, AfterViewInit, OnDestroy {
                 this.selectedChanged.emit(s);
             }
         }));
+
         this._subscriptions.push(
             this.columns.changes.subscribe(( columns: DatagridColumn[] ) => {
                 this.columnService.updateColumnList(this.columns.map(col => col.hideable));


### PR DESCRIPTION
- closes #950
- Fixes issue with  component when using  on the datagrid itself that casued  error

I had to make a change to the footer spec related to using ChangeDetectorRef to manage updates to the child component. I'm not 100% sure its the right way to use it in testing. 

Tested in Chrome, Firefox, Safari, Edge & IE11

Signed-off-by: Matt Hippely <mhippely@vmware.com>