### PR TITLE
Fix: A modal window takes place when it is in a hidden state #1622

### DIFF
--- a/src/clarity-angular/modal/modal.ts
+++ b/src/clarity-angular/modal/modal.ts
@@ -13,7 +13,8 @@ import {
     OnDestroy,
     Output,
     SimpleChange,
-    ViewChild
+    ViewChild,
+    ElementRef
 } from "@angular/core";
 
 import {FocusTrapDirective} from "../utils/focus-trap/focus-trap.directive";
@@ -92,7 +93,7 @@ export class Modal implements OnChanges, OnDestroy {
     @Input("clrModalPreventClose") stopClose: boolean = false;
     @Output("clrModalAlternateClose") altClose: EventEmitter<boolean> = new EventEmitter<boolean>(false);
 
-    constructor(private _scrollingService: ScrollingService) {}
+    constructor(private _scrollingService: ScrollingService,private elementRef: ElementRef) {}
 
     get sizeClass(): string {
         if (this.size) {
@@ -123,6 +124,9 @@ export class Modal implements OnChanges, OnDestroy {
         }
         this._open = true;
         this._openChanged.emit(true);
+        debugger;
+        const componentContainer = this.elementRef.nativeElement;
+        componentContainer.style("display", "inline-block");
     }
 
     @HostListener("body:keyup.escape")
@@ -140,6 +144,9 @@ export class Modal implements OnChanges, OnDestroy {
         this._openChanged.emit(false);
         // SPECME
         this.focusTrap.setPreviousFocus();  // Handles moving focus back to the element that had it before.
+        debugger;
+        const componentContainer = this.elementRef.nativeElement;
+        componentContainer.style("display", "block");
     }
 
     fadeDone(e: AnimationEvent) {

--- a/src/clarity-angular/modal/modal.ts
+++ b/src/clarity-angular/modal/modal.ts
@@ -6,6 +6,7 @@
 import {animate, AnimationEvent, state, style, transition, trigger} from "@angular/animations";
 import {
     Component,
+    ElementRef,
     EventEmitter,
     HostListener,
     Input,
@@ -13,8 +14,7 @@ import {
     OnDestroy,
     Output,
     SimpleChange,
-    ViewChild,
-    ElementRef
+    ViewChild
 } from "@angular/core";
 
 import {FocusTrapDirective} from "../utils/focus-trap/focus-trap.directive";
@@ -27,7 +27,7 @@ import {GHOST_PAGE_ANIMATION} from "./utils/ghost-page-animations";
     viewProviders: [ScrollingService],
     templateUrl: "./modal.html",
     styles: [`
-        :host { display: inline-block; }
+        :host { display: inline; }
     `],
     animations: [
         trigger("fadeDown",
@@ -93,7 +93,7 @@ export class Modal implements OnChanges, OnDestroy {
     @Input("clrModalPreventClose") stopClose: boolean = false;
     @Output("clrModalAlternateClose") altClose: EventEmitter<boolean> = new EventEmitter<boolean>(false);
 
-    constructor(private _scrollingService: ScrollingService,private elementRef: ElementRef) {}
+    constructor(private _scrollingService: ScrollingService, private elementRef: ElementRef) {}
 
     get sizeClass(): string {
         if (this.size) {
@@ -107,8 +107,16 @@ export class Modal implements OnChanges, OnDestroy {
     ngOnChanges(changes: {[propName: string]: SimpleChange}): void {
         if (!this.bypassScrollService && changes && changes.hasOwnProperty("_open")) {
             if (changes._open.currentValue) {
+                const hostElement = this.elementRef.nativeElement;
+                if (hostElement) {
+                    hostElement.style["display"] = "inline";
+                }
                 this._scrollingService.stopScrolling();
             } else {
+                const hostElement = this.elementRef.nativeElement;
+                if (hostElement) {
+                    hostElement.style["display"] = "none";
+                }
                 this._scrollingService.resumeScrolling();
             }
         }
@@ -124,9 +132,6 @@ export class Modal implements OnChanges, OnDestroy {
         }
         this._open = true;
         this._openChanged.emit(true);
-        debugger;
-        const componentContainer = this.elementRef.nativeElement;
-        componentContainer.style("display", "inline-block");
     }
 
     @HostListener("body:keyup.escape")
@@ -144,9 +149,6 @@ export class Modal implements OnChanges, OnDestroy {
         this._openChanged.emit(false);
         // SPECME
         this.focusTrap.setPreviousFocus();  // Handles moving focus back to the element that had it before.
-        debugger;
-        const componentContainer = this.elementRef.nativeElement;
-        componentContainer.style("display", "block");
     }
 
     fadeDone(e: AnimationEvent) {


### PR DESCRIPTION
This file changes is to fixed white space taken by model (clr-modal) when it is hidden. 

So when model is hidden, I have applied display property none and when model is open i have added display property inline. 

