### PR TITLE
CORE Add clarity-icons/clarity-icons-api.js back to build

### DIFF
--- a/webpack.icons.config.js
+++ b/webpack.icons.config.js
@@ -6,6 +6,7 @@ module.exports = {
         "index": "./src/clarity-icons/index.ts",
         "interfaces/icon-alias": "./src/clarity-icons/interfaces/icon-alias.ts",
         "interfaces/icon-template": "./src/clarity-icons/interfaces/icon-template.ts",
+        "clarity-icons-api": "./src/clarity-icons/clarity-icons-api.ts",
         "clarity-icons-lite.min": "./src/clarity-icons/index.ts",
         "clarity-icons.min": "./src/clarity-icons/clarity-icons-sfx.ts",
         "shapes/all-shapes": "./src/clarity-icons/shapes/all-shapes.ts",


### PR DESCRIPTION
3d00bd443b9100fcce1af6f3e95aa1a2218f9202 replaced the old build with webpack and removed clarity-icons/clarity-icons-api.js from the build output.
There is no production need for this file, but it can be used to setup a non-browser unit test environment in node.

Issue #1553

Signed-off-by: Marque Davis <mdavis777@gmail.com>