### PR TITLE
[NG] fixing double onCommit event firing with AltNext Wizard

### DIFF
--- a/src/clarity-angular/wizard/providers/wizard-navigation.spec.ts
+++ b/src/clarity-angular/wizard/providers/wizard-navigation.spec.ts
@@ -530,6 +530,26 @@ export default function(): void {
                 expect(currentPage.onCommit.emit).toHaveBeenCalledTimes(1);
             });
 
+
+            it("should only commit page once on last page if there are wizard overrides", function() {
+                let wiz = context.clarityDirective;
+                let testPage = pageCollectionService.lastPage;
+                spyOn(testPage.onCommit, "emit");
+
+                wiz.navService.setCurrentPage(testPage);
+                expect(wiz.currentPage).toBe(testPage, "last page was made current");
+                context.detectChanges();
+
+                wiz.stopNext = true;
+                context.detectChanges();
+                expect(wiz.navService.wizardHasAltNext).toBe(true, "navService registers that we have an alt next");
+
+                wizardNavigationService.checkAndCommitCurrentPage("finish");
+
+                expect(testPage.onCommit.emit).toHaveBeenCalledTimes(1);
+            });
+
+
             it("should notify wizardFinished if finish", function() {
                 let calledAsExpected = false;
                 let checkMe = wizardNavigationService.wizardFinished.subscribe(() => {

--- a/src/clarity-angular/wizard/providers/wizard-navigation.ts
+++ b/src/clarity-angular/wizard/providers/wizard-navigation.ts
@@ -488,9 +488,11 @@ export class WizardNavigationService implements OnDestroy {
         }
 
         // order is very important with these emitters!
-        if (isFinish || isDangerFinish) {
+        if (isFinish) {
             // mark page as complete
-            this.pageCollection.commitPage(currentPage);
+            if (!this.wizardHasAltNext) {
+                this.pageCollection.commitPage(currentPage);
+            }
             this._wizardFinished.next();
         }
 


### PR DESCRIPTION
Closes: #1034

Signed-off-by: Scott Mathis <smathis@vmware.com>