### PR TITLE
[web] adding info on where to find specific nav component code examples

### DIFF
--- a/src/app/documentation/demos/nav/layout-no-sidenav.html
+++ b/src/app/documentation/demos/nav/layout-no-sidenav.html
@@ -55,6 +55,14 @@
         </div>
     </div>
 </div>
+<clr-alert>
+    <div class="alert-item">
+        <span class="alert-text">
+            For code examples on the specific navigation components (header, subnav, sidenav)
+            see <a routerLink="/documentation/header">header</a> documentation.
+        </span>
+    </div>
+</clr-alert>
 <pre><code clr-code-highlight="language-html">
 &lt;div class=&quot;main-container&quot;&gt;
     &lt;header class=&quot;header header-6&quot;&gt;

--- a/src/app/documentation/demos/nav/layout-no-subnav.html
+++ b/src/app/documentation/demos/nav/layout-no-subnav.html
@@ -52,6 +52,14 @@
         </div>
     </div>
 </div>
+<clr-alert>
+    <div class="alert-item">
+        <span class="alert-text">
+            For code examples on the specific navigation components (header, subnav, sidenav)
+            see <a routerLink="/documentation/header">header</a> documentation.
+        </span>
+    </div>
+</clr-alert>
 <pre><code clr-code-highlight="language-html">
 &lt;div class=&quot;main-container&quot;&gt;
     &lt;header class=&quot;header header-6&quot;&gt;

--- a/src/app/documentation/demos/nav/layout-only-header.html
+++ b/src/app/documentation/demos/nav/layout-only-header.html
@@ -36,6 +36,14 @@
         </div>
     </div>
 </div>
+<clr-alert>
+    <div class="alert-item">
+        <span class="alert-text">
+            For code examples on the specific navigation components (header, subnav, sidenav)
+            see <a routerLink="/documentation/header">header</a> documentation.
+        </span>
+    </div>
+</clr-alert>
 <pre><code clr-code-highlight="language-html">
 &lt;div class=&quot;main-container&quot;&gt;
     &lt;header class=&quot;header header-6&quot;&gt;

--- a/src/app/documentation/demos/nav/layout-sidenav-primary.html
+++ b/src/app/documentation/demos/nav/layout-sidenav-primary.html
@@ -54,6 +54,14 @@
         </div>
     </div>
 </div>
+<clr-alert>
+    <div class="alert-item">
+        <span class="alert-text">
+            For code examples on the specific navigation components (header, subnav, sidenav)
+            see <a routerLink="/documentation/header">header</a> documentation.
+        </span>
+    </div>
+</clr-alert>
 <pre><code clr-code-highlight="language-html">
 &lt;div class=&quot;main-container&quot;&gt;
     &lt;div class=&quot;alert alert-app-level&quot;&gt;

--- a/src/app/documentation/demos/nav/layout-subnav-primary.html
+++ b/src/app/documentation/demos/nav/layout-subnav-primary.html
@@ -73,6 +73,14 @@
         </div>
     </div>
 </div>
+<clr-alert>
+    <div class="alert-item">
+        <span class="alert-text">
+            For code examples on the specific navigation components (header, subnav, sidenav)
+            see <a routerLink="/documentation/header">header</a> documentation.
+        </span>
+    </div>
+</clr-alert>
 <pre><code clr-code-highlight="language-html">
 &lt;div class=&quot;main-container&quot;&gt;
     &lt;div class=&quot;alert alert-app-level&quot;&gt;

--- a/src/app/documentation/demos/nav/navigation.demo.html
+++ b/src/app/documentation/demos/nav/navigation.demo.html
@@ -8,8 +8,10 @@
         <p>Clarity has three navigation components: header, subnav, and sidenav. Following are the possible combinations
             of navigation.</p>
 
+
         <h6 id="header-as-primary-navigation-and-subnav-as-secondary-navigation">1. Header as primary navigation and
             subnav as secondary navigation</h6>
+
         <clr-layout-no-sidenav-demo></clr-layout-no-sidenav-demo>
 
         <h6 id="header-as-primary-navigation-and-sidenav-as-secondary-navigation">2. Header as primary navigation and


### PR DESCRIPTION
It's not obvious how to fill out the heading and subnav, etc when copying our navigation code. Adding info alert on top of each code snippet to add clarity.

<img width="1427" alt="screen shot 2017-09-08 at 10 08 32 am" src="https://user-images.githubusercontent.com/1827742/30224019-f0bd1114-9481-11e7-8a17-eaeb26d218c6.png">


Signed-off-by: Jeeyun Lim <jeeyun.lim@gmail.com>