### PR TITLE
Tabs chocolate

### DIFF
--- a/src/app/tabs/tabs-angular.demo.html
+++ b/src/app/tabs/tabs-angular.demo.html
@@ -7,7 +7,7 @@
 <div class="clr-example">
     <button class="btn btn-primary" (click)="inOverflow = !inOverflow">Toggle</button>
     <clr-tabs>
-        <clr-tab *ngIf="true">
+        <clr-tab>
             <button clrTabLink>Dashboard</button>
             <clr-tab-content clrTabContentId="content1" *clrIfActive>
                 <p>Content for Dashboard tab. Here is a <a href="javascript://">link</a> that can be accessed via clicking

--- a/src/clarity-angular/data/datagrid/helpers.spec.ts
+++ b/src/clarity-angular/data/datagrid/helpers.spec.ts
@@ -8,7 +8,7 @@
  * when we have the time. This will be very helpful in future refactors due to Angular upgrades, or simply
  * just to avoid leaks since destroying fixtures is automatic with this.
  */
-import {DebugElement, Type} from "@angular/core";
+import {DebugElement, InjectionToken, Type} from "@angular/core";
 import {ComponentFixture, TestBed} from "@angular/core/testing";
 import {By} from "@angular/platform-browser";
 
@@ -38,7 +38,8 @@ export class TestContext<D, C> {
         this.clarityElement = this.clarityDebugElement.nativeElement;
     }
 
-    getClarityProvider(token: any) {
+    // The Function type here is just to tell Typescript to be nice with abstract classes. Weird.
+    getClarityProvider<T>(token: Type<T>|InjectionToken<T>|Function): T {
         return this.clarityDebugElement.injector.get(token);
     }
 

--- a/src/clarity-angular/data/datagrid/render/body-renderer.spec.ts
+++ b/src/clarity-angular/data/datagrid/render/body-renderer.spec.ts
@@ -22,7 +22,7 @@ export default function(): void {
         });
 
         it("emits its scrollbar width when notified of a change", function() {
-            const mockDomAdapter: MockDomAdapter = context.getClarityProvider(DomAdapter);
+            const mockDomAdapter = <MockDomAdapter>context.getClarityProvider(DomAdapter);
             const organizer: DatagridRenderOrganizer = context.getClarityProvider(DatagridRenderOrganizer);
             let scrollbarWidth: number;
             organizer.scrollbarWidth.subscribe(width => scrollbarWidth = width);

--- a/src/clarity-angular/data/datagrid/render/cell-renderer.spec.ts
+++ b/src/clarity-angular/data/datagrid/render/cell-renderer.spec.ts
@@ -19,7 +19,7 @@ export default function(): void {
 
         beforeEach(function() {
             context = this.create(DatagridCellRenderer, SimpleTest, [MOCK_ORGANIZER_PROVIDER, HideableColumnService]);
-            organizer = context.getClarityProvider(DatagridRenderOrganizer);
+            organizer = <MockDatagridRenderOrganizer>context.getClarityProvider(DatagridRenderOrganizer);
         });
 
         it("allows to set the width of the cell in pixels", function() {

--- a/src/clarity-angular/data/datagrid/render/head-renderer.spec.ts
+++ b/src/clarity-angular/data/datagrid/render/head-renderer.spec.ts
@@ -18,7 +18,7 @@ export default function(): void {
 
         beforeEach(function() {
             context = this.create(DatagridHeadRenderer, SimpleTest, [MOCK_ORGANIZER_PROVIDER]);
-            organizer = context.getClarityProvider(DatagridRenderOrganizer);
+            organizer = <MockDatagridRenderOrganizer>context.getClarityProvider(DatagridRenderOrganizer);
         });
 
         it("adds right padding corresponding to the scrollbar of the body", function() {

--- a/src/clarity-angular/data/datagrid/render/header-renderer.spec.ts
+++ b/src/clarity-angular/data/datagrid/render/header-renderer.spec.ts
@@ -27,8 +27,8 @@ export default function(): void {
             context = this.create(
                 DatagridHeaderRenderer, SimpleTest,
                 [MOCK_ORGANIZER_PROVIDER, MOCK_DOM_ADAPTER_PROVIDER, Sort, FiltersProvider, Page, StateDebouncer]);
-            domAdapter = context.getClarityProvider(DomAdapter);
-            organizer = context.getClarityProvider(DatagridRenderOrganizer);
+            domAdapter = <MockDomAdapter>context.getClarityProvider(DomAdapter);
+            organizer = <MockDatagridRenderOrganizer>context.getClarityProvider(DatagridRenderOrganizer);
         });
 
         it("computes and sets the width of a column based on its scrollWidth", function() {

--- a/src/clarity-angular/data/datagrid/render/row-master-renderer.spec.ts
+++ b/src/clarity-angular/data/datagrid/render/row-master-renderer.spec.ts
@@ -18,7 +18,7 @@ export default function(): void {
 
         beforeEach(function() {
             context = this.createOnly(DatagridRowMasterRenderer, FullTest, [MOCK_ORGANIZER_PROVIDER], [TestCounter]);
-            organizer = context.getClarityProvider(DatagridRenderOrganizer);
+            organizer = <MockDatagridRenderOrganizer>context.getClarityProvider(DatagridRenderOrganizer);
         });
 
         it("adds the .datagrid-row-master class to the host", function() {

--- a/src/clarity-angular/data/datagrid/render/row-renderer.spec.ts
+++ b/src/clarity-angular/data/datagrid/render/row-renderer.spec.ts
@@ -35,7 +35,7 @@ export default function(): void {
 
         beforeEach(function() {
             context = this.create(DatagridRowRenderer, SimpleTest, PROVIDERS);
-            organizer = context.getClarityProvider(DatagridRenderOrganizer);
+            organizer = <MockDatagridRenderOrganizer>context.getClarityProvider(DatagridRenderOrganizer);
             organizer.widths = [{px: 42, strict: false}, {px: 24, strict: true}];
             cellWidthSpy = spyOn(DatagridCellRenderer.prototype, "setWidth");
         });

--- a/src/clarity-angular/data/datagrid/render/table-renderer.spec.ts
+++ b/src/clarity-angular/data/datagrid/render/table-renderer.spec.ts
@@ -18,7 +18,7 @@ export default function(): void {
 
         beforeEach(function() {
             context = this.create(DatagridTableRenderer, SimpleTest, [MOCK_ORGANIZER_PROVIDER]);
-            organizer = context.getClarityProvider(DatagridRenderOrganizer);
+            organizer = <MockDatagridRenderOrganizer>context.getClarityProvider(DatagridRenderOrganizer);
         });
 
         it("toggles in and out of table mode when notified", function() {

--- a/src/clarity-angular/layout/tabs/chocolate/active-oompa-loompa.ts
+++ b/src/clarity-angular/layout/tabs/chocolate/active-oompa-loompa.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {ChangeDetectorRef, Directive, Inject} from "@angular/core";
+
+import {OompaLoompa} from "../../../utils/chocolate/oompa-loompa";
+import {IF_ACTIVE_ID, IfActiveService} from "../../../utils/conditional/if-active.service";
+
+import {TabsWillyWonka} from "./tabs-willy-wonka";
+
+@Directive({selector: "[clrTabLink], clr-tab-content"})
+export class ActiveOompaLoompa extends OompaLoompa {
+    constructor(cdr: ChangeDetectorRef, willyWonka: TabsWillyWonka, @Inject(IF_ACTIVE_ID) private id: number,
+                private ifActive: IfActiveService) {
+        super(cdr, willyWonka);
+    }
+
+    get flavor() {
+        return this.ifActive.current === this.id;
+    }
+}

--- a/src/clarity-angular/layout/tabs/chocolate/tabs-willy-wonka.ts
+++ b/src/clarity-angular/layout/tabs/chocolate/tabs-willy-wonka.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Directive} from "@angular/core";
+import {WillyWonka} from "../../../utils/chocolate/willy-wonka";
+
+@Directive({selector: "clr-tabs"})
+export class TabsWillyWonka extends WillyWonka {}

--- a/src/clarity-angular/layout/tabs/index.ts
+++ b/src/clarity-angular/layout/tabs/index.ts
@@ -5,6 +5,8 @@
  */
 import {Type} from "@angular/core";
 
+import {ActiveOompaLoompa} from "./chocolate/active-oompa-loompa";
+import {TabsWillyWonka} from "./chocolate/tabs-willy-wonka";
 import {Tab} from "./tab";
 import {TabContent} from "./tab-content";
 import {TabLinkDirective} from "./tab-link.directive";
@@ -17,4 +19,5 @@ export * from "./tab-content";
 export * from "./tab-overflow-content";
 export * from "./tab-link.directive";
 
-export const TABS_DIRECTIVES: Type<any>[] = [TabContent, Tab, Tabs, TabOverflowContent, TabLinkDirective];
+export const TABS_DIRECTIVES: Type<any>[] =
+    [TabContent, Tab, Tabs, TabOverflowContent, TabLinkDirective, TabsWillyWonka, ActiveOompaLoompa];

--- a/src/clarity-angular/layout/tabs/tab-content.spec.ts
+++ b/src/clarity-angular/layout/tabs/tab-content.spec.ts
@@ -10,7 +10,6 @@ import {IF_ACTIVE_ID_PROVIDER, IfActiveService} from "../../utils/conditional/if
 
 import {AriaService} from "./aria-service";
 import {TabContent} from "./tab-content";
-import {ClrTabsModule} from "./tabs.module";
 
 @Component({
     template: `
@@ -27,8 +26,7 @@ describe("TabContent", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ClrTabsModule],
-            declarations: [TestComponent],
+            declarations: [TestComponent, TabContent],
             providers: [AriaService, IfActiveService, IF_ACTIVE_ID_PROVIDER]
         });
         fixture = TestBed.createComponent(TestComponent);

--- a/src/clarity-angular/layout/tabs/tab-content.ts
+++ b/src/clarity-angular/layout/tabs/tab-content.ts
@@ -3,11 +3,8 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import {Component, ElementRef, Inject, Input, OnDestroy, Renderer2, TemplateRef, ViewChild} from "@angular/core";
-import {Subscription} from "rxjs/Subscription";
-
+import {Component, Inject, Input, TemplateRef, ViewChild} from "@angular/core";
 import {IF_ACTIVE_ID, IfActiveService} from "../../utils/conditional/if-active.service";
-
 import {AriaService} from "./aria-service";
 
 let nbTabContentComponents: number = 0;
@@ -17,27 +14,22 @@ let nbTabContentComponents: number = 0;
     template: `
         <ng-content></ng-content>
     `,
-    host: {"role": "tabpanel"}
+    host: {
+        "[id]": "tabContentId",
+        "[attr.aria-labelledby]": "ariaLabelledBy",
+        "[attr.aria-hidden]": "!active",
+        "[attr.data-hidden]": "!active",
+        "role": "tabpanel"
+    }
 })
-export class TabContent implements OnDestroy {
+export class TabContent {
     @ViewChild("tabContentProjectedRef") templateRef: TemplateRef<TabContent>;
 
     constructor(public ifActiveService: IfActiveService, @Inject(IF_ACTIVE_ID) public id: number,
-                private ariaService: AriaService, private renderer: Renderer2, private el: ElementRef) {
+                private ariaService: AriaService) {
         if (!this.tabContentId) {
             this.tabContentId = "clr-tab-content-" + (nbTabContentComponents++);
         }
-
-        this.setAttributes();
-        this.subscriptions.push(this.ifActiveService.currentChange.subscribe(() => {
-            this.setAttributes();
-        }));
-    }
-
-    private subscriptions: Subscription[] = [];
-
-    ngOnDestroy() {
-        this.subscriptions.forEach((sub: Subscription) => sub.unsubscribe());
     }
 
     get ariaLabelledBy(): string {
@@ -55,12 +47,5 @@ export class TabContent implements OnDestroy {
 
     get active() {
         return this.ifActiveService.current === this.id;
-    }
-
-    setAttributes() {
-        this.renderer.setAttribute(this.el.nativeElement, "id", this.tabContentId);
-        this.renderer.setAttribute(this.el.nativeElement, "aria-labelledby", this.ariaLabelledBy);
-        this.renderer.setAttribute(this.el.nativeElement, "aria-hidden", `${!this.active}`);
-        this.renderer.setAttribute(this.el.nativeElement, "data-hidden", `${!this.active}`);
     }
 }

--- a/src/clarity-angular/layout/tabs/tab-link.directive.spec.ts
+++ b/src/clarity-angular/layout/tabs/tab-link.directive.spec.ts
@@ -8,6 +8,7 @@ import {ComponentFixture, TestBed} from "@angular/core/testing";
 
 import {IfActiveService} from "../../utils/conditional/if-active.service";
 
+import {TabsWillyWonka} from "./chocolate/tabs-willy-wonka";
 import {TabLinkDirective} from "./tab-link.directive";
 import {TabsService} from "./tabs-service";
 import {ClrTabsModule} from "./tabs.module";
@@ -32,8 +33,11 @@ describe("TabLink Directive", () => {
     let instance: any;
 
     beforeEach(() => {
-        TestBed.configureTestingModule(
-            {imports: [ClrTabsModule], declarations: [TestComponent], providers: [IfActiveService, TabsService]});
+        TestBed.configureTestingModule({
+            imports: [ClrTabsModule],
+            declarations: [TestComponent],
+            providers: [IfActiveService, TabsService, TabsWillyWonka]
+        });
 
         fixture = TestBed.createComponent(TestComponent);
         fixture.detectChanges();
@@ -48,7 +52,7 @@ describe("TabLink Directive", () => {
 
     it("sets itself as active when clicked", () => {
         const links: TabLinkDirective[] = instance.tabLinkChildren.toArray();
-        expect(links[0].active).toEqual(true);
+        expect(links[0].active).toEqual(false);
         expect(links[1].active).toEqual(false);
 
         const tabLinks: HTMLElement[] = compiled.querySelectorAll("button");

--- a/src/clarity-angular/layout/tabs/tab-link.directive.spec.ts
+++ b/src/clarity-angular/layout/tabs/tab-link.directive.spec.ts
@@ -48,6 +48,9 @@ describe("TabLink Directive", () => {
 
     it("sets itself as active when clicked", () => {
         const links: TabLinkDirective[] = instance.tabLinkChildren.toArray();
+        expect(links[0].active).toEqual(true);
+        expect(links[1].active).toEqual(false);
+
         const tabLinks: HTMLElement[] = compiled.querySelectorAll("button");
         tabLinks[1].click();
         fixture.detectChanges();

--- a/src/clarity-angular/layout/tabs/tab-link.directive.ts
+++ b/src/clarity-angular/layout/tabs/tab-link.directive.ts
@@ -10,14 +10,10 @@ import {
     HostListener,
     Inject,
     Input,
-    Renderer2,
     ViewContainerRef
 } from "@angular/core";
-import {Subscription} from "rxjs/Subscription";
-
 import {IF_ACTIVE_ID, IfActiveService} from "../../utils/conditional/if-active.service";
 import {TemplateRefContainer} from "../../utils/template-ref/template-ref-container";
-
 import {AriaService} from "./aria-service";
 
 let nbTabLinkComponents: number = 0;
@@ -25,11 +21,15 @@ let nbTabLinkComponents: number = 0;
 @Directive({
     selector: "[clrTabLink]",
     host: {
+        "[id]": "tabLinkId",
+        "[attr.aria-selected]": "active",
+        "[attr.aria-controls]": "ariaControls",
         "role": "presentation",
         "[class.btn]": "true",
         "[class.btn-link]": "!inOverflow",
         "[class.nav-link]": "!inOverflow",
-        "[class.nav-item]": "!inOverflow"
+        "[class.nav-item]": "!inOverflow",
+        "[class.active]": "active"
     }
 })
 export class TabLinkDirective {
@@ -38,7 +38,7 @@ export class TabLinkDirective {
 
     constructor(public ifActiveService: IfActiveService, @Inject(IF_ACTIVE_ID) private id: number,
                 private ariaService: AriaService, private el: ElementRef, private cfr: ComponentFactoryResolver,
-                private viewContainerRef: ViewContainerRef, private renderer: Renderer2) {
+                private viewContainerRef: ViewContainerRef) {
         if (!this.tabLinkId) {
             this.tabLinkId = "clr-tab-link-" + (nbTabLinkComponents++);
         }
@@ -49,12 +49,14 @@ export class TabLinkDirective {
         const factory = this.cfr.resolveComponentFactory(TemplateRefContainer);
         this.templateRefContainer =
             this.viewContainerRef.createComponent(factory, 1, undefined, [[this.el.nativeElement]]).instance;
-    }
 
-    private subscriptions: Subscription[] = [];
-
-    ngOnDestroy() {
-        this.subscriptions.forEach((sub: Subscription) => sub.unsubscribe());
+        // if there's no active tab, set the one associated with this link as active
+        // it will be overridden if a tab created after this one sets it explicitly
+        // TODO: when we have another component using IfActiveService, the same logic might be
+        // needed. If this is a recurring pattern, let's consider moving this logic to IfActiveService.
+        if (!this.ifActiveService.current) {
+            this.ifActiveService.current = id;
+        }
     }
 
     get ariaControls(): string {
@@ -77,35 +79,5 @@ export class TabLinkDirective {
 
     get active() {
         return this.ifActiveService.current === this.id;
-    }
-
-    setAttributes() {
-        this.renderer.setAttribute(this.el.nativeElement, "id", this.tabLinkId);
-        this.renderer.setAttribute(this.el.nativeElement, "aria-selected", `${this.active}`);
-        // this.ariaService.ariaControls gets assigned in TabContent, which runs after tab-link.directive.ts
-        // so if it has no assigned value, don't set the attribute yet.
-        if (this.ariaControls) {
-            this.renderer.setAttribute(this.el.nativeElement, "aria-controls", this.ariaControls);
-        }
-    }
-
-    setActiveClass() {
-        if (this.active) {
-            this.renderer.addClass(this.el.nativeElement, "active");
-        } else {
-            this.renderer.removeClass(this.el.nativeElement, "active");
-        }
-    }
-
-    ngAfterViewInit() {
-        // The attributes need to be set after view is initialized. If they were set in the constructor,
-        // when the fist tab activation happens, this.active and this.ariaControls wouldn't be assigned yet.
-        this.setAttributes();
-        this.setActiveClass();
-
-        this.subscriptions.push(this.ifActiveService.currentChange.subscribe(() => {
-            this.setAttributes();
-            this.setActiveClass();
-        }));
     }
 }

--- a/src/clarity-angular/layout/tabs/tab-link.directive.ts
+++ b/src/clarity-angular/layout/tabs/tab-link.directive.ts
@@ -49,14 +49,6 @@ export class TabLinkDirective {
         const factory = this.cfr.resolveComponentFactory(TemplateRefContainer);
         this.templateRefContainer =
             this.viewContainerRef.createComponent(factory, 1, undefined, [[this.el.nativeElement]]).instance;
-
-        // if there's no active tab, set the one associated with this link as active
-        // it will be overridden if a tab created after this one sets it explicitly
-        // TODO: when we have another component using IfActiveService, the same logic might be
-        // needed. If this is a recurring pattern, let's consider moving this logic to IfActiveService.
-        if (!this.ifActiveService.current) {
-            this.ifActiveService.current = id;
-        }
     }
 
     get ariaControls(): string {

--- a/src/clarity-angular/layout/tabs/tab.spec.ts
+++ b/src/clarity-angular/layout/tabs/tab.spec.ts
@@ -8,6 +8,7 @@ import {ComponentFixture, TestBed} from "@angular/core/testing";
 
 import {IfActiveService} from "../../utils/conditional/if-active.service";
 
+import {TabsWillyWonka} from "./chocolate/tabs-willy-wonka";
 import {Tab} from "./tab";
 import {TabsService} from "./tabs-service";
 import {ClrTabsModule} from "./tabs.module";
@@ -30,8 +31,11 @@ describe("Tab", () => {
     let instance: any;
 
     beforeEach(() => {
-        TestBed.configureTestingModule(
-            {imports: [ClrTabsModule], declarations: [TestComponent], providers: [IfActiveService, TabsService]});
+        TestBed.configureTestingModule({
+            imports: [ClrTabsModule],
+            declarations: [TestComponent],
+            providers: [IfActiveService, TabsService, TabsWillyWonka]
+        });
         fixture = TestBed.createComponent(TestComponent);
         fixture.detectChanges();
         compiled = fixture.nativeElement;

--- a/src/clarity-angular/layout/tabs/tabs.spec.ts
+++ b/src/clarity-angular/layout/tabs/tabs.spec.ts
@@ -3,11 +3,12 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import {Component, ViewChild} from "@angular/core";
+import {Component, Type, ViewChild} from "@angular/core";
 import {ComponentFixture, TestBed} from "@angular/core/testing";
 
-import {IfActiveService} from "../../utils/conditional/if-active.service";
+import {addHelpers, TestContext} from "../../data/datagrid/helpers.spec";
 
+import {Tab} from "./tab";
 import {Tabs} from "./tabs";
 import {TabsService} from "./tabs-service";
 import {ClrTabsModule} from "./tabs.module";
@@ -15,7 +16,7 @@ import {ClrTabsModule} from "./tabs.module";
 @Component({
     template: `
     <clr-tabs>
-        <clr-tab>
+        <clr-tab #first>
             <button clrTabLink>Tab1</button>
             <clr-tab-content *clrIfActive>
                 <p>Content1</p>
@@ -47,53 +48,109 @@ import {ClrTabsModule} from "./tabs.module";
 })
 class TestComponent {
     @ViewChild(Tabs) tabsInstance: Tabs;
+    @ViewChild("first") firstTab: Tab;
     inOverflow: boolean = false;
 }
 
+@Component({
+    template: `
+    <clr-tabs>
+        <clr-tab *ngIf="true" #first>
+            <button clrTabLink>Tab1</button>
+            <clr-tab-content *clrIfActive>Content1</clr-tab-content>
+        </clr-tab>
+        <clr-tab>
+            <button clrTabLink>Tab2</button>
+            <clr-tab-content *clrIfActive>Content2</clr-tab-content>
+        </clr-tab>
+    </clr-tabs>
+   `
+})
+class NgIfFirstTest {
+    @ViewChild("first") firstTab: Tab;
+}
+
+@Component({
+    template: `
+    <clr-tabs>
+        <clr-tab #first>
+            <button clrTabLink>Tab1</button>
+            <clr-tab-content *clrIfActive>Content1</clr-tab-content>
+        </clr-tab>
+        <clr-tab *ngIf="true">
+            <button clrTabLink>Tab2</button>
+            <clr-tab-content *clrIfActive>Content2</clr-tab-content>
+        </clr-tab>
+    </clr-tabs>
+   `
+})
+class NgIfSecondTest {
+    @ViewChild("first") firstTab: Tab;
+}
+
 describe("Tabs", () => {
-    let fixture: ComponentFixture<any>;
-    let instance: any;
-    let compiled: any;
+    describe("Projection", () => {
+        let fixture: ComponentFixture<any>;
+        let instance: any;
+        let compiled: any;
 
-    beforeEach(() => {
-        TestBed.configureTestingModule(
-            {imports: [ClrTabsModule], declarations: [TestComponent], providers: [Tabs, IfActiveService, TabsService]});
+        beforeEach(() => {
+            TestBed.configureTestingModule({imports: [ClrTabsModule], declarations: [TestComponent]});
 
-        fixture = TestBed.createComponent(TestComponent);
-        fixture.detectChanges();
-        instance = fixture.componentInstance.tabsInstance;
-        compiled = fixture.nativeElement;
+            fixture = TestBed.createComponent(TestComponent);
+            fixture.detectChanges();
+            instance = fixture.componentInstance.tabsInstance;
+            compiled = fixture.nativeElement;
+        });
+
+        afterEach(() => {
+            fixture.destroy();
+        });
+
+        it("projects all the links and just the active content", () => {
+            expect(compiled.querySelectorAll("button.nav-link").length).toEqual(4);
+            expect(compiled.querySelectorAll("p").length).toEqual(1);
+
+            const content: HTMLElement = compiled.querySelector("p");
+            expect(content.textContent.trim()).toMatch("Content1");
+        });
+
+        it("projects correctly when there's one or more overflow tabs", () => {
+            expect(compiled.querySelector(".tabs-overflow")).toBeNull();
+            expect(compiled.querySelector(".tab4")).toBeDefined();
+            expect(compiled.querySelector(".tabs-overflow .tab4")).toBeNull();
+
+            fixture.componentInstance.inOverflow = true;
+            fixture.detectChanges();
+            expect(compiled.querySelector(".tabs-overflow")).toBeDefined();
+
+            const toggle: HTMLElement = compiled.querySelector(".dropdown-toggle");
+            toggle.click();
+            fixture.detectChanges();
+            expect(compiled.querySelector(".tabs-overflow .tab4")).toBeDefined();
+
+        });
     });
 
-    afterEach(() => {
-        fixture.destroy();
-    });
+    describe("Default tab", function() {
+        addHelpers();
 
-    it("projects all the links and just the active content", () => {
-        expect(compiled.querySelectorAll("button.nav-link").length).toEqual(4);
-        expect(compiled.querySelectorAll("p").length).toEqual(1);
+        function expectFirstTabActive<T extends TestComponent|NgIfFirstTest|NgIfSecondTest>(testType: Type<T>) {
+            const context: TestContext<Tabs, T> = this.create(Tabs, testType);
+            const tabsService = context.getClarityProvider(TabsService);
+            expect(tabsService.activeTab).toEqual(context.testComponent.firstTab);
+        }
 
-        const content: HTMLElement = compiled.querySelector("p");
-        expect(content.textContent.trim()).toMatch("Content1");
-    });
+        it("sets the first tab as active by default", function() {
+            expectFirstTabActive.call(this, TestComponent);
+        });
 
-    it("sets the first tab as active by default", () => {
-        expect(instance.tabsService.activeTab).toEqual(instance.tabsService.children[0]);
-    });
+        it("doesn't ignore tabs with *ngIf", function() {
+            expectFirstTabActive.call(this, NgIfFirstTest);
+        });
 
-    it("projects correctly when there's one or more overflow tabs", () => {
-        expect(compiled.querySelector(".tabs-overflow")).toBeNull();
-        expect(compiled.querySelector(".tab4")).toBeDefined();
-        expect(compiled.querySelector(".tabs-overflow .tab4")).toBeNull();
-
-        fixture.componentInstance.inOverflow = true;
-        fixture.detectChanges();
-        expect(compiled.querySelector(".tabs-overflow")).toBeDefined();
-
-        const toggle: HTMLElement = compiled.querySelector(".dropdown-toggle");
-        toggle.click();
-        fixture.detectChanges();
-        expect(compiled.querySelector(".tabs-overflow .tab4")).toBeDefined();
-
+        it("doesn't prioritize tabs with *ngIf", function() {
+            expectFirstTabActive.call(this, NgIfSecondTest);
+        });
     });
 });

--- a/src/clarity-angular/layout/tabs/tabs.spec.ts
+++ b/src/clarity-angular/layout/tabs/tabs.spec.ts
@@ -8,7 +8,6 @@ import {ComponentFixture, TestBed} from "@angular/core/testing";
 
 import {IfActiveService} from "../../utils/conditional/if-active.service";
 
-import {TabLinkDirective} from "./tab-link.directive";
 import {Tabs} from "./tabs";
 import {TabsService} from "./tabs-service";
 import {ClrTabsModule} from "./tabs.module";
@@ -16,7 +15,7 @@ import {ClrTabsModule} from "./tabs.module";
 @Component({
     template: `
     <clr-tabs>
-        <clr-tab *ngIf="true">
+        <clr-tab>
             <button clrTabLink>Tab1</button>
             <clr-tab-content *clrIfActive>
                 <p>Content1</p>
@@ -25,7 +24,7 @@ import {ClrTabsModule} from "./tabs.module";
 
         <clr-tab>
             <button clrTabLink>Tab2</button>
-            <clr-tab-content *clrIfActive="isSecondTabActive">
+            <clr-tab-content *clrIfActive>
                 <p>Content2</p>
             </clr-tab-content>
         </clr-tab>
@@ -39,7 +38,7 @@ import {ClrTabsModule} from "./tabs.module";
 
         <clr-tab>
             <button clrTabLink [clrTabLinkInOverflow]="inOverflow" class="tab4">Tab4</button>
-            <clr-tab-content *clrIfActive="isFourthTabActive">
+            <clr-tab-content *clrIfActive>
                 <p class="content-overflow">Content4</p>
             </clr-tab-content>
         </clr-tab>
@@ -49,8 +48,6 @@ import {ClrTabsModule} from "./tabs.module";
 class TestComponent {
     @ViewChild(Tabs) tabsInstance: Tabs;
     inOverflow: boolean = false;
-    isSecondTabActive: boolean = false;
-    isFourthTabActive: boolean = false;
 }
 
 describe("Tabs", () => {
@@ -63,10 +60,9 @@ describe("Tabs", () => {
             {imports: [ClrTabsModule], declarations: [TestComponent], providers: [Tabs, IfActiveService, TabsService]});
 
         fixture = TestBed.createComponent(TestComponent);
-
+        fixture.detectChanges();
         instance = fixture.componentInstance.tabsInstance;
         compiled = fixture.nativeElement;
-        fixture.detectChanges();
     });
 
     afterEach(() => {
@@ -74,55 +70,15 @@ describe("Tabs", () => {
     });
 
     it("projects all the links and just the active content", () => {
-        expect(compiled.querySelectorAll("button.nav-link.nav-item.btn-link").length).toEqual(4);
+        expect(compiled.querySelectorAll("button.nav-link").length).toEqual(4);
         expect(compiled.querySelectorAll("p").length).toEqual(1);
-        expect(compiled.querySelectorAll("button.active").length).toEqual(1);
-        const activeTabNativeEl: HTMLElement = instance.tabLinkDirectives.first.el.nativeElement;
-        expect(compiled.querySelector("button.active")).toEqual(activeTabNativeEl);
 
-        expect(instance.tabsService.activeTab.tabLink).toEqual(instance.tabLinkDirectives.first);
         const content: HTMLElement = compiled.querySelector("p");
         expect(content.textContent.trim()).toMatch("Content1");
     });
 
-
-    it("sets the second tab as active at the beginning", () => {
-        fixture.componentInstance.isSecondTabActive = true;
-        fixture.detectChanges();
-        const activeTablinkDirective = instance.tabLinkDirectives.find((tabLink: TabLinkDirective) => {
-            if (tabLink.active) {
-                return tabLink;
-            }
-        });
-        expect(compiled.querySelectorAll("button.nav-link.nav-item.btn-link").length).toEqual(4);
-        expect(compiled.querySelectorAll("button.active").length).toEqual(1);
-        const activeTabNativeEl: HTMLElement = activeTablinkDirective.el.nativeElement;
-        expect(compiled.querySelector("button.active")).toEqual(activeTabNativeEl);
-        expect(compiled.querySelectorAll("p").length).toEqual(1);
-
-        expect(instance.tabsService.activeTab.tabLink).toEqual(activeTablinkDirective);
-        const content: HTMLElement = compiled.querySelector("p");
-        expect(content.textContent.trim()).toMatch("Content2");
-    });
-
-    it("sets the overflow tab as active at the beginning", () => {
-        fixture.componentInstance.isFourthTabActive = true;
-        fixture.componentInstance.inOverflow = true;
-        fixture.detectChanges();
-        const activeTablinkDirective = instance.tabLinkDirectives.find((tabLink: TabLinkDirective) => {
-            if (tabLink.active) {
-                return tabLink;
-            }
-        });
-        expect(compiled.querySelector(".tabs-overflow")).toBeDefined();
-        expect(compiled.querySelectorAll("button.nav-link.nav-item.btn-link").length).toEqual(3);
-        expect(compiled.querySelectorAll("button.active").length)
-            .toEqual(2, `both .dropdown-toggle and the active overflow tab should have 'active' class.`);
-        expect(compiled.querySelectorAll("p").length).toEqual(1);
-
-        expect(instance.tabsService.activeTab.tabLink).toEqual(activeTablinkDirective);
-        const content: HTMLElement = compiled.querySelector("p");
-        expect(content.textContent.trim()).toMatch("Content4");
+    it("sets the first tab as active by default", () => {
+        expect(instance.tabsService.activeTab).toEqual(instance.tabsService.children[0]);
     });
 
     it("projects correctly when there's one or more overflow tabs", () => {

--- a/src/clarity-angular/layout/tabs/tabs.ts
+++ b/src/clarity-angular/layout/tabs/tabs.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import {AfterContentInit, Component, ContentChildren, QueryList} from "@angular/core";
+import {Component, ContentChildren, QueryList} from "@angular/core";
 
 import {IfActiveService} from "../../utils/conditional/if-active.service";
 import {IfOpenService} from "../../utils/conditional/if-open.service";
@@ -45,7 +45,7 @@ import {TabsService} from "./tabs-service";
     `,
     providers: [IfActiveService, IfOpenService, TabsService]
 })
-export class Tabs implements AfterContentInit {
+export class Tabs {
     @ContentChildren(TabLinkDirective, {descendants: true}) tabLinkDirectives: QueryList<TabLinkDirective>;
 
     constructor(public ifActiveService: IfActiveService, public ifOpenService: IfOpenService,
@@ -57,16 +57,5 @@ export class Tabs implements AfterContentInit {
 
     toggleOverflow(event: any) {
         this.ifOpenService.toggleWithEvent(event);
-    }
-
-    ngAfterContentInit() {
-        // if there's no active tab, set the one associated with this link as active
-        // it will be overridden if a tab created after this one sets it explicitly
-        // TODO: when we have another component using IfActiveService, the same logic might be
-        // needed. If this is a recurring pattern, let's consider moving this logic to IfActiveService.
-
-        if (!this.ifActiveService.current && !this.tabLinkDirectives.first.active) {
-            this.tabLinkDirectives.first.activate();
-        }
     }
 }

--- a/src/clarity-angular/layout/tabs/tabs.ts
+++ b/src/clarity-angular/layout/tabs/tabs.ts
@@ -55,6 +55,12 @@ export class Tabs {
         return this.tabsService.overflowTabs.indexOf(this.tabsService.activeTab) > -1;
     }
 
+    ngAfterContentInit() {
+        if (typeof this.ifActiveService.current === "undefined") {
+            this.tabLinkDirectives.first.activate();
+        }
+    }
+
     toggleOverflow(event: any) {
         this.ifOpenService.toggleWithEvent(event);
     }


### PR DESCRIPTION
#1514 introduced chocolate errors in tabs. So I reverted it and rewrote a new fix for #1318.

As now standard with chocolate errors, we let Willy Wonka and the Oompa Loompas handle it. The actual fix is 10 lines long, but I wanted to add unit tests for it and got sucked in when trying to improve the helpers slightly. So there is a bunch on non-related tests cleanups, all revolving around stronger, safer typing.