### PR TITLE
[core] Use headless Chrome in all OSs for unit tests

### DIFF
--- a/build/karma.conf.js
+++ b/build/karma.conf.js
@@ -86,25 +86,16 @@ module.exports = function (config) {
         colors: true,
         logLevel: config.LOG_INFO,
         autoWatch: false,
-        browsers: ["Chrome_Canary_Headless"],
+        browsers: ["Chrome_Headless"],
         singleRun: true,
 
         customLaunchers: {
-            Chrome_Canary_Headless: {
-                base: 'ChromeCanary',
-                flags: ['--headless', '--disable-gpu', '--remote-debugging-port=9222']
-            },
             Chrome_Headless: {
                 base: 'Chrome',
                 flags: ['--headless', '--disable-gpu', '--remote-debugging-port=9222']
             }
 
         }
-    }
-
-    // Override for Travis CI
-    if(process.env.TRAVIS && process.env.TEST_SUITE === "test") {
-        configuration.browsers = ['Chrome_Headless'];
     }
 
     config.set(configuration);


### PR DESCRIPTION
It seems like headless Chrome is supported in Linux/Windows/Mac with latest versions of Chrome. Removing conditional logic to run karma tests with Canary in local env. Devs should install the latest version of Chrome to run unit tests locally.


Signed-off-by: Jeeyun Lim <jeeyun.lim@gmail.com>