### PR TITLE
[NG] Tree View Animation Fix - 0.10.0 - DO NOT MERGE

### DIFF
--- a/src/clarity-angular/data/tree-view/_tree-view.clarity.scss
+++ b/src/clarity-angular/data/tree-view/_tree-view.clarity.scss
@@ -160,6 +160,7 @@ clr-tree-node {
 //Tree Nodes containing TreeNodes are wrapped with this class
 .clr-treenode-children {
     margin-left: $clr-tree-node-children-margin;
+    overflow-y: hidden;
 }
 
 .clr-tree--compact.clr-treenode,

--- a/src/clarity-angular/data/tree-view/tree-node.ts
+++ b/src/clarity-angular/data/tree-view/tree-node.ts
@@ -48,12 +48,10 @@ import {Expand} from "../../utils/expand/providers/expand";
     animations: [
         trigger("childNodesState", [
             state("expanded", style({
-                "height": "*",
-                "overflow-y": "hidden"
+                "height": "*"
             })),
             state("collapsed", style({
-                "height": 0,
-                "overflow-y": "hidden"
+                "height": 0
             })),
             transition(
                 "expanded <=> collapsed", animate("0.2s ease-in-out")


### PR DESCRIPTION
This change is not really needed because in the collapse mode in the 0.10.0 tree, the nodes are removed from the DOM but just adding it for safety.

Tested on: Safari, Firefox, Chrome

Signed-off-by: Aditya Bhandari <adityab@vmware.com>