### PR TITLE
[WEB] updating examples of alerts in modals

### DIFF
--- a/src/app/documentation/demos/alert/static/alert-modals.demo.html
+++ b/src/app/documentation/demos/alert/static/alert-modals.demo.html
@@ -9,13 +9,6 @@
         <div class="modal static bump-down">
             <div class="modal-dialog" role="dialog" aria-hidden="true">
                 <div class="modal-content">
-                    <div class="alert alert-danger">
-                        <div class="alert-item">
-                            <span class="alert-text">
-                                Alert in a modal.
-                            </span>
-                        </div>
-                    </div>
                     <div class="modal-header">
                         <button aria-label="Close" class="close" type="button">
                             <clr-icon aria-hidden="true" shape="close"></clr-icon>
@@ -23,6 +16,13 @@
                         <h3 class="modal-title">I have a nice title</h3>
                     </div>
                     <div class="modal-body">
+                        <div class="alert alert-danger">
+                            <div class="alert-item">
+                                <span class="alert-text">
+                                    Alert in a modal.
+                                </span>
+                            </div>
+                        </div>
                         <p>But not much to say...</p>
                     </div>
                     <div class="modal-footer">


### PR DESCRIPTION
Updated examples of alerts in modals on web dox to show proper placement below modal title, instead of above it.

![screen shot 2017-07-07 at 3 14 48 pm](https://user-images.githubusercontent.com/2728359/27975327-3b0b5f50-6327-11e7-9f4d-8a2066419edc.png)

Signed-off-by: Scott Mathis <smathis@vmware.com>