### PR TITLE
Improve the word wrapping of the stack-view

### DIFF
--- a/src/clarity-angular/data/stack-view/_stack-view.clarity.scss
+++ b/src/clarity-angular/data/stack-view/_stack-view.clarity.scss
@@ -44,6 +44,7 @@ $clr-stack-font-weight: clr-getTypePropertyValueForDomElement(stackview_text, fo
         border-radius: $clr-default-borderradius;
         overflow-y: auto;
         background-color: $gray-lighter;
+        word-wrap: break-word;
 
         /* this fixes the overflow problem of children elements in a wrapper with a border-radius in Chrome */
         -webkit-mask-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAA5JREFUeNpiYGBgAAgwAAAEAAGbA+oJAAAAAElFTkSuQmCC);


### PR DESCRIPTION
When the content of the stack-view appears to be too long in some of the
browsers it doesn't fit in the container and scrollers appear.

This will:
* Allow the browser to brake unbreakable words, so the content fits in the container
* Avoid appearance of the scrollers around the stack-view

Fixes #1304

Before:
![image](https://user-images.githubusercontent.com/31008054/29314052-e2e3ab5e-81c4-11e7-8021-4826981eca77.png)

After:
![image](https://user-images.githubusercontent.com/31008054/29314073-fe6fc664-81c4-11e7-8ecb-afb7257e1efa.png)


