### PR TITLE
[NG] Adjust step nav height for inline wizards.

### DIFF
--- a/src/clarity-angular/wizard/_wizard.clarity.scss
+++ b/src/clarity-angular/wizard/_wizard.clarity.scss
@@ -538,6 +538,10 @@
             min-height: 100%;
             height: auto;
             max-height: 100%;
+
+            .clr-wizard-stepnav {
+                height: 100%;
+            }
         }
     }
 


### PR DESCRIPTION
- closes #1711

## Browsers
Tested in:

- Chrome
- Safari
- Firefox
- IE 11
- Edge

Signed-off-by: Matt Hippely <mhippely@vmware.com>