### PR TITLE
[NG] Set disabled attribute when clrWizardButtonDisabled is true

### DIFF
--- a/src/clarity-angular/wizard/wizard-button.spec.ts
+++ b/src/clarity-angular/wizard/wizard-button.spec.ts
@@ -1105,6 +1105,17 @@ export default function(): void {
                     expect(actualButton.classList.contains("disabled")).toBe(true);
                 });
 
+                it("disabled buttons should have disabled attribute set", () => {
+                    myTestComponent.disableBtn = true;
+                    fixture.detectChanges();
+                    expect(actualButton.getAttribute("disabled")).toBe("");
+                });
+
+                it("enabled buttons should not have a disabled attribute", () => {
+                    // button inits with disabled false
+                    expect(actualButton.getAttribute("disabled")).toBe(null);
+                });
+
                 it("unknown button types should not be primary", () => {
                     // button inits as empty type
                     expect(actualButton.classList.contains("btn-primary")).toBe(false);

--- a/src/clarity-angular/wizard/wizard-button.ts
+++ b/src/clarity-angular/wizard/wizard-button.ts
@@ -40,6 +40,7 @@ export const CUSTOM_BUTTON_TYPES: any = {
             [class.btn-success]="isFinish"
             [class.btn-danger]="isDanger"
             [class.disabled]="isDisabled"
+            [attr.disabled]="_disabledAttribute"
             (click)="click()">
             <ng-content></ng-content>
         </button>
@@ -91,6 +92,13 @@ export class WizardButton {
 
     public get isPrimaryAction(): boolean {
         return this.isNext || this.isDanger || this.isFinish;
+    }
+
+    public get _disabledAttribute(): string|null {
+        if (this.isDisabled) {
+            return "";
+        }
+        return null;
     }
 
     public get isDisabled(): boolean {


### PR DESCRIPTION
Tested in Chrome, FF, IE11, and Edge.

Fixes: #1551

Signed-off-by: Brian Duncan <bduncan@vmware.com>