### PR TITLE
[NG] Update global alerts pager to recognize deprecated alert types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2362,9 +2362,9 @@
             "dev": true
         },
         "clang-format": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.1.0.tgz",
-            "integrity": "sha512-0Aru49uTLoROl4sPTyO3fvF/NZ+fnGEy5i7bsRwA/bAYT+eWaAxK3sDxRvm/AW7Nwq83BvARH/npeF8OIAaGVQ==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.2.1.tgz",
+            "integrity": "sha512-AdmYODau6wAdbZtMMeq0kICR3VTEPO4austhr1+U1izMlgz3mnFRBhXTE98Bq+q2Xf+xpzaW9geqdsJRL9ML7Q==",
             "dev": true,
             "requires": {
                 "async": "1.5.2",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "awesome-typescript-loader": "^3.2.3",
         "cheerio": "^0.22.0",
         "circular-dependency-plugin": "^3.0.0",
-        "clang-format": "^1.0.55",
+        "clang-format": "^1.2.1",
         "codelyzer": "~3.1.1",
         "colors": "^1.1.2",
         "commander": "^2.11.0",

--- a/src/clarity-angular/data/datagrid/render/noop-dom-adapter.spec.ts
+++ b/src/clarity-angular/data/datagrid/render/noop-dom-adapter.spec.ts
@@ -53,6 +53,5 @@ export default function(): void {
                 expect(this.domAdapter.userDefinedWidth(this.element)).toBe(0);
             });
         });
-
     });
 }

--- a/src/clarity-angular/emphasis/alert/alerts.spec.ts
+++ b/src/clarity-angular/emphasis/alert/alerts.spec.ts
@@ -137,6 +137,78 @@ describe("Alerts component", function() {
             fixture.detectChanges();
             expect(compiled.querySelectorAll("clr-alerts-pager").length).toBe(0);
         });
+
+        describe("sets classname as expected", function() {
+            it("sets danger classname as expected", function() {
+                const alertsContainer: Element = fixture.nativeElement.querySelector(".alerts");
+                const myAlert: Alert = fixture.componentInstance.alertsInstance.currentAlert;
+                myAlert.alertType = "danger";
+                fixture.detectChanges();
+
+                expect(alertsContainer.classList.contains("alert-danger")).toBe(true);
+            });
+            it("sets info classname as expected", function() {
+                const alertsContainer: Element = fixture.nativeElement.querySelector(".alerts");
+                const myAlert: Alert = fixture.componentInstance.alertsInstance.currentAlert;
+                myAlert.alertType = "info";
+                fixture.detectChanges();
+
+                expect(alertsContainer.classList.contains("alert-info")).toBe(true);
+            });
+            it("sets success classname as expected", function() {
+                const alertsContainer: Element = fixture.nativeElement.querySelector(".alerts");
+                const myAlert: Alert = fixture.componentInstance.alertsInstance.currentAlert;
+                myAlert.alertType = "success";
+                fixture.detectChanges();
+
+                expect(alertsContainer.classList.contains("alert-success")).toBe(true);
+            });
+            it("sets warning classname as expected", function() {
+                const alertsContainer: Element = fixture.nativeElement.querySelector(".alerts");
+                const myAlert: Alert = fixture.componentInstance.alertsInstance.currentAlert;
+                myAlert.alertType = "warning";
+                fixture.detectChanges();
+
+                expect(alertsContainer.classList.contains("alert-warning")).toBe(true);
+            });
+            // no tests for unexpected/unrecognized values because the alert types service ignores them
+            // and only changes an alert type when given a known value.
+        });
+
+        describe("sets classname as expected with deprecated alert type", function() {
+            it("sets danger classname as expected", function() {
+                const alertsContainer: Element = fixture.nativeElement.querySelector(".alerts");
+                const myAlert: Alert = fixture.componentInstance.alertsInstance.currentAlert;
+                myAlert.alertType = "alert-danger";
+                fixture.detectChanges();
+
+                expect(alertsContainer.classList.contains("alert-danger")).toBe(true);
+            });
+            it("sets info classname as expected", function() {
+                const alertsContainer: Element = fixture.nativeElement.querySelector(".alerts");
+                const myAlert: Alert = fixture.componentInstance.alertsInstance.currentAlert;
+                myAlert.alertType = "alert-info";
+                fixture.detectChanges();
+
+                expect(alertsContainer.classList.contains("alert-info")).toBe(true);
+            });
+            it("sets success classname as expected", function() {
+                const alertsContainer: Element = fixture.nativeElement.querySelector(".alerts");
+                const myAlert: Alert = fixture.componentInstance.alertsInstance.currentAlert;
+                myAlert.alertType = "alert-success";
+                fixture.detectChanges();
+
+                expect(alertsContainer.classList.contains("alert-success")).toBe(true);
+            });
+            it("sets warning classname as expected", function() {
+                const alertsContainer: Element = fixture.nativeElement.querySelector(".alerts");
+                const myAlert: Alert = fixture.componentInstance.alertsInstance.currentAlert;
+                myAlert.alertType = "alert-warning";
+                fixture.detectChanges();
+
+                expect(alertsContainer.classList.contains("alert-warning")).toBe(true);
+            });
+        });
     });
 
     describe("Supports dynamic alerts", function() {

--- a/src/clarity-angular/emphasis/alert/alerts.ts
+++ b/src/clarity-angular/emphasis/alert/alerts.ts
@@ -7,16 +7,17 @@ import {AfterContentInit, Component, ContentChildren, EventEmitter, Input, Outpu
 import {Alert} from "./alert";
 import {MultiAlertService} from "./providers/multi-alert-service";
 
+// the 'alert-*' alert types are deprecated and should be removed in 0.12 or later
 @Component({
     selector: "clr-alerts",
     templateUrl: "./alerts.html",
     providers: [MultiAlertService],
     host: {
         "[class.alerts]": "true",
-        "[class.alert-danger]": "this.currentAlertType == 'danger'",
-        "[class.alert-info]": "this.currentAlertType == 'info'",
-        "[class.alert-success]": "this.currentAlertType == 'success'",
-        "[class.alert-warning]": "this.currentAlertType == 'warning'"
+        "[class.alert-danger]": "this.currentAlertType == 'danger' || this.currentAlertType == 'alert-danger'",
+        "[class.alert-info]": "this.currentAlertType == 'info' || this.currentAlertType == 'alert-info'",
+        "[class.alert-success]": "this.currentAlertType == 'success' || this.currentAlertType == 'alert-success'",
+        "[class.alert-warning]": "this.currentAlertType == 'warning' || this.currentAlertType == 'alert-warning'"
     },
     styles: [":host { display: block }"]
 })

--- a/src/clarity-angular/layout/tabs/tabs.spec.ts
+++ b/src/clarity-angular/layout/tabs/tabs.spec.ts
@@ -116,11 +116,9 @@ class NestedTabsTest {
 }
 
 describe("Tabs", () => {
-
     addHelpers();
 
     describe("Projection", () => {
-
         let context: TestContext<Tabs, TestComponent>;
         let compiled: any;
 
@@ -159,7 +157,6 @@ describe("Tabs", () => {
     });
 
     describe("Nested Projection", () => {
-
         let context: TestContext<Tabs, NestedTabsTest>;
         let compiled: any;
 
@@ -183,7 +180,6 @@ describe("Tabs", () => {
     });
 
     describe("Default tab", function() {
-
         function expectFirstTabActive<T extends TestComponent|NgIfFirstTest|NgIfSecondTest>(testType: Type<T>) {
             const context: TestContext<Tabs, T> = this.create(Tabs, testType);
             const tabsService = context.getClarityProvider(TabsService);


### PR DESCRIPTION
• previously only recognized “info” and such
• now recognizes both “info” and deprecated “alert-info” alert types
• also added tests for this functionality

Tested in:
✔︎ Chrome

Closes: #1747

Signed-off-by: Scott Mathis <smathis@vmware.com>