### PR TITLE
[CORE] Adds html-reporter plugin for gemini@latest

### DIFF
--- a/.gemini.conf.yml
+++ b/.gemini.conf.yml
@@ -6,6 +6,12 @@ browsers:
     desiredCapabilities:
       browserName: chrome
 
+system:
+  plugins:
+    html-reporter:
+      enabled: true
+
+
 #compositeImage: true
 #sessionsPerBrowser: 2
 tolerance: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,8 @@ before_install:
   - export DISPLAY=:99.0
 
 before_script:
-  - npm install -g gemini@4.19.3
+  - npm install -g gemini
+  - npm install -g html-reporter
   - npm install -g selenium-standalone
   - selenium-standalone install
   - xvfb-run --server-args="-screen 0, 1600x2400x24" selenium-standalone start > selenium.txt &


### PR DESCRIPTION
I figured out what the issue was, the html-reporter plug-in needs to also be installed globally (duh). 
This PR will get us back on the latest gemini with html-reporter. 