### PR TITLE
[NG] Update global alerts pager to recognize deprecated alert types - v0.10

### DIFF
--- a/src/app/progress-bars/progress-bar-inline.ts
+++ b/src/app/progress-bars/progress-bar-inline.ts
@@ -43,7 +43,6 @@ export class ProgressBarInlineDemo implements OnInit {
     runProgressBar(): void {
         this.stopProgressBar();
         this.inlineProgressTimerId = setInterval(() => {
-
             const oldProgressValue: number = this.inlineProgress;
             let increment: number = Math.floor(Math.random() * 15) + 1;
             increment = parseInt(increment + "", 10);

--- a/src/clarity-angular/button/button-group/button-group.spec.ts
+++ b/src/clarity-angular/button/button-group/button-group.spec.ts
@@ -27,7 +27,6 @@ export default function(): void {
         });
 
         describe("Buttons in Inline Buttons View Container", () => {
-
             beforeEach(() => {
                 fixture = TestBed.createComponent(BtnGroupInlineViewContainer);
                 fixture.detectChanges();
@@ -63,11 +62,9 @@ export default function(): void {
                 expect(btnGroupChildrenCompiled[3].classList.contains("btn")).toBe(true);
                 expect(btnGroupChildrenCompiled[4].classList.contains("btn")).toBe(true);
             });
-
         });
 
         describe("Buttons in both View Containers", () => {
-
             beforeEach(() => {
                 fixture = TestBed.createComponent(BtnGroupBothViewContainersTest);
                 fixture.detectChanges();
@@ -124,11 +121,9 @@ export default function(): void {
                 expect(dropdownMenu.children[1].classList.contains("btn")).toBe(true);
                 expect(dropdownMenu.children[2].classList.contains("btn")).toBe(true);
             });
-
         });
 
         describe("Flip Test 1", () => {
-
             beforeEach(() => {
                 fixture = TestBed.createComponent(BtnGroupFlipTest1);
                 fixture.detectChanges();
@@ -233,7 +228,6 @@ export default function(): void {
         });
 
         describe("Flip Test 2", () => {
-
             beforeEach(() => {
                 fixture = TestBed.createComponent(BtnGroupFlipTest2);
                 fixture.detectChanges();
@@ -289,7 +283,6 @@ export default function(): void {
         });
 
         describe("Content Projection Update", () => {
-
             beforeEach(() => {
                 fixture = TestBed.createComponent(BtnGroupProjectionUpdateTest);
                 fixture.detectChanges();
@@ -357,7 +350,6 @@ export default function(): void {
 
         /* This feature is not recommended but we are just testing the fallback */
         describe("Buttons in Menu View Container", () => {
-
             beforeEach(() => {
                 fixture = TestBed.createComponent(BtnGroupMenuViewContainer);
                 fixture.detectChanges();
@@ -404,11 +396,9 @@ export default function(): void {
                 expect(compiled.textContent).toMatch(/Button 4/);
                 expect(compiled.textContent).toMatch(/Button 5/);
             });
-
         });
 
         describe("Toggling Button Group Overflow Menus", () => {
-
             beforeEach(() => {
                 fixture = TestBed.createComponent(BtnGroupEHCAIWCTest);
                 fixture.detectChanges();
@@ -473,9 +463,7 @@ export default function(): void {
                 expect(compiled.textContent).not.toMatch(/Button 9/);
                 expect(compiled.textContent).not.toMatch(/Button 10/);
             });
-
         });
-
     });
 }
 

--- a/src/clarity-angular/button/button-group/button.spec.ts
+++ b/src/clarity-angular/button/button-group/button.spec.ts
@@ -18,7 +18,6 @@ export default function(): void {
         const buttons: Button[] = [];
 
         beforeEach(() => {
-
             TestBed.configureTestingModule({
                 imports: [ClrButtonGroupModule],
                 declarations: [TestButtonComponent],
@@ -95,7 +94,6 @@ export default function(): void {
         });
 
         it("emits a click event", () => {
-
             expect(fixture.componentInstance.flag).toBe(false);
 
             const btn: any = fixture.nativeElement.querySelector("#testBtn");

--- a/src/clarity-angular/button/button-loading/loading-button.spec.ts
+++ b/src/clarity-angular/button/button-loading/loading-button.spec.ts
@@ -17,7 +17,6 @@ describe("Loading Buttons", () => {
     let componentInstance: TestLoadingButtonComponent;
 
     beforeEach(() => {
-
         TestBed.configureTestingModule(
             {imports: [ClrLoadingModule, ClrLoadingButtonModule], declarations: [TestLoadingButtonComponent]});
 

--- a/src/clarity-angular/data/datagrid/datagrid-column.spec.ts
+++ b/src/clarity-angular/data/datagrid/datagrid-column.spec.ts
@@ -319,7 +319,6 @@ export default function(): void {
             });
 
             it("adds the .datagrid-column--hidden when not visible", function() {
-
                 context.clarityDirective.hideable = new DatagridHideableColumn(null, "dg-col-0", true);
                 context.detectChanges();
                 expect(context.clarityElement.classList.contains("datagrid-column--hidden")).toBeTruthy();

--- a/src/clarity-angular/data/datagrid/datagrid-hideable-column.spec.ts
+++ b/src/clarity-angular/data/datagrid/datagrid-hideable-column.spec.ts
@@ -80,7 +80,6 @@ export default function(): void {
             expect(changeValue).toBeUndefined();
             expect(nbChanges).toBe(0);
         });
-
     });
 }
 

--- a/src/clarity-angular/data/datagrid/datagrid-row.spec.ts
+++ b/src/clarity-angular/data/datagrid/datagrid-row.spec.ts
@@ -33,7 +33,6 @@ const PROVIDERS = [
 
 export default function(): void {
     describe("DatagridRow component", function() {
-
         describe("View", function() {
             // Until we can properly type "this"
             let context: TestContext<DatagridRow, FullTest>;
@@ -327,7 +326,6 @@ export default function(): void {
 
                 hideableColumnService.updateColumnList(hiddenColumns);
                 expect(context.clarityDirective.updateCellsForColumns).toHaveBeenCalled();
-
             });
         });
     });

--- a/src/clarity-angular/data/datagrid/datagrid.spec.ts
+++ b/src/clarity-angular/data/datagrid/datagrid.spec.ts
@@ -52,7 +52,6 @@ export default function(): void {
                 context.clarityDirective.resize();
                 expect(resizeDone).toBe(true);
             });
-
         });
 
         describe("Template API", function() {
@@ -269,7 +268,6 @@ export default function(): void {
                 expect(headActionOverflowCell).toBeNull();
                 expect(actionOverflowCell.length).toEqual(0);
             });
-
         });
 
         describe("Expandable rows", function() {
@@ -383,8 +381,6 @@ export default function(): void {
                     expect(() => context.detectChanges()).not.toThrow();
                 });
             });
-
-
         });
     });
 }

--- a/src/clarity-angular/data/datagrid/providers/drag-dispatcher.ts
+++ b/src/clarity-angular/data/datagrid/providers/drag-dispatcher.ts
@@ -58,14 +58,12 @@ export class DragDispatcher {
             });
 
             dragEndListener = this._renderer.listen("document", endOnEvent, (endEvent: any) => {
-
                 // Unsubscribing from mouseMoveListener
                 dragMoveListener();
                 this.notifyDragEnd(endEvent);
                 // Unsubscribing from itself
                 dragEndListener();
             });
-
         });
     }
 

--- a/src/clarity-angular/data/datagrid/providers/hideable-column.service.spec.ts
+++ b/src/clarity-angular/data/datagrid/providers/hideable-column.service.spec.ts
@@ -9,7 +9,6 @@ import {HideableColumnService} from "./hideable-column.service";
 
 export default function(): void {
     describe("DatagridHideableColumn provider", function() {
-
         let columnService: HideableColumnService;
 
         beforeEach(function() {
@@ -65,7 +64,6 @@ export default function(): void {
             expect(columnService.checkForAllColumnsVisible).toBe(true);
             testColumns[0].hidden = true;
             expect(columnService.checkForAllColumnsVisible).toBe(false);
-
         });
 
         it("provides an observable that pushes the latest columnListChange", function() {

--- a/src/clarity-angular/data/datagrid/providers/items.spec.ts
+++ b/src/clarity-angular/data/datagrid/providers/items.spec.ts
@@ -172,7 +172,6 @@ export default function(): void {
              * is if the filters themselves changed, which we already tested
              */
         });
-
     });
 }
 

--- a/src/clarity-angular/data/datagrid/providers/page.spec.ts
+++ b/src/clarity-angular/data/datagrid/providers/page.spec.ts
@@ -101,6 +101,5 @@ export default function(): void {
             expect(currentPage).toBe(1);
             expect(nbChanges).toBe(3);
         });
-
     });
 }

--- a/src/clarity-angular/data/datagrid/render/dom-adapter.spec.ts
+++ b/src/clarity-angular/data/datagrid/render/dom-adapter.spec.ts
@@ -75,6 +75,5 @@ export default function(): void {
                 expect(this.domAdapter.userDefinedWidth(this.element)).toBe(0);
             });
         });
-
     });
 }

--- a/src/clarity-angular/data/datagrid/render/main-renderer.ts
+++ b/src/clarity-angular/data/datagrid/render/main-renderer.ts
@@ -102,7 +102,6 @@ export class DatagridMainRenderer implements AfterContentInit, AfterViewChecked,
         let allStrict = true;
 
         this.headers.forEach((header, index) => {
-
             // On the last header column check whether all columns have strict widths.
             // If all columns have strict widths, remove the strict width from the last column and make it the column's
             // minimum width so that when all previous columns shrink, it will get a flexible width and cover the empty

--- a/src/clarity-angular/data/datagrid/render/render-organizer.spec.ts
+++ b/src/clarity-angular/data/datagrid/render/render-organizer.spec.ts
@@ -46,6 +46,5 @@ export default function(): void {
             this.organizer.resize();
             expect(this.organizer.widths).toEqual([]);
         });
-
     });
 }

--- a/src/clarity-angular/data/stack-view/stack-block.spec.ts
+++ b/src/clarity-angular/data/stack-view/stack-block.spec.ts
@@ -108,7 +108,6 @@ export default function(): void {
             fixture.detectChanges();
 
             expect(getBlockInstance(fixture).expandable).toBeTruthy();
-
         });
 
         it("starts collapsed", () => {

--- a/src/clarity-angular/data/tree-view/tree-node.spec.ts
+++ b/src/clarity-angular/data/tree-view/tree-node.spec.ts
@@ -31,7 +31,6 @@ export default function(): void {
         });
 
         describe("Tree Node Basics", () => {
-
             beforeEach(() => {
                 fixture = TestBed.createComponent(BasicTreeNodeTestComponent);
                 fixture.detectChanges();
@@ -298,7 +297,6 @@ export default function(): void {
         });
 
         describe("Basic Tree Node Selection", () => {
-
             beforeEach(() => {
                 fixture = TestBed.createComponent(BasicTreeNodeSelectionTestComponent);
                 fixture.detectChanges();
@@ -444,7 +442,6 @@ export default function(): void {
             });
 
             it("initializes the tree with the selection state set by the user", () => {
-
                 // A1
                 expect(a1Node.expanded).toBe(true);
                 expect(a1Node.indeterminate).toBe(true);

--- a/src/clarity-angular/emphasis/alert/alerts-pager.spec.ts
+++ b/src/clarity-angular/emphasis/alert/alerts-pager.spec.ts
@@ -41,7 +41,6 @@ describe("Alerts pager component", function() {
     });
 
     describe("Template API", function() {
-
         beforeEach(function() {
             const service = new MultiAlertService();
             const queryList = new QueryList<Alert>();

--- a/src/clarity-angular/emphasis/alert/alerts.spec.ts
+++ b/src/clarity-angular/emphasis/alert/alerts.spec.ts
@@ -41,7 +41,6 @@ describe("Alerts component", function() {
     });
 
     describe("Template API", function() {
-
         let fixture: ComponentFixture<any>;
 
         beforeEach(function() {
@@ -91,7 +90,6 @@ describe("Alerts component", function() {
     });
 
     describe("View basics", function() {
-
         let fixture: ComponentFixture<TestComponent>;
         let compiled: any;
         let alertElements: Array<Element>;

--- a/src/clarity-angular/emphasis/alert/alerts.spec.ts
+++ b/src/clarity-angular/emphasis/alert/alerts.spec.ts
@@ -139,6 +139,78 @@ describe("Alerts component", function() {
             fixture.detectChanges();
             expect(compiled.querySelectorAll("clr-alerts-pager").length).toBe(0);
         });
+
+        describe("sets classname as expected", function() {
+            it("sets danger classname as expected", function() {
+                const alertsContainer: Element = fixture.nativeElement.querySelector(".alerts");
+                const myAlert: Alert = fixture.componentInstance.alertsInstance.currentAlert;
+                myAlert.alertType = "danger";
+                fixture.detectChanges();
+
+                expect(alertsContainer.classList.contains("alert-danger")).toBe(true);
+            });
+            it("sets info classname as expected", function() {
+                const alertsContainer: Element = fixture.nativeElement.querySelector(".alerts");
+                const myAlert: Alert = fixture.componentInstance.alertsInstance.currentAlert;
+                myAlert.alertType = "info";
+                fixture.detectChanges();
+
+                expect(alertsContainer.classList.contains("alert-info")).toBe(true);
+            });
+            it("sets success classname as expected", function() {
+                const alertsContainer: Element = fixture.nativeElement.querySelector(".alerts");
+                const myAlert: Alert = fixture.componentInstance.alertsInstance.currentAlert;
+                myAlert.alertType = "success";
+                fixture.detectChanges();
+
+                expect(alertsContainer.classList.contains("alert-success")).toBe(true);
+            });
+            it("sets warning classname as expected", function() {
+                const alertsContainer: Element = fixture.nativeElement.querySelector(".alerts");
+                const myAlert: Alert = fixture.componentInstance.alertsInstance.currentAlert;
+                myAlert.alertType = "warning";
+                fixture.detectChanges();
+
+                expect(alertsContainer.classList.contains("alert-warning")).toBe(true);
+            });
+            // no tests for unexpected/unrecognized values because the alert types service ignores them
+            // and only changes an alert type when given a known value.
+        });
+
+        describe("sets classname as expected with deprecated alert type", function() {
+            it("sets danger classname as expected", function() {
+                const alertsContainer: Element = fixture.nativeElement.querySelector(".alerts");
+                const myAlert: Alert = fixture.componentInstance.alertsInstance.currentAlert;
+                myAlert.alertType = "alert-danger";
+                fixture.detectChanges();
+
+                expect(alertsContainer.classList.contains("alert-danger")).toBe(true);
+            });
+            it("sets info classname as expected", function() {
+                const alertsContainer: Element = fixture.nativeElement.querySelector(".alerts");
+                const myAlert: Alert = fixture.componentInstance.alertsInstance.currentAlert;
+                myAlert.alertType = "alert-info";
+                fixture.detectChanges();
+
+                expect(alertsContainer.classList.contains("alert-info")).toBe(true);
+            });
+            it("sets success classname as expected", function() {
+                const alertsContainer: Element = fixture.nativeElement.querySelector(".alerts");
+                const myAlert: Alert = fixture.componentInstance.alertsInstance.currentAlert;
+                myAlert.alertType = "alert-success";
+                fixture.detectChanges();
+
+                expect(alertsContainer.classList.contains("alert-success")).toBe(true);
+            });
+            it("sets warning classname as expected", function() {
+                const alertsContainer: Element = fixture.nativeElement.querySelector(".alerts");
+                const myAlert: Alert = fixture.componentInstance.alertsInstance.currentAlert;
+                myAlert.alertType = "alert-warning";
+                fixture.detectChanges();
+
+                expect(alertsContainer.classList.contains("alert-warning")).toBe(true);
+            });
+        });
     });
 
     describe("Supports dynamic alerts", function() {

--- a/src/clarity-angular/emphasis/alert/alerts.ts
+++ b/src/clarity-angular/emphasis/alert/alerts.ts
@@ -7,6 +7,7 @@ import {AfterContentInit, Component, ContentChildren, EventEmitter, Input, Outpu
 import {Alert} from "./alert";
 import {MultiAlertService} from "./providers/multi-alert-service";
 
+// alert types in the format of "alert-*" are deprecated and will be removed in 0.12 or later
 @Component({
     selector: "clr-alerts",
     templateUrl: "./alerts.html",

--- a/src/clarity-angular/emphasis/alert/alerts.ts
+++ b/src/clarity-angular/emphasis/alert/alerts.ts
@@ -13,10 +13,10 @@ import {MultiAlertService} from "./providers/multi-alert-service";
     providers: [MultiAlertService],
     host: {
         "[class.alerts]": "true",
-        "[class.alert-danger]": "this.currentAlertType == 'danger'",
-        "[class.alert-info]": "this.currentAlertType == 'info'",
-        "[class.alert-success]": "this.currentAlertType == 'success'",
-        "[class.alert-warning]": "this.currentAlertType == 'warning'"
+        "[class.alert-danger]": "this.currentAlertType == 'danger' || this.currentAlertType == 'alert-danger'",
+        "[class.alert-info]": "this.currentAlertType == 'info' || this.currentAlertType == 'alert-info'",
+        "[class.alert-success]": "this.currentAlertType == 'success' || this.currentAlertType == 'alert-success'",
+        "[class.alert-warning]": "this.currentAlertType == 'warning' || this.currentAlertType == 'alert-warning'"
     },
     styles: [":host { display: block }"]
 })

--- a/src/clarity-angular/layout/tabs/tab-content.spec.ts
+++ b/src/clarity-angular/layout/tabs/tab-content.spec.ts
@@ -37,5 +37,4 @@ describe("TabContent", () => {
     it("projects content", () => {
         expect(compiled.textContent.trim()).toMatch("Content1");
     });
-
 });

--- a/src/clarity-angular/layout/tabs/tab.spec.ts
+++ b/src/clarity-angular/layout/tabs/tab.spec.ts
@@ -50,5 +50,4 @@ describe("Tab", () => {
         expect(instance.tabLink.ariaControls).toMatch(/clr-tab-content-[0-9]/);
         expect(instance.tabContent.ariaLabelledBy).toMatch(/clr-tab-link-[0-9]/);
     });
-
 });

--- a/src/clarity-angular/layout/tabs/tabs.spec.ts
+++ b/src/clarity-angular/layout/tabs/tabs.spec.ts
@@ -116,11 +116,9 @@ class NestedTabsTest {
 }
 
 describe("Tabs", () => {
-
     addHelpers();
 
     describe("Projection", () => {
-
         let context: TestContext<Tabs, TestComponent>;
         let compiled: any;
 
@@ -155,12 +153,10 @@ describe("Tabs", () => {
             toggle.click();
             context.fixture.detectChanges();
             expect(compiled.querySelector(".tabs-overflow .tab4")).toBeDefined();
-
         });
     });
 
     describe("Nested Projection", () => {
-
         let context: TestContext<Tabs, NestedTabsTest>;
         let compiled: any;
 
@@ -184,7 +180,6 @@ describe("Tabs", () => {
     });
 
     describe("Default tab", function() {
-
         function expectFirstTabActive<T extends TestComponent|NgIfFirstTest|NgIfSecondTest>(testType: Type<T>) {
             const context: TestContext<Tabs, T> = this.create(Tabs, testType);
             const tabsService = context.getClarityProvider(TabsService);

--- a/src/clarity-angular/popover/common/popover-old.directive.spec.ts
+++ b/src/clarity-angular/popover/common/popover-old.directive.spec.ts
@@ -10,7 +10,6 @@ import {ComponentFixture, TestBed} from "@angular/core/testing";
 import {PopoverDirectiveOld} from "./popover-old.directive";
 
 describe("Popover directive (old)", () => {
-
     let fixture: ComponentFixture<any>;
     let compiled: any;
 

--- a/src/clarity-angular/popover/dropdown/dropdown-menu.spec.ts
+++ b/src/clarity-angular/popover/dropdown/dropdown-menu.spec.ts
@@ -45,7 +45,6 @@ export default function(): void {
             expect((<any>context.clarityDirective).anchorPoint).toEqual(Point.TOP_RIGHT);
             expect((<any>context.clarityDirective).popoverPoint).toEqual(Point.RIGHT_BOTTOM);
         });
-
     });
 }
 

--- a/src/clarity-angular/popover/tooltip/tooltip-content.spec.ts
+++ b/src/clarity-angular/popover/tooltip/tooltip-content.spec.ts
@@ -63,7 +63,6 @@ export default function(): void {
             expect(context.clarityElement.classList).not.toContain("tooltip-sm");
             expect(context.clarityElement.classList).toContain("tooltip-lg");
         });
-
     });
 }
 

--- a/src/clarity-angular/popover/tooltip/tooltip.spec.ts
+++ b/src/clarity-angular/popover/tooltip/tooltip.spec.ts
@@ -9,7 +9,6 @@ import {addHelpers, TestContext} from "../../data/datagrid/helpers.spec";
 import {Tooltip} from "./tooltip";
 
 describe("Tooltip component", function() {
-
     addHelpers();
 
     describe("Simple", function() {
@@ -22,9 +21,7 @@ describe("Tooltip component", function() {
         it("projects anchor content", function() {
             expect(context.clarityElement.textContent).toMatch(/Hello/);
         });
-
     });
-
 });
 
 @Component({

--- a/src/clarity-angular/utils/animations/fade-slide/fade-slide.spec.ts
+++ b/src/clarity-angular/utils/animations/fade-slide/fade-slide.spec.ts
@@ -14,7 +14,6 @@ import {
 import {fadeSlide} from "./index";
 
 describe("FadeSlide", () => {
-
     describe("invalid direction", () => {
         it("should throw an error", () => {
             expect(() => {

--- a/src/clarity-angular/utils/animations/fade/fade.spec.ts
+++ b/src/clarity-angular/utils/animations/fade/fade.spec.ts
@@ -14,9 +14,7 @@ import {
 import {fade} from "./index";
 
 describe("Fade", () => {
-
     describe("default", () => {
-
         const defaultFade: AnimationMetadata[] = fade();
         const enterTransition: AnimationTransitionMetadata = defaultFade[0] as AnimationTransitionMetadata;
         const exitTransition: AnimationTransitionMetadata = defaultFade[1] as AnimationTransitionMetadata;
@@ -46,7 +44,6 @@ describe("Fade", () => {
 
             expect(step1.styles).toEqual(style({opacity: 0}));
         });
-
     });
 
     describe("fade with custom opacity", () => {
@@ -80,7 +77,5 @@ describe("Fade", () => {
 
             expect(step1.styles).toEqual(style({opacity: 0}));
         });
-
     });
-
 });

--- a/src/clarity-angular/utils/animations/slide/slide.spec.ts
+++ b/src/clarity-angular/utils/animations/slide/slide.spec.ts
@@ -14,7 +14,6 @@ import {
 import {slide} from "./index";
 
 describe("Slide", () => {
-
     describe("invalid direction", () => {
         it("should throw an error", () => {
             expect(() => {

--- a/src/clarity-angular/utils/conditional/all.spec.ts
+++ b/src/clarity-angular/utils/conditional/all.spec.ts
@@ -17,7 +17,6 @@ import IfOpenDirectiveSpecs from "./if-open.directive.spec";
 import IfOpenServiceSpecs from "./if-open.service.spec";
 
 describe("Conditional Utils", function() {
-
     describe("clrIfActive", function() {
         IfActiveServiceSpecs();
         IfActiveDirectiveSpecs();
@@ -27,5 +26,4 @@ describe("Conditional Utils", function() {
         IfOpenServiceSpecs();
         IfOpenDirectiveSpecs();
     });
-
 });

--- a/src/clarity-angular/utils/conditional/if-active.service.spec.ts
+++ b/src/clarity-angular/utils/conditional/if-active.service.spec.ts
@@ -8,7 +8,6 @@ import {IfActiveService} from "./if-active.service";
 
 export default function(): void {
     describe("IfActiveService provider", function() {
-
         let ifActiveService: IfActiveService;
 
         beforeEach(function() {

--- a/src/clarity-angular/utils/conditional/if-open.service.spec.ts
+++ b/src/clarity-angular/utils/conditional/if-open.service.spec.ts
@@ -8,7 +8,6 @@ import {IfOpenService} from "./if-open.service";
 
 export default function(): void {
     describe("IfOpenService provider", function() {
-
         let ifOpenService: IfOpenService;
 
         beforeEach(function() {

--- a/src/clarity-angular/utils/focus-trap/focus-trap.directive.spec.ts
+++ b/src/clarity-angular/utils/focus-trap/focus-trap.directive.spec.ts
@@ -95,9 +95,7 @@ describe("FocusTrap", () => {
             levelTwoButton.focus();
             expect(document.activeElement)
                 .toEqual(levelTwoButton, `element inside currently active focus trap directive wasn't focused`);
-
         });
-
     });
 
 
@@ -140,7 +138,6 @@ describe("FocusTrap", () => {
             fixture.detectChanges();
             expect(document.activeElement).toBe(initialActiveElement);
         });
-
     });
 });
 

--- a/src/clarity-angular/utils/scrolling/scrolling-service.spec.ts
+++ b/src/clarity-angular/utils/scrolling/scrolling-service.spec.ts
@@ -24,5 +24,4 @@ describe("ScrollingService", () => {
         scrollingService.resumeScrolling();
         expect(document.body.classList.contains("no-scrolling")).toBe(false);
     });
-
 });

--- a/src/clarity-angular/wizard/providers/page-collection.spec.ts
+++ b/src/clarity-angular/wizard/providers/page-collection.spec.ts
@@ -79,7 +79,6 @@ export default function(): void {
         });
 
         it(".pageRange() should return the range of wizard pages", function() {
-
             expect(pageCollectionService.pageRange(0, 0)).toEqual([pageCollectionService.firstPage]);
 
             expect(pageCollectionService.pageRange(4, 4)).toEqual([pageCollectionService.lastPage]);
@@ -101,11 +100,9 @@ export default function(): void {
             expect(pageCollectionService.pageRange(3, undefined)).toEqual([]);
 
             expect(pageCollectionService.pageRange(null, undefined)).toEqual([]);
-
         });
 
         it(".getPageRangeFromPages() should return the range of wizard pages", function() {
-
             expect(pageCollectionService.getPageRangeFromPages(pageCollectionService.firstPage,
                                                                pageCollectionService.lastPage))
                 .toEqual(pageCollectionService.pageRange(0, 4));
@@ -117,11 +114,9 @@ export default function(): void {
             expect(pageCollectionService.getPageRangeFromPages(pageCollectionService.getPageByIndex(1),
                                                                pageCollectionService.getPageByIndex(3)))
                 .toEqual(pageCollectionService.pageRange(1, 3));
-
         });
 
         it(".getPreviousPage() should return the previous page of the current page", function() {
-
             expect(pageCollectionService.getPreviousPage(pageCollectionService.lastPage))
                 .toEqual(pageCollectionService.getPageByIndex(3));
 
@@ -129,11 +124,9 @@ export default function(): void {
                 .toEqual(pageCollectionService.getPageByIndex(1));
 
             expect(pageCollectionService.getPreviousPage(pageCollectionService.firstPage)).toBeNull();
-
         });
 
         it(".getNextPage() should return the next page of the current page", function() {
-
             expect(pageCollectionService.getNextPage(pageCollectionService.firstPage))
                 .toEqual(pageCollectionService.getPageByIndex(1));
 
@@ -141,11 +134,9 @@ export default function(): void {
                 .toEqual(pageCollectionService.getPageByIndex(3));
 
             expect(pageCollectionService.getNextPage(pageCollectionService.lastPage)).toBeNull();
-
         });
 
         it(".getStepItemIdForPage() should return the step id of the page", function() {
-
             const firstPageId = context.clarityDirective.pages.first.id;
             const lastPageId = context.clarityDirective.pages.last.id;
 
@@ -154,7 +145,6 @@ export default function(): void {
 
             expect(pageCollectionService.getStepItemIdForPage(pageCollectionService.firstPage)).toBe(firstPageStepId);
             expect(pageCollectionService.getStepItemIdForPage(pageCollectionService.lastPage)).toBe(lastPageStepId);
-
         });
 
         it(".commitPage() should set the page's completed property to true", function() {

--- a/src/clarity-angular/wizard/providers/wizard-navigation.spec.ts
+++ b/src/clarity-angular/wizard/providers/wizard-navigation.spec.ts
@@ -145,7 +145,6 @@ export default function(): void {
             wizardNavigationService.currentPage = testPage;
             wizardNavigationService.previous();
             expect(wizardNavigationService.currentPage).toEqual(previousPage);
-
         });
 
         it(".previous() set current page to incomplete if set to forceForward navigation", function() {

--- a/src/clarity-angular/wizard/wizard-page.spec.ts
+++ b/src/clarity-angular/wizard/wizard-page.spec.ts
@@ -523,7 +523,6 @@ export default function(): void {
                     fixture.detectChanges();
                     expect(testWizardPage.current).toBe(true);
                 });
-
             });
 
             describe("disabled", () => {

--- a/src/clarity-angular/wizard/wizard-stepnav-item.spec.ts
+++ b/src/clarity-angular/wizard/wizard-stepnav-item.spec.ts
@@ -71,7 +71,6 @@ export default function(): void {
         });
 
         describe("Typescript API", () => {
-
             describe("id", () => {
                 it("should call page collection service for step item id", () => {
                     const pageCollectionSpy = spyOn(testItemComponent.pageCollection, "getStepItemIdForPage");

--- a/src/clarity-icons/clarity-icons-element.ts
+++ b/src/clarity-icons/clarity-icons-element.ts
@@ -148,7 +148,6 @@ ClarityIconElement.prototype._setAriaLabelledBy = function() {
 };
 
 ClarityIconElement.prototype._injectTemplate = function() {
-
     this.innerHTML = this.currentShapeTemplate;
 
     if (this.currentTitleAttrVal) {

--- a/src/clarity-icons/clarity-icons.spec.ts
+++ b/src/clarity-icons/clarity-icons.spec.ts
@@ -538,8 +538,6 @@ describe("ClarityIcons", () => {
                 .toBe(removeWhitespace(getErrorShape(clrIconUniqId, customTitle)));
             expect(console.error).toHaveBeenCalled();
         });
-
-
     });
 
     describe("SVG Icon Markups", () => {
@@ -626,6 +624,5 @@ describe("ClarityIcons", () => {
 
             testAllShapesRequiredAttributes(currentAllShapes);
         });
-
     });
 });

--- a/src/ks-app/src/app/containers/progress/progress-bars.component.ts
+++ b/src/ks-app/src/app/containers/progress/progress-bars.component.ts
@@ -58,7 +58,6 @@ export class KSProgressBars {
     runProgressBar(): void {
         this.stopProgressBar();
         this.inlineProgressTimerId = window.setInterval(() => {
-
             const oldProgressValue: number = this.inlineProgress;
             let increment: number = Math.floor(Math.random() * 15) + 1;
             increment = parseInt(increment + "", 10);


### PR DESCRIPTION
• previously only recognized “info” and such
• now recognizes both “info” and deprecated “alert-info” alert types
• also added tests for this functionality

Tested in:
✔︎ Chrome

Closes: #1747

Signed-off-by: Scott Mathis <smathis@vmware.com>