### PR TITLE
[NG] fix bug with selection with pagination and server-driven datagrids

### DIFF
--- a/src/app/datagrid/datagrid.demo.html
+++ b/src/app/datagrid/datagrid.demo.html
@@ -16,11 +16,12 @@
     <li><a [routerLink]="['./filtering']">Custom filters</a></li>
     <li><a [routerLink]="['./string-filtering']">Built-in filters</a></li>
     <li><a [routerLink]="['./pagination']">Pagination</a></li>
-    <li><a [routerLink]="['./pagination-scrolling']">Pagination & Scrolling</a></li>
+    <li><a [routerLink]="['./pagination-scrolling']">Pagination &amp; Scrolling</a></li>
     <li><a [routerLink]="['./selection']">Selection</a></li>
     <li><a [routerLink]="['./selection-single']">Selection (Single)</a></li>
     <li><a [routerLink]="['./preserve-selection']">Preserve Selection</a></li>
     <li><a [routerLink]="['./server-driven']">Server-driven datagrid</a></li>
+    <li><a [routerLink]="['./selection-server']">Server-driven &amp; Selection</a></li>
     <li><a [routerLink]="['./placeholder']">Placeholder</a></li>
     <li><a [routerLink]="['./scrolling']">Scrolling</a></li>
     <li><a [routerLink]="['./column-sizing']">Column sizing</a></li>

--- a/src/app/datagrid/datagrid.demo.module.ts
+++ b/src/app/datagrid/datagrid.demo.module.ts
@@ -4,6 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import {CommonModule} from "@angular/common";
+import {HttpClientModule} from "@angular/common/http";
 import {NgModule} from "@angular/core";
 import {FormsModule} from "@angular/forms";
 
@@ -27,6 +28,7 @@ import {DatagridPaginationDemo} from "./pagination/pagination";
 import {DatagridPlaceholderDemo} from "./placeholder/placeholder";
 import {DatagridPreserveSelectionDemo} from "./preserve-selection/preserve-selection";
 import {DatagridScrollingDemo} from "./scrolling/scrolling";
+import {DatagridSelectionServerDemo} from "./selection-server/selection-server";
 import {DatagridSelectionSingleDemo} from "./selection-single/selection-single";
 import {DatagridSelectionDemo} from "./selection/selection";
 import {DatagridServerDrivenDemo} from "./server-driven/server-driven";
@@ -39,7 +41,7 @@ import {ColorFilter} from "./utils/color-filter";
 import {Example} from "./utils/example";
 
 @NgModule({
-    imports: [CommonModule, FormsModule, ClarityModule, ROUTING, UtilsDemoModule],
+    imports: [CommonModule, FormsModule, HttpClientModule, ClarityModule, ROUTING, UtilsDemoModule],
     declarations: [
         DatagridDemo,
         DatagridBasicStructureDemo,
@@ -52,6 +54,7 @@ import {Example} from "./utils/example";
         DatagridPaginationScrollingDemo,
         DatagridSelectionDemo,
         DatagridSelectionSingleDemo,
+        DatagridSelectionServerDemo,
         DatagridPreserveSelectionDemo,
         DatagridServerDrivenDemo,
         DatagridSmartIteratorDemo,
@@ -79,6 +82,7 @@ import {Example} from "./utils/example";
         DatagridPaginationScrollingDemo,
         DatagridSelectionDemo,
         DatagridSelectionSingleDemo,
+        DatagridSelectionServerDemo,
         DatagridPreserveSelectionDemo,
         DatagridServerDrivenDemo,
         DatagridSmartIteratorDemo,

--- a/src/app/datagrid/datagrid.demo.routing.ts
+++ b/src/app/datagrid/datagrid.demo.routing.ts
@@ -21,6 +21,7 @@ import {DatagridPaginationDemo} from "./pagination/pagination";
 import {DatagridPlaceholderDemo} from "./placeholder/placeholder";
 import {DatagridPreserveSelectionDemo} from "./preserve-selection/preserve-selection";
 import {DatagridScrollingDemo} from "./scrolling/scrolling";
+import {DatagridSelectionServerDemo} from "./selection-server/selection-server";
 import {DatagridSelectionSingleDemo} from "./selection-single/selection-single";
 import {DatagridSelectionDemo} from "./selection/selection";
 import {DatagridServerDrivenDemo} from "./server-driven/server-driven";
@@ -48,6 +49,7 @@ const ROUTES: Routes = [{
         {path: "selection", component: DatagridSelectionDemo},
         {path: "selection-single", component: DatagridSelectionSingleDemo},
         {path: "preserve-selection", component: DatagridPreserveSelectionDemo},
+        {path: "selection-server", component: DatagridSelectionServerDemo},
         {path: "server-driven", component: DatagridServerDrivenDemo},
         {path: "placeholder", component: DatagridPlaceholderDemo},
         {path: "scrolling", component: DatagridScrollingDemo},

--- a/src/app/datagrid/selection-server/selection-server.html
+++ b/src/app/datagrid/selection-server/selection-server.html
@@ -1,0 +1,51 @@
+<!--
+  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<h2>Server-driven &amp; Selection</h2>
+
+<h3>Single Selection</h3>
+
+<clr-datagrid (clrDgRefresh)="refreshSingle($event)" [clrDgLoading]="loadingSingle" [(clrDgSingleSelected)]="selected">
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column>First Name</clr-dg-column>
+    <clr-dg-column>Last Name</clr-dg-column>
+    <clr-dg-column>Avatar</clr-dg-column>
+
+    <clr-dg-row *ngFor="let user of usersSingle; trackBy: trackById" [clrDgItem]="user">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.first_name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.last_name}}</clr-dg-cell>
+        <clr-dg-cell><img [src]="user.avatar" width="14" /></clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>
+        {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
+        of {{totalSingle}} users
+        <clr-dg-pagination #pagination [clrDgTotalItems]="totalSingle" [clrDgPageSize]="perPage"></clr-dg-pagination>
+    </clr-dg-footer>
+</clr-datagrid>
+
+<h3>Multi-selection</h3>
+
+<clr-datagrid (clrDgRefresh)="refreshMulti($event)" [clrDgLoading]="loadingMulti" [(clrDgSelected)]="list">
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column>First Name</clr-dg-column>
+    <clr-dg-column>Last Name</clr-dg-column>
+    <clr-dg-column>Avatar</clr-dg-column>
+
+    <clr-dg-row *ngFor="let user of usersMulti; trackBy: trackById" [clrDgItem]="user">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.first_name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.last_name}}</clr-dg-cell>
+        <clr-dg-cell><img [src]="user.avatar" width="14" /></clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>
+        {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
+        of {{totalMulti}} users
+        <clr-dg-pagination #pagination [clrDgTotalItems]="totalMulti" [clrDgPageSize]="perPage"></clr-dg-pagination>
+    </clr-dg-footer>
+</clr-datagrid>

--- a/src/app/datagrid/selection-server/selection-server.ts
+++ b/src/app/datagrid/selection-server/selection-server.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import "rxjs/add/operator/map";
+
+import {HttpClient} from "@angular/common/http";
+import {Component} from "@angular/core";
+
+import {State} from "../../../clarity-angular/data/datagrid";
+
+export interface ApiUser {
+    id: number;
+    first_name: string;
+    last_name: string;
+    avatar: string;
+}
+
+export interface UserResponse {
+    page: number;
+    per_page: number;
+    total_pages: number;
+    total: number;
+    data: ApiUser[];
+}
+
+@Component({
+    selector: "clr-datagrid-selection-server-demo",
+    templateUrl: "selection-server.html",
+    styleUrls: ["../datagrid.demo.scss"]
+})
+export class DatagridSelectionServerDemo {
+    usersSingle: ApiUser[] = [];
+    totalSingle: number;
+    loadingSingle: boolean = true;
+    usersMulti: ApiUser[] = [];
+    totalMulti: number;
+    loadingMulti: boolean = true;
+
+    list: any[] = [];
+    selected: any;
+    perPage: number = 3;
+
+    constructor(private http: HttpClient) {}
+
+    trackById(index: number, item: any) {
+        return item.id;
+    }
+
+    refreshSingle(state: State) {
+        this.loadingSingle = true;
+        const page = (state && state.page) ? state.page.from / this.perPage + 1 : 1;
+        const url = `https://reqres.in/api/users?per_page=${this.perPage}&page=${page}`;
+
+        this.http.get(url).subscribe((response: UserResponse) => {
+            this.usersSingle = response.data;
+            this.loadingSingle = false;
+            this.totalSingle = response.total;
+        });
+    }
+
+    refreshMulti(state: State) {
+        this.loadingMulti = true;
+        const page = (state && state.page) ? state.page.from / this.perPage + 1 : 1;
+        const url = `https://reqres.in/api/users?per_page=${this.perPage}&page=${page}`;
+
+        this.http.get(url).subscribe((response: UserResponse) => {
+            this.usersMulti = response.data;
+            this.loadingMulti = false;
+            this.totalMulti = response.total;
+        });
+    }
+}

--- a/src/app/datagrid/selection-single/selection-single.html
+++ b/src/app/datagrid/selection-single/selection-single.html
@@ -39,7 +39,7 @@
     <clr-dg-column>Creation date</clr-dg-column>
     <clr-dg-column>Favorite color</clr-dg-column>
 
-    <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
+    <clr-dg-row *clrDgItems="let user of users; trackBy: trackBy" [clrDgItem]="user">
         <clr-dg-cell>{{user.id}}</clr-dg-cell>
         <clr-dg-cell>{{user.name}}</clr-dg-cell>
         <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
@@ -48,7 +48,9 @@
         </clr-dg-cell>
     </clr-dg-row>
 
-    <clr-dg-footer>{{users.length}} users</clr-dg-footer>
+    <clr-dg-footer>{{users.length}} users
+        <clr-dg-pagination></clr-dg-pagination>
+    </clr-dg-footer>
 </clr-datagrid>
 
 <clr-example [clrCode]="example" clrLanguage="html"></clr-example>

--- a/src/app/datagrid/selection-single/selection-single.ts
+++ b/src/app/datagrid/selection-single/selection-single.ts
@@ -32,8 +32,12 @@ export class DatagridSelectionSingleDemo {
     singleSelected: User;
 
     constructor(private inventory: Inventory) {
-        inventory.size = 10;
+        inventory.size = 103;
         inventory.reset();
         this.users = inventory.all;
+    }
+
+    trackBy(index: number, item: any) {
+        return index;
     }
 }

--- a/src/app/datagrid/selection/selection.html
+++ b/src/app/datagrid/selection/selection.html
@@ -75,7 +75,7 @@
         </ng-container>
     </clr-dg-column>
 
-    <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
+    <clr-dg-row *clrDgItems="let user of users; trackBy: trackBy" [clrDgItem]="user">
         <clr-dg-action-overflow>
             <button class="action-item" (click)="onEdit(user)">Edit</button>
             <button class="action-item" (click)="onDelete(user)">Delete</button>
@@ -89,7 +89,9 @@
         </clr-dg-cell>
     </clr-dg-row>
 
-    <clr-dg-footer>{{users.length}} users</clr-dg-footer>
+    <clr-dg-footer>{{users.length}} users
+        <clr-dg-pagination></clr-dg-pagination>
+    </clr-dg-footer>
 </clr-datagrid>
 
 <clr-example [clrCode]="example" clrLanguage="html"></clr-example>

--- a/src/app/datagrid/selection/selection.ts
+++ b/src/app/datagrid/selection/selection.ts
@@ -50,7 +50,7 @@ export class DatagridSelectionDemo {
     }
 
     constructor(private inventory: Inventory) {
-        inventory.size = 10;
+        inventory.size = 103;
         inventory.reset();
         this.users = inventory.all;
     }
@@ -76,5 +76,9 @@ export class DatagridSelectionDemo {
     onAdd() {
         this.cleanUp();
         this.toAdd = this.selected.slice();
+    }
+
+    trackBy(index: number, item: any) {
+        return index;
     }
 }

--- a/src/clarity-angular/data/datagrid/all.spec.ts
+++ b/src/clarity-angular/data/datagrid/all.spec.ts
@@ -24,6 +24,7 @@ import DatagridFilterSpecs from "./datagrid-filter.spec";
 import DatagridFooterSpecs from "./datagrid-footer.spec";
 import DatagridHideableColumnDirectiveSpec from "./datagrid-hideable-column.directive.spec";
 import DatagridHideableColumnSpec from "./datagrid-hideable-column.spec";
+import DatagridItemsTrackBySpecs from "./datagrid-items-trackby.spec";
 import DatagridItemsSpecs from "./datagrid-items.spec";
 import DatagridPaginationSpecs from "./datagrid-pagination.spec";
 import DatagridPlaceholderSpecs from "./datagrid-placeholder.spec";
@@ -67,6 +68,7 @@ describe("Datagrid", function() {
         DatagridFilterSpecs();
         DatagridColumnSpecs();
         DatagridItemsSpecs();
+        DatagridItemsTrackBySpecs();
         DatagridRowSpecs();
         DatagridRowDetailSpecs();
         DatagridPaginationSpecs();

--- a/src/clarity-angular/data/datagrid/datagrid-items-trackby.spec.ts
+++ b/src/clarity-angular/data/datagrid/datagrid-items-trackby.spec.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component, ViewChild} from "@angular/core";
+import {TestBed} from "@angular/core/testing";
+
+import {DatagridItems} from "./datagrid-items";
+import {ClrDatagridModule} from "./datagrid.module";
+import {FiltersProvider} from "./providers/filters";
+import {Items} from "./providers/items";
+import {Page} from "./providers/page";
+import {Sort} from "./providers/sort";
+import {StateDebouncer} from "./providers/state-debouncer.provider";
+
+export default function(): void {
+    describe("DatagridItemsTrackby directive", function() {
+        beforeEach(function() {
+            /*
+             * Since the DatagridItems element is a template that isn't rendered in the DOM,
+             * we can't use our usual shortcut, we need to rely on @ViewChild
+             */
+            TestBed.configureTestingModule({
+                imports: [ClrDatagridModule],
+                declarations: [FullTest],
+                providers: [Items, FiltersProvider, Sort, Page, StateDebouncer]
+            });
+            this.fixture = TestBed.createComponent(FullTest);
+            this.fixture.detectChanges();
+            this.testComponent = this.fixture.componentInstance;
+            this.itemsProvider = TestBed.get(Items);
+        });
+
+        afterEach(function() {
+            this.fixture.destroy();
+        });
+
+        it("receives an input for the trackBy option", function() {
+            expect(this.itemsProvider.trackBy).toBeUndefined();
+            this.testComponent.trackBy = (index: number, item: any) => index;
+            this.fixture.detectChanges();
+            expect(this.itemsProvider.trackBy).toBe(this.testComponent.trackBy);
+        });
+    });
+}
+
+
+@Component({template: `<div *ngFor="let n of numbers; trackBy: trackBy">{{n}}</div>`})
+class FullTest {
+    @ViewChild(DatagridItems) datagridItems: DatagridItems;
+
+    numbers = [1, 2, 3, 4, 5];
+
+    trackBy: (index: number, item: any) => any;
+}

--- a/src/clarity-angular/data/datagrid/datagrid-items-trackby.ts
+++ b/src/clarity-angular/data/datagrid/datagrid-items-trackby.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Directive, Input, Optional, TrackByFunction} from "@angular/core";
+
+import {Items} from "./providers/items";
+
+@Directive({
+    selector: "[ngForTrackBy]",
+})
+export class DatagridItemsTrackBy {
+    constructor(@Optional() private _items: Items) {}
+
+    @Input("ngForTrackBy")
+    set trackBy(value: TrackByFunction<Function>) {
+        if (this._items) {
+            this._items.trackBy = value;
+        }
+    }
+}

--- a/src/clarity-angular/data/datagrid/datagrid-row.ts
+++ b/src/clarity-angular/data/datagrid/datagrid-row.ts
@@ -13,6 +13,7 @@ import {DatagridCell} from "./datagrid-cell";
 import {DatagridHideableColumn} from "./datagrid-hideable-column";
 import {ExpandableRowsCount} from "./providers/global-expandable-rows";
 import {HideableColumnService} from "./providers/hideable-column.service";
+import {Items} from "./providers/items";
 import {RowActionService} from "./providers/row-action-service";
 import {Selection, SelectionType} from "./providers/selection";
 
@@ -31,7 +32,7 @@ let nbRow: number = 0;
                          class="datagrid-select datagrid-fixed-column">
                 <div class="radio">
                     <input type="radio" [id]="id" [name]="selection.id + '-radio'" [value]="item"
-                           [(ngModel)]="selection.currentSingle">
+                        [checked]="item === selection.currentSingle" [(ngModel)]="selection.currentSingle">
                     <label for="{{id}}"></label>
                 </div>
             </clr-dg-cell>
@@ -70,6 +71,7 @@ let nbRow: number = 0;
 })
 export class DatagridRow implements AfterContentInit {
     public id: string;
+    public index: number;
 
     /* reference to the enum so that template can access */
     public SELECTION_TYPE = SelectionType;
@@ -81,8 +83,9 @@ export class DatagridRow implements AfterContentInit {
 
     constructor(public selection: Selection, public rowActionService: RowActionService,
                 public globalExpandable: ExpandableRowsCount, public expand: Expand,
-                public hideableColumnService: HideableColumnService) {
-        this.id = "clr-dg-row" + (nbRow++);
+                public hideableColumnService: HideableColumnService, private items: Items) {
+        this.index = nbRow++;
+        this.id = "clr-dg-row" + this.index;
     }
 
     private _selected = false;
@@ -93,7 +96,7 @@ export class DatagridRow implements AfterContentInit {
         if (this.selection.selectionType === SelectionType.None) {
             return this._selected;
         } else {
-            return this.selection.isSelected(this.item);
+            return this.selection.isSelected(this.item, this.index);
         }
     }
 
@@ -165,6 +168,12 @@ export class DatagridRow implements AfterContentInit {
                 this.updateCellsForColumns(columnList);
             }
         });
+
+        // Check if item was selected in single selection mode and server driven, rehydrate if necessary
+        if (this.items.trackBy && this.selection.currentSingle &&
+            this.items.trackBy(0, this.selection.currentSingle) === this.items.trackBy(0, this.item)) {
+            this.item = this.selection.currentSingle;
+        }
     }
 
     /**********

--- a/src/clarity-angular/data/datagrid/index.ts
+++ b/src/clarity-angular/data/datagrid/index.ts
@@ -21,6 +21,7 @@ import {DatagridFilter} from "./datagrid-filter";
 import {DatagridFooter} from "./datagrid-footer";
 import {DatagridHideableColumnDirective} from "./datagrid-hidable-column.directive";
 import {DatagridItems} from "./datagrid-items";
+import {DatagridItemsTrackBy} from "./datagrid-items-trackby";
 import {DatagridPagination} from "./datagrid-pagination";
 import {DatagridPlaceholder} from "./datagrid-placeholder";
 import {DatagridRow} from "./datagrid-row";
@@ -44,6 +45,7 @@ export * from "./datagrid-column-toggle";
 export * from "./datagrid-hidable-column.directive";
 export * from "./datagrid-filter";
 export * from "./datagrid-items";
+export * from "./datagrid-items-trackby";
 export * from "./datagrid-row";
 export * from "./datagrid-row-detail";
 export * from "./datagrid-cell";
@@ -64,8 +66,8 @@ export * from "./built-in/comparators/datagrid-property-comparator";
 export const DATAGRID_DIRECTIVES: Type<any>[] = [
     // Core
     Datagrid, DatagridActionBar, DatagridActionOverflow, DatagridColumn, DatagridColumnToggle,
-    DatagridHideableColumnDirective, DatagridFilter, DatagridItems, DatagridRow, DatagridRowDetail,
-    DatagridDetailRegisterer, DatagridCell, DatagridFooter, DatagridPagination, DatagridPlaceholder,
+    DatagridHideableColumnDirective, DatagridFilter, DatagridItems, DatagridItemsTrackBy, DatagridRow,
+    DatagridRowDetail, DatagridDetailRegisterer, DatagridCell, DatagridFooter, DatagridPagination, DatagridPlaceholder,
 
     // Renderers
     DatagridMainRenderer, DatagridTableRenderer, DatagridHeadRenderer, DatagridHeaderRenderer, DatagridBodyRenderer,

--- a/src/clarity-angular/data/datagrid/providers/selection.spec.ts
+++ b/src/clarity-angular/data/datagrid/providers/selection.spec.ts
@@ -114,6 +114,33 @@ export default function(): void {
             expect(selectionInstance.isSelected(4)).toBe(false);
         });
 
+        it("handles clrDgItems trackBy index expressions in multi selection type", function() {
+            // IMPORTANT, using clrDgItems with trackBy will use trackBy reference in multi
+            selectionInstance.selectionType = SelectionType.Multi;
+            itemsInstance.trackBy = (index, item) => index;
+            // Must set the trackBy before setting the items
+            itemsInstance.all = ["a", "b", "c", "d", "e"];
+            selectionInstance.current = [1, 3];
+            expect(selectionInstance.isSelected("a")).toBe(false);
+            expect(selectionInstance.isSelected("b")).toBe(true);
+            expect(selectionInstance.isSelected("c")).toBe(false);
+            expect(selectionInstance.isSelected("d")).toBe(true);
+            expect(selectionInstance.isSelected("e")).toBe(false);
+        });
+
+        it("handles clrDgItems trackBy index expressions in single selection type", function() {
+            selectionInstance.selectionType = SelectionType.Single;
+            itemsInstance.trackBy = (index, item) => index;
+            // Must set the trackBy before setting the items
+            itemsInstance.all = ["a", "b", "c", "d", "e"];
+            selectionInstance.currentSingle = "c";
+            expect(selectionInstance.isSelected("a")).toBe(false);
+            expect(selectionInstance.isSelected("b")).toBe(false);
+            expect(selectionInstance.isSelected("c")).toBe(true);
+            expect(selectionInstance.isSelected("d")).toBe(false);
+            expect(selectionInstance.isSelected("e")).toBe(false);
+        });
+
         it("exposes an Observable to follow selection changes in multi selection type", function() {
             let nbChanges = 0;
             let currentSelection: any[];


### PR DESCRIPTION
Since you cannot use clrDgItems with server-driven datagrids, we need to ensure the trackBy function is leveraged as part of the comparison process for determining if something is equal or not. This is due to server-driven datagrids getting new objects with each page (from an API for example), and those don't strictly equal one another. You must use trackBy for selection to display correctly, though selection does persist without it.

closes #1393