### PR TITLE
[NG] Import DOCUMENT from @angular/common

### DIFF
--- a/src/clarity-angular/utils/scrolling/scrolling-service.spec.ts
+++ b/src/clarity-angular/utils/scrolling/scrolling-service.spec.ts
@@ -3,8 +3,8 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
+import {DOCUMENT} from "@angular/common";
 import {inject} from "@angular/core/testing";
-import {DOCUMENT} from "@angular/platform-browser";
 
 import {ScrollingService} from "./scrolling-service";
 

--- a/src/clarity-angular/utils/scrolling/scrolling-service.ts
+++ b/src/clarity-angular/utils/scrolling/scrolling-service.ts
@@ -3,8 +3,8 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
+import {DOCUMENT} from "@angular/common";
 import {Inject, Injectable} from "@angular/core";
-import {DOCUMENT} from "@angular/platform-browser";
 
 @Injectable()
 export class ScrollingService {


### PR DESCRIPTION
instead of @angular/platform-browser. NG5 support.

Signed-off-by: Chris Ha <chunghha@users.noreply.github.com>