### PR TITLE
[WEB] Fixes issue with badges in labels that have code snippets modified by…

### DIFF
--- a/src/app/documentation/demos/labels/labels-clickable.demo.html
+++ b/src/app/documentation/demos/labels/labels-clickable.demo.html
@@ -11,4 +11,4 @@
     <a href="javascript://" class="label label-light-blue clickable">San Francisco</a>
     <a href="javascript://" class="label clickable">Seattle</a>
 </div>
-<clr-code-snippet [clrCode]="example"></clr-code-snippet>
+<clr-code-snippet class="prism-fix" [clrCode]="example"></clr-code-snippet>

--- a/src/app/documentation/demos/labels/labels-color-options.demo.html
+++ b/src/app/documentation/demos/labels/labels-color-options.demo.html
@@ -13,4 +13,4 @@
         <span class="label label-light-blue">San Francisco</span>
     </div>
 </div>
-<clr-code-snippet [clrCode]="example"></clr-code-snippet>
+<clr-code-snippet class="prism-fix" [clrCode]="example"></clr-code-snippet>

--- a/src/app/documentation/demos/labels/labels-default.demo.html
+++ b/src/app/documentation/demos/labels/labels-default.demo.html
@@ -11,4 +11,4 @@
     <span class="label">San Francisco</span>
     <span class="label">Seattle</span>
 </div>
-<clr-code-snippet [clrCode]="example"></clr-code-snippet>
+<clr-code-snippet class="prism-fix" [clrCode]="example"></clr-code-snippet>

--- a/src/app/documentation/demos/labels/labels-status.demo.html
+++ b/src/app/documentation/demos/labels/labels-status.demo.html
@@ -10,4 +10,4 @@
     <span class="label label-warning">Warning</span>
     <span class="label label-danger">Error</span>
 </div>
-<clr-code-snippet [clrCode]="example"></clr-code-snippet>
+<clr-code-snippet class="prism-fix" [clrCode]="example"></clr-code-snippet>

--- a/src/app/documentation/demos/labels/labels-with-badges.demo.html
+++ b/src/app/documentation/demos/labels/labels-with-badges.demo.html
@@ -16,4 +16,4 @@
     <a href="javascript://" class="label label-light-blue clickable">Atlanta<span class="badge">99+</span></a>
     <a href="javascript://" class="label clickable">Philadephia<span class="badge">0</span></a>
 </div>
-<clr-code-snippet [clrCode]="example"></clr-code-snippet>
+<clr-code-snippet class="prism-fix" [clrCode]="example"></clr-code-snippet>

--- a/src/styles/labels.scss
+++ b/src/styles/labels.scss
@@ -1,0 +1,12 @@
+/*!
+ * Copyright (c) 2016-2017 VMWare, Inc. All Rights Reserved.
+ * This software is released under MIT License.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+// Fixes specific prism issue only for labels with badges (#1700: https://github.com/vmware/clarity/issues/1700)
+.prism-fix {
+    pre {
+        margin-top: 7px;
+    }
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -17,5 +17,6 @@ $clrweb-altGray: #f3f5f8;
 @import 'community.scss';
 @import 'tabs.scss';
 @import "code";
+@import "labels";
 
 @import 'error-pages.scss';


### PR DESCRIPTION
## Before
<img width="596" alt="screen shot 2017-12-12 at 3 08 17 pm" src="https://user-images.githubusercontent.com/433692/33913453-bdbec998-df4e-11e7-8ba6-6556517ad797.png">

## After
<img width="593" alt="screen shot 2017-12-12 at 3 07 47 pm" src="https://user-images.githubusercontent.com/433692/33913443-b8fe28cc-df4e-11e7-897a-90335166f0c6.png">


- closes #1700

Signed-off-by: Matt Hippely <mhippely@vmware.com>