### PR TITLE
[CORE] Use gemini version 4.19.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   - export DISPLAY=:99.0
 
 before_script:
-  - npm install -g gemini
+  - npm install -g gemini@4.19.3
   - npm install -g selenium-standalone
   - selenium-standalone install
   - xvfb-run --server-args="-screen 0, 1600x2400x24" selenium-standalone start > selenium.txt &

--- a/build/tasks/gemini.js
+++ b/build/tasks/gemini.js
@@ -54,7 +54,7 @@ gulp.task('css:test', ["build"], function() {
 
 
     var spawn = require('child_process').spawn;
-    var cssTest = spawn('gemini', ['test', testPath, '--reporter', 'flat'], { stdio: 'inherit' });
+    var cssTest = spawn('gemini', ['test', testPath, '--reporter', 'flat', '--reporter', 'html'], { stdio: 'inherit' });
 
     cssTest.on('exit', function(code) {
         process.exit(code);


### PR DESCRIPTION
- This uses an older version of gemini until we can work out why the html-reporter plugin is not working with the v5x alpha

Signed-off-by: Matt Hippely <mhippely@vmware.com>