### PR TITLE
[NG] Fix updateNavigation() to not change the page unless the current…

### DIFF
--- a/src/clarity-angular/wizard/providers/wizard-navigation.ts
+++ b/src/clarity-angular/wizard/providers/wizard-navigation.ts
@@ -892,7 +892,9 @@ export class WizardNavigationService implements OnDestroy {
         this.pageCollection.updateCompletedStates();
 
         currentPageRemoved = this.pageCollection.pagesAsArray.indexOf(this.currentPage) < 0;
-        toSetCurrent = this.pageCollection.findFirstIncompletePage();
-        this.currentPage = toSetCurrent;
+        if (currentPageRemoved) {
+            toSetCurrent = this.pageCollection.findFirstIncompletePage();
+            this.currentPage = toSetCurrent;
+        }
     }
 }


### PR DESCRIPTION
… page is deleted

updateNavigation() was not checking to see if the current page was deleted
before changing pages.  This caused the wizard to change pages when
not necessary or expected.

Fixes #1283

Signed-off-by: Frank Sheiness <syndesis@gmail.com>