### PR TITLE
Adjusting whitespace of dropdown menus

### DIFF
--- a/src/clarity-angular/layout/nav/_header.clarity.scss
+++ b/src/clarity-angular/layout/nav/_header.clarity.scss
@@ -362,7 +362,7 @@ $clr-header-nav-text-horizontal-padding: $clr_baselineRem_1;
                 //Pull the dropdown menus of all dropdowns up to compensate
                 //for the height of the header.
                 .dropdown-menu {
-                    margin-top: -1 * $clr_baselineRem_0_375;
+                    margin-top: -1 * baselineRem(4/24);
                     // TODO: As of 0.10.0 the dropdown-menu inside header without clrIfOpen directive (legacy)
                     // will create empty space beyond the .main-container if the right isn't set to zero.
                     // Re-evaluate later if we can come up with a better solution.

--- a/src/clarity-angular/popover/dropdown/_dropdown.clarity.scss
+++ b/src/clarity-angular/popover/dropdown/_dropdown.clarity.scss
@@ -76,7 +76,7 @@ $dropdown-white: clr-getColor(lightest);
         display: flex;
         flex-direction: column;
         background: $dropdown-white;
-        padding: $clr_baselineRem_0_75 0;
+        padding: $clr_baselineRem_0_5 0;
         border: 1px solid clr-getColor(light-midtone);
         box-shadow: 0 1px 3px rgba(clr-getColor(dark), 0.25);
         min-width: baselineRem(5);
@@ -84,11 +84,12 @@ $dropdown-white: clr-getColor(lightest);
         border-radius: $clr-default-borderradius;
         visibility: hidden;
         z-index: map-get($clr-layers, dropdown-menu);
-
+        
         .dropdown-header {
             @include clr-getTypePropertiesForDomElement(dropdown_header, (font-size, font-weight, letter-spacing));
-
+            
             padding: 0 $clr_baselineRem_0_5;
+            line-height: $clr_baselineRem_0_75;
             margin: 0;
             color: clr-getColor(darkest);
 
@@ -198,7 +199,7 @@ $dropdown-white: clr-getColor(lightest);
 
         .dropdown-divider {
             border-bottom: 1px solid clr-getColor(light);
-            margin: $clr_baselineRem_0_75 0;
+            margin: $clr_baselineRem_0_25 0;
         }
     }
 


### PR DESCRIPTION
Adjusting whitespace of dropdown menus to make them more compact and to balance the horizontal and vertical whitespace.

• changed the top and bottom padding of the drop-down menu to 12px (was previously 18px)
• changed the top and bottom padding of drop-down menu dividers to 6px (was previously 24px)
• adjusted the placement of drop downs in the header so that the drop-down menu did not overlap the header area as much (previously overlapped by 8px, now overlaps by 3px)

Signed-off-by: Scott Mathis <smathis@vmware.com>