### PR TITLE
[NG] Properly debounce state changes for Datagrid

### DIFF
--- a/src/clarity-angular/data/datagrid/built-in/filters/datagrid-string-filter.spec.ts
+++ b/src/clarity-angular/data/datagrid/built-in/filters/datagrid-string-filter.spec.ts
@@ -12,12 +12,13 @@ import {StringFilter} from "../../interfaces/string-filter";
 import {CustomFilter} from "../../providers/custom-filter";
 import {FiltersProvider} from "../../providers/filters";
 import {Page} from "../../providers/page";
+import {StateDebouncer} from "../../providers/state-debouncer.provider";
 import {DomAdapter} from "../../render/dom-adapter";
 
 import {DatagridStringFilter} from "./datagrid-string-filter";
 import {DatagridStringFilterImpl} from "./datagrid-string-filter-impl";
 
-const PROVIDERS = [FiltersProvider, DomAdapter, Page];
+const PROVIDERS = [FiltersProvider, DomAdapter, Page, StateDebouncer];
 
 export default function(): void {
     describe("DatagridStringFilter component", function() {

--- a/src/clarity-angular/data/datagrid/datagrid-column.spec.ts
+++ b/src/clarity-angular/data/datagrid/datagrid-column.spec.ts
@@ -21,10 +21,12 @@ import {DragDispatcher} from "./providers/drag-dispatcher";
 import {FiltersProvider} from "./providers/filters";
 import {Page} from "./providers/page";
 import {Sort} from "./providers/sort";
+import {StateDebouncer} from "./providers/state-debouncer.provider";
 import {DomAdapter} from "./render/dom-adapter";
 import {DatagridRenderOrganizer} from "./render/render-organizer";
 
-const PROVIDERS_NEEDED = [Sort, FiltersProvider, DatagridRenderOrganizer, DomAdapter, DragDispatcher, Page];
+const PROVIDERS_NEEDED =
+    [Sort, FiltersProvider, DatagridRenderOrganizer, DomAdapter, DragDispatcher, Page, StateDebouncer];
 
 export default function(): void {
     describe("DatagridColumn component", function() {
@@ -36,8 +38,9 @@ export default function(): void {
             let component: DatagridColumn;
 
             beforeEach(function() {
-                sortService = new Sort();
-                filtersService = new FiltersProvider(new Page());
+                const stateDebouncer = new StateDebouncer();
+                sortService = new Sort(stateDebouncer);
+                filtersService = new FiltersProvider(new Page(stateDebouncer), stateDebouncer);
                 comparator = new TestComparator();
                 dragDispatcherService = undefined;
                 component = new DatagridColumn(sortService, filtersService, dragDispatcherService);

--- a/src/clarity-angular/data/datagrid/datagrid-filter.spec.ts
+++ b/src/clarity-angular/data/datagrid/datagrid-filter.spec.ts
@@ -12,6 +12,7 @@ import {Filter} from "./interfaces/filter";
 import {CustomFilter} from "./providers/custom-filter";
 import {FiltersProvider} from "./providers/filters";
 import {Page} from "./providers/page";
+import {StateDebouncer} from "./providers/state-debouncer.provider";
 
 export default function(): void {
     describe("DatagridFilter component", function() {
@@ -21,7 +22,8 @@ export default function(): void {
             let component: DatagridFilter;
 
             beforeEach(function() {
-                filterService = new FiltersProvider(new Page());
+                const stateDebouncer = new StateDebouncer();
+                filterService = new FiltersProvider(new Page(stateDebouncer), stateDebouncer);
                 filter = new TestFilter();
                 component = new DatagridFilter(filterService);
             });
@@ -65,7 +67,7 @@ export default function(): void {
 
             beforeEach(function() {
                 filter = new TestFilter();
-                context = this.create(DatagridFilter, FullTest, [FiltersProvider, Page]);
+                context = this.create(DatagridFilter, FullTest, [FiltersProvider, Page, StateDebouncer]);
             });
 
             it("receives an input for the filter logic", function() {
@@ -93,7 +95,7 @@ export default function(): void {
             let context: TestContext<DatagridFilter, FullTest>;
 
             beforeEach(function() {
-                context = this.create(DatagridFilter, FullTest, [FiltersProvider, Page]);
+                context = this.create(DatagridFilter, FullTest, [FiltersProvider, Page, StateDebouncer]);
             });
 
             it("projects content into the dropdown", function() {

--- a/src/clarity-angular/data/datagrid/datagrid-footer.spec.ts
+++ b/src/clarity-angular/data/datagrid/datagrid-footer.spec.ts
@@ -13,8 +13,9 @@ import {Items} from "./providers/items";
 import {Page} from "./providers/page";
 import {Selection, SelectionType} from "./providers/selection";
 import {Sort} from "./providers/sort";
+import {StateDebouncer} from "./providers/state-debouncer.provider";
 
-const PROVIDERS_NEEDED = [Selection, Items, FiltersProvider, Sort, Page, HideableColumnService];
+const PROVIDERS_NEEDED = [Selection, Items, FiltersProvider, Sort, Page, HideableColumnService, StateDebouncer];
 
 export default function(): void {
     describe("DatagridFooter component", function() {

--- a/src/clarity-angular/data/datagrid/datagrid-hideable-column.directive.spec.ts
+++ b/src/clarity-angular/data/datagrid/datagrid-hideable-column.directive.spec.ts
@@ -12,10 +12,12 @@ import {DragDispatcher} from "./providers/drag-dispatcher";
 import {FiltersProvider} from "./providers/filters";
 import {Page} from "./providers/page";
 import {Sort} from "./providers/sort";
+import {StateDebouncer} from "./providers/state-debouncer.provider";
 import {DomAdapter} from "./render/dom-adapter";
 import {DatagridRenderOrganizer} from "./render/render-organizer";
 
-const PROVIDERS_NEEDED = [Sort, FiltersProvider, DatagridRenderOrganizer, DomAdapter, DragDispatcher, Page];
+const PROVIDERS_NEEDED =
+    [Sort, FiltersProvider, DatagridRenderOrganizer, DomAdapter, DragDispatcher, Page, StateDebouncer];
 
 export default function(): void {
     describe("DatagridHideableColumnDirective directive", function() {

--- a/src/clarity-angular/data/datagrid/datagrid-hideable-column.spec.ts
+++ b/src/clarity-angular/data/datagrid/datagrid-hideable-column.spec.ts
@@ -12,10 +12,12 @@ import {DragDispatcher} from "./providers/drag-dispatcher";
 import {FiltersProvider} from "./providers/filters";
 import {Page} from "./providers/page";
 import {Sort} from "./providers/sort";
+import {StateDebouncer} from "./providers/state-debouncer.provider";
 import {DomAdapter} from "./render/dom-adapter";
 import {DatagridRenderOrganizer} from "./render/render-organizer";
 
-const PROVIDERS_NEEDED = [Sort, FiltersProvider, DatagridRenderOrganizer, DomAdapter, DragDispatcher, Page];
+const PROVIDERS_NEEDED =
+    [Sort, FiltersProvider, DatagridRenderOrganizer, DomAdapter, DragDispatcher, Page, StateDebouncer];
 
 
 export default function(): void {

--- a/src/clarity-angular/data/datagrid/datagrid-items.spec.ts
+++ b/src/clarity-angular/data/datagrid/datagrid-items.spec.ts
@@ -12,6 +12,7 @@ import {FiltersProvider} from "./providers/filters";
 import {Items} from "./providers/items";
 import {Page} from "./providers/page";
 import {Sort} from "./providers/sort";
+import {StateDebouncer} from "./providers/state-debouncer.provider";
 
 export default function(): void {
     describe("DatagridItems directive", function() {
@@ -23,7 +24,7 @@ export default function(): void {
             TestBed.configureTestingModule({
                 imports: [ClrDatagridModule],
                 declarations: [FullTest],
-                providers: [Items, FiltersProvider, Sort, Page]
+                providers: [Items, FiltersProvider, Sort, Page, StateDebouncer]
             });
             this.fixture = TestBed.createComponent(FullTest);
             this.fixture.detectChanges();

--- a/src/clarity-angular/data/datagrid/datagrid-pagination.spec.ts
+++ b/src/clarity-angular/data/datagrid/datagrid-pagination.spec.ts
@@ -8,6 +8,7 @@ import {Component} from "@angular/core";
 import {DatagridPagination} from "./datagrid-pagination";
 import {TestContext} from "./helpers.spec";
 import {Page} from "./providers/page";
+import {StateDebouncer} from "./providers/state-debouncer.provider";
 
 export default function(): void {
     describe("DatagridPagination component", function() {
@@ -16,7 +17,7 @@ export default function(): void {
             let component: DatagridPagination;
 
             beforeEach(function() {
-                pageService = new Page();
+                pageService = new Page(new StateDebouncer());
                 component = new DatagridPagination(pageService);
                 component.ngOnInit();  // For the subscription that will get destroyed.
             });
@@ -75,7 +76,7 @@ export default function(): void {
             let context: TestContext<DatagridPagination, FullTest>;
 
             beforeEach(function() {
-                context = this.create(DatagridPagination, FullTest, [Page]);
+                context = this.create(DatagridPagination, FullTest, [Page, StateDebouncer]);
             });
 
             it("receives an input for page size", function() {
@@ -111,7 +112,7 @@ export default function(): void {
             let context: TestContext<DatagridPagination, FullTest>;
 
             beforeEach(function() {
-                context = this.create(DatagridPagination, FullTest, [Page]);
+                context = this.create(DatagridPagination, FullTest, [Page, StateDebouncer]);
             });
 
             it("doesn't display anything if there is only one page", function() {

--- a/src/clarity-angular/data/datagrid/datagrid-placeholder.spec.ts
+++ b/src/clarity-angular/data/datagrid/datagrid-placeholder.spec.ts
@@ -12,12 +12,13 @@ import {FiltersProvider} from "./providers/filters";
 import {Items} from "./providers/items";
 import {Page} from "./providers/page";
 import {Sort} from "./providers/sort";
+import {StateDebouncer} from "./providers/state-debouncer.provider";
 
 export default function(): void {
     describe("DatagridPlaceholder component", function() {
         describe("Typescript API", function() {
             beforeEach(function() {
-                this.pageProvider = new Page();
+                this.pageProvider = new Page(new StateDebouncer());
                 this.itemsProvider = new Items(null, null, this.pageProvider);
                 this.component = new DatagridPlaceholder(this.itemsProvider, this.pageProvider);
             });
@@ -37,7 +38,8 @@ export default function(): void {
             let pageProvider: Page;
 
             beforeEach(function() {
-                context = this.create(DatagridPlaceholder, SimpleTest, [Items, Page, Sort, FiltersProvider]);
+                context =
+                    this.create(DatagridPlaceholder, SimpleTest, [Items, Page, Sort, FiltersProvider, StateDebouncer]);
                 itemsProvider = TestBed.get(Items);
                 pageProvider = TestBed.get(Page);
             });

--- a/src/clarity-angular/data/datagrid/datagrid-row-detail.spec.ts
+++ b/src/clarity-angular/data/datagrid/datagrid-row-detail.spec.ts
@@ -17,6 +17,7 @@ import {Page} from "./providers/page";
 import {RowActionService} from "./providers/row-action-service";
 import {Selection, SelectionType} from "./providers/selection";
 import {Sort} from "./providers/sort";
+import {StateDebouncer} from "./providers/state-debouncer.provider";
 import {DatagridRenderOrganizer} from "./render/render-organizer";
 
 export default function(): void {
@@ -26,7 +27,7 @@ export default function(): void {
         beforeEach(function() {
             context = this.create(DatagridRowDetail, FullTest, [
                 Selection, Items, FiltersProvider, Sort, Page, RowActionService, Expand, DatagridRenderOrganizer,
-                HideableColumnService
+                HideableColumnService, StateDebouncer
             ]);
         });
 
@@ -107,7 +108,7 @@ export default function(): void {
         beforeEach(function() {
             context = this.create(DatagridRowDetail, HiddenTest, [
                 Selection, Items, FiltersProvider, Sort, Page, RowActionService, Expand, DatagridRenderOrganizer,
-                HideableColumnService
+                HideableColumnService, StateDebouncer
             ]);
             hideableColumnService = context.getClarityProvider(HideableColumnService);
         });

--- a/src/clarity-angular/data/datagrid/datagrid-row.spec.ts
+++ b/src/clarity-angular/data/datagrid/datagrid-row.spec.ts
@@ -22,12 +22,13 @@ import {Page} from "./providers/page";
 import {RowActionService} from "./providers/row-action-service";
 import {Selection, SelectionType} from "./providers/selection";
 import {Sort} from "./providers/sort";
+import {StateDebouncer} from "./providers/state-debouncer.provider";
 import {DomAdapter} from "./render/dom-adapter";
 import {DatagridRenderOrganizer} from "./render/render-organizer";
 
 const PROVIDERS = [
     Selection, Items, FiltersProvider, Sort, Page, RowActionService, ExpandableRowsCount, DatagridRenderOrganizer,
-    DomAdapter, HideableColumnService, DatagridWillyWonka
+    DomAdapter, HideableColumnService, DatagridWillyWonka, StateDebouncer
 ];
 
 export default function(): void {

--- a/src/clarity-angular/data/datagrid/datagrid.spec.ts
+++ b/src/clarity-angular/data/datagrid/datagrid.spec.ts
@@ -175,6 +175,23 @@ export default function(): void {
                         customFilter, testStringFilter, {property: "test", value: "1234"}
                     ]);
                 });
+
+                it("emits early enough to avoid chocolate errors on the loading input", function() {
+                    context.testComponent.fakeLoad = true;
+                    const page: Page = context.getClarityProvider(Page);
+                    page.current = 2;
+                    expect(() => context.detectChanges()).not.toThrow();
+                });
+
+                // Actually not fixed yet, my bad
+                xit("doesn't emit when the datagrid is destroyed", function() {
+                    context.testComponent.filter = true;
+                    context.detectChanges();
+                    context.testComponent.nbRefreshed = 0;
+                    context.testComponent.destroy = true;
+                    context.detectChanges();
+                    expect(context.testComponent.nbRefreshed).toBe(0);
+                });
             });
         });
 
@@ -351,8 +368,12 @@ export default function(): void {
 
 @Component({
     template: `
-    <clr-datagrid [(clrDgSelected)]="selected" [clrDgLoading]="loading" (clrDgRefresh)="refresh($event)">
-        <clr-dg-column>First</clr-dg-column>
+    <clr-datagrid *ngIf="!destroy"
+                  [(clrDgSelected)]="selected" [clrDgLoading]="loading" (clrDgRefresh)="refresh($event)">
+        <clr-dg-column>
+            First
+            <clr-dg-filter *ngIf="filter" [clrDgFilter]="testFilter"></clr-dg-filter>
+        </clr-dg-column>
         <clr-dg-column>Second</clr-dg-column>
     
         <clr-dg-row *clrDgItems="let item of items">
@@ -373,9 +394,18 @@ class FullTest {
     nbRefreshed = 0;
     latestState: State;
 
+    fakeLoad = false;
+
+    // Filter needed to test the non-emission of refresh on destroy, even with an active filter
+    filter = false;
+    testFilter = new TestFilter();
+
+    destroy = false;
+
     refresh(state: State) {
         this.nbRefreshed++;
         this.latestState = state;
+        this.loading = this.fakeLoad;
     }
 }
 

--- a/src/clarity-angular/data/datagrid/providers/filters.spec.ts
+++ b/src/clarity-angular/data/datagrid/providers/filters.spec.ts
@@ -9,11 +9,13 @@ import {Filter} from "../interfaces/filter";
 
 import {FiltersProvider} from "./filters";
 import {Page} from "./page";
+import {StateDebouncer} from "./state-debouncer.provider";
 
 export default function(): void {
     describe("FiltersProvider provider", function() {
         beforeEach(function() {
-            this.filtersInstance = new FiltersProvider(new Page());
+            const stateDebouncer = new StateDebouncer();
+            this.filtersInstance = new FiltersProvider(new Page(stateDebouncer), stateDebouncer);
             this.evenFilter = new EvenFilter();
             this.positiveFilter = new PositiveFilter();
             this.filtersInstance.add(this.evenFilter);

--- a/src/clarity-angular/data/datagrid/providers/filters.ts
+++ b/src/clarity-angular/data/datagrid/providers/filters.ts
@@ -9,10 +9,11 @@ import {Subject} from "rxjs/Subject";
 
 import {Filter} from "../interfaces/filter";
 import {Page} from "./page";
+import {StateDebouncer} from "./state-debouncer.provider";
 
 @Injectable()
 export class FiltersProvider {
-    constructor(private _page: Page) {}
+    constructor(private _page: Page, private stateDebouncer: StateDebouncer) {}
     /**
      * This subject is the list of filters that changed last, not the whole list.
      * We emit a list rather than just one filter to allow batch changes to several at once.
@@ -93,10 +94,12 @@ export class FiltersProvider {
     }
 
     private resetPageAndEmitFilterChange(filters: Filter<any>[]) {
+        this.stateDebouncer.changeStart();
         // filtering may change the page number such that current page number doesn't exist in the filtered dataset.
         // So here we always set the current page to 1 so that it'll fetch first page's data with the given filter.
         this._page.current = 1;
         this._change.next(filters);
+        this.stateDebouncer.changeDone();
     }
 }
 

--- a/src/clarity-angular/data/datagrid/providers/items.spec.ts
+++ b/src/clarity-angular/data/datagrid/providers/items.spec.ts
@@ -12,6 +12,7 @@ import {FiltersProvider} from "./filters";
 import {Items} from "./items";
 import {Page} from "./page";
 import {Sort} from "./sort";
+import {StateDebouncer} from "./state-debouncer.provider";
 
 const ALL_ITEMS = [9, 3, 5, 8, 2, 6, 10, 7, 4, 1];
 
@@ -23,11 +24,12 @@ export default function(): void {
         }
 
         beforeEach(function() {
-            this.pageInstance = new Page();
-            this.filtersInstance = new FiltersProvider(this.pageInstance);
+            const stateDebouncer = new StateDebouncer();
+            this.pageInstance = new Page(stateDebouncer);
+            this.filtersInstance = new FiltersProvider(this.pageInstance, stateDebouncer);
             this.evenFilter = new EvenFilter();
             this.filtersInstance.add(this.evenFilter);
-            this.sortInstance = new Sort();
+            this.sortInstance = new Sort(stateDebouncer);
             this.comparator = new TestComparator();
             this.itemsInstance = new Items(this.filtersInstance, this.sortInstance, this.pageInstance);
         });

--- a/src/clarity-angular/data/datagrid/providers/page.spec.ts
+++ b/src/clarity-angular/data/datagrid/providers/page.spec.ts
@@ -4,11 +4,12 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import {Page} from "./page";
+import {StateDebouncer} from "./state-debouncer.provider";
 
 export default function(): void {
     describe("Page provider", function() {
         beforeEach(function() {
-            this.pageInstance = new Page();
+            this.pageInstance = new Page(new StateDebouncer());
         });
 
         it("has page size 0 by default", function() {

--- a/src/clarity-angular/data/datagrid/providers/page.ts
+++ b/src/clarity-angular/data/datagrid/providers/page.ts
@@ -6,9 +6,12 @@
 import {Injectable} from "@angular/core";
 import {Observable} from "rxjs/Observable";
 import {Subject} from "rxjs/Subject";
+import {StateDebouncer} from "./state-debouncer.provider";
 
 @Injectable()
 export class Page {
+    constructor(private stateDebouncer: StateDebouncer) {}
+
     /**
      * Page size, a value of 0 means no pagination
      */
@@ -88,8 +91,10 @@ export class Page {
     }
     public set current(page: number) {
         if (page !== this._current) {
+            this.stateDebouncer.changeStart();
             this._current = page;
             this._change.next(page);
+            this.stateDebouncer.changeDone();
         }
     }
 

--- a/src/clarity-angular/data/datagrid/providers/selection.spec.ts
+++ b/src/clarity-angular/data/datagrid/providers/selection.spec.ts
@@ -13,6 +13,7 @@ import {Items} from "./items";
 import {Page} from "./page";
 import {Selection, SelectionType} from "./selection";
 import {Sort} from "./sort";
+import {StateDebouncer} from "./state-debouncer.provider";
 
 const numberSort = (a: number, b: number) => a - b;
 
@@ -24,9 +25,10 @@ export default function(): void {
     let itemsInstance: Items;
     describe("Selection provider", function() {
         beforeEach(function() {
-            pageInstance = new Page();
-            filtersInstance = new FiltersProvider(pageInstance);
-            sortInstance = new Sort();
+            const stateDebouncer = new StateDebouncer();
+            pageInstance = new Page(stateDebouncer);
+            filtersInstance = new FiltersProvider(pageInstance, stateDebouncer);
+            sortInstance = new Sort(stateDebouncer);
             itemsInstance = new Items(filtersInstance, sortInstance, pageInstance);
 
             selectionInstance = new Selection(itemsInstance, filtersInstance);

--- a/src/clarity-angular/data/datagrid/providers/sort.spec.ts
+++ b/src/clarity-angular/data/datagrid/providers/sort.spec.ts
@@ -6,11 +6,12 @@
 import {Comparator} from "../interfaces/comparator";
 
 import {Sort} from "./sort";
+import {StateDebouncer} from "./state-debouncer.provider";
 
 export default function(): void {
     describe("Sort provider", function() {
         beforeEach(function() {
-            this.sortInstance = new Sort();
+            this.sortInstance = new Sort(new StateDebouncer());
             this.comparator = new TestComparator();
         });
 

--- a/src/clarity-angular/data/datagrid/providers/sort.ts
+++ b/src/clarity-angular/data/datagrid/providers/sort.ts
@@ -8,9 +8,12 @@ import {Observable} from "rxjs/Observable";
 import {Subject} from "rxjs/Subject";
 
 import {Comparator} from "../interfaces/comparator";
+import {StateDebouncer} from "./state-debouncer.provider";
 
 @Injectable()
 export class Sort {
+    constructor(private stateDebouncer: StateDebouncer) {}
+
     /**
      * Currently active comparator
      */
@@ -19,8 +22,10 @@ export class Sort {
         return this._comparator;
     }
     public set comparator(value: Comparator<any>) {
+        this.stateDebouncer.changeStart();
         this._comparator = value;
         this.emitChange();
+        this.stateDebouncer.changeDone();
     }
 
     /**
@@ -31,8 +36,10 @@ export class Sort {
         return this._reverse;
     }
     public set reverse(value: boolean) {
+        this.stateDebouncer.changeStart();
         this._reverse = value;
         this.emitChange();
+        this.stateDebouncer.changeDone();
     }
 
     /**
@@ -58,6 +65,7 @@ export class Sort {
      * @memberof Sort
      */
     public toggle(sortBy: Comparator<any>, forceReverse?: boolean) {
+        this.stateDebouncer.changeStart();
         // We modify private properties directly, to batch the change event
         if (this.comparator === sortBy) {
             this._reverse = typeof forceReverse !== "undefined" ? forceReverse || !this._reverse : !this._reverse;
@@ -66,6 +74,7 @@ export class Sort {
             this._reverse = typeof forceReverse !== "undefined" ? forceReverse : false;
         }
         this.emitChange();
+        this.stateDebouncer.changeDone();
     }
 
     /**

--- a/src/clarity-angular/data/datagrid/providers/state-debouncer.provider.ts
+++ b/src/clarity-angular/data/datagrid/providers/state-debouncer.provider.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import {Injectable} from "@angular/core";
+import {Observable} from "rxjs/Observable";
+import {Subject} from "rxjs/Subject";
+
+/*
+ * This provider implements some form of synchronous debouncing through a lock pattern
+ * to avoid emitting multiple state changes for a single user action.
+ */
+@Injectable()
+export class StateDebouncer {
+    /**
+     * The Observable that lets other classes subscribe to global state changes
+     */
+    private _change = new Subject<void>();
+    // We do not want to expose the Subject itself, but the Observable which is read-only
+    public get change(): Observable<void> {
+        return this._change.asObservable();
+    }
+
+    /*
+     * This is the lock, to only emit once all the changes have finished processing
+     */
+    private nbChanges = 0;
+
+    public changeStart() {
+        this.nbChanges++;
+    }
+
+    public changeDone() {
+        if (--this.nbChanges === 0) {
+            this._change.next();
+        }
+    }
+}

--- a/src/clarity-angular/data/datagrid/providers/state.provider.ts
+++ b/src/clarity-angular/data/datagrid/providers/state.provider.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import "rxjs/add/operator/map";
+
+import {Injectable} from "@angular/core";
+import {Observable} from "rxjs/Observable";
+
+import {DatagridPropertyComparator} from "../built-in/comparators/datagrid-property-comparator";
+import {DatagridPropertyStringFilter} from "../built-in/filters/datagrid-property-string-filter";
+import {DatagridStringFilterImpl} from "../built-in/filters/datagrid-string-filter-impl";
+import {State} from "../interfaces/state";
+
+import {FiltersProvider} from "./filters";
+import {Page} from "./page";
+import {Sort} from "./sort";
+import {StateDebouncer} from "./state-debouncer.provider";
+
+/**
+ * This provider aggregates state changes from the various providers of the Datagrid
+ */
+@Injectable()
+export class StateProvider {
+    constructor(private filters: FiltersProvider, private sort: Sort, private page: Page,
+                private debouncer: StateDebouncer) {}
+
+    /**
+     * The Observable that lets other classes subscribe to global state changes
+     */
+    change: Observable<State> = this.debouncer.change.map(() => this.state);
+
+    /*
+     * By making this a getter, we open the possibility for a setter in the future.
+     * It's been requested a couple times.
+     */
+    get state(): State {
+        const state: State = {};
+        if (this.page.size > 0) {
+            state.page = {from: this.page.firstItem, to: this.page.lastItem, size: this.page.size};
+        }
+        if (this.sort.comparator) {
+            if (this.sort.comparator instanceof DatagridPropertyComparator) {
+                /*
+                 * Special case for the default object property comparator,
+                 * we give the property name instead of the actual comparator.
+                 */
+                state.sort = {by: (<DatagridPropertyComparator>this.sort.comparator).prop, reverse: this.sort.reverse};
+            } else {
+                state.sort = {by: this.sort.comparator, reverse: this.sort.reverse};
+            }
+        }
+
+        const activeFilters = this.filters.getActiveFilters();
+        if (activeFilters.length > 0) {
+            state.filters = [];
+            for (const filter of activeFilters) {
+                if (filter instanceof DatagridStringFilterImpl) {
+                    const stringFilter = (<DatagridStringFilterImpl>filter).filterFn;
+                    if (stringFilter instanceof DatagridPropertyStringFilter) {
+                        /*
+                         * Special case again for the default object property filter,
+                         * we give the property name instead of the full filter object.
+                         */
+                        state.filters.push({
+                            property: (<DatagridPropertyStringFilter>stringFilter).prop,
+                            value: (<DatagridStringFilterImpl>filter).value
+                        });
+                        continue;
+                    }
+                }
+                state.filters.push(filter);
+            }
+        }
+        return state;
+    }
+}

--- a/src/clarity-angular/data/datagrid/render/header-renderer.spec.ts
+++ b/src/clarity-angular/data/datagrid/render/header-renderer.spec.ts
@@ -9,6 +9,7 @@ import {TestContext} from "../helpers.spec";
 import {FiltersProvider} from "../providers/filters";
 import {Page} from "../providers/page";
 import {Sort} from "../providers/sort";
+import {StateDebouncer} from "../providers/state-debouncer.provider";
 
 import {DomAdapter} from "./dom-adapter";
 import {MOCK_DOM_ADAPTER_PROVIDER, MockDomAdapter} from "./dom-adapter.mock";
@@ -23,8 +24,9 @@ export default function(): void {
         let organizer: MockDatagridRenderOrganizer;
 
         beforeEach(function() {
-            context = this.create(DatagridHeaderRenderer, SimpleTest,
-                                  [MOCK_ORGANIZER_PROVIDER, MOCK_DOM_ADAPTER_PROVIDER, Sort, FiltersProvider, Page]);
+            context = this.create(
+                DatagridHeaderRenderer, SimpleTest,
+                [MOCK_ORGANIZER_PROVIDER, MOCK_DOM_ADAPTER_PROVIDER, Sort, FiltersProvider, Page, StateDebouncer]);
             domAdapter = context.getClarityProvider(DomAdapter);
             organizer = context.getClarityProvider(DatagridRenderOrganizer);
         });

--- a/src/clarity-angular/data/datagrid/render/row-renderer.spec.ts
+++ b/src/clarity-angular/data/datagrid/render/row-renderer.spec.ts
@@ -15,6 +15,7 @@ import {Page} from "../providers/page";
 import {RowActionService} from "../providers/row-action-service";
 import {Selection} from "../providers/selection";
 import {Sort} from "../providers/sort";
+import {StateDebouncer} from "../providers/state-debouncer.provider";
 
 import {DatagridCellRenderer} from "./cell-renderer";
 import {DomAdapter} from "./dom-adapter";
@@ -24,7 +25,7 @@ import {DatagridRowRenderer} from "./row-renderer";
 
 const PROVIDERS = [
     Selection, Items, FiltersProvider, Sort, Page, RowActionService, ExpandableRowsCount, MOCK_ORGANIZER_PROVIDER,
-    DomAdapter, HideableColumnService, DatagridWillyWonka
+    DomAdapter, HideableColumnService, DatagridWillyWonka, StateDebouncer
 ];
 export default function(): void {
     describe("DatagridRowRenderer directive", function() {


### PR DESCRIPTION
Our previous solution actually emitted too late, which broke
server-driven datagrids that relied on the `[clrDgLoading]` input.

~Also fixes #1099 as a nice side-effect.~ My bad, it didn't.

I am not 100% happy with this pattern, having to remember to call `changeStart()` and `changeDone()` everywhere is tedious, but at the same time allows us to catch more of these cases if they come from somewhere else the the 3 main state providers. I tried using zones for this, only emitting when they were no more microtasks left, but Angular subscribes before us so change detection happens before we can emit (subscribers are called in order).

Also, it's pretty painful to add a single provider anywhere in the Datagrid right now, we have to go through dozens of spec files to update them. We need to centralize this somehow.