### PR TITLE
[NG] fix chocolate error in columns hidden by default

### DIFF
--- a/src/clarity-angular/data/datagrid/datagrid.spec.ts
+++ b/src/clarity-angular/data/datagrid/datagrid.spec.ts
@@ -381,6 +381,13 @@ export default function(): void {
                     expect(() => context.detectChanges()).not.toThrow();
                 });
             });
+
+            describe("column hidden by default", function() {
+                it("doesn't taunt with chocolate on columns hidden by default", function() {
+                    const context = this.create(Datagrid, HiddenColumnTest);
+                    expect(() => context.detectChanges()).not.toThrow();
+                });
+            });
         });
     });
 }
@@ -646,4 +653,26 @@ class TestStringFilter implements StringFilter<number> {
     accepts(item: number, search: string) {
         return true;
     }
+}
+
+
+@Component({
+    selector: "hidden-column-test",
+    template: `
+    <clr-datagrid>
+        <clr-dg-column>
+            <ng-container *clrDgHideableColumn="{hidden: true}">
+                First
+            </ng-container>
+        </clr-dg-column>
+        <clr-dg-column>Second</clr-dg-column>
+    
+        <clr-dg-row *ngFor="let item of items;">
+            <clr-dg-cell>{{item}}</clr-dg-cell>
+            <clr-dg-cell>{{item * item}}</clr-dg-cell>
+        </clr-dg-row>
+    </clr-datagrid>`
+})
+class HiddenColumnTest {
+    items = [1, 2, 3];
 }

--- a/src/ks-app/src/app/containers/data/datagrid.component.html
+++ b/src/ks-app/src/app/containers/data/datagrid.component.html
@@ -107,7 +107,7 @@
     </ng-container>
   </clr-dg-column>
   <clr-dg-column>
-    <ng-container *clrDgHideableColumn>
+    <ng-container *clrDgHideableColumn="{hidden:true}">
       Pokemon
     </ng-container>
   </clr-dg-column>
@@ -123,7 +123,21 @@
     <clr-dg-cell *ngIf="showId">{{user.id}}</clr-dg-cell>
     <clr-dg-cell>{{user.name}}</clr-dg-cell>
     <clr-dg-cell *ngIf="showDate">{{user.creation | date}}</clr-dg-cell>
-    <clr-dg-cell>{{user.pokemon.name}}</clr-dg-cell>
+    <clr-dg-cell>
+      {{user.pokemon.name}}
+      <clr-signpost>
+        <button
+          type="button"
+          class="signpost-action btn btn-small btn-link"
+          [class.active]="open"
+          clrSignpostTrigger>
+          <clr-icon shape="help-info"></clr-icon>
+        </button>
+        <clr-signpost-content *clrIfOpen [clrPosition]="'top-middle'">
+          The pokemon is strong.
+        </clr-signpost-content>
+      </clr-signpost>
+    </clr-dg-cell>
     <clr-dg-cell>
       <span class="color-square" [style.backgroundColor]="user.color"></span>
     </clr-dg-cell>


### PR DESCRIPTION
- Fixes 1069

Datagrid cell was throwing a 🍫  error when a user sets columns hidden by default. The main reason was that mapping the cell with the corresponding column header was taking place after the cell's view was checked and as a result, the cell properties had to change. 

This PR solution is to give the hidden class to a cell only after the mapping process completes with the help of `Renderer2`.

I have added one unit test that makes sure there is no 🍫  error when the columns are hidden by default. Also, I have done a manual testing in our `ks-app`.
 

Tested on: Chrome

Signed-off-by: Shijir Tsogoo <stsogoo@vmware.com>