### PR TITLE
[UI] Icon Buttons Fix

### DIFF
--- a/src/clarity-angular/button/_buttons.clarity.scss
+++ b/src/clarity-angular/button/_buttons.clarity.scss
@@ -344,7 +344,7 @@ $clr-button-appearance-map: (
     }
 
     .btn-icon {
-        min-width: unset;
+        min-width: 0;
     }
 
     //Overflow


### PR DESCRIPTION
Icon Buttons Fix for min-width. `min-width: unset` doesnt work on IE. Overriding with `min-width: 0`

Tested on IE11, Edge, Safari, Firefox, Chrome

Signed-off-by: Aditya Bhandari <adityab@vmware.com>