### PR TITLE
Allowing non-SVG items added to Clarity Icons to be sized

### DIFF
--- a/src/clarity-icons/clarity-icons.scss
+++ b/src/clarity-icons/clarity-icons.scss
@@ -95,10 +95,12 @@ clr-icon {
     .clr-i-badge {
         @include setIconColor($clr-icon-color-danger);
     }
-    &>svg {
+    & > * {
         height: 100%;
         width: 100%;
         display: block;
+    }
+    & > svg {
         transition: inherit;
     }
     .clr-i-solid,


### PR DESCRIPTION
Closes: #1567 

Signed-off-by: Scott Mathis <smathis@vmware.com>