### PR TITLE
[UI] Updates dark theme color issues

### DIFF
--- a/src/clr-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clr-angular/data/datagrid/_datagrid.clarity.scss
@@ -5,7 +5,7 @@
 @include exports('datagrid.clarity') {
     @include basic-table(".datagrid", ".datagrid-head", ".datagrid-body",
         ".datagrid-row", ".datagrid-column", ".datagrid-cell");
-    
+
     $clr-datagrid-icon-size: 0.583333rem;
     $clr-datagrid-action-arrow-size: 0.25rem;
     $clr-datagrid-fixed-column-size: (2 * $clr-table-cellpadding) + $clr-table-lineheight;
@@ -33,7 +33,7 @@
             display: flex;
             justify-content: center;
             align-items: center;
-            background: rgba($clr-white, 0.6);
+            background: $clr-datagrid-loading-background;
         }
 
     }

--- a/src/clr-angular/data/datagrid/_variables.datagrid.scss
+++ b/src/clr-angular/data/datagrid/_variables.datagrid.scss
@@ -14,3 +14,4 @@ $clr-datagrid-action-toggle: $clr-dark-gray;
 $clr-datagrid-popover-bg-color: $clr-white;
 $clr-datagrid-popover-border-color: $clr-light-midtone-gray;
 $clr-datagrid-action-popover-hover-color: $gray-light;
+$clr-datagrid-loading-background: rgba($clr-white, 0.6);

--- a/src/clr-angular/utils/_theme.dark.clarity.scss
+++ b/src/clr-angular/utils/_theme.dark.clarity.scss
@@ -340,6 +340,7 @@ $clr-datagrid-popover-bg-color: #22343c;
 $clr-datagrid-action-toggle: $clr-datagrid-font-color;
 $clr-datagrid-popover-border-color: $clr-black;
 $clr-datagrid-action-popover-hover-color: $clr-datagrid-row-hover;
+$clr-datagrid-loading-background: rgba(0, 0, 0, 0.5);
 // END: Datagrid
 
 /*********
@@ -359,7 +360,7 @@ $clr-dropdown-bg-active-color: $clr-global-selection-color;
 $clr-dropdown-bg-hover-color: $clr-global-hover-bg-color;
 $clr-dropdown-font-color: #adbbc4;
 $clr-dropdown-selection-color: #324f61;
-$clr-dropdown-box-shadow: rgba(clr-getColor(dark), 0.25);
+$clr-dropdown-box-shadow: rgba(0, 0, 0, 0.5);
 $clr-dropdown-divider-color: $clr-dropdown-border-color;
 $clr-dropdown-header-color: #ADBBC4;
 // END: Dropdown overrides


### PR DESCRIPTION
- Adds background color to datagrid in loading state (closes #1795)
- Updates drop-shadow color for dropdowns

## Datagrid Loading Before
![screen shot 2017-12-20 at 10 16 07 am](https://user-images.githubusercontent.com/433692/34225881-cb0d76b0-e57c-11e7-81b1-8fb4ac26fcbc.png)

## Datagrid Loading After 
<img width="1179" alt="screen shot 2017-12-20 at 10 45 42 am" src="https://user-images.githubusercontent.com/433692/34225819-90222794-e57c-11e7-95a7-095ed639c431.png">

## Dropdown Before
<img width="423" alt="screen shot 2017-12-20 at 11 58 17 am" src="https://user-images.githubusercontent.com/433692/34225997-237d5d88-e57d-11e7-93fb-f3ea342af08d.png">

## Dropdown After
<img width="434" alt="screen shot 2017-12-20 at 10 45 27 am" src="https://user-images.githubusercontent.com/433692/34225914-e8f0189a-e57c-11e7-91c3-897d0499cd36.png">

Tested on:

- Chrome
- Safari
- Firefox
- IE11
- Edge
