### PR TITLE
[ICONS] make Safari's HTMLElement.prototype.constructor writable

### DIFF
--- a/src/clarity-icons/clarity-icons-element.ts
+++ b/src/clarity-icons/clarity-icons-element.ts
@@ -27,7 +27,13 @@ export function ClarityIconElement() {
 
 (ClarityIconElement as any).observedAttributes = [ "shape", "size" ];
 
-ClarityIconElement.prototype = Object.create(HTMLElement.prototype);
+ClarityIconElement.prototype = Object.create(HTMLElement.prototype, {
+    constructor: {
+        configurable: true,
+        writable: true,
+        value: ClarityIconElement
+    }
+});
 
 ClarityIconElement.prototype.constructor = ClarityIconElement;
 


### PR DESCRIPTION
Backporting https://github.com/vmware/clarity/pull/1301 to v0.9

Signed-off-by: Shijir Tsogoo <stsogoo@vmware.com>