### PR TITLE
[UI] Adds additional header color to dark theme

### DIFF
--- a/src/clarity-angular/utils/_theme.dark.clarity.scss
+++ b/src/clarity-angular/utils/_theme.dark.clarity.scss
@@ -448,6 +448,7 @@ $clr-header-2-bg-color: #165266;
 $clr-header-3-bg-color: #1a4c72;
 $clr-header-4-bg-color: #5c3552;
 $clr-header-5-bg-color: #3e436a;
+$clr-header-6-bg-color: #0F171C;
 // END Header overrides
 
 /*****************


### PR DESCRIPTION
- Dark theme can use `.header-6` for an additional dark theme nav header
- closes #1749

Signed-off-by: Matt Hippely <mhippely@vmware.com>