### PR TITLE
[NG] Add disabled, type & name attr to clr-button

### DIFF
--- a/src/app/button-group/angular/basic-structure/basic-button-group.html
+++ b/src/app/button-group/angular/basic-structure/basic-button-group.html
@@ -8,11 +8,11 @@
 
 <div class="clr-example">
     <clr-button-group>
-        <clr-button>1</clr-button>
-        <clr-button>2</clr-button>
-        <clr-button>3</clr-button>
-        <clr-button>4</clr-button>
-        <clr-button>5</clr-button>
+        <clr-button name="button1" id="test">1</clr-button>
+        <clr-button type="button">2</clr-button>
+        <clr-button disabled>3</clr-button>
+        <clr-button disabled="false">4</clr-button>
+        <clr-button disabled="123">5</clr-button>
         <clr-button>6</clr-button>
     </clr-button-group>
 </div>
@@ -20,11 +20,11 @@
 <pre>
     <code [clr-code-highlight]="'language-html'">
     &lt;clr-button-group&gt;
-        &lt;clr-button&gt;1&lt;/clr-button&gt;
-        &lt;clr-button&gt;2&lt;/clr-button&gt;
-        &lt;clr-button&gt;3&lt;/clr-button&gt;
-        &lt;clr-button&gt;4&lt;/clr-button&gt;
-        &lt;clr-button&gt;5&lt;/clr-button&gt;
+        &lt;clr-button name=&quot;button1&quot; id=&quot;test&quot;&gt;1&lt;/clr-button&gt;
+        &lt;clr-button type=&quot;button&quot;&gt;2&lt;/clr-button&gt;
+        &lt;clr-button disabled&gt;3&lt;/clr-button&gt;
+        &lt;clr-button disabled=&quot;false&quot;&gt;4&lt;/clr-button&gt;
+        &lt;clr-button disabled=&quot;123&quot;&gt;5&lt;/clr-button&gt;
         &lt;clr-button&gt;6&lt;/clr-button&gt;
     &lt;/clr-button-group&gt;
     </code>

--- a/src/clarity-angular/button/button-group/button.ts
+++ b/src/clarity-angular/button/button-group/button.ts
@@ -12,7 +12,12 @@ import {ButtonInGroupService} from "../providers/buttonInGroup.service";
     selector: "clr-button",
     template: `
         <ng-template #buttonProjectedRef>
-            <button [class]="classNames" (click)="emitClick()">
+            <button 
+                [class]="classNames" 
+                (click)="emitClick()"
+                [attr.type]="type"
+                [attr.name]="name"
+                [attr.disabled]="disabled">
                 <ng-content></ng-content>
             </button>
         </ng-template>
@@ -53,8 +58,53 @@ export class Button {
 
     @Input("class")
     set classNames(value: string) {
-        if (value) {
-            this._classNames = value;
+        if (typeof value === "string") {
+            let classNames: string[] = value.split(" ");
+            if (classNames.indexOf("btn") === -1) {
+                classNames.push("btn");
+            }
+            this._classNames = classNames.join(" ");
+        }
+    }
+
+    private _name: string = null;
+
+    get name(): string {
+        return this._name;
+    }
+
+    @Input("name")
+    set name(value: string) {
+        if (typeof value === "string") {
+            this._name = value;
+        }
+    }
+
+    private _type: string = null;
+
+    get type(): string {
+        return this._type;
+    }
+
+    @Input("type")
+    set type(value: string) {
+        if (typeof value === "string") {
+            this._type = value;
+        }
+    }
+
+    private _disabled: any = null;
+
+    get disabled(): any {
+        return this._disabled;
+    }
+
+    @Input("disabled")
+    set disabled(value: any) {
+        if (value !== null && value !== false) {
+            this._disabled = "";
+        } else {
+            this._disabled = null;
         }
     }
 


### PR DESCRIPTION
Fixes: #1009

Added type, name and disabled attribute for `clr-button`

![image](https://cloud.githubusercontent.com/assets/1426805/26732194/9b760b38-476b-11e7-8fa2-e2394eddb8cf.png)


Tested on Chrome, Firefox, Safari, IE11, Edge

Signed-off-by: Aditya Bhandari <adityab@vmware.com>