### PR TITLE
[WEB] bugfix: Code Highlight example not work

### DIFF
--- a/src/app/documentation/demos/code/code-highlight-snippet.ts
+++ b/src/app/documentation/demos/code/code-highlight-snippet.ts
@@ -6,15 +6,16 @@
 import {Component} from "@angular/core";
 
 const HTML_EXAMPLE = `
+<!-- "&#123;" left curly brace / "&#125;" right curly brace -->
 <pre>
     <code clr-code-highlight="language-css">
-        .some-component {
+        .some-component &#123;
             display: flex;
             flex-direction: column;
             justify-content: space-between;
             align-items: center;
             flex-wrap: wrap;
-        }
+        &#125;
     </code>
 </pre>
 `;


### PR DESCRIPTION
- '{' and '}' make code highlight example break (angular reporst template syntax error)
- use '&#' style to escape

Signed-off-by: Seven Lju <dna2gle@gmail.com>