### PR TITLE
[NG] Fix 2 incorrect signpost positions

### DIFF
--- a/src/clarity-angular/popover/signpost/signpost.specs.ts
+++ b/src/clarity-angular/popover/signpost/signpost.specs.ts
@@ -339,7 +339,7 @@ export default function(): void {
             expect(testClass).toBeDefined();
 
             expect(signpost.anchorPoint).toBe(Point.LEFT_BOTTOM);
-            expect(signpost.popoverPoint).toBe(Point.RIGHT_BOTTOM);
+            expect(signpost.popoverPoint).toBe(Point.RIGHT_TOP);
             expect(signpost.signpostOptions.offsetY).toBe(-18);
             expect(signpost.signpostOptions.offsetX).toBe(-14);
         });
@@ -387,7 +387,7 @@ export default function(): void {
             expect(testClass).toBeDefined();
 
             expect(signpost.anchorPoint).toBe(Point.LEFT_TOP);
-            expect(signpost.popoverPoint).toBe(Point.RIGHT_TOP);
+            expect(signpost.popoverPoint).toBe(Point.RIGHT_BOTTOM);
             expect(signpost.signpostOptions.offsetY).toBe(18);
             expect(signpost.signpostOptions.offsetX).toBe(-14);
         });

--- a/src/clarity-angular/popover/signpost/signpost.ts
+++ b/src/clarity-angular/popover/signpost/signpost.ts
@@ -272,7 +272,7 @@ export class Signpost {
                 break;
             case ("left-top"):
                 this.anchorPoint = Point.LEFT_TOP;
-                this.popoverPoint = Point.RIGHT_TOP;
+                this.popoverPoint = Point.RIGHT_BOTTOM;
                 this.signpostOptions.offsetY = 18;
                 this.signpostOptions.offsetX = -14;
                 break;
@@ -284,7 +284,7 @@ export class Signpost {
                 break;
             case ("left-bottom"):
                 this.anchorPoint = Point.LEFT_BOTTOM;
-                this.popoverPoint = Point.RIGHT_BOTTOM;
+                this.popoverPoint = Point.RIGHT_TOP;
                 this.signpostOptions.offsetY = -18;
                 this.signpostOptions.offsetX = -14;
                 break;


### PR DESCRIPTION
- Reverses the popoverPoint for `left-top` and `left-bottom` them so that the left-top is above trigger and left-bottom is below the trigger
- updates specs accordingly

Signed-off-by: Matt Hippely <mhippely@vmware.com>