### PR TITLE
[ICONS] make Safari's HTMLElement.prototype.constructor writable in iOS 9.x

### DIFF
--- a/src/clarity-icons/clarity-icons-element.ts
+++ b/src/clarity-icons/clarity-icons-element.ts
@@ -27,7 +27,13 @@ export function ClarityIconElement() {
 
 (ClarityIconElement as any).observedAttributes = [ "shape", "size" ];
 
-ClarityIconElement.prototype = Object.create(HTMLElement.prototype);
+ClarityIconElement.prototype = Object.create(HTMLElement.prototype, {
+    constructor: {
+        configurable: true,
+        writable: true,
+        value: ClarityIconElement
+    }
+});
 
 ClarityIconElement.prototype.constructor = ClarityIconElement;
 


### PR DESCRIPTION
Fixes #1289

Before:
<img width="436" alt="screenshot 2017-08-14 14 51 45" src="https://user-images.githubusercontent.com/3958008/29293757-1366061a-8101-11e7-8f34-87f5d58bf991.png">

After:
<img width="431" alt="screenshot 2017-08-14 14 47 39" src="https://user-images.githubusercontent.com/3958008/29293783-2d30e2d6-8101-11e7-9954-a9d8814727c8.png">

Signed-off-by: Shijir Tsogoo <stsogoo@vmware.com>