### PR TITLE
[CORE] Adds html-reporter plugin for gemini@latest

### DIFF
--- a/.gemini.conf.yml
+++ b/.gemini.conf.yml
@@ -6,6 +6,12 @@ browsers:
     desiredCapabilities:
       browserName: chrome
 
+system:
+  plugins:
+    html-reporter:
+      enabled: true
+
+
 #compositeImage: true
 #sessionsPerBrowser: 2
 tolerance: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,8 @@ before_install:
   - export DISPLAY=:99.0
 
 before_script:
-  - npm install -g gemini@4.19.3
+  - npm install -g gemini
+  - npm install -g html-reporter
   - npm install -g selenium-standalone
   - selenium-standalone install
   - xvfb-run --server-args="-screen 0, 1600x2400x24" selenium-standalone start > selenium.txt &

--- a/build/tasks/gemini.js
+++ b/build/tasks/gemini.js
@@ -54,7 +54,7 @@ gulp.task('css:test', ["build"], function() {
 
 
     var spawn = require('child_process').spawn;
-    var cssTest = spawn('gemini', ['test', testPath, '--reporter', 'flat', '--reporter', 'html'], { stdio: 'inherit' });
+    var cssTest = spawn('gemini', ['test', testPath, '--reporter', 'flat'], { stdio: 'inherit' });
 
     cssTest.on('exit', function(code) {
         process.exit(code);


### PR DESCRIPTION
Updates the build process for `gemini, gemini config and travis config` to allow us to run the latest gemini with the `html-reporter` plugin.

Signed-off-by: Matt Hippely <mhippely@vmware.com>