### PR TITLE
[CORE] Updates link in demo app to s/min/umd/g for clarity-icons-lite.

### DIFF
--- a/src/app/index.html
+++ b/src/app/index.html
@@ -36,7 +36,7 @@
     <!-- @endif -->
 
     <!-- @if NODE_ENV='prod' -->
-    <script src="bundles/clarity-icons-lite.umd.js"></script>
+    <script src="bundles/clarity-icons-lite.min.js"></script>
     <script src="bundles/clarity-angular.min.js"></script>
 
     <!--Add font-awesome dependency. Needed for select boxes and check boxes-->


### PR DESCRIPTION
Short and simple. All this does is change umd -> min for the clarity-icons-lite script link in the demo app we use for dev. 

Signed-off-by: Matt Hippely <mhippely@vmware.com>