### PR TITLE
[NG] Fixes HideableColumnService error when looking up by undefined id

### DIFF
--- a/src/app/datagrid/selection/selection.html
+++ b/src/app/datagrid/selection/selection.html
@@ -70,7 +70,9 @@
     <clr-dg-column>Name</clr-dg-column>
     <clr-dg-column>Creation date</clr-dg-column>
     <clr-dg-column>
-        Favorite color
+        <ng-container *clrDgHideableColumn>
+            Favorite color
+        </ng-container>
     </clr-dg-column>
 
     <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">

--- a/src/clarity-angular/data/datagrid/providers/hideable-column.service.spec.ts
+++ b/src/clarity-angular/data/datagrid/providers/hideable-column.service.spec.ts
@@ -172,5 +172,24 @@ export default function (): void {
             // Test that the flag is correct.
             expect(unFlaggedColumns[2].lastVisibleColumn).toBe(false);
         });
+
+        it("looks up columns by id", function() {
+            // test that it accounts for undefined
+            let nonHideableColumn: DatagridHideableColumn;
+            let visibleTestColumns: DatagridHideableColumn[] = [
+                new DatagridHideableColumn(null, "dg-col-1", false),
+                nonHideableColumn,
+                new DatagridHideableColumn(null, "dg-col-2", false),
+                new DatagridHideableColumn(null, "dg-col-3", false)
+            ];
+
+            // Setup
+            columnService.updateColumnList(visibleTestColumns);
+            // Test that we can find something that is a hideable column
+            expect(visibleTestColumns[0]).toEqual(columnService.getColumnById("dg-col-1"));
+
+            // Test that we gracefully do not find something that is not a hideable column and no errors.
+            expect(columnService.getColumnById("")).toBeUndefined();
+        });
     });
 };

--- a/src/clarity-angular/data/datagrid/providers/hideable-column.service.ts
+++ b/src/clarity-angular/data/datagrid/providers/hideable-column.service.ts
@@ -192,9 +192,9 @@ export class HideableColumnService {
      * @returns HideableColumn
      *
      */
-    public getColumnById( id: string ): DatagridHideableColumn {
+    public getColumnById( id: string ): undefined | DatagridHideableColumn {
         if ( id ) {
-            return this._columnList.find(column => column.id === id);
+            return this._columnList.find(column => column && column.id === id);
         }
         return;
     }


### PR DESCRIPTION
- Adds a guard to getColumnById lookup
- Adds a test for getColumnById fn (both defined and undefined hideable columns
- closes #837

Signed-off-by: Matt Hippely <mhippely@vmware.com>