### PR TITLE
[NG] update dependency ng-packagr to ^1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
         "karma-webpack": "^2.0.4",
         "lite-server": "^2.3.0",
         "loader-utils": "^1.1.0",
-        "ng-packagr": "^1.2.0",
+        "ng-packagr": "^1.5.0",
         "npm-run-all": "^4.1.1",
         "optimize-css-assets-webpack-plugin": "^3.2.0",
         "postcss-loader": "^1.3.3",


### PR DESCRIPTION
New flagship feature of ng-packagr are secondary entrypoints
- https://github.com/dherges/ng-packagr#secondary-entry-points
- https://github.com/dherges/ng-packagr/pull/184

Do you plan to follow the [Angular Material style of splitting up the library into sub-packages](https://github.com/angular/material2/blob/master/CHANGELOG.md#breaking-changes-2)?
