### PR TITLE
[NG] Flag Popover outside of Host

### DIFF
--- a/src/clarity-angular/popover/dropdown/dropdown-menu.ts
+++ b/src/clarity-angular/popover/dropdown/dropdown-menu.ts
@@ -18,8 +18,11 @@ import {POPOVER_HOST_ANCHOR} from "../common/popover-host-anchor.token";
     }
 })
 export class DropdownMenu extends AbstractPopover {
-    constructor(injector: Injector, @Inject(POPOVER_HOST_ANCHOR) parentHost: ElementRef,
+    constructor(injector: Injector, @Optional() @Inject(POPOVER_HOST_ANCHOR) parentHost: ElementRef,
                 @Optional() @SkipSelf() nested: DropdownMenu) {
+        if (!parentHost) {
+            throw new Error("clr-dropdown-menu should only be used inside of a clr-dropdown");
+        }
         super(injector, parentHost);
         if (!nested) {
             // Default positioning for normal dropdown is bottom-left

--- a/src/clarity-angular/popover/signpost/signpost-content.ts
+++ b/src/clarity-angular/popover/signpost/signpost-content.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import {Component, ElementRef, Inject, Injector, Input, SkipSelf} from "@angular/core";
+import {Component, ElementRef, Inject, Injector, Input, Optional, SkipSelf} from "@angular/core";
 
 import {AbstractPopover} from "../common/abstract-popover";
 import {POPOVER_HOST_ANCHOR} from "../common/popover-host-anchor.token";
@@ -44,7 +44,10 @@ const POSITIONS: string[] = [
     host: {"[class.signpost-content]": "true"}
 })
 export class SignpostContent extends AbstractPopover {
-    constructor(injector: Injector, @Inject(POPOVER_HOST_ANCHOR) parentHost: ElementRef) {
+    constructor(injector: Injector, @Optional() @Inject(POPOVER_HOST_ANCHOR) parentHost: ElementRef) {
+        if (!parentHost) {
+            throw new Error("clr-signpost-content should only be used inside of a clr-signpost");
+        }
         super(injector, parentHost);
         // Defaults
         this.position = "right-middle";

--- a/src/clarity-angular/popover/tooltip/tooltip-content.ts
+++ b/src/clarity-angular/popover/tooltip/tooltip-content.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import {Component, ElementRef, Inject, Injector, Input, SkipSelf} from "@angular/core";
+import {Component, ElementRef, Inject, Injector, Input, Optional, SkipSelf} from "@angular/core";
 import {AbstractPopover} from "../common/abstract-popover";
 import {Point} from "../common/popover";
 import {POPOVER_HOST_ANCHOR} from "../common/popover-host-anchor.token";
@@ -25,7 +25,10 @@ const SIZES: string[] = ["xs", "sm", "md", "lg"];
     }
 })
 export class TooltipContent extends AbstractPopover {
-    constructor(injector: Injector, @Inject(POPOVER_HOST_ANCHOR) parentHost: ElementRef) {
+    constructor(injector: Injector, @Optional() @Inject(POPOVER_HOST_ANCHOR) parentHost: ElementRef) {
+        if (!parentHost) {
+            throw new Error("clr-tooltip-content should only be used inside of a clr-tooltip");
+        }
         super(injector, parentHost);
         // Defaults
         this.position = "right";


### PR DESCRIPTION
Throw error when:
1. `clr-dropdown-menu` is used outside of `clr-dropdown`
2. `clr-signpost-content` is used outside of `clr-signpost`
3. `clr-tooltip-content` is used outside of `clr-tooltip`

![image](https://user-images.githubusercontent.com/1426805/31963120-aee562bc-b8cd-11e7-9b49-9fc1180c7555.png)

Tested on Chrome

Signed-off-by: Aditya Bhandari <adityab@vmware.com>