### PR TITLE
Adds focus method detection to FocusTrap

### DIFF
--- a/src/clarity-angular/utils/focus-trap/focus-trap.directive.ts
+++ b/src/clarity-angular/utils/focus-trap/focus-trap.directive.ts
@@ -33,7 +33,9 @@ export class FocusTrapDirective implements AfterViewInit, OnDestroy {
     }
 
     public setPreviousFocus(): void {
-        this._previousActiveElement.focus();
+        if (this._previousActiveElement && this._previousActiveElement.focus) {
+            this._previousActiveElement.focus();
+        }
     }
 
     ngOnDestroy() {


### PR DESCRIPTION
## Guard code for FocusTrap.setPreviousFocus
- Addresses use cases for IE11 where the `FocusTrap._previousActiveElement` may not have the focus method
- Closes #1587

Signed-off-by: Matt Hippely <mhippely@vmware.com>