### PR TITLE
[CORE] Mention location of docs in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,10 @@ These documents provide guidance creating a well-crafted commit message:
  * [How to Write a Git Commit Message](http://chris.beams.io/posts/git-commit/)
  * [Closing Issues Via Commit Messages](https://help.github.com/articles/closing-issues-via-commit-messages/)
 
+#### Contributing to Documentation
+
+The [Clarity documentation website](https://vmware.github.io/clarity/documentation) is also housed in this repository under the `new-website` branch.  You can contribute to the documentation by submitting pull requests against that branch.
+
 ## Reporting Bugs and Creating Issues
 
 You can submit an issue or a bug to our [GitHub repository](https://github.com/vmware/clarity/issues).  You must provide:


### PR DESCRIPTION
[CORE] Mention location of documentation website in CONTRIBUTING.md

The documentation for clarity is provided by the https://vmware.github.io/clarity/documentation/ website.  This is stored in this repository under the `new-website` branch, which is not indexed by github, so searching for text snippets from the documentation will not return any results.  This adds a brief mention to `CONTRIGBUTING.md` which tells people where to look for the documentation if they need to propose changes. 

Signed-off-by: Alex Mellnik <a.r.mellnik@gmail.com>