### PR TITLE
[NG] set buttons to ready when using the clrWizardOpen binding

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -50,6 +50,9 @@ module.exports = function(karma) {
                 flags: ['--headless', '--disable-gpu', '--remote-debugging-port=9222']
             }
 
+        },
+        mochaReporter: {
+            ignoreSkipped: true
         }
     });
 };

--- a/src/clarity-angular/wizard/wizard.spec.ts
+++ b/src/clarity-angular/wizard/wizard.spec.ts
@@ -44,12 +44,14 @@ export default function(): void {
                 let wizardNavigationService: WizardNavigationService;
                 let pageCollectionService: PageCollectionService;
                 let wizard: Wizard;
+                let component: UnopenedWizardTestComponent;
 
                 beforeEach(function() {
                     context = this.create(Wizard, UnopenedWizardTestComponent);
                     wizardNavigationService = context.getClarityProvider(WizardNavigationService);
                     pageCollectionService = context.getClarityProvider(PageCollectionService);
                     wizard = context.clarityDirective;
+                    component = context.testComponent;
                     context.detectChanges();
                 });
 
@@ -64,6 +66,15 @@ export default function(): void {
                         expect(wizard._open).toBe(false, "hidden wizard._open should be false");
                         wizard.open();
                         expect(wizard._open).toBe(true, "visible wizard._open should be true");
+                    });
+
+                    it("should handle two way binding on clrWizardOpen", () => {
+                        expect(wizard._open).toBe(false, "hidden wizard._open should be false");
+                        expect(component.open).toBe(false, "component binding is set to false");
+                        component.open = true;
+                        context.detectChanges();
+                        expect(wizard._open).toBe(true, "hidden wizard._open should be true");
+                        expect(component.open).toBe(true, "component binding is set to true");
                     });
                 });
 

--- a/src/clarity-angular/wizard/wizard.ts
+++ b/src/clarity-angular/wizard/wizard.ts
@@ -156,7 +156,14 @@ export class Wizard implements OnInit, OnDestroy, AfterContentInit, DoCheck {
      * @type {boolean}
      * @memberof Wizard
      */
-    @Input("clrWizardOpen") _open: boolean = false;
+    public _open: boolean = false;
+    @Input("clrWizardOpen")
+    set clrWizardOpen(open: boolean) {
+        if (open) {
+            this.buttonService.buttonsReady = true;
+        }
+        this._open = open;
+    }
 
     /**
      * Emits when the wizard is opened or closed. Emits through the


### PR DESCRIPTION
The wizard API is used everywhere to verify behavior, and when you use the two way binding directly to toggle the wizard it was not setting the buttons to ready state. This adds a setter for the clrWizardOpen binding.

We didn't have any tests on the clrWizardOpen binding, so added one to guard against it in the future. Also set mocha reporter to ignore skipped.

closes #1615, related to 4610fd46e3dfcc9c4e4766b42da3a399c1216c31.