### PR TITLE
[ICONS] Fixes the formatting for clarity-icons-element

### DIFF
--- a/src/clarity-icons/clarity-icons-element.ts
+++ b/src/clarity-icons/clarity-icons-element.ts
@@ -23,13 +23,8 @@ export function ClarityIconElement() {
 
 (ClarityIconElement as any).observedAttributes = ["shape", "size"];
 
-ClarityIconElement.prototype = Object.create(HTMLElement.prototype, {
-    constructor: {
-        configurable: true,
-        writable: true,
-        value: ClarityIconElement
-    }
-});
+ClarityIconElement.prototype = Object.create(
+    HTMLElement.prototype, {constructor: {configurable: true, writable: true, value: ClarityIconElement}});
 
 ClarityIconElement.prototype.constructor = ClarityIconElement;
 


### PR DESCRIPTION
Not quite sure how this file got through but I ran the formatter on it and that should make Travis happy again. 

Signed-off-by: Matt Hippely <mhippely@vmware.com>