### PR TITLE
Implementation of whole row selection 

### DIFF
--- a/src/app/datagrid/datagrid.demo.html
+++ b/src/app/datagrid/datagrid.demo.html
@@ -19,6 +19,7 @@
     <li><a [routerLink]="['./pagination-scrolling']">Pagination & Scrolling</a></li>
     <li><a [routerLink]="['./selection']">Selection</a></li>
     <li><a [routerLink]="['./selection-single']">Selection (Single)</a></li>
+    <li><a [routerLink]="['./selection-row-mode']">Selection (Row Mode)</a></li>
     <li><a [routerLink]="['./preserve-selection']">Preserve Selection</a></li>
     <li><a [routerLink]="['./server-driven']">Server-driven datagrid</a></li>
     <li><a [routerLink]="['./placeholder']">Placeholder</a></li>

--- a/src/app/datagrid/datagrid.demo.module.ts
+++ b/src/app/datagrid/datagrid.demo.module.ts
@@ -27,6 +27,7 @@ import {DatagridPaginationDemo} from "./pagination/pagination";
 import {DatagridPlaceholderDemo} from "./placeholder/placeholder";
 import {DatagridPreserveSelectionDemo} from "./preserve-selection/preserve-selection";
 import {DatagridScrollingDemo} from "./scrolling/scrolling";
+import {DatagridSelectionRowModeDemo} from "./selection-row-mode/selection-row-mode";
 import {DatagridSelectionSingleDemo} from "./selection-single/selection-single";
 import {DatagridSelectionDemo} from "./selection/selection";
 import {DatagridServerDrivenDemo} from "./server-driven/server-driven";
@@ -52,6 +53,7 @@ import {Example} from "./utils/example";
         DatagridPaginationScrollingDemo,
         DatagridSelectionDemo,
         DatagridSelectionSingleDemo,
+        DatagridSelectionRowModeDemo,
         DatagridPreserveSelectionDemo,
         DatagridServerDrivenDemo,
         DatagridSmartIteratorDemo,
@@ -79,6 +81,7 @@ import {Example} from "./utils/example";
         DatagridPaginationScrollingDemo,
         DatagridSelectionDemo,
         DatagridSelectionSingleDemo,
+        DatagridSelectionRowModeDemo,
         DatagridPreserveSelectionDemo,
         DatagridServerDrivenDemo,
         DatagridSmartIteratorDemo,

--- a/src/app/datagrid/datagrid.demo.routing.ts
+++ b/src/app/datagrid/datagrid.demo.routing.ts
@@ -21,6 +21,7 @@ import {DatagridPaginationDemo} from "./pagination/pagination";
 import {DatagridPlaceholderDemo} from "./placeholder/placeholder";
 import {DatagridPreserveSelectionDemo} from "./preserve-selection/preserve-selection";
 import {DatagridScrollingDemo} from "./scrolling/scrolling";
+import {DatagridSelectionRowModeDemo} from "./selection-row-mode/selection-row-mode";
 import {DatagridSelectionSingleDemo} from "./selection-single/selection-single";
 import {DatagridSelectionDemo} from "./selection/selection";
 import {DatagridServerDrivenDemo} from "./server-driven/server-driven";
@@ -47,6 +48,7 @@ const ROUTES: Routes = [{
         {path: "pagination-scrolling", component: DatagridPaginationScrollingDemo},
         {path: "selection", component: DatagridSelectionDemo},
         {path: "selection-single", component: DatagridSelectionSingleDemo},
+        {path: "selection-row-mode", component: DatagridSelectionRowModeDemo},
         {path: "preserve-selection", component: DatagridPreserveSelectionDemo},
         {path: "server-driven", component: DatagridServerDrivenDemo},
         {path: "placeholder", component: DatagridPlaceholderDemo},

--- a/src/app/datagrid/selection-row-mode/selection-row-mode.html
+++ b/src/app/datagrid/selection-row-mode/selection-row-mode.html
@@ -1,0 +1,118 @@
+<!--
+  ~ Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<h2>Selection (Row mode)</h2>
+
+<p>
+    Depending on the use case, you might want to allow selection when clicking anywhere in the grid row.
+</p>
+<p>
+    Note that this is not recommeded when the rows are containing clickable cells. If your cells contain input, buttons, etc.
+    this option is not recommended
+</p>
+<ul>
+    <li>
+        For row selection mode add <code class="clr-code">[(clDgRowSelection)]</code> and set it to <code class="clr-code">true</code>.
+    </li>
+    <li>
+        For hiding the selection column add <code class="clr-code">[(clDgHideSelectionColumn)]</code> and set it to <code class="clr-code">true</code>.
+    </li>
+</ul>
+
+<p>
+    In the following examples, we simply display the names of the selected users
+</p>
+
+<div class="card card-block">
+    <p class="card-text username-list">
+        Selected user:
+        <em *ngIf="!singleSelected">No user selected.</em>
+        <span class="username" *ngIf="singleSelected">{{singleSelected.name}}</span>
+    </p>
+</div>
+
+<h3>Single selection</h3>
+
+<clr-datagrid [(clrDgSingleSelected)]="singleSelected" [clDgRowSelection]="true">
+
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column>Name</clr-dg-column>
+    <clr-dg-column>Creation date</clr-dg-column>
+    <clr-dg-column>Favorite color</clr-dg-column>
+
+    <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>
+            <span class="color-square" [style.backgroundColor]="user.color"></span>
+        </clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>{{users.length}} users</clr-dg-footer>
+</clr-datagrid>
+
+<clr-example [clrCode]="singleSelectionExample" clrLanguage="html"></clr-example>
+
+<h3>Multi selection</h3>
+
+<div class="card card-block">
+    <p class="card-text username-list">
+        Selected users:
+        <em *ngIf="multiSelected.length == 0">No user selected.</em>
+        <span class="username" *ngFor="let user of multiSelected">{{user.name}}</span>
+    </p>
+</div>
+
+<clr-datagrid [(clrDgSelected)]="multiSelected" [clDgRowSelection]="true">
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column>Name</clr-dg-column>
+    <clr-dg-column>Creation date</clr-dg-column>
+    <clr-dg-column>Favorite color</clr-dg-column>
+
+    <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>
+            <span class="color-square" [style.backgroundColor]="user.color"></span>
+        </clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>{{users.length}} users</clr-dg-footer>
+</clr-datagrid>
+
+<clr-example [clrCode]="multiSelectionExample" clrLanguage="html"></clr-example>
+
+<h3>Multi selection with hidden selection column</h3>
+
+<div class="card card-block">
+    <p class="card-text username-list">
+        Selected users:
+        <em *ngIf="hiddenMultiSelected.length == 0">No user selected.</em>
+        <span class="username" *ngFor="let user of hiddenMultiSelected">{{user.name}}</span>
+    </p>
+</div>
+
+<clr-datagrid [(clrDgSelected)]="hiddenMultiSelected" clDgHideSelectionColumn="true">
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column>Name</clr-dg-column>
+    <clr-dg-column>Creation date</clr-dg-column>
+    <clr-dg-column>Favorite color</clr-dg-column>
+
+    <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>
+            <span class="color-square" [style.backgroundColor]="user.color"></span>
+        </clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>{{users.length}} users</clr-dg-footer>
+</clr-datagrid>
+
+<clr-example [clrCode]="hiddenSelectionExample" clrLanguage="html"></clr-example>

--- a/src/app/datagrid/selection-row-mode/selection-row-mode.html
+++ b/src/app/datagrid/selection-row-mode/selection-row-mode.html
@@ -17,9 +17,6 @@
     <li>
         For row selection mode add <code class="clr-code">[(clDgRowSelection)]</code> and set it to <code class="clr-code">true</code>.
     </li>
-    <li>
-        For hiding the selection column add <code class="clr-code">[(clDgHideSelectionColumn)]</code> and set it to <code class="clr-code">true</code>.
-    </li>
 </ul>
 
 <p>
@@ -86,33 +83,3 @@
 </clr-datagrid>
 
 <clr-example [clrCode]="multiSelectionExample" clrLanguage="html"></clr-example>
-
-<h3>Multi selection with hidden selection column</h3>
-
-<div class="card card-block">
-    <p class="card-text username-list">
-        Selected users:
-        <em *ngIf="hiddenMultiSelected.length == 0">No user selected.</em>
-        <span class="username" *ngFor="let user of hiddenMultiSelected">{{user.name}}</span>
-    </p>
-</div>
-
-<clr-datagrid [(clrDgSelected)]="hiddenMultiSelected" clDgHideSelectionColumn="true">
-    <clr-dg-column>User ID</clr-dg-column>
-    <clr-dg-column>Name</clr-dg-column>
-    <clr-dg-column>Creation date</clr-dg-column>
-    <clr-dg-column>Favorite color</clr-dg-column>
-
-    <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
-        <clr-dg-cell>{{user.id}}</clr-dg-cell>
-        <clr-dg-cell>{{user.name}}</clr-dg-cell>
-        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
-        <clr-dg-cell>
-            <span class="color-square" [style.backgroundColor]="user.color"></span>
-        </clr-dg-cell>
-    </clr-dg-row>
-
-    <clr-dg-footer>{{users.length}} users</clr-dg-footer>
-</clr-datagrid>
-
-<clr-example [clrCode]="hiddenSelectionExample" clrLanguage="html"></clr-example>

--- a/src/app/datagrid/selection-row-mode/selection-row-mode.ts
+++ b/src/app/datagrid/selection-row-mode/selection-row-mode.ts
@@ -32,20 +32,6 @@ const MULTI_SELECTION_EXAMPLE = `
 Selected users: <span *ngFor="let user of selected">{{user.name}}</span>
 `;
 
-
-const HIDDEN_SELECTION_EXAMPLE = `
-<clr-datagrid [(clrDgSelected)]="selected" clDgHideSelectionColumn="true">
-    <-- ... -->
-    <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
-        <-- ... -->
-    </clr-dg-row>
-   <-- ... -->
-</clr-datagrid>
-
-Selected users: <span *ngFor="let user of selected">{{user.name}}</span>
-`;
-
-
 @Component({
     moduleId: module.id,
     selector: "clr-datagrid-selection-row-mode-demo",
@@ -56,11 +42,9 @@ Selected users: <span *ngFor="let user of selected">{{user.name}}</span>
 export class DatagridSelectionRowModeDemo {
     singleSelectionExample = SINGLE_SELECTION_EXAMPLE;
     multiSelectionExample = MULTI_SELECTION_EXAMPLE;
-    hiddenSelectionExample = HIDDEN_SELECTION_EXAMPLE;
     users: User[];
     singleSelected: User;
     multiSelected: User[] = [];
-    hiddenMultiSelected: User[] = [];
 
     constructor(private inventory: Inventory) {
         inventory.size = 10;

--- a/src/app/datagrid/selection-row-mode/selection-row-mode.ts
+++ b/src/app/datagrid/selection-row-mode/selection-row-mode.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component} from "@angular/core";
+
+import {Inventory} from "../inventory/inventory";
+import {User} from "../inventory/user";
+
+const SINGLE_SELECTION_EXAMPLE = `
+<clr-datagrid [(clrDgSingleSelected)]="selectedUser" [clDgRowSelection]="true">
+    <-- ... -->
+    <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
+        <-- ... -->
+    </clr-dg-row>
+   <-- ... -->
+</clr-datagrid>
+
+Selected user: <span class="username" *ngIf="selectedUser">{{selectedUser.name}}</span>
+`;
+
+const MULTI_SELECTION_EXAMPLE = `
+<clr-datagrid [(clrDgSelected)]="selected" [clDgRowSelection]="true">
+    <-- ... -->
+    <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
+        <-- ... -->
+    </clr-dg-row>
+   <-- ... -->
+</clr-datagrid>
+
+Selected users: <span *ngFor="let user of selected">{{user.name}}</span>
+`;
+
+
+const HIDDEN_SELECTION_EXAMPLE = `
+<clr-datagrid [(clrDgSelected)]="selected" clDgHideSelectionColumn="true">
+    <-- ... -->
+    <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
+        <-- ... -->
+    </clr-dg-row>
+   <-- ... -->
+</clr-datagrid>
+
+Selected users: <span *ngFor="let user of selected">{{user.name}}</span>
+`;
+
+
+@Component({
+    moduleId: module.id,
+    selector: "clr-datagrid-selection-row-mode-demo",
+    providers: [Inventory],
+    templateUrl: "selection-row-mode.html",
+    styleUrls: ["../datagrid.demo.scss"]
+})
+export class DatagridSelectionRowModeDemo {
+    singleSelectionExample = SINGLE_SELECTION_EXAMPLE;
+    multiSelectionExample = MULTI_SELECTION_EXAMPLE;
+    hiddenSelectionExample = HIDDEN_SELECTION_EXAMPLE;
+    users: User[];
+    singleSelected: User;
+    multiSelected: User[] = [];
+    hiddenMultiSelected: User[] = [];
+
+    constructor(private inventory: Inventory) {
+        inventory.size = 10;
+        inventory.reset();
+        this.users = inventory.all;
+    }
+}

--- a/src/clarity-angular/data/datagrid/datagrid-action-overflow.spec.ts
+++ b/src/clarity-angular/data/datagrid/datagrid-action-overflow.spec.ts
@@ -83,18 +83,20 @@ export default function(): void {
             context.detectChanges();
             expect(context.clarityDirective.open).toBe(false);
         });
-
     });
 }
 
 @Component({
     template: `
-        <div class="outside-click-test">
-            This is an area outside of the action overflow
-        </div>
-        <clr-dg-action-overflow [(clrDgActionOverflowOpen)]="open">
-            <button class="action-item">Hello world</button>
-        </clr-dg-action-overflow>`
+        <div>
+            <div class="outside-click-test">
+                This is an area outside of the action overflow
+            </div>
+            <clr-dg-action-overflow [(clrDgActionOverflowOpen)]="open">
+                <button class="action-item">Hello world</button>
+            </clr-dg-action-overflow>
+        </div>`
+
 })
 class SimpleTest {
     open: boolean;

--- a/src/clarity-angular/data/datagrid/datagrid-row.spec.ts
+++ b/src/clarity-angular/data/datagrid/datagrid-row.spec.ts
@@ -152,6 +152,71 @@ export default function(): void {
                    expect(context.clarityDirective.selected).toBe(false);
                }));
 
+            it("selects the model on click only when `rowSelectionMode` is enabled (Single selection)", function() {
+                selectionProvider.selectionType = SelectionType.Single;
+                context.testComponent.item = {id: 1};
+                context.detectChanges();
+                const row = context.clarityElement;
+                row.click();
+                context.detectChanges();
+                expect(selectionProvider.currentSingle).toBeUndefined();
+
+                // Enabling the rowSelectionMode
+                selectionProvider.rowSelectionMode = true;
+                context.detectChanges();
+                row.click();
+                context.detectChanges();
+                expect(selectionProvider.currentSingle).toEqual(context.testComponent.item);
+            });
+
+            it("selects the model on click only when `rowSelectionMode` is enabled (Multi selection)", function() {
+                selectionProvider.selectionType = SelectionType.Multi;
+                context.testComponent.item = {id: 1};
+                context.detectChanges();
+                const row = context.clarityElement;
+                expect(selectionProvider.current).toEqual([]);
+                row.click();
+                context.detectChanges();
+                expect(selectionProvider.current).toEqual([]);
+
+                // Enabling the rowSelectionMode
+                selectionProvider.rowSelectionMode = true;
+                context.detectChanges();
+                row.click();
+                context.detectChanges();
+                expect(selectionProvider.current).toEqual([context.testComponent.item]);
+
+                row.click();
+                context.detectChanges();
+                expect(selectionProvider.current).toEqual([]);
+            });
+
+            it("doesn't have input for selection when hideSelectionColumn is enabled (Single selection)", function() {
+                selectionProvider.selectionType = SelectionType.Single;
+                context.detectChanges();
+
+                let input = context.clarityElement.querySelector("input");
+                expect(input).toBeDefined();
+
+                selectionProvider.hideSelectionColumn = true;
+                context.detectChanges();
+                input = context.clarityElement.querySelector("input");
+                expect(input).toBeNull();
+            });
+
+            it("doesn't have input for selection when hideSelectionColumn is enabled (Multi selection)", function() {
+                selectionProvider.selectionType = SelectionType.Multi;
+                context.detectChanges();
+
+                let input = context.clarityElement.querySelector("input");
+                expect(input).toBeDefined();
+
+                selectionProvider.hideSelectionColumn = true;
+                context.detectChanges();
+                input = context.clarityElement.querySelector("input");
+                expect(input).toBeNull();
+            });
+
             function flushAndAssertSelected(selected: boolean) {
                 context.detectChanges();
                 // ngModel is asynchronous, we need an extra change detection

--- a/src/clarity-angular/data/datagrid/datagrid-row.spec.ts
+++ b/src/clarity-angular/data/datagrid/datagrid-row.spec.ts
@@ -191,30 +191,23 @@ export default function(): void {
                 expect(selectionProvider.current).toEqual([]);
             });
 
-            it("doesn't have input for selection when hideSelectionColumn is enabled (Single selection)", function() {
-                selectionProvider.selectionType = SelectionType.Single;
-                context.detectChanges();
-
-                let input = context.clarityElement.querySelector("input");
-                expect(input).toBeDefined();
-
-                selectionProvider.hideSelectionColumn = true;
-                context.detectChanges();
-                input = context.clarityElement.querySelector("input");
-                expect(input).toBeNull();
-            });
-
-            it("doesn't have input for selection when hideSelectionColumn is enabled (Multi selection)", function() {
+            it("select the model on space or enter when `rowSelectionMode` is enabled", function() {
                 selectionProvider.selectionType = SelectionType.Multi;
+                selectionProvider.rowSelectionMode = true;
+                context.testComponent.item = {id: 1};
+                const row = context.clarityElement;
                 context.detectChanges();
 
-                let input = context.clarityElement.querySelector("input");
-                expect(input).toBeDefined();
-
-                selectionProvider.hideSelectionColumn = true;
+                const event: any = new Event("keypress");
+                event.keyCode = 13;  // Enter
+                row.dispatchEvent(event);
                 context.detectChanges();
-                input = context.clarityElement.querySelector("input");
-                expect(input).toBeNull();
+                expect(selectionProvider.current).toEqual([context.testComponent.item]);
+
+                event.keyCode = 32;  // Space
+                row.dispatchEvent(event);
+                context.detectChanges();
+                expect(selectionProvider.current).toEqual([]);
             });
 
             function flushAndAssertSelected(selected: boolean) {

--- a/src/clarity-angular/data/datagrid/datagrid-row.ts
+++ b/src/clarity-angular/data/datagrid/datagrid-row.ts
@@ -3,7 +3,16 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import {AfterContentInit, Component, ContentChildren, EventEmitter, Input, Output, QueryList} from "@angular/core";
+import {
+    AfterContentInit,
+    Component,
+    ContentChildren,
+    EventEmitter,
+    HostListener,
+    Input,
+    Output,
+    QueryList
+} from "@angular/core";
 import {Subscription} from "rxjs/Subscription";
 
 import {Expand} from "../../utils/expand/providers/expand";
@@ -23,11 +32,11 @@ let nbRow: number = 0;
     selector: "clr-dg-row",
     template: `
         <clr-dg-row-master class="datagrid-row-flex">
-            <clr-dg-cell *ngIf="selection.selectionType === SELECTION_TYPE.Multi"
+            <clr-dg-cell *ngIf="selection.selectionType === SELECTION_TYPE.Multi && !selection.hideSelectionColumn"
                          class="datagrid-select datagrid-fixed-column">
                 <clr-checkbox [ngModel]="selected" (ngModelChange)="toggle($event)"></clr-checkbox>
             </clr-dg-cell>
-            <clr-dg-cell *ngIf="selection.selectionType === SELECTION_TYPE.Single"
+            <clr-dg-cell *ngIf="selection.selectionType === SELECTION_TYPE.Single && !selection.hideSelectionColumn"
                          class="datagrid-select datagrid-fixed-column">
                 <div class="radio">
                     <input type="radio" [id]="id" [name]="selection.id + '-radio'" [value]="item"
@@ -65,7 +74,11 @@ let nbRow: number = 0;
             <ng-content select="clr-dg-row-detail"></ng-content>
         </ng-template>
     `,
-    host: {"[class.datagrid-row]": "true", "[class.datagrid-selected]": "selected"},
+    host: {
+        "[class.datagrid-row]": "true",
+        "[class.datagrid-selected]": "selected",
+        "[attr.tabindex]": "selection.rowSelectionMode ? 0 : null"
+    },
     providers: [Expand, {provide: LoadingListener, useExisting: Expand}]
 })
 export class DatagridRow implements AfterContentInit {
@@ -130,6 +143,26 @@ export class DatagridRow implements AfterContentInit {
         if (this.expand.expandable) {
             this.expanded = !this.expanded;
             this.expandedChange.emit(this.expanded);
+        }
+    }
+
+    @HostListener("click", ["$event"])
+    public toggleSelection(event: any) {
+        if (!this.selection.rowSelectionMode) {
+            return;
+        }
+
+        switch (this.selection.selectionType) {
+            case SelectionType.None:
+                break;
+            case SelectionType.Single:
+                this.selection.currentSingle = this.item;
+                break;
+            case SelectionType.Multi:
+                this.toggle();
+                break;
+            default:
+                break;
         }
     }
 

--- a/src/clarity-angular/data/datagrid/datagrid-row.ts
+++ b/src/clarity-angular/data/datagrid/datagrid-row.ts
@@ -8,6 +8,7 @@ import {
     Component,
     ContentChildren,
     EventEmitter,
+    HostBinding,
     HostListener,
     Input,
     Output,
@@ -32,11 +33,11 @@ let nbRow: number = 0;
     selector: "clr-dg-row",
     template: `
         <clr-dg-row-master class="datagrid-row-flex">
-            <clr-dg-cell *ngIf="selection.selectionType === SELECTION_TYPE.Multi && !selection.hideSelectionColumn"
+            <clr-dg-cell *ngIf="selection.selectionType === SELECTION_TYPE.Multi"
                          class="datagrid-select datagrid-fixed-column">
                 <clr-checkbox [ngModel]="selected" (ngModelChange)="toggle($event)"></clr-checkbox>
             </clr-dg-cell>
-            <clr-dg-cell *ngIf="selection.selectionType === SELECTION_TYPE.Single && !selection.hideSelectionColumn"
+            <clr-dg-cell *ngIf="selection.selectionType === SELECTION_TYPE.Single"
                          class="datagrid-select datagrid-fixed-column">
                 <div class="radio">
                     <input type="radio" [id]="id" [name]="selection.id + '-radio'" [value]="item"
@@ -87,15 +88,21 @@ export class DatagridRow implements AfterContentInit {
     /* reference to the enum so that template can access */
     public SELECTION_TYPE = SelectionType;
 
+    private readonly ENTER_KEY_CODE = 13;
+    private readonly SPACE_KEY_CODE = 32;
+
     /**
      * Model of the row, to use for selection
      */
     @Input("clrDgItem") item: any;
 
+    @HostBinding("attr.role") role: string;
+
     constructor(public selection: Selection, public rowActionService: RowActionService,
                 public globalExpandable: ExpandableRowsCount, public expand: Expand,
                 public hideableColumnService: HideableColumnService) {
         this.id = "clr-dg-row" + (nbRow++);
+        this.role = selection.rowSelectionMode ? "button" : null;
     }
 
     private _selected = false;
@@ -146,8 +153,8 @@ export class DatagridRow implements AfterContentInit {
         }
     }
 
-    @HostListener("click", ["$event"])
-    public toggleSelection(event: any) {
+    @HostListener("click")
+    public toggleSelection() {
         if (!this.selection.rowSelectionMode) {
             return;
         }
@@ -163,6 +170,20 @@ export class DatagridRow implements AfterContentInit {
                 break;
             default:
                 break;
+        }
+    }
+
+    @HostListener("keypress", ["$event"])
+    public keypress(event: KeyboardEvent) {
+        if (!this.selection.rowSelectionMode) {
+            return;
+        }
+
+        // Check to see if space or enter were pressed
+        if (event.keyCode === this.ENTER_KEY_CODE || event.keyCode === this.SPACE_KEY_CODE) {
+            // Prevent the default action to stop scrolling when space is pressed
+            event.preventDefault();
+            this.toggleSelection();
         }
     }
 

--- a/src/clarity-angular/data/datagrid/datagrid.html
+++ b/src/clarity-angular/data/datagrid/datagrid.html
@@ -13,7 +13,7 @@
                     <div class="datagrid-row datagrid-row-flex">
                         <!-- header for datagrid where you can select multiple rows -->
                         <div class="datagrid-column datagrid-select datagrid-fixed-column"
-                             *ngIf="selection.selectionType === SELECTION_TYPE.Multi">
+                             *ngIf="selection.selectionType === SELECTION_TYPE.Multi && !selection.hideSelectionColumn">
                         <span class="datagrid-column-title">
                             <clr-checkbox [(ngModel)]="allSelected"></clr-checkbox>
                         </span>
@@ -21,7 +21,7 @@
                         </div>
                         <!-- header for datagrid where you can select one row only -->
                         <div class="datagrid-column datagrid-select datagrid-fixed-column"
-                             *ngIf="selection.selectionType === SELECTION_TYPE.Single">
+                             *ngIf="selection.selectionType === SELECTION_TYPE.Single && !selection.hideSelectionColumn">
                             <div class="datagrid-column-separator"></div>
                         </div>
                         <!-- header for single row action; only display if we have at least one actionable row in datagrid -->

--- a/src/clarity-angular/data/datagrid/datagrid.html
+++ b/src/clarity-angular/data/datagrid/datagrid.html
@@ -13,7 +13,7 @@
                     <div class="datagrid-row datagrid-row-flex">
                         <!-- header for datagrid where you can select multiple rows -->
                         <div class="datagrid-column datagrid-select datagrid-fixed-column"
-                             *ngIf="selection.selectionType === SELECTION_TYPE.Multi && !selection.hideSelectionColumn">
+                             *ngIf="selection.selectionType === SELECTION_TYPE.Multi">
                         <span class="datagrid-column-title">
                             <clr-checkbox [(ngModel)]="allSelected"></clr-checkbox>
                         </span>
@@ -21,7 +21,7 @@
                         </div>
                         <!-- header for datagrid where you can select one row only -->
                         <div class="datagrid-column datagrid-select datagrid-fixed-column"
-                             *ngIf="selection.selectionType === SELECTION_TYPE.Single && !selection.hideSelectionColumn">
+                             *ngIf="selection.selectionType === SELECTION_TYPE.Single">
                             <div class="datagrid-column-separator"></div>
                         </div>
                         <!-- header for single row action; only display if we have at least one actionable row in datagrid -->

--- a/src/clarity-angular/data/datagrid/datagrid.ts
+++ b/src/clarity-angular/data/datagrid/datagrid.ts
@@ -111,6 +111,23 @@ export class Datagrid implements AfterContentInit, AfterViewInit, OnDestroy {
     @Output("clrDgSingleSelectedChange") singleSelectedChanged = new EventEmitter<any>(false);
 
     /**
+     * Selection/Deselection on row click mode
+     */
+    @Input("clDgRowSelection")
+    set rowSelectionMode(value: boolean) {
+        this.selection.rowSelectionMode = value;
+    }
+
+    /**
+     * Hide selection column and use row selection mode
+     */
+    @Input("clDgHideSelectionColumn")
+    set hideSelectionColumn(value: boolean) {
+        this.selection.rowSelectionMode = true;
+        this.selection.hideSelectionColumn = true;
+    }
+
+    /**
      * Indicates if all currently displayed items are selected
      */
     public get allSelected() {

--- a/src/clarity-angular/data/datagrid/datagrid.ts
+++ b/src/clarity-angular/data/datagrid/datagrid.ts
@@ -119,15 +119,6 @@ export class Datagrid implements AfterContentInit, AfterViewInit, OnDestroy {
     }
 
     /**
-     * Hide selection column and use row selection mode
-     */
-    @Input("clDgHideSelectionColumn")
-    set hideSelectionColumn(value: boolean) {
-        this.selection.rowSelectionMode = true;
-        this.selection.hideSelectionColumn = true;
-    }
-
-    /**
      * Indicates if all currently displayed items are selected
      */
     public get allSelected() {

--- a/src/clarity-angular/data/datagrid/providers/selection.ts
+++ b/src/clarity-angular/data/datagrid/providers/selection.ts
@@ -82,8 +82,6 @@ export class Selection {
 
     public rowSelectionMode: boolean = false;
 
-    public hideSelectionColumn: boolean = false;
-
     private get _selectable(): boolean {
         return (this._selectionType === SelectionType.Multi) || (this._selectionType === SelectionType.Single);
     }

--- a/src/clarity-angular/data/datagrid/providers/selection.ts
+++ b/src/clarity-angular/data/datagrid/providers/selection.ts
@@ -79,6 +79,11 @@ export class Selection {
             this.current = [];
         }
     }
+
+    public rowSelectionMode: boolean = false;
+
+    public hideSelectionColumn: boolean = false;
+
     private get _selectable(): boolean {
         return (this._selectionType === SelectionType.Multi) || (this._selectionType === SelectionType.Single);
     }


### PR DESCRIPTION
Implementation of whole row selection

* New `clDgRowSelection` input property for Datagrid indicating if the row selection should be enabled.
  Selection works the same way if you click on the input in the first column.
  For Multi selection on second click the row gets deselected.
* New `clDgRowSelection` input property for Datagrid indicating if the selection column should be available
  This automatically turns on `clDgRowSelection` in case of Single and Multi selection
* Added support for row actions in case of Row selection enabled
* Added "Selection (Row mode)" demo page on Datagrid demo page with examples of the newly introduced functunality

Fixes #476

Signed-off-by: Mincho Tonev <mtonev@vmware.com>