### PR TITLE
[ICONS] added transparent bg in printed SVGs

### DIFF
--- a/build/write-svg-icons.js
+++ b/build/write-svg-icons.js
@@ -158,13 +158,15 @@ let breakUpAllShapeTemplates = (shapes) => {
 
 let makeSVG = (shapeTitle, shapeContent) => {
 
-    let openingTag = `<svg version="1.1" viewBox="0 0 36 36" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">`;
+    let openingTag = `<svg version="1.1" width="36" height="36"  viewBox="0 0 36 36" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">`;
     let title = `<title>${shapeTitle}</title>`;
+    let transparentBG = `<rect x="0" y="0" width="36" height="36" fill-opacity="0"/>`;
     let closingTag = `</svg>`;
 
     return `${openingTag}
                 ${title}
                 ${shapeContent}
+                ${transparentBG}
             ${closingTag}`;
 
 


### PR DESCRIPTION
Fixes #1026

![screenshot 2017-07-28 12 14 14](https://user-images.githubusercontent.com/3958008/28733694-2cb50a34-7392-11e7-84ff-3d9493d2bfb4.png)
(One on the left side is the screenshot taken before the fix.)

Signed-off-by: Shijir Tsogoo <stsogoo@vmware.com>