### PR TITLE
[UI] Adds bootstrap as a peer dependency for clarity-ui 

### DIFF
--- a/npm/clarity-ui/package.json
+++ b/npm/clarity-ui/package.json
@@ -8,7 +8,8 @@
         "url" : "git@github.com:vmware/clarity.git"
     },
     "peerDependencies": {
-        "clarity-icons": "@VERSION"
+        "clarity-icons": "@VERSION",
+        "bootstrap": "4.0.0-alpha.5"
     },
     "author": "clarity",
     "license": "MIT",


### PR DESCRIPTION
This updates the Clarity-ui `peerDependencies` with the version of bootstrap needed.

- Closes #1769

Signed-off-by: Matt Hippely <mhippely@vmware.com>