### PR TITLE
[NG] fix wizard issue where buttons with NgIf would throw expression has changed error

### DIFF
--- a/src/clarity-angular/wizard/providers/button-hub.mock.ts
+++ b/src/clarity-angular/wizard/providers/button-hub.mock.ts
@@ -5,6 +5,8 @@
  */
 
 export class ButtonHubMock {
+    public buttonsReady: boolean = false;
+
     public buttonClicked(type: string): string {
         return type;
     }

--- a/src/clarity-angular/wizard/providers/button-hub.ts
+++ b/src/clarity-angular/wizard/providers/button-hub.ts
@@ -10,6 +10,8 @@ import {Subject} from "rxjs/Subject";
 
 @Injectable()
 export class ButtonHubService {
+    public buttonsReady: boolean = false;
+
     private _previousBtnClicked = new Subject<any>();
     public get previousBtnClicked(): Observable<any> {
         return this._previousBtnClicked.asObservable();

--- a/src/clarity-angular/wizard/wizard-button.spec.ts
+++ b/src/clarity-angular/wizard/wizard-button.spec.ts
@@ -23,10 +23,12 @@ import {ClrWizardModule} from "./wizard.module";
             [clrWizardButtonDisabled]="disableBtn"
             [clrWizardButtonHidden]="hideBtn"
             (clrWizardButtonClicked)="doClick($event)"
+            *ngIf="show"
         >hello {{ projector }}</clr-wizard-button>
     `
 })
 class ViewTestComponent {
+    public show: boolean = true;
     public btnType: string = "";
     public disableBtn: boolean = false;
     public hideBtn: boolean = false;
@@ -113,6 +115,7 @@ export default function(): void {
                     ]
                 });
                 fixture = TestBed.createComponent(TestComponent);
+                buttonHub.buttonsReady = true;
                 fixture.detectChanges();
                 buttonDebugEl = fixture.debugElement.query(By.directive(WizardButton));
                 buttonComponent = buttonDebugEl.componentInstance;
@@ -832,6 +835,7 @@ export default function(): void {
                     ]
                 });
                 fixture = TestBed.createComponent(ViewTestComponent);
+                buttonHub.buttonsReady = true;
                 fixture.detectChanges();
                 buttonDebugEl = fixture.debugElement.query(By.directive(WizardButton));
                 buttonComponent = buttonDebugEl.componentInstance;
@@ -893,6 +897,20 @@ export default function(): void {
                     fixture.detectChanges();
                     expect(buttonComponent.isDisabled).toBe(false, "updates when set back");
                 });
+
+                it("should render properly even with ngIf is applied", () => {
+                    // Test when buttons are not ready
+                    buttonHub.buttonsReady = false;
+                    expect(buttonComponent.isDisabled).toBe(false, "should always be false if buttons aren't ready");
+                    // Test with buttons ready.
+                    buttonHub.buttonsReady = true;
+                    fixture.detectChanges();
+                    expect(buttonComponent.isDisabled).toBe(false, "should be the default value");
+                    // Test setting to hide
+                    myTestComponent.disableBtn = true;
+                    fixture.detectChanges();
+                    expect(buttonComponent.isDisabled).toBe(true, "should now be disabled");
+                });
             });
 
             describe("hidden input", () => {
@@ -908,6 +926,20 @@ export default function(): void {
                     myTestComponent.hideBtn = false;
                     fixture.detectChanges();
                     expect(buttonComponent.isHidden).toBe(false, "updates when set back");
+                });
+
+                it("binds to the host even with ngIf is applied", () => {
+                    // Test when buttons are not ready
+                    buttonHub.buttonsReady = false;
+                    expect(buttonComponent.isHidden).toBe(false, "should always be false if buttons aren't ready");
+                    // Test with buttons ready.
+                    buttonHub.buttonsReady = true;
+                    fixture.detectChanges();
+                    expect(buttonComponent.isHidden).toBe(false, "should be the default value");
+                    // Test setting to hide
+                    myTestComponent.hideBtn = true;
+                    fixture.detectChanges();
+                    expect(buttonComponent.isHidden).toBe(true, "should now be hidden");
                 });
             });
 
@@ -980,6 +1012,7 @@ export default function(): void {
                     ]
                 });
                 fixture = TestBed.createComponent(ViewTestComponent);
+                buttonHub.buttonsReady = true;
                 fixture.detectChanges();
                 buttonDebugEl = fixture.debugElement.query(By.directive(WizardButton));
                 buttonComponent = buttonDebugEl.componentInstance;

--- a/src/clarity-angular/wizard/wizard-button.ts
+++ b/src/clarity-angular/wizard/wizard-button.ts
@@ -99,6 +99,11 @@ export class WizardButton {
         const nav = this.navService;
         const page = this.navService.currentPage;
 
+        // Ensure we don't change the response until buttons are ready to avoid chocolate
+        if (!this.buttonService.buttonsReady) {
+            return !disabled;
+        }
+
         if (this.disabled || nav.wizardStopNavigation || !page) {
             return true;
         }
@@ -130,6 +135,11 @@ export class WizardButton {
         // dealing with negatives here. cognitively easier to think of it like this...
         const hidden = true;
         const nav = this.navService;
+
+        // Ensure we don't change the response until buttons are ready to avoid chocolate
+        if (!this.buttonService.buttonsReady) {
+            return !hidden;
+        }
 
         if (this.hidden) {
             return true;

--- a/src/clarity-angular/wizard/wizard.ts
+++ b/src/clarity-angular/wizard/wizard.ts
@@ -424,6 +424,11 @@ export class Wizard implements OnInit, OnDestroy, AfterContentInit, DoCheck {
             navService.hideWizardGhostPages = false;
             this.deactivateGhostPages();
         }
+
+        // Only trigger buttons ready if default is open (inlined)
+        if (this._open) {
+            this.buttonService.buttonsReady = true;
+        }
     }
 
     /**
@@ -514,6 +519,9 @@ export class Wizard implements OnInit, OnDestroy, AfterContentInit, DoCheck {
         if (!this.currentPage) {
             this.navService.setFirstPageCurrent();
         }
+
+        // Only render buttons when wizard is opened, to avoid chocolate errors
+        this.buttonService.buttonsReady = true;
 
         this.setGhostPages();
         this._openChanged.emit(true);


### PR DESCRIPTION
The problem was in the lifecycle of the buttons the host binding for isHidden on a button would flip between true/false, due to the change of state in the navigation service provider. This delays the evaluation of the button's host binding until later in the cycle.

closes #1439