### PR TITLE
[NG] fix selection with pagination in datagrid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "clr-all",
-    "version": "0.11.0-alpha.1",
+    "version": "0.11.0-beta.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/app/datagrid/datagrid.demo.html
+++ b/src/app/datagrid/datagrid.demo.html
@@ -6,7 +6,7 @@
 
 <h2>Datagrid</h2>
 
-<ul>
+<ul class="datagrid-nav">
     <li><a [routerLink]="['./kitchen-sink']">Kitchen Sink (for CSS regression)</a></li>
     <li><a [routerLink]="['./structure']">Basic structure</a></li>
     <li><a [routerLink]="['./custom-rendering']">Custom cell rendering</a></li>

--- a/src/app/datagrid/datagrid.demo.scss
+++ b/src/app/datagrid/datagrid.demo.scss
@@ -4,7 +4,7 @@
 
 @import "../_utils/code";
 
-ul {
+.datagrid-nav {
     column-count: 3;
 }
 

--- a/src/app/datagrid/inventory/inventory.ts
+++ b/src/app/datagrid/inventory/inventory.ts
@@ -89,8 +89,9 @@ export class Inventory {
     }
 
     fetch(skip: number = 0, limit: number = this._currentQuery.length): Promise<FetchResult> {
-        const result:
-            FetchResult = {users: this._currentQuery.slice(skip, skip + limit), length: this._currentQuery.length};
+        // Stringify and parse to mimic new object creation like a real HTTP request
+        const items = JSON.stringify(this._currentQuery.slice(skip, skip + limit));
+        const result: FetchResult = {users: JSON.parse(items), length: this._currentQuery.length};
         this._currentQuery = null;
         return this._fakeHttp(result);
     }

--- a/src/app/datagrid/selection-single/selection-single.html
+++ b/src/app/datagrid/selection-single/selection-single.html
@@ -24,6 +24,8 @@
     have access to the full objects, we could perform any operation we want on it.
 </p>
 
+<h3>Client side, no trackBy</h3>
+
 <div class="card card-block">
     <p class="card-text username-list">
         Selected user:
@@ -48,7 +50,105 @@
         </clr-dg-cell>
     </clr-dg-row>
 
-    <clr-dg-footer>{{users.length}} users</clr-dg-footer>
+    <clr-dg-footer>
+        {{users.length}} users
+        <clr-dg-pagination></clr-dg-pagination>
+    </clr-dg-footer>
 </clr-datagrid>
 
-<clr-example [clrCode]="example" clrLanguage="html"></clr-example>
+<h3>Client side, trackBy index</h3>
+
+<div class="card card-block">
+    <p class="card-text username-list">
+        Selected user:
+        <em *ngIf="!trackByIndexSingleSelected">No user selected.</em>
+        <span class="username" *ngIf="trackByIndexSingleSelected">{{trackByIndexSingleSelected.name}}</span>
+    </p>
+</div>
+
+<clr-datagrid [(clrDgSingleSelected)]="trackByIndexSingleSelected">
+
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column>Name</clr-dg-column>
+    <clr-dg-column>Creation date</clr-dg-column>
+    <clr-dg-column>Favorite color</clr-dg-column>
+
+    <clr-dg-row *clrDgItems="let user of trackByIndexUsers; trackBy: trackByIndex" [clrDgItem]="user">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>
+            <span class="color-square" [style.backgroundColor]="user.color"></span>
+        </clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>
+        {{users.length}} users
+        <clr-dg-pagination></clr-dg-pagination>
+    </clr-dg-footer>
+</clr-datagrid>
+
+<h3>Client side, trackBy item</h3>
+
+<div class="card card-block">
+    <p class="card-text username-list">
+        Selected user:
+        <em *ngIf="!trackByIdSingleSelected">No user selected.</em>
+        <span class="username" *ngIf="trackByIdSingleSelected">{{trackByIdSingleSelected.name}}</span>
+    </p>
+</div>
+
+<clr-datagrid [(clrDgSingleSelected)]="trackByIdSingleSelected">
+        
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column>Name</clr-dg-column>
+    <clr-dg-column>Creation date</clr-dg-column>
+    <clr-dg-column>Favorite color</clr-dg-column>
+
+    <clr-dg-row *clrDgItems="let user of trackByIdUsers; trackBy: trackById" [clrDgItem]="user">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>
+            <span class="color-square" [style.backgroundColor]="user.color"></span>
+        </clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>
+        {{users.length}} users
+        <clr-dg-pagination></clr-dg-pagination>
+    </clr-dg-footer>
+</clr-datagrid>
+
+<h3>Server-driven, trackBy item</h3>
+
+<div class="card card-block">
+    <p class="card-text username-list">
+        Selected user:
+        <em *ngIf="!trackByIdSingleSelected">No user selected.</em>
+        <span class="username" *ngIf="trackByIdSingleSelected">{{trackByIdSingleSelected.name}}</span>
+    </p>
+</div>
+
+<clr-datagrid (clrDgRefresh)="refresh($event)" [(clrDgSingleSelected)]="trackByIdServerSingleSelected" [clrDgLoading]="loading">
+        
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column>Name</clr-dg-column>
+    <clr-dg-column>Creation date</clr-dg-column>
+    <clr-dg-column>Favorite color</clr-dg-column>
+
+    <clr-dg-row *ngFor="let user of trackByIdServerUsers; trackBy: trackById" [clrDgItem]="user">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>
+            <span class="color-square" [style.backgroundColor]="user.color"></span>
+        </clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>
+        {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
+        of {{total}} users
+        <clr-dg-pagination #pagination [clrDgTotalItems]="total"></clr-dg-pagination>
+    </clr-dg-footer>
+</clr-datagrid>

--- a/src/app/datagrid/selection-single/selection-single.ts
+++ b/src/app/datagrid/selection-single/selection-single.ts
@@ -5,20 +5,9 @@
  */
 import {Component} from "@angular/core";
 
-import {Inventory} from "../inventory/inventory";
+import {State} from "../../../clr-angular/data/datagrid";
+import {FetchResult, Inventory} from "../inventory/inventory";
 import {User} from "../inventory/user";
-
-const EXAMPLE = `
-<clr-datagrid [(clrDgSingleSelected)]="selectedUser">
-    <-- ... -->
-    <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
-        <-- ... -->
-    </clr-dg-row>
-   <-- ... -->
-</clr-datagrid>
-
-Selected user: <span class="username" *ngIf="selectedUser">{{selectedUser.name}}</span>
-`;
 
 @Component({
     selector: "clr-datagrid-selection-single-demo",
@@ -27,13 +16,54 @@ Selected user: <span class="username" *ngIf="selectedUser">{{selectedUser.name}}
     styleUrls: ["../datagrid.demo.scss"]
 })
 export class DatagridSelectionSingleDemo {
-    example = EXAMPLE;
     users: User[];
     singleSelected: User;
 
+    trackByIndexUsers: User[];
+    trackByIndexSingleSelected: User;
+
+    trackByIdUsers: User[];
+    trackByIdSingleSelected: User;
+
+    trackByIdServerUsers: User[];
+    trackByIdServerSingleSelected: User;
+
+    loading: boolean = true;
+    total: number;
+
     constructor(private inventory: Inventory) {
-        inventory.size = 10;
-        inventory.reset();
-        this.users = inventory.all;
+        this.inventory.size = 100;
+        this.inventory.latency = 500;
+        this.inventory.reset();
+        this.users = this.trackByIndexUsers = this.trackByIdUsers = this.inventory.all;
+    }
+
+    refresh(state: State) {
+        // this.loading = true;
+        const filters: {[prop: string]: any[]} = {};
+        if (state.filters) {
+            for (const filter of state.filters) {
+                const {property, value} = <{property: string, value: string}>filter;
+                filters[property] = [value];
+            }
+        }
+        this.inventory.filter(filters)
+            .sort(<{by: string, reverse: boolean}>state.sort)
+            .fetch(state.page.from, state.page.size)
+            .then((result: FetchResult) => {
+                setTimeout(() => {
+                    this.trackByIdServerUsers = result.users;
+                    this.total = result.length;
+                    this.loading = false;
+                });
+            });
+    }
+
+    trackByIndex(index: number, item: User) {
+        return index;
+    }
+
+    trackById(index: number, item: User) {
+        return item.id;
     }
 }

--- a/src/app/datagrid/selection/selection.html
+++ b/src/app/datagrid/selection/selection.html
@@ -29,43 +29,17 @@
     have access to the full objects, we could perform any operation we want on them.
 </p>
 
+<h3>Client side, no trackBy</h3>
+
 <div class="card card-block">
     <p class="card-text username-list">
         Selected users:
-        <em *ngIf="selected.length == 0">No user selected.</em>
-        <span class="username" *ngFor="let user of selected">{{user.name}}</span>
-    </p>
-
-    <p class="card-text username-list">
-        Users to be added to group:
-        <em *ngIf="toAdd.length == 0">No user selected.</em>
-        <span class="username" *ngFor="let user of toAdd">{{user.name}}</span>
-    </p>
-
-    <p class="card-text username-list">
-        Users to be deleted:
-        <em *ngIf="toDelete.length == 0">No user selected.</em>
-        <span class="username" *ngFor="let user of toDelete">{{user.name}}</span>
-    </p>
-
-    <p class="card-text username-list">
-        User to be edited:
-        <em *ngIf="!toEdit">No user selected.</em>
-        <span class="username" *ngIf="toEdit">{{toEdit.name}}</span>
+        <em *ngIf="clientNoTrackBySelected.length == 0">No user selected.</em>
+        <span class="username" *ngFor="let user of clientNoTrackBySelected">{{user.name}}</span>
     </p>
 </div>
 
-<clr-datagrid [(clrDgSelected)]="selected">
-    <clr-dg-action-bar>
-        <div class="btn-group btn-sm" role="group" aria-label="Available Actions" *ngIf="selected.length > 0">
-            <button type="button" class="btn btn-secondary" (click)="onAdd()"><clr-icon shape="plus"></clr-icon> Add
-                to
-                group</button>
-            <button type="button" class="btn btn-secondary" (click)="onDelete()" ><clr-icon shape="close"></clr-icon> Delete</button>
-            <button type="button" class="btn btn-secondary" (click)="onEdit()" *ngIf="selected.length == 1"><clr-icon shape="pencil"></clr-icon> Edit</button>
-        </div>
-    </clr-dg-action-bar>
-
+<clr-datagrid [(clrDgSelected)]="clientNoTrackBySelected">
     <clr-dg-column>User ID</clr-dg-column>
     <clr-dg-column>Name</clr-dg-column>
     <clr-dg-column>Creation date</clr-dg-column>
@@ -75,12 +49,7 @@
         </ng-container>
     </clr-dg-column>
 
-    <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
-        <clr-dg-action-overflow>
-            <button class="action-item" (click)="onEdit(user)">Edit</button>
-            <button class="action-item" (click)="onDelete(user)">Delete</button>
-        </clr-dg-action-overflow>
-
+    <clr-dg-row *clrDgItems="let user of clientNoTrackByUsers" [clrDgItem]="user">
         <clr-dg-cell>{{user.id}}</clr-dg-cell>
         <clr-dg-cell>{{user.name}}</clr-dg-cell>
         <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
@@ -89,7 +58,118 @@
         </clr-dg-cell>
     </clr-dg-row>
 
-    <clr-dg-footer>{{users.length}} users</clr-dg-footer>
+    <clr-dg-footer>
+        {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
+        of {{total}} users
+        <clr-dg-pagination #pagination [clrDgTotalItems]="total"></clr-dg-pagination>
+    </clr-dg-footer>
 </clr-datagrid>
 
-<clr-example [clrCode]="example" clrLanguage="html"></clr-example>
+<h3>Client side, trackBy index</h3>
+
+<div class="card card-block">
+    <p class="card-text username-list">
+        Selected users:
+        <em *ngIf="clientTrackByIndexSelected.length == 0">No user selected.</em>
+        <span class="username" *ngFor="let user of clientTrackByIndexSelected">{{user.name}}</span>
+    </p>
+</div>
+
+<clr-datagrid [(clrDgSelected)]="clientTrackByIndexSelected">
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column>Name</clr-dg-column>
+    <clr-dg-column>Creation date</clr-dg-column>
+    <clr-dg-column>
+        <ng-container *clrDgHideableColumn>
+            Favorite color
+        </ng-container>
+    </clr-dg-column>
+
+    <clr-dg-row *clrDgItems="let user of clientTrackByIndexUsers; trackBy: trackByIndex" [clrDgItem]="user">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>
+            <span class="color-square" [style.backgroundColor]="user.color"></span>
+        </clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>
+        {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
+        of {{total}} users
+        <clr-dg-pagination #pagination [clrDgTotalItems]="total"></clr-dg-pagination>
+    </clr-dg-footer>
+</clr-datagrid>
+
+<h3>Client side, trackBy item</h3>
+
+<div class="card card-block">
+    <p class="card-text username-list">
+        Selected users:
+        <em *ngIf="clientTrackByIdSelected.length == 0">No user selected.</em>
+        <span class="username" *ngFor="let user of clientTrackByIdSelected">{{user.name}}</span>
+    </p>
+</div>
+
+<clr-datagrid [(clrDgSelected)]="clientTrackByIdSelected">
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column>Name</clr-dg-column>
+    <clr-dg-column>Creation date</clr-dg-column>
+    <clr-dg-column>
+        <ng-container *clrDgHideableColumn>
+            Favorite color
+        </ng-container>
+    </clr-dg-column>
+
+    <clr-dg-row *clrDgItems="let user of clientTrackByIdUsers; trackBy: trackById" [clrDgItem]="user">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>
+            <span class="color-square" [style.backgroundColor]="user.color"></span>
+        </clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>
+        {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
+        of {{total}} users
+        <clr-dg-pagination #pagination [clrDgTotalItems]="total"></clr-dg-pagination>
+    </clr-dg-footer>
+</clr-datagrid>
+
+<h3>Server-driven, trackBy item</h3>
+
+<div class="card card-block">
+    <p class="card-text username-list">
+        Selected users:
+        <em *ngIf="serverTrackByIdSelected.length == 0">No user selected.</em>
+        <span class="username" *ngFor="let user of serverTrackByIdSelected">{{user.name}}</span>
+    </p>
+</div>
+
+<clr-datagrid [(clrDgSelected)]="serverTrackByIdSelected" (clrDgRefresh)="refresh($event)" [clrDgLoading]="loading">
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column>Name</clr-dg-column>
+    <clr-dg-column>Creation date</clr-dg-column>
+    <clr-dg-column>
+        <ng-container *clrDgHideableColumn>
+            Favorite color
+        </ng-container>
+    </clr-dg-column>
+
+    <clr-dg-row *ngFor="let user of serverTrackByIdUsers; trackBy: trackById" [clrDgItem]="user">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>
+            <span class="color-square" [style.backgroundColor]="user.color"></span>
+        </clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>
+        {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
+        of {{total}} users
+        <clr-dg-pagination #pagination [clrDgTotalItems]="total" [clrDgPageSize]="10"></clr-dg-pagination>
+    </clr-dg-footer>
+</clr-datagrid>
+    

--- a/src/app/datagrid/sorting/sorting.ts
+++ b/src/app/datagrid/sorting/sorting.ts
@@ -5,7 +5,7 @@
  */
 import {Component} from "@angular/core";
 
-import {ClrDatagridSortOrder} from "../../../clr-angular";
+import {ClrDatagridSortOrder} from "../../../clr-angular/data/datagrid/interfaces/sort-order";
 import {Inventory} from "../inventory/inventory";
 import {User} from "../inventory/user";
 import {PokemonComparator} from "../utils/pokemon-comparator";

--- a/src/app/tree-view/utils/example.ts
+++ b/src/app/tree-view/utils/example.ts
@@ -5,7 +5,7 @@
  */
 import {AfterViewInit, Component, Input, ViewChild} from "@angular/core";
 
-import {ClrCodeHighlight} from "../../../clr-angular";
+import {ClrCodeHighlight} from "../../../clr-angular/code/syntax-highlight/syntax-highlight";
 
 @Component({
     selector: "clr-example",

--- a/src/clr-angular/data/datagrid/all.spec.ts
+++ b/src/clr-angular/data/datagrid/all.spec.ts
@@ -24,6 +24,7 @@ import DatagridFilterSpecs from "./datagrid-filter.spec";
 import DatagridFooterSpecs from "./datagrid-footer.spec";
 import DatagridHideableColumnSpec from "./datagrid-hideable-column.model.spec";
 import DatagridHideableColumnDirectiveSpec from "./datagrid-hideable-column.spec";
+import DatagridItemsTrackBySpecs from "./datagrid-items-trackby.spec";
 import DatagridItemsSpecs from "./datagrid-items.spec";
 import DatagridPaginationSpecs from "./datagrid-pagination.spec";
 import DatagridPlaceholderSpecs from "./datagrid-placeholder.spec";
@@ -67,6 +68,7 @@ describe("Datagrid", function() {
         DatagridFilterSpecs();
         DatagridColumnSpecs();
         DatagridItemsSpecs();
+        DatagridItemsTrackBySpecs();
         DatagridRowSpecs();
         DatagridRowDetailSpecs();
         DatagridPaginationSpecs();

--- a/src/clr-angular/data/datagrid/datagrid-items-trackby.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-items-trackby.spec.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component, ViewChild} from "@angular/core";
+import {TestBed} from "@angular/core/testing";
+
+import {ClrDatagridItems} from "./datagrid-items";
+import {ClrDatagridModule} from "./datagrid.module";
+import {FiltersProvider} from "./providers/filters";
+import {Items} from "./providers/items";
+import {Page} from "./providers/page";
+import {Sort} from "./providers/sort";
+import {StateDebouncer} from "./providers/state-debouncer.provider";
+
+export default function(): void {
+    describe("DatagridItemsTrackby directive", function() {
+        beforeEach(function() {
+            /*
+             * Since the DatagridItems element is a template that isn't rendered in the DOM,
+             * we can't use our usual shortcut, we need to rely on @ViewChild
+             */
+            TestBed.configureTestingModule({
+                imports: [ClrDatagridModule],
+                declarations: [FullTest],
+                providers: [Items, FiltersProvider, Sort, Page, StateDebouncer]
+            });
+            this.fixture = TestBed.createComponent(FullTest);
+            this.fixture.detectChanges();
+            this.testComponent = this.fixture.componentInstance;
+            this.itemsProvider = TestBed.get(Items);
+        });
+
+        afterEach(function() {
+            this.fixture.destroy();
+        });
+
+        it("receives an input for the trackBy option", function() {
+            expect(this.itemsProvider.trackBy).toBeUndefined();
+            this.testComponent.trackBy = (index: number, item: any) => index;
+            this.fixture.detectChanges();
+            expect(this.itemsProvider.trackBy).toBe(this.testComponent.trackBy);
+        });
+    });
+}
+
+
+@Component({template: `<div *ngFor="let n of numbers; trackBy: trackBy">{{n}}</div>`})
+class FullTest {
+    @ViewChild(ClrDatagridItems) datagridItems: ClrDatagridItems;
+
+    numbers = [1, 2, 3, 4, 5];
+
+    trackBy: (index: number, item: any) => any;
+}

--- a/src/clr-angular/data/datagrid/datagrid-items-trackby.ts
+++ b/src/clr-angular/data/datagrid/datagrid-items-trackby.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Directive, Input, Optional, TrackByFunction} from "@angular/core";
+
+import {Items} from "./providers/items";
+
+@Directive({
+    selector: "[ngForTrackBy]",
+})
+export class ClrDatagridItemsTrackBy {
+    constructor(@Optional() private _items: Items) {}
+
+    @Input("ngForTrackBy")
+    set trackBy(value: TrackByFunction<Function>) {
+        if (this._items) {
+            this._items.trackBy = value;
+        }
+    }
+}

--- a/src/clr-angular/data/datagrid/datagrid-row.ts
+++ b/src/clr-angular/data/datagrid/datagrid-row.ts
@@ -41,7 +41,7 @@ let nbRow: number = 0;
                          class="datagrid-select datagrid-fixed-column">
                 <div class="radio">
                     <input type="radio" [id]="id" [name]="selection.id + '-radio'" [value]="item"
-                           [(ngModel)]="selection.currentSingle">
+                           [(ngModel)]="selection.currentSingle" [checked]="selection.currentSingle === item">
                     <label for="{{id}}"></label>
                 </div>
             </clr-dg-cell>

--- a/src/clr-angular/data/datagrid/datagrid.module.ts
+++ b/src/clr-angular/data/datagrid/datagrid.module.ts
@@ -31,6 +31,7 @@ import {ClrDatagridFilter} from "./datagrid-filter";
 import {ClrDatagridFooter} from "./datagrid-footer";
 import {ClrDatagridHideableColumn} from "./datagrid-hideable-column";
 import {ClrDatagridItems} from "./datagrid-items";
+import {ClrDatagridItemsTrackBy} from "./datagrid-items-trackby";
 import {ClrDatagridPagination} from "./datagrid-pagination";
 import {ClrDatagridPlaceholder} from "./datagrid-placeholder";
 import {ClrDatagridRow} from "./datagrid-row";
@@ -52,8 +53,9 @@ import {DatagridTableRenderer} from "./render/table-renderer";
 export const CLR_DATAGRID_DIRECTIVES: Type<any>[] = [
     // Core
     ClrDatagrid, ClrDatagridActionBar, ClrDatagridActionOverflow, ClrDatagridColumn, ClrDatagridColumnToggle,
-    ClrDatagridHideableColumn, ClrDatagridFilter, ClrDatagridItems, ClrDatagridRow, ClrDatagridRowDetail,
-    DatagridDetailRegisterer, ClrDatagridCell, ClrDatagridFooter, ClrDatagridPagination, ClrDatagridPlaceholder,
+    ClrDatagridHideableColumn, ClrDatagridFilter, ClrDatagridItems, ClrDatagridItemsTrackBy, ClrDatagridRow,
+    ClrDatagridRowDetail, DatagridDetailRegisterer, ClrDatagridCell, ClrDatagridFooter, ClrDatagridPagination,
+    ClrDatagridPlaceholder,
 
     // Renderers
     DatagridMainRenderer, DatagridTableRenderer, DatagridHeadRenderer, DatagridHeaderRenderer, DatagridBodyRenderer,

--- a/src/clr-angular/data/datagrid/providers/items.ts
+++ b/src/clr-angular/data/datagrid/providers/items.ts
@@ -82,10 +82,11 @@ export class Items {
     public set all(items: any[]) {
         if (this.smart) {
             this._all = items;
-            this.emitAllChanges();
+            this.emitAllChanges(items);
             this._filterItems();
         } else {
             this._displayed = items;
+            this.emitAllChanges(items);
             this.emitChange();
         }
     }
@@ -126,10 +127,8 @@ export class Items {
     }
 
     private _allChanges = new Subject<any[]>();
-    private emitAllChanges(): void {
-        if (this.smart) {
-            this._allChanges.next(this._all);
-        }
+    private emitAllChanges(items: any[]): void {
+        this._allChanges.next(items);
     }
 
     public get allChanges(): Observable<any[]> {

--- a/src/clr-angular/data/datagrid/providers/selection.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/selection.spec.ts
@@ -32,9 +32,6 @@ export default function(): void {
             itemsInstance = new Items(filtersInstance, sortInstance, pageInstance);
 
             selectionInstance = new Selection(itemsInstance, filtersInstance);
-
-            itemsInstance.smartenUp();
-            itemsInstance.all = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         });
 
         afterEach(function() {
@@ -42,185 +39,349 @@ export default function(): void {
             itemsInstance.destroy();
         });
 
-        it("starts inactive", function() {
-            expect(selectionInstance.selectionType).toBe(SelectionType.None);
-            expect(selectionInstance.current).toBeUndefined();
-            selectionInstance.setSelected(4, true);
-            expect(selectionInstance.current).toBeUndefined();
-        });
-
-        it("can select/deselect items in multi selection type", function() {
-            selectionInstance.selectionType = SelectionType.Multi;
-            selectionInstance.setSelected(4, true);
-            expect(selectionInstance.current).toEqual([4]);
-            selectionInstance.setSelected(2, true);
-            expect(selectionInstance.current).toEqual([4, 2]);
-        });
-
-        it("can select/deselect all items at once in multi selection type if no pagination exist", function() {
-            selectionInstance.selectionType = SelectionType.Multi;
-            selectionInstance.toggleAll();
-            expect(selectionInstance.current).toEqual(itemsInstance.displayed);
-            selectionInstance.toggleAll();
-            expect(selectionInstance.current).toEqual([]);
-            selectionInstance.setSelected(4, true);
-            expect(selectionInstance.current).toEqual([4]);
-            selectionInstance.toggleAll();
-            expect(selectionInstance.current.sort(numberSort)).toEqual(itemsInstance.displayed);
-        });
-
-        it("can select/deselect items only on the current page", function() {
-            selectionInstance.selectionType = SelectionType.Multi;
-            pageInstance.size = 3;
-            selectionInstance.current = [4, 1, 2];
-            pageInstance.current = 2;
-            selectionInstance.toggleAll();
-            expect(selectionInstance.current).toEqual([4, 1, 2, 5, 6]);
-            selectionInstance.toggleAll();
-            expect(selectionInstance.current).toEqual([1, 2]);
-        });
-
-        it("can't select/deselect all items at once in other single selection type", function() {
-            selectionInstance.selectionType = SelectionType.Single;
-            selectionInstance.toggleAll();
-            expect(selectionInstance.currentSingle).toBeUndefined();
-            selectionInstance.currentSingle = 4;
-            selectionInstance.toggleAll();
-            expect(selectionInstance.currentSingle).toEqual(4);
-        });
-
-        it("can detect if an item is selected", function() {
-            selectionInstance.selectionType = SelectionType.Multi;
-            expect(selectionInstance.isSelected(4)).toBe(false);
-            selectionInstance.setSelected(4, true);
-            expect(selectionInstance.isSelected(4)).toBe(true);
-            selectionInstance.setSelected(4, false);
-            expect(selectionInstance.isSelected(4)).toBe(false);
-        });
-
-        it("can detect if all items are selected in multi selection type", function() {
-            selectionInstance.selectionType = SelectionType.Multi;
-            expect(selectionInstance.isAllSelected()).toBe(false);
-            selectionInstance.setSelected(4, true);
-            expect(selectionInstance.isAllSelected()).toBe(false);
-            selectionInstance.current = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
-            expect(selectionInstance.isAllSelected()).toBe(true);
-        });
-
-        it("accepts pre-selected items in multi selection type", function() {
-            selectionInstance.selectionType = SelectionType.Multi;
-            selectionInstance.current = [4, 2];
-            expect(selectionInstance.isSelected(1)).toBe(false);
-            expect(selectionInstance.isSelected(2)).toBe(true);
-            expect(selectionInstance.isSelected(3)).toBe(false);
-            expect(selectionInstance.isSelected(4)).toBe(true);
-        });
-
-        it("accepts pre-selected item in single selection type", function() {
-            selectionInstance.selectionType = SelectionType.Single;
-            selectionInstance.currentSingle = 2;
-            expect(selectionInstance.isSelected(1)).toBe(false);
-            expect(selectionInstance.isSelected(2)).toBe(true);
-            expect(selectionInstance.isSelected(3)).toBe(false);
-            expect(selectionInstance.isSelected(4)).toBe(false);
-        });
-
-        it("exposes an Observable to follow selection changes in multi selection type", function() {
-            let nbChanges = 0;
-            let currentSelection: any[];
-            selectionInstance.change.subscribe((items: any[]) => {
-                nbChanges++;
-                currentSelection = items;
+        describe("with smart items", function() {
+            beforeEach(function() {
+                itemsInstance.smartenUp();
+                itemsInstance.all = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
             });
-            expect(currentSelection).toBeUndefined();
-            selectionInstance.selectionType = SelectionType.Multi;
-            expect(currentSelection).toEqual([]);
-            selectionInstance.setSelected(4, true);
-            expect(selectionInstance.current).toEqual([4]);
-            selectionInstance.toggleAll();
-            expect(selectionInstance.current.sort(numberSort)).toEqual(itemsInstance.displayed);
-            selectionInstance.toggleAll();
-            expect(selectionInstance.current).toEqual([]);
-            expect(nbChanges).toBe(4);
-        });
 
-        it("exposes an Observable to follow selection changes in single selection type", function() {
-            let nbChanges = 0;
-            let currentSelection: any;
-            selectionInstance.change.subscribe((items: any) => {
-                nbChanges++;
-                currentSelection = items;
+            it("starts inactive", function() {
+                expect(selectionInstance.selectionType).toBe(SelectionType.None);
+                expect(selectionInstance.current).toBeUndefined();
+                selectionInstance.setSelected(4, true);
+                expect(selectionInstance.current).toBeUndefined();
             });
-            expect(currentSelection).toBeUndefined();
-            selectionInstance.selectionType = SelectionType.Single;
-            expect(currentSelection).toBeUndefined();
-            selectionInstance.currentSingle = 4;
-            selectionInstance.currentSingle = 2;
-            expect(nbChanges).toBe(3);
+
+            it("can select/deselect items in multi selection type", function() {
+                selectionInstance.selectionType = SelectionType.Multi;
+                selectionInstance.setSelected(4, true);
+                expect(selectionInstance.current).toEqual([4]);
+                selectionInstance.setSelected(2, true);
+                expect(selectionInstance.current).toEqual([4, 2]);
+            });
+
+            it("can select/deselect all items at once in multi selection type", function() {
+                selectionInstance.selectionType = SelectionType.Multi;
+                selectionInstance.toggleAll();
+                expect(selectionInstance.current).toEqual(itemsInstance.displayed);
+                selectionInstance.toggleAll();
+                expect(selectionInstance.current).toEqual([]);
+                selectionInstance.setSelected(4, true);
+                expect(selectionInstance.current).toEqual([4]);
+                selectionInstance.toggleAll();
+                expect(selectionInstance.current.sort(numberSort)).toEqual(itemsInstance.displayed);
+            });
+
+            it("can't select/deselect all items at once in other single selection type", function() {
+                selectionInstance.selectionType = SelectionType.Single;
+                selectionInstance.toggleAll();
+                expect(selectionInstance.currentSingle).toBeUndefined();
+                selectionInstance.currentSingle = 4;
+                selectionInstance.toggleAll();
+                expect(selectionInstance.currentSingle).toEqual(4);
+            });
+
+            it("can select/deselect all items at once in multi selection type if no pagination exist", function() {
+                selectionInstance.selectionType = SelectionType.Multi;
+                selectionInstance.toggleAll();
+                expect(selectionInstance.current).toEqual(itemsInstance.displayed);
+                selectionInstance.toggleAll();
+                expect(selectionInstance.current).toEqual([]);
+                selectionInstance.setSelected(4, true);
+                expect(selectionInstance.current).toEqual([4]);
+                selectionInstance.toggleAll();
+                expect(selectionInstance.current.sort(numberSort)).toEqual(itemsInstance.displayed);
+            });
+
+            it("can select/deselect items only on the current page", function() {
+                selectionInstance.selectionType = SelectionType.Multi;
+                pageInstance.size = 3;
+                selectionInstance.current = [4, 1, 2];
+                pageInstance.current = 2;
+                selectionInstance.toggleAll();
+                expect(selectionInstance.current).toEqual([4, 1, 2, 5, 6]);
+                selectionInstance.toggleAll();
+                expect(selectionInstance.current).toEqual([1, 2]);
+            });
+
+            it("can't select/deselect all items at once in other single selection type", function() {
+                selectionInstance.selectionType = SelectionType.Single;
+                selectionInstance.toggleAll();
+                expect(selectionInstance.currentSingle).toBeUndefined();
+                selectionInstance.currentSingle = 4;
+                selectionInstance.toggleAll();
+                expect(selectionInstance.currentSingle).toEqual(4);
+            });
+
+            it("can detect if an item is selected", function() {
+                selectionInstance.selectionType = SelectionType.Multi;
+                expect(selectionInstance.isSelected(4)).toBe(false);
+                selectionInstance.setSelected(4, true);
+                expect(selectionInstance.isSelected(4)).toBe(true);
+                selectionInstance.setSelected(4, false);
+                expect(selectionInstance.isSelected(4)).toBe(false);
+            });
+
+            it("can detect if all items are selected in multi selection type", function() {
+                selectionInstance.selectionType = SelectionType.Multi;
+                expect(selectionInstance.isAllSelected()).toBe(false);
+                selectionInstance.setSelected(4, true);
+                expect(selectionInstance.isAllSelected()).toBe(false);
+                selectionInstance.current = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
+                expect(selectionInstance.isAllSelected()).toBe(true);
+            });
+
+            it("accepts pre-selected items in multi selection type", function() {
+                selectionInstance.selectionType = SelectionType.Multi;
+                selectionInstance.current = [4, 2];
+                expect(selectionInstance.isSelected(1)).toBe(false);
+                expect(selectionInstance.isSelected(2)).toBe(true);
+                expect(selectionInstance.isSelected(3)).toBe(false);
+                expect(selectionInstance.isSelected(4)).toBe(true);
+            });
+
+            it("accepts pre-selected item in single selection type", function() {
+                selectionInstance.selectionType = SelectionType.Single;
+                selectionInstance.currentSingle = 2;
+                expect(selectionInstance.isSelected(1)).toBe(false);
+                expect(selectionInstance.isSelected(2)).toBe(true);
+                expect(selectionInstance.isSelected(3)).toBe(false);
+                expect(selectionInstance.isSelected(4)).toBe(false);
+            });
+
+            it("exposes an Observable to follow selection changes in multi selection type", function() {
+                let nbChanges = 0;
+                let currentSelection: any[];
+                selectionInstance.change.subscribe((items: any[]) => {
+                    nbChanges++;
+                    currentSelection = items;
+                });
+                expect(currentSelection).toBeUndefined();
+                selectionInstance.selectionType = SelectionType.Multi;
+                expect(currentSelection).toEqual([]);
+                selectionInstance.setSelected(4, true);
+                expect(selectionInstance.current).toEqual([4]);
+                selectionInstance.toggleAll();
+                expect(selectionInstance.current.sort(numberSort)).toEqual(itemsInstance.displayed);
+                selectionInstance.toggleAll();
+                expect(selectionInstance.current).toEqual([]);
+                expect(nbChanges).toBe(4);
+            });
+
+            it("exposes an Observable to follow selection changes in single selection type", function() {
+                let nbChanges = 0;
+                let currentSelection: any;
+                selectionInstance.change.subscribe((items: any) => {
+                    nbChanges++;
+                    currentSelection = items;
+                });
+                expect(currentSelection).toBeUndefined();
+                selectionInstance.selectionType = SelectionType.Single;
+                expect(currentSelection).toBeUndefined();
+                selectionInstance.currentSingle = 4;
+                selectionInstance.currentSingle = 2;
+                expect(nbChanges).toBe(3);
+            });
+
+            it("clears selection when a filter is added", function() {
+                selectionInstance.selectionType = SelectionType.Multi;
+                selectionInstance.current = [4, 2];
+
+                const evenFilter: EvenFilter = new EvenFilter();
+
+                filtersInstance.add(<ClrDatagridFilterInterface<any>>evenFilter);
+
+                evenFilter.toggle();
+
+                expect(selectionInstance.current.length).toBe(0);
+            });
+
+            it("keeps only the remaining selection when the items are updated", fakeAsync(function() {
+                   selectionInstance.selectionType = SelectionType.Multi;
+                   selectionInstance.current = [4, 2];
+
+                   itemsInstance.all = [1, 2, 3, 5];
+
+                   tick();
+
+                   expect(selectionInstance.current.length).toBe(1);
+                   expect(selectionInstance.current).toEqual([2]);
+               }));
+
+            it("keeps all the selections when the items are updated " +
+                   "and the contain all the previous selection",
+               fakeAsync(function() {
+                   selectionInstance.selectionType = SelectionType.Multi;
+                   selectionInstance.current = [4, 2];
+
+                   itemsInstance.all = [1, 2, 3, 4, 5];
+
+                   tick();
+
+                   expect(selectionInstance.current.length).toBe(2);
+                   expect(selectionInstance.current).toEqual([4, 2]);
+               }));
+
+            it("clears the selections when the items are updated and " +
+                   "they do not contain the previous selection",
+               fakeAsync(function() {
+                   selectionInstance.selectionType = SelectionType.Multi;
+                   selectionInstance.current = [4, 2];
+
+                   itemsInstance.all = [1, 3, 5];
+
+                   tick();
+
+                   expect(selectionInstance.current.length).toBe(0);
+                   expect(selectionInstance.current).toEqual([]);
+               }));
+
+            it("maintains the selection when the page is changed", function() {
+                selectionInstance.selectionType = SelectionType.Multi;
+                selectionInstance.current = [4, 2];
+
+                pageInstance.size = 3;
+
+                pageInstance.current = 2;
+
+                expect(selectionInstance.current).toEqual([4, 2]);
+            });
         });
 
-        it("clears selection when a filter is added", function() {
-            selectionInstance.selectionType = SelectionType.Multi;
-            selectionInstance.current = [4, 2];
+        describe("client-side selection and pagination", function() {
+            const items = [{id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}, {id: 6}, {id: 7}, {id: 8}, {id: 9}, {id: 10}];
+            function testSelectedItems(selectedIndexes: any[]) {
+                items.forEach((item, index) => {
+                    const state = selectedIndexes.indexOf(index) > -1;
+                    expect(selectionInstance.isSelected(item)).toEqual(state);
+                });
+            }
 
-            const evenFilter: EvenFilter = new EvenFilter();
+            beforeEach(function() {
+                beforeEach(function() {
+                    itemsInstance.smartenUp();
+                    itemsInstance.all = items;
+                    pageInstance.size = 3;
+                });
+            });
 
-            filtersInstance.add(<ClrDatagridFilterInterface<any>>evenFilter);
+            describe("multi-selection", function() {
+                function testMultiSelection() {
+                    selectionInstance.setSelected(items[2], true);
+                    testSelectedItems([2]);
+                    expect(selectionInstance.current).toEqual([items[2]]);
+                    pageInstance.current = 3;
+                    testSelectedItems([2]);
+                    expect(selectionInstance.current).toEqual([items[2]]);
+                }
 
-            evenFilter.toggle();
+                beforeEach(function() {
+                    selectionInstance.selectionType = SelectionType.Multi;
+                });
 
-            expect(selectionInstance.current.length).toBe(0);
+                it("should support no trackBy", function() {
+                    testMultiSelection();
+                });
+
+                it("should support trackBy item", function() {
+                    itemsInstance.trackBy = (index, item) => item.id;
+                    itemsInstance.all = items;
+                    testMultiSelection();
+                });
+
+                it("should support trackBy index", function() {
+                    itemsInstance.trackBy = (index, item) => index;
+                    itemsInstance.all = items;
+                    testMultiSelection();
+                });
+            });
+
+            describe("single selection", function() {
+                function testSingleSelection() {
+                    selectionInstance.currentSingle = items[2];
+                    pageInstance.current = 2;
+                    testSelectedItems([2]);
+                    selectionInstance.currentSingle = items[5];
+                    pageInstance.current = 3;
+                    testSelectedItems([5]);
+                }
+
+                beforeEach(function() {
+                    selectionInstance.selectionType = SelectionType.Single;
+                });
+
+                it("should support no trackBy", function() {
+                    testSingleSelection();
+                });
+
+                it("should support trackBy item", function() {
+                    itemsInstance.trackBy = (index, item) => item.id;
+                    itemsInstance.all = items;
+                    testSingleSelection();
+                });
+
+                it("should support trackBy index", function() {
+                    itemsInstance.trackBy = (index, item) => index;
+                    itemsInstance.all = items;
+                    testSingleSelection();
+                });
+            });
         });
 
-        it("keeps only the remaining selection when the items are updated", fakeAsync(function() {
-               selectionInstance.selectionType = SelectionType.Multi;
-               selectionInstance.current = [4, 2];
+        describe("server-driven selection and pagination", function() {
+            const itemsA = [{id: 1}, {id: 2}, {id: 3}];
+            const itemsB = [{id: 4}, {id: 5}, {id: 6}];
+            const itemsC = itemsA.map(item => Object.assign({modified: true}, item));
 
-               itemsInstance.all = [1, 2, 3, 5];
+            function testSelection(stateA, stateB, stateC) {
+                expect(selectionInstance.isSelected(itemsA[0])).toEqual(stateA);
+                expect(selectionInstance.isSelected(itemsB[0])).toEqual(stateB);
+                expect(selectionInstance.isSelected(itemsC[0])).toEqual(stateC);
+            }
 
-               tick();
+            describe("multi-selection", function() {
+                beforeEach(function() {
+                    selectionInstance.selectionType = SelectionType.Multi;
+                });
+                // We don't support server-driven, multi-selection without trackBy.
+                // We don't support server-driven, multi-selection, trackBy index.
+                it("should support trackBy item", fakeAsync(() => {
+                       itemsInstance.trackBy = (index, item) => item.id;
+                       itemsInstance.all = itemsA;
+                       tick();
+                       selectionInstance.setSelected(itemsA[0], true);
+                       testSelection(true, false, false);
+                       itemsInstance.all = itemsB;
+                       tick();
+                       testSelection(true, false, false);
+                       itemsInstance.all = itemsC;
+                       tick();
+                       testSelection(false, false, true);
+                       expect(selectionInstance.current[0].modified).toEqual(true);
+                   }));
+            });
 
-               expect(selectionInstance.current.length).toBe(1);
-               expect(selectionInstance.current).toEqual([2]);
-           }));
-
-        it("keeps all the selections when the items are updated " +
-               "and the contain all the previous selection",
-           fakeAsync(function() {
-               selectionInstance.selectionType = SelectionType.Multi;
-               selectionInstance.current = [4, 2];
-
-               itemsInstance.all = [1, 2, 3, 4, 5];
-
-               tick();
-
-               expect(selectionInstance.current.length).toBe(2);
-               expect(selectionInstance.current).toEqual([4, 2]);
-           }));
-
-        it("clears the selections when the items are updated and " +
-               "they do not contain the previous selection",
-           fakeAsync(function() {
-               selectionInstance.selectionType = SelectionType.Multi;
-               selectionInstance.current = [4, 2];
-
-               itemsInstance.all = [1, 3, 5];
-
-               tick();
-
-               expect(selectionInstance.current.length).toBe(0);
-               expect(selectionInstance.current).toEqual([]);
-           }));
-
-        it("maintains the selection when the page is changed", function() {
-            selectionInstance.selectionType = SelectionType.Multi;
-            selectionInstance.current = [4, 2];
-
-            pageInstance.size = 3;
-
-            pageInstance.current = 2;
-
-            expect(selectionInstance.current).toEqual([4, 2]);
+            describe("single selection", function() {
+                beforeEach(function() {
+                    selectionInstance.selectionType = SelectionType.Single;
+                });
+                // We don't support server-driven, multi-selection without trackBy.
+                // We don't support server-driven, multi-selection, trackBy index.
+                it("should support trackBy item", fakeAsync(() => {
+                       itemsInstance.trackBy = (index, item) => item.id;
+                       itemsInstance.all = itemsA;
+                       tick();
+                       selectionInstance.currentSingle = itemsA[0];
+                       testSelection(true, false, false);
+                       itemsInstance.all = itemsB;
+                       tick();
+                       testSelection(true, false, false);
+                       // itemsInstance.all = itemsC;
+                       // tick();
+                       // testSelection(false, false, true);
+                       // expect(selectionInstance.currentSingle.modified).toEqual(true);
+                   }));
+            });
         });
     });
 }

--- a/src/clr-angular/data/datagrid/render/main-renderer.spec.ts
+++ b/src/clr-angular/data/datagrid/render/main-renderer.spec.ts
@@ -200,7 +200,6 @@ export default function(): void {
                 let scrollSpyFlag: boolean = false;
                 organizer.scrollbar.subscribe(() => {
                     scrollSpyFlag = true;
-                    console.log("Test");
                 });
 
                 context.detectChanges();

--- a/src/clr-angular/data/datagrid/render/row-renderer.spec.ts
+++ b/src/clr-angular/data/datagrid/render/row-renderer.spec.ts
@@ -58,8 +58,6 @@ export default function(): void {
             context.testComponent.show = true;
             context.detectChanges();
             expect(cellWidthSpy.calls.allArgs()).toEqual([[false, 42], [true, 24]]);
-            console.log(organizer.widths);
-            console.log("cellWidthSpy: ", cellWidthSpy);
         });
 
         it("sets the size of cells when they change dynamically", function() {


### PR DESCRIPTION
This will update the current value instance when new items are set, such as from pagination, by using trackby to ensure that current array or item maps correctly to the instances of the currently displayed items.

It does this by always updating the `current` or `currentSingle` value with the updated instance if it could be matched based on the trackBy. This way our current equality checks work and the only time that we have to do lookups is during setting the state of a selected item. Gets should remain as fast as before.

There are 8 scenarios for selection and pagination that we can properly support. They are the following four scenarios for both single and multi-selection (2x4=8, yay math). There are explicit unit tests for each of these 8 scenarios.

* client side, no trackBy
* client side, trackBy index
* client side, trackBy item
* server side, trackBy item

Server side trackBy index and server side no trackBy don't make any sense because we cannot properly track instances of objects over pages. We need trackBy to know how to identify the object key, and using the index is folly because we only know the index of the current page (which might be index `4` but on page 4 that would actually be the index `44` and the Datagrid doesn't know that). 

fixes #1393 