### PR TITLE
[WEB] Fixes typos in Signpost documentation.

### DIFF
--- a/src/app/documentation/demos/signposts/signpost.demo.html
+++ b/src/app/documentation/demos/signposts/signpost.demo.html
@@ -14,7 +14,7 @@
         <p>A signpost displays contextual help or information in a popover dialog. Like a tooltip, it has an
             arrow/pointer that extends out to the trigger element, but the dialog is larger to fit more content.
             Signposts are designed to show a relatively small amount of content which may include: a title, images,
-            text links of image links. A vertical scrollbar (browser default) may be used if the content exeeds the
+            text links of image links. A vertical scrollbar (browser default) may be used if the content exceeds the
             maximum height of the dialog.</p>
         <h5 style="margin: 24px 0 12px;">Size</h5>
         <ul class="list">
@@ -36,8 +36,8 @@
         </ul>
         <h3>Interaction</h3>
         <p>Clicking the icon triggers the signpost. It remains visible until the user clicks the close icon or clicks
-            anywhere outside of the dialig to dismiss it. To keep the interface uncluttered, only one signpost is
-            displayed at a time. When a dialog is visibl, clicking an icon to open another one automatically dismisses
+            anywhere outside of the dialog to dismiss it. To keep the interface uncluttered, only one signpost is
+            displayed at a time. When a dialog is visible, clicking an icon to open another one automatically dismisses
             the previous dialog.</p>
         <div class="clrweb-DoxMedia">
             <div class="clrweb-DoxMedia-block">
@@ -94,7 +94,7 @@
                 space on a page
             </li>
             <li>
-                Use sparingly as a device to add immediate, relevent information
+                Use sparingly as a device to add immediate, relevant information
             </li>
         </ul>
 


### PR DESCRIPTION
This PR addresses three typos on the `Signpost` documentation page.

Signed-off-by: Matt Hippely <hippely@gmail.com>