### PR TITLE
[NG] Put back the unsubscription in the row renderer

### DIFF
--- a/src/clarity-angular/data/datagrid/render/row-renderer.ts
+++ b/src/clarity-angular/data/datagrid/render/row-renderer.ts
@@ -3,19 +3,22 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import {AfterContentInit, ContentChildren, Directive, QueryList} from "@angular/core";
+import {AfterContentInit, ContentChildren, Directive, OnDestroy, QueryList} from "@angular/core";
 import {Subscription} from "rxjs/Subscription";
 
 import {DatagridCellRenderer} from "./cell-renderer";
 import {DatagridRenderOrganizer} from "./render-organizer";
 
 @Directive({selector: "clr-dg-row, clr-dg-row-detail"})
-export class DatagridRowRenderer implements AfterContentInit {
+export class DatagridRowRenderer implements AfterContentInit, OnDestroy {
     constructor(private organizer: DatagridRenderOrganizer) {
         this.subscription = organizer.alignColumns.subscribe(() => this.setWidths());
     }
 
     private subscription: Subscription;
+    ngOnDestroy() {
+        this.subscription.unsubscribe();
+    }
 
     @ContentChildren(DatagridCellRenderer) cells: QueryList<DatagridCellRenderer>;
 


### PR DESCRIPTION
For some reason we missed it when it was removed in 9581b7e6b552b2045b8de3eb2f9be96fd3522747. We need to be more careful with 2k-lines reviews.

Fixes #1417.