### PR TITLE
[UI] Fixed the size of large spinners

### DIFF
--- a/src/app/spinners/spinner-sizes.html
+++ b/src/app/spinners/spinner-sizes.html
@@ -16,7 +16,7 @@
     &lt;span class=&quot;spinner spinner-sm&quot;&gt;
         Loading...
     &lt;/span&gt;
-</code>
+    </code>
 </pre>
 
 <h5>Medium</h5>
@@ -27,11 +27,12 @@
 </div>
 
 <pre>
-<code clr-code-highlight="language-html">
-&lt;span class=&quot;spinner spinner-md&quot;&gt;
-    Loading...
-&lt;/span&gt;
-</code></pre>
+    <code clr-code-highlight="language-html">
+    &lt;span class=&quot;spinner spinner-md&quot;&gt;
+        Loading...
+    &lt;/span&gt;
+    </code>
+</pre>
 
 <h5>Large (default)</h5>
 <div class="clr-example squeeze">
@@ -41,8 +42,9 @@
 </div>
 
 <pre>
-<code clr-code-highlight="language-html">
-&lt;div class=&quot;spinner spinner-lg&quot;&gt;
-    Loading...
-&lt;/div&gt;
-</code></pre>
+    <code clr-code-highlight="language-html">
+    &lt;div class=&quot;spinner spinner-lg&quot;&gt;
+        Loading...
+    &lt;/div&gt;
+    </code>
+</pre>

--- a/src/app/spinners/spinner.demo.scss
+++ b/src/app/spinners/spinner.demo.scss
@@ -11,11 +11,3 @@
         background: #313131;
     }
 }
-
-ul{
-    font-weight: 600;
-
-    span{
-        font-weight: 200;
-    }
-}

--- a/src/clarity-angular/progress/spinner/_spinner.clarity.scss
+++ b/src/clarity-angular/progress/spinner/_spinner.clarity.scss
@@ -14,7 +14,7 @@
         // spinner-lg is the default
         position: relative;
         display: inline-block;
-        @include min-height(rem(72/16));
+        @include min-height($clr_baselineRem_3);
         animation: spin 1s linear infinite;
         margin: 0;
         padding: 0;
@@ -23,11 +23,12 @@
         overflow: hidden;
 
         &.spinner-md {
-            @include min-height(rem(36/$clr-rem-denominator));
+            @include min-height($clr_baselineRem_1_5);
         }
 
-        &.spinner-inline, &.spinner-sm {
-            @include min-height(rem(18/$clr-rem-denominator));
+        &.spinner-inline,
+        &.spinner-sm {
+            @include min-height($clr_baselineRem_0_75);
         }
 
         &.spinner-inline {


### PR DESCRIPTION
Fixes: #1044 

Before:
![image](https://user-images.githubusercontent.com/1426805/27095557-fc700064-5022-11e7-8f38-29905ebe5ead.png)


After:
![image](https://user-images.githubusercontent.com/1426805/27095530-e646da88-5022-11e7-869c-ba04e6bc94c6.png)


Tested on Chrome

Note: The change to the demo html is because the code snippets were not rendering properly.

Signed-off-by: Aditya Bhandari <adityab@vmware.com>