### PR TITLE
Note importance of not double-importing clarity-icons

### DIFF
--- a/src/app/icons/icons-api/icons-api.component.html
+++ b/src/app/icons/icons-api/icons-api.component.html
@@ -8,6 +8,7 @@
     It's worth noting that you can also access the API from the <code class="clr-code">"clarity-icons"</code> module in Typescript. For
     example:
     <clr-code-snippet [clrCode]="apiImports" clrLanguage="typescript"></clr-code-snippet>
+    If you load <code class="clr-code">"clarity-icons"</code> like this make sure that you are not also loading it via a script tag or in some other manner.
 </p>
 
 <h3 class="paragraph-header">Retrieve icons</h3>

--- a/src/app/icons/icons-get-started/icons-get-started.component.html
+++ b/src/app/icons/icons-get-started/icons-get-started.component.html
@@ -64,9 +64,9 @@
 <clr-alert [clrAlertClosable]="false">
     <div clr-alert-item class="alert-item">
         <span class="alert-text">
-            One thing that should be noted here is that if you are loading Clarity Icons in Typescript,
-                make sure you are not loading it through the script tag again. Otherwise you will have two different
-                instances of Clarity Icons that override one another.
+            If you load the Clarity Icons in Typescript, make sure you are not
+            loading it through the script tag again. Otherwise you will have
+            two different instances of Clarity Icons that override one another.
         </span>
     </div>
 </clr-alert>
@@ -86,6 +86,3 @@
 <div class="example-btn-wrapper">
     <a href="https://embed.plnkr.co/PlgTCx/" target="_blank" class="btn btn-primary btn-sm">View example</a>
 </div>
-
-
-


### PR DESCRIPTION
This seems like a common mistake so I thought it would make sense to add another brief warning in the custom icon page.

#689
vmware/clarity-seed#63

(https://github.com/vmware/clarity/pull/1818 was the same pull request but I forgot the DCO).  