### PR TITLE
[NG] Popover Anchor Fix. DO NOT MERGE

### DIFF
--- a/src/app/signpost/signpost.demo.html
+++ b/src/app/signpost/signpost.demo.html
@@ -4,14 +4,10 @@
     <div class="content-area">
         <div class="signpost-demo">
             <div class="signpost-item"
-                *ngFor="let position of positions">
+                 *ngFor="let position of positions">
                 <div class="signpost-positions">
                     <div class="description">
-                        <div class="select">
-                            <section class="form-block">
-                                <h4>{{  position.description }}</h4>
-                            </section>
-                        </div>
+                        <h4>{{ position.description }}</h4>
                     </div>
                     <div class="position">
                         <clr-signpost [clrSignpostPosition]="position.position">

--- a/src/clarity-angular/popover/common/popover.directive.spec.ts
+++ b/src/clarity-angular/popover/common/popover.directive.spec.ts
@@ -49,8 +49,8 @@ describe("Popover directive", () => {
 @Component({
     template: `
         <span #anchor1>anchor1</span>
-        <div [clrPopoverAnchor]="anchor1">
-            <span #popover>popover1</span>
+        <div [clrPopoverAnchor]="anchor1" #popover>
+            <span>popover1</span>
         </div>
     `
 })

--- a/src/clarity-angular/popover/common/popover.directive.ts
+++ b/src/clarity-angular/popover/common/popover.directive.ts
@@ -19,6 +19,7 @@ export class PopoverDirective {
     }
 
     ngOnInit() {
+        this.updateView(this.ifOpenService.open);
         this.ifOpenService.openChange.subscribe((change) => {
             this.updateView(change);
         });
@@ -34,7 +35,7 @@ export class PopoverDirective {
 
     createPopover() {
         // we take the first child element; usually there should only be one anyways
-        this._popoverInstance = new Popover(this.el.nativeElement.children[0]);
+        this._popoverInstance = new Popover(this.el.nativeElement);
         this._subscription = this._popoverInstance.anchor(
             this.anchorElem, this.anchorPoint, this.popoverPoint, this.popoverOptions).subscribe(() => {
             // if a scroll event is detected, close the popover

--- a/src/clarity-angular/popover/dropdown/_dropdown.clarity.scss
+++ b/src/clarity-angular/popover/dropdown/_dropdown.clarity.scss
@@ -202,6 +202,15 @@ $dropdown-white: clr-getColor(lightest);
         }
     }
 
+    .dropdown-menu-wrapper.is-open > .dropdown-menu {
+        //HATE THIS but this is the only solution that i can think of right now.
+        //NOTE: this makes sure that the width of .dropdown-menu-wrapper is not zero.
+        //WHY?: the wrapper is used in the angular component and has position: absolute
+        //when the menu is opened. position: absolute on the wrapper as well the menu
+        //makes the width of of the wrapper 0 and breaks all the *-right positions
+        position: static;
+    }
+
     //Directions
     .btn-group-overflow,
     .dropdown {
@@ -338,4 +347,6 @@ $dropdown-white: clr-getColor(lightest);
 
         }
     }
+
+
 }

--- a/src/clarity-angular/popover/dropdown/dropdown.ts
+++ b/src/clarity-angular/popover/dropdown/dropdown.ts
@@ -24,8 +24,12 @@ import {IfOpenService} from "../../utils/conditional/if-open.service";
     selector: "clr-dropdown",
     template: `
         <ng-content select="[clrDropdownToggle]"></ng-content>
-        <div class="dropdown-menu-wrapper" [clrPopoverAnchor]="anchor" [clrPopoverAnchorPoint]="anchorPoint"
-             [clrPopoverPopoverPoint]="popoverPoint" [clrPopoverOptions]="popoverOptions">
+        <div class="dropdown-menu-wrapper" 
+             [class.is-open]="ifOpenService.addClass" 
+             [clrPopoverAnchor]="anchor" 
+             [clrPopoverAnchorPoint]="anchorPoint"
+             [clrPopoverPopoverPoint]="popoverPoint" 
+             [clrPopoverOptions]="popoverOptions">
             <ng-content select="[clr-dropdown-menu, .dropdown-menu]"></ng-content>
         </div>
     `,

--- a/src/clarity-angular/popover/signpost/_signposts.clarity.scss
+++ b/src/clarity-angular/popover/signpost/_signposts.clarity.scss
@@ -373,6 +373,10 @@
             display: inline-block;
         }
 
+        &-popover {
+            z-index: map-get($clr-layers, tooltips);
+        }
+
         &-content {
             background-color: transparent;
             min-width: 216px;
@@ -380,7 +384,6 @@
             min-height: 84px;
             max-height: 504px;
             display: inline-block;
-            z-index: map-get($clr-layers, tooltips);
 
             .signpost-flex-wrap {
                 border: 1px solid $clr-dark-midtone-gray;

--- a/src/clarity-angular/popover/signpost/signpost.ts
+++ b/src/clarity-angular/popover/signpost/signpost.ts
@@ -47,7 +47,8 @@ const signpostPositions: string[] = [
             </ng-container>
         </div>
         
-        <div [clrPopoverAnchor]="anchor"
+        <div class="signpost-popover"
+             [clrPopoverAnchor]="anchor"
              [clrPopoverAnchorPoint]="anchorPoint"
              [clrPopoverPopoverPoint]="popoverPoint"
              [clrPopoverOptions]="signpostOptions">

--- a/src/clarity-angular/utils/conditional/if-open.directive.ts
+++ b/src/clarity-angular/utils/conditional/if-open.directive.ts
@@ -104,5 +104,6 @@ export class IfOpenDirective implements OnInit {
             this.updateView(change);
             this.openChange.emit(change);
         });
+        this.ifOpenService.addClass = true;
     }
 }

--- a/src/clarity-angular/utils/conditional/if-open.service.ts
+++ b/src/clarity-angular/utils/conditional/if-open.service.ts
@@ -83,4 +83,9 @@ export class IfOpenService {
     public get open(): boolean {
         return this._open;
     }
+
+    //NOTE: This is just for dropdowns. This adds a class on the dropdown menu wrapper
+    //which removes the position: absolute from dropdown menu inside of it
+    //TODO: Remove this when we get rid of the deprecated dropdown
+    public addClass: boolean = false;
 }


### PR DESCRIPTION
Fixes: #1126

Had to use a nasty hack. Do not merge without @youdz review.

Why use the hack?
Hack is needed to make sure that the `.dropdown-menu` does not have `position: absolute` because `.dropdown-menu-wrapper` which is only present in the Angular component already has it because of `clrPopoverAnchor`. If we don't do this, a `position: absolute` on both wrapper and menu causes the wrapper width to become 0 and all *-right positions are rendered incorrectly.

Components Tested: Dropdowns & Signposts

Signed-off-by: Aditya Bhandari <adityab@vmware.com>