### PR TITLE
[UI] Fixes light theme spinner color

### DIFF
--- a/src/clarity-angular/progress/spinner/_variables.spinner.scss
+++ b/src/clarity-angular/progress/spinner/_variables.spinner.scss
@@ -5,6 +5,6 @@
  */
 
 // Usage: ../progress/spinner/_spinner.clarity.scss
-$clr-spinner-color: #49AFD9;
-$clr-spinner-bg-color: $clr-black; //TODO: Confirm with UX the correct bg color here.
+$clr-spinner-color: $action-blues-dark-midtone;
+$clr-spinner-bg-color: $clr-black;
 $clr-spinner-opacity: 0.15;


### PR DESCRIPTION
This fixes the light theme spinner with the correct snake color. 

## Before
<img width="214" alt="screen shot 2017-12-06 at 6 12 27 pm" src="https://user-images.githubusercontent.com/433692/33692882-7226ae78-daa4-11e7-905d-1f2c4f2a4287.png">

## After 
<img width="382" alt="screen shot 2017-12-06 at 6 31 45 pm" src="https://user-images.githubusercontent.com/433692/33692870-64d64760-daa4-11e7-89af-4396f0354a43.png">

Signed-off-by: Matt Hippely <mhippely@vmware.com>