### PR TITLE
[UI] remUnits pushed looping progress bar down

### DIFF
--- a/src/clr-angular/progress/progress-bars/_progress-bars.clarity.scss
+++ b/src/clr-angular/progress/progress-bars/_progress-bars.clarity.scss
@@ -126,9 +126,6 @@
                 right: 0;
                 line-height: 1em;
                 margin-top: -0.375em;
-                // TODO: we will need to define different text colors depending on the
-                // background. at the very least we may find ourselves needing light/dark.
-                color: clr-getTextColor();
             }
         }
     }
@@ -212,7 +209,7 @@
         &::after {
             animation: clr-progress-looper 2s ease-in-out infinite;
             content: ' ';
-            top: 0.166667rem;
+            top: 0.142rem;
             bottom: 0;
             left: 0;
             position: absolute;


### PR DESCRIPTION
• I went with the direct edit to the top positioning of the inner looping progress bar because it was a more surgical, precise edit.
• Changing vertical alignment, positioning, and max-height led to unintended regressions in static/inline progress bars. It was also more complicated due to the relationship of the heigh/max-height values.
• I also fixed the percent label that can be displayed on progress bars in the dark theme. It was being set to #565656. I changed that.

Closes: #1785

Tested in:
✔︎ Chrome
✔︎ Firefox
✔︎ Safari
✔︎ IE11
✔︎ Edge

Signed-off-by: Scott Mathis <smathis@vmware.com>