### PR TITLE
[NG] custom label for button group menu

### DIFF
--- a/src/app/button-group/angular/button-group-angular.ts
+++ b/src/app/button-group/angular/button-group-angular.ts
@@ -19,6 +19,7 @@ import {Component} from "@angular/core";
             <li><a [routerLink]="['./hide-overflow']">Hide/Show Overflow Toggle</a></li>
             <li><a [routerLink]="['./mixed-buttons']">Mixed Buttons</a></li>
             <li><a [routerLink]="['./move-button-in-menu']">Move Button In Menu</a></li>
+            <li><a [routerLink]="['./move-button-in-menu-with-custom-label']">Move Button In Menu with Custom Label</a></li>
             <li><a [routerLink]="['./move-multiple-buttons-in-menu']">Move Multiple Buttons In Menu</a></li>
             <li><a [routerLink]="['./move-all-in-menu']">Move All Buttons In Menu</a></li>
             <li><a [routerLink]="['./projection-update-test-1']">Projection Update Test 1</a></li>

--- a/src/app/button-group/angular/move-button-in-menu-with-custom-label/move-button-in-menu-with-custom-label.html
+++ b/src/app/button-group/angular/move-button-in-menu-with-custom-label/move-button-in-menu-with-custom-label.html
@@ -1,0 +1,21 @@
+<!--
+  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<h4>Move Button In Menu</h4>
+
+<div class="clr-example example-min-height">
+    <clr-button-group [clrMenuLabel]="'More'">
+        <clr-button>1</clr-button>
+        <clr-button>2</clr-button>
+        <clr-button>3</clr-button>
+        <clr-button [clrInMenu]="true">4</clr-button>
+        <clr-button [clrInMenu]="true">5</clr-button>
+        <clr-button [clrInMenu]="flip">6</clr-button>
+    </clr-button-group>
+    <div>
+        <button class="btn" (click)="toggleFlip()">Flip</button>
+    </div>
+</div>

--- a/src/app/button-group/angular/move-button-in-menu-with-custom-label/move-button-in-menu-with-custom-label.ts
+++ b/src/app/button-group/angular/move-button-in-menu-with-custom-label/move-button-in-menu-with-custom-label.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component} from "@angular/core";
+
+@Component({
+    moduleId: module.id,
+    selector: "clr-move-button-in-menu-with-custom-label-demo",
+    templateUrl: "./move-button-in-menu-with-custom-label.html",
+    styleUrls: ["../../button-group.demo.css"]
+})
+export class MoveButtonInMenuWithCustomLabelDemo {
+    flip: boolean = false;
+
+    toggleFlip() {
+        this.flip = !this.flip;
+    }
+}

--- a/src/app/button-group/button-group.demo.module.ts
+++ b/src/app/button-group/button-group.demo.module.ts
@@ -15,6 +15,9 @@ import {IconButtonGroupDemo} from "./angular/icon-buttons/icon-button-group";
 import {MenuDirectionsDemo} from "./angular/menu-directions/menu-directions";
 import {MixedButtonGroupDemo} from "./angular/mixed-buttons/mixed-button-group";
 import {MoveAllInMenuDemo} from "./angular/move-all-in-menu/move-all-in-menu";
+import {
+    MoveButtonInMenuWithCustomLabelDemo
+} from "./angular/move-button-in-menu-with-custom-label/move-button-in-menu-with-custom-label";
 import {MoveButtonInMenuDemo} from "./angular/move-button-in-menu/move-button-in-menu";
 import {MoveMultipleButtonInMenuDemo} from "./angular/move-multiple-buttons-in-menu/move-multiple-button-in-menu";
 import {ProjectionUpdateTest1Demo} from "./angular/projection-update-test-1/projection-update-test-1";
@@ -46,6 +49,7 @@ import {ButtonGroupTypes} from "./static/types/button-group-types";
         MixedButtonGroupDemo,
         MoveAllInMenuDemo,
         MoveButtonInMenuDemo,
+        MoveButtonInMenuWithCustomLabelDemo,
         MoveMultipleButtonInMenuDemo,
         ProjectionUpdateTest1Demo,
         ProjectionUpdateTest2Demo,
@@ -76,6 +80,7 @@ import {ButtonGroupTypes} from "./static/types/button-group-types";
         MixedButtonGroupDemo,
         MoveAllInMenuDemo,
         MoveButtonInMenuDemo,
+        MoveButtonInMenuWithCustomLabelDemo,
         MoveMultipleButtonInMenuDemo,
         ProjectionUpdateTest1Demo,
         ProjectionUpdateTest2Demo,

--- a/src/app/button-group/buttons.demo.routing.ts
+++ b/src/app/button-group/buttons.demo.routing.ts
@@ -13,6 +13,9 @@ import {IconButtonGroupDemo} from "./angular/icon-buttons/icon-button-group";
 import {MenuDirectionsDemo} from "./angular/menu-directions/menu-directions";
 import {MixedButtonGroupDemo} from "./angular/mixed-buttons/mixed-button-group";
 import {MoveAllInMenuDemo} from "./angular/move-all-in-menu/move-all-in-menu";
+import {
+    MoveButtonInMenuWithCustomLabelDemo
+} from "./angular/move-button-in-menu-with-custom-label/move-button-in-menu-with-custom-label";
 import {MoveButtonInMenuDemo} from "./angular/move-button-in-menu/move-button-in-menu";
 import {MoveMultipleButtonInMenuDemo} from "./angular/move-multiple-buttons-in-menu/move-multiple-button-in-menu";
 import {ProjectionUpdateTest1Demo} from "./angular/projection-update-test-1/projection-update-test-1";
@@ -60,6 +63,7 @@ const ROUTES: Routes = [{
               {path: "hide-overflow", component: HideShowOverflowToggleDemo},
               {path: "mixed-buttons", component: MixedButtonGroupDemo},
               {path: "move-button-in-menu", component: MoveButtonInMenuDemo},
+              {path: "move-button-in-menu-with-custom-label", component: MoveButtonInMenuWithCustomLabelDemo},
               {path: "move-multiple-buttons-in-menu", component: MoveMultipleButtonInMenuDemo},
               {path: "move-all-in-menu", component: MoveAllInMenuDemo},
               {path: "projection-update-test-1", component: ProjectionUpdateTest1Demo},

--- a/src/clarity-angular/button/button-group/button-group.html
+++ b/src/clarity-angular/button/button-group/button-group.html
@@ -9,7 +9,8 @@
         <button
             class="btn dropdown-toggle"
             (click)="toggleMenu()">
-            <clr-icon shape="ellipsis-horizontal"></clr-icon>
+            <clr-icon *ngIf="menuLabel == ''" shape="ellipsis-horizontal"></clr-icon>
+            <span *ngIf="menuLabel != ''">{{menuLabel}}</span>
         </button>
         <div
             class="dropdown-menu"

--- a/src/clarity-angular/button/button-group/button-group.spec.ts
+++ b/src/clarity-angular/button/button-group/button-group.spec.ts
@@ -21,7 +21,8 @@ export default function(): void {
                 imports: [ClrButtonGroupModule],
                 declarations: [
                     BtnGroupInlineViewContainer, BtnGroupBothViewContainersTest, BtnGroupMenuViewContainer,
-                    BtnGroupFlipTest1, BtnGroupFlipTest2, BtnGroupProjectionUpdateTest, BtnGroupEHCAIWCTest
+                    BtnGroupFlipTest1, BtnGroupFlipTest2, BtnGroupProjectionUpdateTest, BtnGroupEHCAIWCTest,
+                    BtnGroupMenuLabelTest
                 ]
             });
         });
@@ -125,6 +126,25 @@ export default function(): void {
                 expect(dropdownMenu.children[2].classList.contains("btn")).toBe(true);
             });
 
+        });
+
+        describe("Button group wit custom menu label", () => {
+
+            beforeEach(() => {
+                fixture = TestBed.createComponent(BtnGroupMenuLabelTest);
+                fixture.detectChanges();
+                compiled = fixture.nativeElement;
+                testBtnGroup = fixture.componentInstance.btnGroup;
+            });
+
+            afterEach(() => {
+                fixture.destroy();
+            });
+
+            it("renders the custom menu label", () => {
+                const dropdownToggle: HTMLElement = compiled.querySelector(".btn.dropdown-toggle");
+                expect(dropdownToggle.innerText).toContain("MORE");
+            });
         });
 
         describe("Flip Test 1", () => {
@@ -506,6 +526,21 @@ class BtnGroupInlineViewContainer {
     `
 })
 class BtnGroupBothViewContainersTest {
+    @ViewChild(ButtonGroup) btnGroup: ButtonGroup;
+}
+
+@Component({
+    template: `
+        <clr-button-group [clrMenuLabel]="'more'">
+            <clr-button>Button 1</clr-button>
+            <clr-button>Button 2</clr-button>
+            <clr-button [clrInMenu]="true">Button 3</clr-button>
+            <clr-button [clrInMenu]="true">Button 4</clr-button>
+            <clr-button [clrInMenu]="true">Button 5</clr-button>
+        </clr-button-group>
+    `
+})
+class BtnGroupMenuLabelTest {
     @ViewChild(ButtonGroup) btnGroup: ButtonGroup;
 }
 

--- a/src/clarity-angular/button/button-group/button-group.ts
+++ b/src/clarity-angular/button/button-group/button-group.ts
@@ -166,6 +166,17 @@ export class ButtonGroup {
         this._openMenu = value;
     }
 
+    private _menuLabel: string = "";
+
+    get menuLabel(): string {
+        return this._menuLabel;
+    }
+
+    @Input("clrMenuLabel")
+    set menuLabel(value: string) {
+        this._menuLabel = value;
+    }
+
     public anchorPoint: Point = Point.BOTTOM_LEFT;  // default if menuPosition isn't set
     public popoverPoint: Point = Point.LEFT_TOP;    // default if menuPosition isn't set
 


### PR DESCRIPTION
`[clrMenuLabel]` on a `<clr-button-group>` sets a custom button label instead of the 'ellipsis-horizontal' icon

Partly Fixes #1347 

Signed-off-by: Marvin Osswald <mail@marvinosswald.de>