### PR TITLE
[DO-NOT-REVIEW] Alerts Pager Bug Fix

### DIFF
--- a/src/app/alert/angular/alert-angular-app-level-alerts.demo.html
+++ b/src/app/alert/angular/alert-angular-app-level-alerts.demo.html
@@ -7,7 +7,7 @@
 <div class="clr-example">
     <div class="main-container">
         <clr-alerts>
-            <clr-alert [clrAlertType]="'info'" [clrAlertAppLevel]="true">
+            <clr-alert [clrAlertType]="'info'" [clrAlertAppLevel]="true" *ngIf="toggle1">
                 <div class="alert-item">
                     <span class="alert-text">
                         View additional alerts using the pager
@@ -17,7 +17,7 @@
                     </div>
                 </div>
             </clr-alert>
-            <clr-alert [clrAlertType]="'warning'" [clrAlertAppLevel]="true">
+            <clr-alert [clrAlertType]="'warning'" [clrAlertAppLevel]="true" *ngIf="toggle2">
                 <div class="alert-item">
                     <span class="alert-text">
                         Application level alerts should only be used for important messages.
@@ -27,7 +27,7 @@
                     </div>
                 </div>
             </clr-alert>
-            <clr-alert [clrAlertType]="'danger'" [clrAlertAppLevel]="true">
+            <clr-alert [clrAlertType]="'danger'" [clrAlertAppLevel]="true" *ngIf="toggle3">
                 <div class="alert-item">
                     <span class="alert-text">
                         Don't add too many of these alerts!
@@ -46,11 +46,14 @@
         <div class="content-container">
             <div class="content-area">
                 <p>
-                    Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-                    Delectus non beatae omnis esse quibusdam dolorum voluptatem
-                    reiciendis quaerat assumenda optio, porro expedita similique
-                    dolore quidem aliquam. Ullam, eaque enim nobis.
+                    Use the following button group to toggle alerts in the alerts pager
                 </p>
+                <p></p>
+                <div class="btn-group btn-sm">
+                    <button class="btn" (click)="toggleAlert(1)">Toggle Alert 1</button>
+                    <button class="btn" (click)="toggleAlert(2)">Toggle Alert 2</button>
+                    <button class="btn" (click)="toggleAlert(3)">Toggle Alert 3</button>
+                </div>
             </div>
         </div>
     </div>
@@ -61,7 +64,17 @@
         &lt;clr-alert [clrAlertType]=&quot;'info'&quot; [clrAlertAppLevel]=&quot;true&quot;&gt;
             &lt;div class=&quot;alert-item&quot;&gt;
                 &lt;span class=&quot;alert-text&quot;&gt;
-                    This is the first app level alert.
+                    View additional alerts using the pager
+                &lt;/span&gt;
+                &lt;div class=&quot;alert-actions&quot;&gt;
+                    &lt;button class=&quot;btn alert-action&quot;&gt;Fix&lt;/button&gt;
+                &lt;/div&gt;
+            &lt;/div&gt;
+        &lt;/clr-alert&gt;
+        &lt;clr-alert [clrAlertType]=&quot;'warning'&quot; [clrAlertAppLevel]=&quot;true&quot;&gt;
+            &lt;div class=&quot;alert-item&quot;&gt;
+                &lt;span class=&quot;alert-text&quot;&gt;
+                    Application level alerts should only be used for important messages.
                 &lt;/span&gt;
                 &lt;div class=&quot;alert-actions&quot;&gt;
                     &lt;button class=&quot;btn alert-action&quot;&gt;Fix&lt;/button&gt;
@@ -71,7 +84,7 @@
         &lt;clr-alert [clrAlertType]=&quot;'danger'&quot; [clrAlertAppLevel]=&quot;true&quot;&gt;
             &lt;div class=&quot;alert-item&quot;&gt;
                 &lt;span class=&quot;alert-text&quot;&gt;
-                    This is a second app level alert.
+                    Don't add too many of these alerts!
                 &lt;/span&gt;
                 &lt;div class=&quot;alert-actions&quot;&gt;
                     &lt;button class=&quot;btn alert-action&quot;&gt;Fix&lt;/button&gt;

--- a/src/app/alert/angular/alert-angular-app-level-alerts.ts
+++ b/src/app/alert/angular/alert-angular-app-level-alerts.ts
@@ -10,4 +10,18 @@ import {Component} from "@angular/core";
     styleUrls: ["../alert.demo.scss"],
     templateUrl: "./alert-angular-app-level-alerts.demo.html"
 })
-export class AlertAngularAppLevelAlertsDemo {}
+export class AlertAngularAppLevelAlertsDemo {
+    toggle1: boolean = true;
+    toggle2: boolean = true;
+    toggle3: boolean = true;
+
+    toggleAlert(alertNum: number): void {
+        if (alertNum === 1) {
+            this.toggle1 = !this.toggle1;
+        } else if (alertNum === 2) {
+            this.toggle2 = !this.toggle2;
+        } else if (alertNum === 3) {
+            this.toggle3 = !this.toggle3;
+        }
+    }
+}

--- a/src/clarity-angular/emphasis/alert/alerts.spec.ts
+++ b/src/clarity-angular/emphasis/alert/alerts.spec.ts
@@ -49,7 +49,6 @@ describe("Alerts component", function() {
                 TestBed.configureTestingModule({imports: [ClrEmphasisModule], declarations: [componentType]});
 
                 fixture = TestBed.createComponent(componentType);
-                // fixture.detectChanges();
             };
         });
 
@@ -138,6 +137,17 @@ describe("Alerts component", function() {
             fixture.componentInstance.alertInstances.toArray()[0].close();
             fixture.detectChanges();
             expect(compiled.querySelectorAll("clr-alerts-pager").length).toBe(0);
+        });
+
+        it("makes the previous alert active when the current alert is removed from the DOM", function() {
+            fixture.componentInstance.currentAlertIndex = 1;
+            fixture.detectChanges();
+            expect(alertElements[0].classList).toContain("alert-hidden");
+
+            fixture.componentInstance.alertInstances.reset([this.alert]);
+            fixture.detectChanges();
+
+            console.log(fixture.componentInstance.currentAlertIndex);
         });
     });
 


### PR DESCRIPTION
Fixes a bug with the alerts pager component where if a user is viewing the last alert and that last alert is removed from the DOM, the alert pager disappears. More info below:

Before:
![before](https://user-images.githubusercontent.com/1426805/32860626-325be194-ca20-11e7-91db-fc16a39cb5a5.gif)

After:
![after](https://user-images.githubusercontent.com/1426805/32860631-346a0056-ca20-11e7-9ba2-5c9b0f7e8da7.gif)

Tested on Chrome


Signed-off-by: Aditya Bhandari <adityab@vmware.com>