### PR TITLE
[WEB] Update website with rem unit info

### DIFF
--- a/src/app/documentation/demos/app-layout/app-layout.demo.html
+++ b/src/app/documentation/demos/app-layout/app-layout.demo.html
@@ -182,9 +182,28 @@
         <p><img src="assets/images/documentation/app-layout/24_baseline.png?1481674789140619000" alt="24px Baseline" /></p>
 
         <h6 id="repeat-24px-in-your-layout">Repeat 24px in Your Layout</h6>
+        <p>
+            Calculate the vertical margins and padding between elements using the Clarity baseline.
+            A multiple of 24px can be a whole or half-ratio. Common numbers include: 6px, 12px, 18px,
+            24px, 30px, 36px, 42px, 48px, 54px, 60px, 66px, 72px.
+        </p>
 
-        <p>Calculate the vertical margins and padding between elements using the Clarity baseline. A multiple of 24px can be a whole or half-ratio. Common numbers include:</p>
 
-        <p>6 px, 12px, 18px, 24px, 30px, 36px, 42px, 48px, 54px, 60px, 66px, 72px</p>
+        <h6 id="rem-units">Changing vertical rhythm with rem</h6>
+        <p>
+            Clarity uses <a href="https://developer.mozilla.org/en-US/docs/Learn/CSS/Introduction_to_CSS/Values_and_units" target="_blank">rem units</a> for its whitespace and sizing. If the 24px vertical baseline
+            is too large or too small for your needs, you can edit this globally across a Clarity application
+            by changing the <code class="clr-code">font-size</code> style of the <code class="clr-code">html</code>
+            element, as in the example below.
+        </p>
+
+        <clr-code-snippet [clrCode]="htmlExample"></clr-code-snippet>
+
+        <p>
+            Note that the declaration on the <code class="clr-code">html</code> selector needs to happen 
+            <em>after</em> the Clarity CSS has been loaded. Also note that the "grid" for Clarity layouts and
+            components is equal to one-fourth of the baseline. So instead of a 6px grid, the example above will
+            put your application on a 5px grid.
+        </p>
     </article>
 </clr-doc-wrapper>

--- a/src/app/documentation/demos/app-layout/app-layout.demo.ts
+++ b/src/app/documentation/demos/app-layout/app-layout.demo.ts
@@ -6,6 +6,13 @@
 import {Component} from "@angular/core";
 import {ClarityDocComponent} from "../clarity-doc";
 
+const HTML_EXAMPLE = `
+html {
+    /* the following line of CSS would change Clarity to a 20px vertical rhythm with a 5px grid */
+    font-size: 20px;
+}
+`;
+
 @Component({
     selector: "clr-app-layout-demo",
     templateUrl: "./app-layout.demo.html",
@@ -18,4 +25,6 @@ export class AppLayoutDemo extends ClarityDocComponent {
     constructor() {
         super("app-layout");
     }
+
+    htmlExample = HTML_EXAMPLE;
 }

--- a/src/app/documentation/demos/color/color-palette.ts
+++ b/src/app/documentation/demos/color/color-palette.ts
@@ -219,11 +219,11 @@ export class ColorPalette {
         {
             type: "Neutral-grey",
             colors: [
-                {value: "#747474", text: "light", primary: true},
+                {value: "#737373", text: "light", primary: true},
                 {value: "#313131", text: "light"},
                 {value: "#444444", text: "light"},
                 {value: "#565656", text: "light", bulleted: true},
-                {value: "#747474", text: "light"},
+                {value: "#737373", text: "light"},
                 {value: "#9A9A9A", text: "dark"},
                 {value: "#CCCCCC", text: "dark"},
                 {value: "#DDDDDD", text: "dark"},


### PR DESCRIPTION
• updated color palette with #737373
• #747474 was incorrectly indicated as being accessible vs. #fafafa; it is not
• updated app-layout dox with info about rem units and using them to update layout

Tested in:
✔︎ Chrome

<img width="1434" alt="screen shot 2017-10-17 at 11 23 47 am" src="https://user-images.githubusercontent.com/2728359/31682178-31bab192-b32e-11e7-898f-537f3a4a448d.png">

<img width="1433" alt="screen shot 2017-10-17 at 11 23 32 am" src="https://user-images.githubusercontent.com/2728359/31682190-3850c6f4-b32e-11e7-8257-af37d3e53544.png">

Signed-off-by: Scott Mathis <smathis@vmware.com>