### PR TITLE
[NG] fix selection when using datagrid and OnPush mode

### DIFF
--- a/src/clarity-angular/data/datagrid/datagrid-row.ts
+++ b/src/clarity-angular/data/datagrid/datagrid-row.ts
@@ -35,7 +35,7 @@ let nbRow: number = 0;
         <clr-dg-row-master class="datagrid-row-flex">
             <clr-dg-cell *ngIf="selection.selectionType === SELECTION_TYPE.Multi"
                          class="datagrid-select datagrid-fixed-column">
-                <clr-checkbox [ngModel]="selected" (ngModelChange)="toggle($event)"></clr-checkbox>
+                <clr-checkbox [clrChecked]="selected" (clrCheckedChange)="toggle($event)"></clr-checkbox>
             </clr-dg-cell>
             <clr-dg-cell *ngIf="selection.selectionType === SELECTION_TYPE.Single"
                          class="datagrid-select datagrid-fixed-column">

--- a/src/clarity-angular/data/datagrid/helpers.spec.ts
+++ b/src/clarity-angular/data/datagrid/helpers.spec.ts
@@ -57,9 +57,13 @@ export function addHelpers(): void {
          * Ideally we would just make "this" a TestContext, but typing "this" in typescript
          * is a bit too new for all IDEs to correctly process it.
          */
-        this.create = <D, C>(clarityDirective: Type<D>, testComponent: Type<C>, providers: any[] = []) => {
-            TestBed.configureTestingModule(
-                {imports: [ClarityModule.forRoot()], declarations: [testComponent], providers: providers});
+        this.create = <D, C>(clarityDirective: Type<D>, testComponent: Type<C>, providers: any[] = [],
+                             extraDirectives: Type<any>[] = []) => {
+            TestBed.configureTestingModule({
+                imports: [ClarityModule.forRoot()],
+                declarations: [testComponent, ...extraDirectives],
+                providers: providers
+            });
             return this._context = new TestContext<D, C>(clarityDirective, testComponent);
         };
 


### PR DESCRIPTION
Since NgModel is async, using NgModel on the selection checkbox for each row doesn't get properly set. Using ClrCheckbox is the solution, plus adding a test to verify the OnPush scenario.

fixes #1258 