### PR TITLE
[NG] Fix nested tabs link

### DIFF
--- a/src/clarity-angular/layout/tabs/tab-link.directive.spec.ts
+++ b/src/clarity-angular/layout/tabs/tab-link.directive.spec.ts
@@ -10,6 +10,7 @@ import {IfActiveService} from "../../utils/conditional/if-active.service";
 
 import {TabsWillyWonka} from "./chocolate/tabs-willy-wonka";
 import {TabLinkDirective} from "./tab-link.directive";
+import {TABS_ID_PROVIDER} from "./tabs-id.provider";
 import {TabsService} from "./tabs-service";
 import {ClrTabsModule} from "./tabs.module";
 
@@ -36,7 +37,7 @@ describe("TabLink Directive", () => {
         TestBed.configureTestingModule({
             imports: [ClrTabsModule],
             declarations: [TestComponent],
-            providers: [IfActiveService, TabsService, TabsWillyWonka]
+            providers: [IfActiveService, TabsService, TabsWillyWonka, TABS_ID_PROVIDER]
         });
 
         fixture = TestBed.createComponent(TestComponent);

--- a/src/clarity-angular/layout/tabs/tab-link.directive.ts
+++ b/src/clarity-angular/layout/tabs/tab-link.directive.ts
@@ -15,6 +15,7 @@ import {
 import {IF_ACTIVE_ID, IfActiveService} from "../../utils/conditional/if-active.service";
 import {TemplateRefContainer} from "../../utils/template-ref/template-ref-container";
 import {AriaService} from "./aria-service";
+import {TABS_ID} from "./tabs-id.provider";
 
 let nbTabLinkComponents: number = 0;
 
@@ -38,7 +39,7 @@ export class TabLinkDirective {
 
     constructor(public ifActiveService: IfActiveService, @Inject(IF_ACTIVE_ID) private id: number,
                 private ariaService: AriaService, private el: ElementRef, private cfr: ComponentFactoryResolver,
-                private viewContainerRef: ViewContainerRef) {
+                private viewContainerRef: ViewContainerRef, @Inject(TABS_ID) public tabsId: number) {
         if (!this.tabLinkId) {
             this.tabLinkId = "clr-tab-link-" + (nbTabLinkComponents++);
         }

--- a/src/clarity-angular/layout/tabs/tab.spec.ts
+++ b/src/clarity-angular/layout/tabs/tab.spec.ts
@@ -10,6 +10,7 @@ import {IfActiveService} from "../../utils/conditional/if-active.service";
 
 import {TabsWillyWonka} from "./chocolate/tabs-willy-wonka";
 import {Tab} from "./tab";
+import {TABS_ID_PROVIDER} from "./tabs-id.provider";
 import {TabsService} from "./tabs-service";
 import {ClrTabsModule} from "./tabs.module";
 
@@ -34,7 +35,7 @@ describe("Tab", () => {
         TestBed.configureTestingModule({
             imports: [ClrTabsModule],
             declarations: [TestComponent],
-            providers: [IfActiveService, TabsService, TabsWillyWonka]
+            providers: [IfActiveService, TabsService, TabsWillyWonka, TABS_ID_PROVIDER]
         });
         fixture = TestBed.createComponent(TestComponent);
         fixture.detectChanges();

--- a/src/clarity-angular/layout/tabs/tabs-id.provider.ts
+++ b/src/clarity-angular/layout/tabs/tabs-id.provider.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {InjectionToken} from "@angular/core";
+
+let nbTabsComponent = 0;
+
+export const TABS_ID = new InjectionToken<number>("TABS_ID");
+
+export function tokenFactory() {
+    return "clr-tabs-" + (nbTabsComponent++);
+}
+
+export const TABS_ID_PROVIDER = {
+    provide: TABS_ID,
+    useFactory: tokenFactory
+};

--- a/src/clarity-angular/layout/tabs/tabs.ts
+++ b/src/clarity-angular/layout/tabs/tabs.ts
@@ -3,26 +3,27 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import {Component, ContentChildren, QueryList} from "@angular/core";
+import {AfterContentInit, Component, ContentChildren, Inject, QueryList} from "@angular/core";
 
 import {IfActiveService} from "../../utils/conditional/if-active.service";
 import {IfOpenService} from "../../utils/conditional/if-open.service";
 
 import {TabLinkDirective} from "./tab-link.directive";
+import {TABS_ID, TABS_ID_PROVIDER} from "./tabs-id.provider";
 import {TabsService} from "./tabs-service";
 
 @Component({
     selector: "clr-tabs",
-    template: `        
+    template: `
         <ul class="nav" role="tablist">
             <!--tab links-->
             <ng-container *ngFor="let link of tabLinkDirectives">
-                <ng-container *ngIf="!link.inOverflow"
+                <ng-container *ngIf="link.tabsId === tabsId && !link.inOverflow"
                               [ngTemplateOutlet]="link.templateRefContainer.template">
                 </ng-container>
             </ng-container>
             <ng-container *ngIf="tabsService.overflowTabs.length > 0">
-                <div class="tabs-overflow bottom-right" [class.open]="ifOpenService.open" 
+                <div class="tabs-overflow bottom-right" [class.open]="ifOpenService.open"
                      (click)="toggleOverflow($event)">
                     <li role="presentation" class="nav-item">
                         <button class="btn btn-link nav-link dropdown-toggle" [class.active]="activeTabInOverflow">
@@ -32,7 +33,7 @@ import {TabsService} from "./tabs-service";
                     <!--tab links in overflow menu-->
                     <clr-tab-overflow-content>
                         <ng-container *ngFor="let link of tabLinkDirectives">
-                            <ng-container *ngIf="link.inOverflow"
+                            <ng-container *ngIf="link.tabsId === tabsId && link.inOverflow"
                                           [ngTemplateOutlet]="link.templateRefContainer.template">
                             </ng-container>
                         </ng-container>
@@ -43,13 +44,14 @@ import {TabsService} from "./tabs-service";
         <!--tab content-->
         <ng-content></ng-content>
     `,
-    providers: [IfActiveService, IfOpenService, TabsService]
+    providers: [IfActiveService, IfOpenService, TabsService, TABS_ID_PROVIDER]
 })
-export class Tabs {
-    @ContentChildren(TabLinkDirective, {descendants: true}) tabLinkDirectives: QueryList<TabLinkDirective>;
+export class Tabs implements AfterContentInit {
+    @ContentChildren(TabLinkDirective, {descendants: true})
+    tabLinkDirectives: QueryList<TabLinkDirective>;
 
     constructor(public ifActiveService: IfActiveService, public ifOpenService: IfOpenService,
-                public tabsService: TabsService) {}
+                public tabsService: TabsService, @Inject(TABS_ID) public tabsId: number) {}
 
     get activeTabInOverflow() {
         return this.tabsService.overflowTabs.indexOf(this.tabsService.activeTab) > -1;

--- a/src/ks-app/src/app/containers/nav/tabs.component.html
+++ b/src/ks-app/src/app/containers/nav/tabs.component.html
@@ -17,7 +17,33 @@
     <clr-tab>
         <button clrTabLink>Management</button>
         <clr-tab-content *clrIfActive="true">
-            <p>Content for Management tab.</p>
+          <clr-tabs>
+            <clr-tab>
+              <button clrTabLink>Management Level1 Tab1</button>
+              <clr-tab-content *clrIfActive>Management Level1 Content1</clr-tab-content>
+            </clr-tab>
+            <clr-tab *ngIf="true">
+              <button clrTabLink>Management Level1 Tab2</button>
+              <clr-tab-content *clrIfActive>
+                <clr-tabs>
+                  <clr-tab>
+                    <button clrTabLink>Management Level2 Tab1</button>
+                    <clr-tab-content *clrIfActive>
+                      <p>
+                        Management Grand Content1
+                      </p>
+                    </clr-tab-content>
+                  </clr-tab>
+                  <clr-tab *ngIf="true">
+                    <button clrTabLink>Management Level2 Tab2</button>
+                    <clr-tab-content *clrIfActive>
+                      <p>Management Grand Content2</p>
+                    </clr-tab-content>
+                  </clr-tab>
+                </clr-tabs>
+              </clr-tab-content>
+            </clr-tab>
+          </clr-tabs>
         </clr-tab-content>
     </clr-tab>
 


### PR DESCRIPTION
- Fixes 1494

Tabs component will now only project its immediate TabLinkDirectives.  

Before:
<img width="667" alt="screenshot 2017-11-29 13 07 12" src="https://user-images.githubusercontent.com/3958008/33404858-be13212a-d51a-11e7-8e49-1216ce965656.png">

After:
<img width="557" alt="screenshot 2017-11-29 13 11 05" src="https://user-images.githubusercontent.com/3958008/33404863-bfebce34-d51a-11e7-8c78-bfaf5ace22ff.png">

Preview: http://nested-tabs-demo.surge.sh/tabs

Tested on: Chrome

Signed-off-by: Shijir Tsogoo <stsogoo@vmware.com>