### PR TITLE
[NG] Fixes the undefined FocusTrap when a modal is closed

### DIFF
--- a/src/clarity-angular/modal/modal.spec.ts
+++ b/src/clarity-angular/modal/modal.spec.ts
@@ -104,6 +104,17 @@ describe("Modal", () => {
            expect(getModalInstance(fixture).close).not.toHaveBeenCalled();
        }));
 
+    it("should not throw an error when close is called on an already closed modal", fakeAsync(() => {
+           // Close the test modal
+           fixture.componentInstance.modalInstance.close();
+           fixture.detectChanges();
+           // App should not throw an error when already closed.
+           expect(() => {
+               fixture.componentInstance.modalInstance.close();
+               fixture.detectChanges();
+           }).not.toThrow();
+       }));
+
     it("offers two-way binding on clrModalOpen", fakeAsync(() => {
            expect(fixture.componentInstance.opened).toBe(true);
            getModalInstance(fixture).close();

--- a/src/clarity-angular/modal/modal.ts
+++ b/src/clarity-angular/modal/modal.ts
@@ -134,12 +134,12 @@ export class Modal implements OnChanges, OnDestroy {
         if (!this.closable || this._open === false) {
             return;
         }
-        this.focusTrap.setPreviousFocus();  // Handles moving focus back to the element that had it before.
         this._open = false;
         // todo: remove this after animation bug is fixed https://github.com/angular/angular/issues/15798
         // this was handled by the fadeDone event below, but that AnimationEvent is not firing in Angular 4.0.
         this._openChanged.emit(false);
         // SPECME
+        this.focusTrap.setPreviousFocus();  // Handles moving focus back to the element that had it before.
     }
 
     fadeDone(e: AnimationEvent) {

--- a/src/clarity-angular/modal/modal.ts
+++ b/src/clarity-angular/modal/modal.ts
@@ -127,7 +127,6 @@ export class Modal implements OnChanges, OnDestroy {
 
     @HostListener("body:keyup.escape")
     close(): void {
-        this.focusTrap.setPreviousFocus();  // Handles moving focus back to the element that had it before.
         if (this.stopClose) {
             this.altClose.emit(false);
             return;
@@ -135,6 +134,7 @@ export class Modal implements OnChanges, OnDestroy {
         if (!this.closable || this._open === false) {
             return;
         }
+        this.focusTrap.setPreviousFocus();  // Handles moving focus back to the element that had it before.
         this._open = false;
         // todo: remove this after animation bug is fixed https://github.com/angular/angular/issues/15798
         // this was handled by the fadeDone event below, but that AnimationEvent is not firing in Angular 4.0.


### PR DESCRIPTION
- closes #1498

Signed-off-by: Matt Hippely <mhippely@vmware.com>