### PR TITLE
[CORE] Remove the html reporter from gemini test command.

### DIFF
--- a/build/tasks/gemini.js
+++ b/build/tasks/gemini.js
@@ -54,7 +54,7 @@ gulp.task('css:test', ["build"], function() {
 
 
     var spawn = require('child_process').spawn;
-    var cssTest = spawn('gemini', ['test', testPath, '--reporter', 'flat', '--reporter', 'html'], { stdio: 'inherit' });
+    var cssTest = spawn('gemini', ['test', testPath, '--reporter', 'flat'], { stdio: 'inherit' });
 
     cssTest.on('exit', function(code) {
         process.exit(code);


### PR DESCRIPTION
It looks like Gemini removed the html reporter recently: 
https://github.com/gemini-testing/gemini/commit/e2613e4c80f013902f3f8df3a92e0bd37fa1d2c4

I'm not sure if we need/use the html reporter but this PR will allow builds to run gemini tests again until we change the gemini setup.

Signed-off-by: Matt Hippely <mhippely@vmware.com>