### PR TITLE
[ICONS] Update already injected icons' templates if their templates are

### DIFF
--- a/src/clr-icons/clr-icons-api.ts
+++ b/src/clr-icons/clr-icons-api.ts
@@ -4,10 +4,10 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import {IconAlias} from "./interfaces/icon-alias";
-import {IconTemplate} from "./interfaces/icon-template";
+import {IconAlias, IconShapeSources} from "./interfaces/icon-interfaces";
+import {ShapeTemplateObserver} from "./utils/shape-template-observer";
 
-const iconShapeSources: IconTemplate = {};
+const iconShapeSources: IconShapeSources = {};
 
 export class ClarityIconsApi {
     private static singleInstance: ClarityIconsApi;
@@ -44,10 +44,12 @@ export class ClarityIconsApi {
             }
 
             iconShapeSources[shapeName] = trimmedShapeTemplate;
+
+            ShapeTemplateObserver.instance.emitChanges(shapeName, trimmedShapeTemplate);
         }
     }
 
-    private setIconAliases(templates: IconTemplate, shapeName: string, aliasNames: string[]): void {
+    private setIconAliases(templates: IconShapeSources, shapeName: string, aliasNames: string[]): void {
         for (const aliasName of aliasNames) {
             if (this.validateName(aliasName)) {
                 Object.defineProperty(templates, aliasName, {
@@ -61,7 +63,7 @@ export class ClarityIconsApi {
         }
     }
 
-    add(icons?: IconTemplate): void {
+    add(icons?: IconShapeSources): void {
         if (typeof icons !== "object") {
             throw new Error(`The argument must be an object literal passed in the following pattern: 
                 { "shape-name": "shape-template" }`);
@@ -88,11 +90,6 @@ export class ClarityIconsApi {
             throw new TypeError("Only string argument is allowed in this method.");
         }
 
-        // if shapeName doesn't exist in the icons templates, throw an error.
-        if (!this.has(shapeName)) {
-            throw new Error(`'${shapeName}' is not found in the Clarity Icons set.`);
-        }
-
         return iconShapeSources[shapeName];
     }
 
@@ -111,7 +108,8 @@ export class ClarityIconsApi {
                     // set an alias to the icon if it exists in iconShapeSources.
                     this.setIconAliases(iconShapeSources, shapeName, aliases[shapeName]);
                 } else {
-                    throw new Error("The icon '" + shapeName + "' you are trying to set an alias to doesn't exist!");
+                    throw new Error(`An icon "${
+                        shapeName}" you are trying to set aliases to doesn't exist in the Clarity Icons sets!`);
                 }
             }
         }

--- a/src/clr-icons/helpers.spec.ts
+++ b/src/clr-icons/helpers.spec.ts
@@ -6,6 +6,7 @@
 
 import {ClarityIcons} from "./index";
 import {CoreShapes} from "./shapes/core-shapes";
+import {changeHandlerCallbacks} from "./utils/shape-template-observer";
 
 // TODO: open question... should we make whitespace removal part of the icon parsing???
 export function removeWhitespace(htmlStr: string): string {
@@ -57,6 +58,14 @@ export function resetShapes(): void {
     }
 
     ClarityIcons.add(CoreShapes);
+}
+
+export function resetCallbacks(): void {
+    for (const callback in changeHandlerCallbacks) {
+        if (changeHandlerCallbacks.hasOwnProperty(callback)) {
+            delete changeHandlerCallbacks[callback];
+        }
+    }
 }
 
 export function giveAngleShapeTitle(titleId: string, titleTxt: string) {

--- a/src/clr-icons/index.ts
+++ b/src/clr-icons/index.ts
@@ -12,16 +12,15 @@ const clarityIcons: ClarityIconsApi = ClarityIconsApi.instance;
 clarityIcons.add(CoreShapes);
 
 // check if there is a global object called "ClarityIcons"
-if (undefined !== window) {
+if (typeof window !== "undefined") {
     if (!window.hasOwnProperty("ClarityIcons")) {
         // Setting a global object called "ClarityIcons" to expose the ClarityIconsApi.
         window.ClarityIcons = clarityIcons;
-
-        // Defining clr-icon custom element
-        customElements.define("clr-icon", ClarityIconElement);
     }
-} else {
+
+    // Defining clr-icon custom element
     customElements.define("clr-icon", ClarityIconElement);
 }
+
 
 export {clarityIcons as ClarityIcons};

--- a/src/clr-icons/interfaces/icon-interfaces.ts
+++ b/src/clr-icons/interfaces/icon-interfaces.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+export interface IconAlias { [key: string]: string[]; }
+export interface IconShapeSources { [key: string]: string; }
+export interface ShapeTemplateObservables { [key: string]: Function[]; }

--- a/src/clr-icons/utils/shape-template-observer.ts
+++ b/src/clr-icons/utils/shape-template-observer.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {ShapeTemplateObservables} from "../interfaces/icon-interfaces";
+
+export const changeHandlerCallbacks: ShapeTemplateObservables = {};
+
+export class ShapeTemplateObserver {
+    private static singleInstance: ShapeTemplateObserver;
+
+    private callbacks: ShapeTemplateObservables = changeHandlerCallbacks;
+
+    private constructor() {}
+
+    public static get instance(): ShapeTemplateObserver {
+        if (!ShapeTemplateObserver.singleInstance) {
+            ShapeTemplateObserver.singleInstance = new ShapeTemplateObserver();
+        }
+
+        return ShapeTemplateObserver.singleInstance;
+    }
+
+    public subscribeTo(shapeName: string, changeHandlerCallback: Function) {
+        if (!this.callbacks[shapeName]) {
+            this.callbacks[shapeName] = [changeHandlerCallback];
+        } else {
+            if (this.callbacks[shapeName].indexOf(changeHandlerCallback) === -1) {
+                this.callbacks[shapeName].push(changeHandlerCallback);
+            }
+        }
+
+        // this returned function give users an ability to remove the subscription
+        return () => {
+            const removeAt = this.callbacks[shapeName].indexOf(changeHandlerCallback);
+            this.callbacks[shapeName].splice(removeAt, 1);
+
+            // if the array is empty, remove the property from the callbacks
+            if (this.callbacks[shapeName].length === 0) {
+                delete this.callbacks[shapeName];
+            }
+        };
+    }
+
+    public emitChanges(shapeName: string, template: string) {
+        if (this.callbacks[shapeName]) {
+            // this will emit changes to all observers
+            // by calling their callback functions on template changes
+            this.callbacks[shapeName].map((changeHandlerCallback: Function) => {
+                changeHandlerCallback(template);
+            });
+        }
+    }
+}


### PR DESCRIPTION
updated in the API

- Fixes 1758

With this PR, it will be possible for users to update icons' templates when they are already in the DOM. This will also solve the case that if users load 3rd party JS libraries (e.g. `clarity-icons.min.js`) right before the closing body tag, not in the head.

I have added two unit tests that make sure the injected templates get updated whenever they are updated in the API and properly show the title if it's specified.  

Before:
https://plnkr.co/edit/3jcwnYDre4MUtUiYQssX?p=preview
After:
https://plnkr.co/edit/9hCdFy9xBA9InLEE23xE?p=preview

Fixes the errors reproduced in the original issue poster's pen:
https://codepen.io/anon/pen/opgMgP

Another example in Angular app:
https://plnkr.co/edit/BoqUNY?p=preview

Tested on: Chrome, Firefox, Safari, Edge, IE11

Signed-off-by: Shijir Tsogoo <stsogoo@vmware.com>