### PR TITLE
[Docs] Fix escaped code tag

### DIFF
--- a/src/app/documentation/demos/tables/tables.demo.html
+++ b/src/app/documentation/demos/tables/tables.demo.html
@@ -46,7 +46,7 @@
 
         <h3 id="compact-tables">Compact Tables</h3>
 
-        <p>Table row heights can be reduced with the &lt;codeclass=”clr-code”&gt;.table-compact&lt;/code&gt;
+        <p>Table row heights can be reduced with the <code class="clr-code">.table-compact</code>
             classname.</p>
 
         <clr-tables-compact-demo></clr-tables-compact-demo>


### PR DESCRIPTION
[Docs] Fix escaped code tag

A `<code>` tag was escaped in the documentation for Compact Tables.

Signed-off-by: Alex Mellnik <a.r.mellnik@gmail.com>