### PR TITLE
[NG] update deprecated exports to not be tree shaken

### DIFF
--- a/src/clr-angular/button/button-group/button-group.module.ts
+++ b/src/clr-angular/button/button-group/button-group.module.ts
@@ -24,9 +24,9 @@ export class ClrButtonGroupModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export const Button = ClrButton;
+export class Button extends ClrButton {}
 /** @deprecated since 0.11 */
-export const ButtonGroup = ClrButtonGroup;
+export class ButtonGroup extends ClrButtonGroup {}
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const BUTTON_GROUP_DIRECTIVES = CLR_BUTTON_GROUP_DIRECTIVES;

--- a/src/clr-angular/button/button-loading/loading-button.module.ts
+++ b/src/clr-angular/button/button-loading/loading-button.module.ts
@@ -21,7 +21,7 @@ export class ClrLoadingButtonModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export const LoadingButton = ClrLoadingButton;
+export class LoadingButton extends ClrLoadingButton {}
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const LOADING_BUTTON_DIRECTIVES = CLR_LOADING_BUTTON_DIRECTIVES;

--- a/src/clr-angular/code/syntax-highlight/syntax-highlight.module.ts
+++ b/src/clr-angular/code/syntax-highlight/syntax-highlight.module.ts
@@ -16,7 +16,7 @@ export class ClrSyntaxHighlightModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export const CodeHighlight = ClrCodeHighlight;
+export class CodeHighlight extends ClrCodeHighlight {}
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const CODE_HIGHLIGHT_DIRECTIVES = CLR_CODE_HIGHLIGHT_DIRECTIVES;

--- a/src/clr-angular/data/datagrid/datagrid.module.ts
+++ b/src/clr-angular/data/datagrid/datagrid.module.ts
@@ -83,33 +83,33 @@ export class ClrDatagridModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export const Datagrid = ClrDatagrid;
+export class Datagrid extends ClrDatagrid {}
 /** @deprecated since 0.11 */
-export const DatagridActionBar = ClrDatagridActionBar;
+export class DatagridActionBar extends ClrDatagridActionBar {}
 /** @deprecated since 0.11 */
-export const DatagridActionOverflow = ClrDatagridActionOverflow;
+export class DatagridActionOverflow extends ClrDatagridActionOverflow {}
 /** @deprecated since 0.11 */
-export const DatagridColumn = ClrDatagridColumn;
+export class DatagridColumn extends ClrDatagridColumn {}
 /** @deprecated since 0.11 */
-export const DatagridColumnToggle = ClrDatagridColumnToggle;
+export class DatagridColumnToggle extends ClrDatagridColumnToggle {}
 /** @deprecated since 0.11 */
-export const DatagridHideableColumnDirective = ClrDatagridHideableColumn;
+export class DatagridHideableColumnDirective extends ClrDatagridHideableColumn {}
 /** @deprecated since 0.11 */
-export const DatagridFilter = ClrDatagridFilter;
+export class DatagridFilter extends ClrDatagridFilter {}
 /** @deprecated since 0.11 */
-export const DatagridItems = ClrDatagridItems;
+export class DatagridItems extends ClrDatagridItems {}
 /** @deprecated since 0.11 */
-export const DatagridRow = ClrDatagridRow;
+export class DatagridRow extends ClrDatagridRow {}
 /** @deprecated since 0.11 */
-export const DatagridRowDetail = ClrDatagridRowDetail;
+export class DatagridRowDetail extends ClrDatagridRowDetail {}
 /** @deprecated since 0.11 */
-export const DatagridCell = ClrDatagridCell;
+export class DatagridCell extends ClrDatagridCell {}
 /** @deprecated since 0.11 */
-export const DatagridFooter = ClrDatagridFooter;
+export class DatagridFooter extends ClrDatagridFooter {}
 /** @deprecated since 0.11 */
-export const DatagridPagination = ClrDatagridPagination;
+export class DatagridPagination extends ClrDatagridPagination {}
 /** @deprecated since 0.11 */
-export const DatagridPlaceholder = ClrDatagridPlaceholder;
+export class DatagridPlaceholder extends ClrDatagridPlaceholder {}
 /** @deprecated since 0.11 */
 export enum SortOrder {
     // Cannot extend an enum so have to redeclare it

--- a/src/clr-angular/data/stack-view/stack-view.module.ts
+++ b/src/clr-angular/data/stack-view/stack-view.module.ts
@@ -35,17 +35,17 @@ export class ClrStackViewModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export const StackView = ClrStackView;
+export class StackView extends ClrStackView {}
 /** @deprecated since 0.11 */
-export const StackHeader = ClrStackHeader;
+export class StackHeader extends ClrStackHeader {}
 /** @deprecated since 0.11 */
-export const StackBlock = ClrStackBlock;
+export class StackBlock extends ClrStackBlock {}
 /** @deprecated since 0.11 */
-export const StackViewCustomTags = ClrStackViewCustomTags;
+export class StackViewCustomTags extends ClrStackViewCustomTags {}
 /** @deprecated since 0.11 */
-export const StackInput = ClrStackInput;
+export class StackInput extends ClrStackInput {}
 /** @deprecated since 0.11 */
-export const StackSelect = ClrStackSelect;
+export class StackSelect extends ClrStackSelect {}
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const STACK_VIEW_DIRECTIVES = CLR_STACK_VIEW_DIRECTIVES;

--- a/src/clr-angular/data/tree-view/tree-view.module.ts
+++ b/src/clr-angular/data/tree-view/tree-view.module.ts
@@ -24,7 +24,7 @@ export class ClrTreeViewModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export const TreeNode = ClrTreeNode;
+export class TreeNode extends ClrTreeNode {}
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const TREE_VIEW_DIRECTIVES = CLR_TREE_VIEW_DIRECTIVES;

--- a/src/clr-angular/deprecations.spec.ts
+++ b/src/clr-angular/deprecations.spec.ts
@@ -34,6 +34,7 @@ import {
     CLR_TABS_DIRECTIVES,
     CLR_TOOLTIP_DIRECTIVES,
     CLR_TREE_VIEW_DIRECTIVES,
+    CLR_VERTICAL_NAV_DIRECTIVES,
     CLR_WIZARD_DIRECTIVES,
     ClrAlert,
     ClrAlertItem,
@@ -87,6 +88,11 @@ import {
     ClrTooltipContent,
     ClrTooltipTrigger,
     ClrTreeNode,
+    ClrVerticalNav,
+    ClrVerticalNavGroup,
+    ClrVerticalNavGroupChildren,
+    ClrVerticalNavIcon,
+    ClrVerticalNavLink,
     ClrWizard,
     ClrWizardButton,
     ClrWizardCustomTags,
@@ -160,6 +166,12 @@ import {
     TooltipTrigger,
     TREE_VIEW_DIRECTIVES,
     TreeNode,
+    VERTICAL_NAV_DIRECTIVES,
+    VerticalNav,
+    VerticalNavGroup,
+    VerticalNavGroupChildren,
+    VerticalNavIcon,
+    VerticalNavLink,
     Wizard,
     WIZARD_DIRECTIVES,
     WizardButton,
@@ -178,39 +190,39 @@ describe("Deprecations", () => {
     describe("since v0.11", () => {
         it("should export deprecated buttons items", () => {
             expect(BUTTON_GROUP_DIRECTIVES).toEqual(CLR_BUTTON_GROUP_DIRECTIVES);
-            expect(Button).toEqual(ClrButton);
-            expect(ButtonGroup).toEqual(ClrButtonGroup);
+            expect(Button.prototype instanceof ClrButton).toBeTruthy();
+            expect(ButtonGroup.prototype instanceof ClrButtonGroup).toBeTruthy();
             expect(LOADING_BUTTON_DIRECTIVES).toEqual(CLR_LOADING_BUTTON_DIRECTIVES);
-            expect(LoadingButton).toEqual(ClrLoadingButton);
+            expect(LoadingButton.prototype instanceof ClrLoadingButton).toBeTruthy();
         });
         it("should export depecreated code highlight items", () => {
             expect(CODE_HIGHLIGHT_DIRECTIVES).toEqual(CLR_CODE_HIGHLIGHT_DIRECTIVES);
-            expect(CodeHighlight).toEqual(ClrCodeHighlight);
+            expect(CodeHighlight.prototype instanceof ClrCodeHighlight).toBeTruthy();
         });
         it("should export deprecated data items", () => {
-            expect(Datagrid).toEqual(ClrDatagrid);
-            expect(DatagridActionBar).toEqual(ClrDatagridActionBar);
-            expect(DatagridActionOverflow).toEqual(ClrDatagridActionOverflow);
-            expect(DatagridColumn).toEqual(ClrDatagridColumn);
-            expect(DatagridColumnToggle).toEqual(ClrDatagridColumnToggle);
-            expect(DatagridFilter).toEqual(ClrDatagridFilter);
-            expect(DatagridHideableColumnDirective).toEqual(ClrDatagridHideableColumn);
-            expect(DatagridItems).toEqual(ClrDatagridItems);
-            expect(DatagridRow).toEqual(ClrDatagridRow);
-            expect(DatagridRowDetail).toEqual(ClrDatagridRowDetail);
-            expect(DatagridCell).toEqual(ClrDatagridCell);
-            expect(DatagridFooter).toEqual(ClrDatagridFooter);
-            expect(DatagridPagination).toEqual(ClrDatagridPagination);
-            expect(DatagridPlaceholder).toEqual(ClrDatagridPlaceholder);
+            expect(Datagrid.prototype instanceof ClrDatagrid).toBeTruthy();
+            expect(DatagridActionBar.prototype instanceof ClrDatagridActionBar).toBeTruthy();
+            expect(DatagridActionOverflow.prototype instanceof ClrDatagridActionOverflow).toBeTruthy();
+            expect(DatagridColumn.prototype instanceof ClrDatagridColumn).toBeTruthy();
+            expect(DatagridColumnToggle.prototype instanceof ClrDatagridColumnToggle).toBeTruthy();
+            expect(DatagridFilter.prototype instanceof ClrDatagridFilter).toBeTruthy();
+            expect(DatagridHideableColumnDirective.prototype instanceof ClrDatagridHideableColumn).toBeTruthy();
+            expect(DatagridItems.prototype instanceof ClrDatagridItems).toBeTruthy();
+            expect(DatagridRow.prototype instanceof ClrDatagridRow).toBeTruthy();
+            expect(DatagridRowDetail.prototype instanceof ClrDatagridRowDetail).toBeTruthy();
+            expect(DatagridCell.prototype instanceof ClrDatagridCell).toBeTruthy();
+            expect(DatagridFooter.prototype instanceof ClrDatagridFooter).toBeTruthy();
+            expect(DatagridPagination.prototype instanceof ClrDatagridPagination).toBeTruthy();
+            expect(DatagridPlaceholder.prototype instanceof ClrDatagridPlaceholder).toBeTruthy();
             expect(DATAGRID_DIRECTIVES).toEqual(CLR_DATAGRID_DIRECTIVES);
-            expect(StackView).toEqual(ClrStackView);
-            expect(StackSelect).toEqual(ClrStackSelect);
-            expect(StackInput).toEqual(ClrStackInput);
-            expect(StackHeader).toEqual(ClrStackHeader);
-            expect(StackViewCustomTags).toEqual(ClrStackViewCustomTags);
-            expect(StackBlock).toEqual(ClrStackBlock);
+            expect(StackView.prototype instanceof ClrStackView).toBeTruthy();
+            expect(StackSelect.prototype instanceof ClrStackSelect).toBeTruthy();
+            expect(StackInput.prototype instanceof ClrStackInput).toBeTruthy();
+            expect(StackHeader.prototype instanceof ClrStackHeader).toBeTruthy();
+            expect(StackViewCustomTags.prototype instanceof ClrStackViewCustomTags).toBeTruthy();
+            expect(StackBlock.prototype instanceof ClrStackBlock).toBeTruthy();
             expect(STACK_VIEW_DIRECTIVES).toEqual(CLR_STACK_VIEW_DIRECTIVES);
-            expect(TreeNode).toEqual(ClrTreeNode);
+            expect(TreeNode.prototype instanceof ClrTreeNode).toBeTruthy();
             expect(TREE_VIEW_DIRECTIVES).toEqual(CLR_TREE_VIEW_DIRECTIVES);
             // Can't test interfaces directly, so just verify if they are exported and can be applied.
             class ComparatorTest implements Comparator<any> {
@@ -245,66 +257,72 @@ describe("Deprecations", () => {
         });
         it("should export deprecated emphasis items", () => {
             expect(ALERT_DIRECTIVES).toEqual(CLR_ALERT_DIRECTIVES);
-            expect(Alert).toEqual(ClrAlert);
-            expect(AlertItem).toEqual(ClrAlertItem);
-            expect(Alerts).toEqual(ClrAlerts);
-            expect(AlertsPager).toEqual(ClrAlertsPager);
+            expect(Alert.prototype instanceof ClrAlert).toBeTruthy();
+            expect(AlertItem.prototype instanceof ClrAlertItem).toBeTruthy();
+            expect(Alerts.prototype instanceof ClrAlerts).toBeTruthy();
+            expect(AlertsPager.prototype instanceof ClrAlertsPager).toBeTruthy();
         });
         it("should export deprecated form items", () => {
-            expect(Checkbox).toEqual(ClrCheckbox);
+            expect(Checkbox.prototype instanceof ClrCheckbox).toBeTruthy();
             expect(CHECKBOX_DIRECTIVES).toEqual(CLR_CHECKBOX_DIRECTIVES);
         });
         it("should export deprecated icon items", () => {
-            expect(IconCustomTag).toEqual(ClrIconCustomTag);
+            expect(IconCustomTag.prototype instanceof ClrIconCustomTag).toBeTruthy();
             expect(ICON_DIRECTIVES).toEqual(CLR_ICON_DIRECTIVES);
         });
         it("should export deprecated layout items", () => {
             expect(NAVIGATION_DIRECTIVES).toEqual(CLR_NAVIGATION_DIRECTIVES);
-            expect(Header).toEqual(ClrHeader);
-            expect(NavLevelDirective).toEqual(ClrNavLevel);
+            expect(Header.prototype instanceof ClrHeader).toBeTruthy();
+            expect(NavLevelDirective.prototype instanceof ClrNavLevel).toBeTruthy();
             expect(TABS_DIRECTIVES).toEqual(CLR_TABS_DIRECTIVES);
-            expect(Tab).toEqual(ClrTab);
-            expect(Tabs).toEqual(ClrTabs);
-            expect(TabLinkDirective).toEqual(ClrTabLink);
-            expect(TabContent).toEqual(ClrTabContent);
-            expect(TabOverflowContent).toEqual(ClrTabOverflowContent);
+            expect(Tab.prototype instanceof ClrTab).toBeTruthy();
+            expect(Tabs.prototype instanceof ClrTabs).toBeTruthy();
+            expect(TabLinkDirective.prototype instanceof ClrTabLink).toBeTruthy();
+            expect(TabContent.prototype instanceof ClrTabContent).toBeTruthy();
+            expect(TabOverflowContent.prototype instanceof ClrTabOverflowContent).toBeTruthy();
+            expect(VERTICAL_NAV_DIRECTIVES).toEqual(CLR_VERTICAL_NAV_DIRECTIVES);
+            expect(VerticalNav.prototype instanceof ClrVerticalNav).toBeTruthy();
+            expect(VerticalNavGroup.prototype instanceof ClrVerticalNavGroup).toBeTruthy();
+            expect(VerticalNavGroupChildren.prototype instanceof ClrVerticalNavGroupChildren).toBeTruthy();
+            expect(VerticalNavIcon.prototype instanceof ClrVerticalNavIcon).toBeTruthy();
+            expect(VerticalNavLink.prototype instanceof ClrVerticalNavLink).toBeTruthy();
         });
         it("should export deprecated modal items", () => {
-            expect(Modal).toEqual(ClrModal);
+            expect(Modal.prototype instanceof ClrModal).toBeTruthy();
             expect(MODAL_DIRECTIVES).toEqual(CLR_MODAL_DIRECTIVES);
         });
         it("should export deprecated popover items", () => {
-            expect(Dropdown).toEqual(ClrDropdown);
-            expect(DropdownItem).toEqual(ClrDropdownItem);
-            expect(DropdownMenu).toEqual(ClrDropdownMenu);
-            expect(DropdownTrigger).toEqual(ClrDropdownTrigger);
+            expect(Dropdown.prototype instanceof ClrDropdown).toBeTruthy();
+            expect(DropdownItem.prototype instanceof ClrDropdownItem).toBeTruthy();
+            expect(DropdownMenu.prototype instanceof ClrDropdownMenu).toBeTruthy();
+            expect(DropdownTrigger.prototype instanceof ClrDropdownTrigger).toBeTruthy();
             expect(menuPositions).toEqual(CLR_MENU_POSITIONS);
             expect(DROPDOWN_DIRECTIVES).toEqual(CLR_DROPDOWN_DIRECTIVES);
-            expect(Signpost).toEqual(ClrSignpost);
-            expect(SignpostContent).toEqual(ClrSignpostContent);
-            expect(SignpostTrigger).toEqual(ClrSignpostTrigger);
+            expect(Signpost.prototype instanceof ClrSignpost).toBeTruthy();
+            expect(SignpostContent.prototype instanceof ClrSignpostContent).toBeTruthy();
+            expect(SignpostTrigger.prototype instanceof ClrSignpostTrigger).toBeTruthy();
             expect(SIGNPOST_DIRECTIVES).toEqual(CLR_SIGNPOST_DIRECTIVES);
-            expect(Tooltip).toEqual(ClrTooltip);
-            expect(TooltipContent).toEqual(ClrTooltipContent);
-            expect(TooltipTrigger).toEqual(ClrTooltipTrigger);
+            expect(Tooltip.prototype instanceof ClrTooltip).toBeTruthy();
+            expect(TooltipContent.prototype instanceof ClrTooltipContent).toBeTruthy();
+            expect(TooltipTrigger.prototype instanceof ClrTooltipTrigger).toBeTruthy();
             expect(TOOLTIP_DIRECTIVES).toEqual(CLR_TOOLTIP_DIRECTIVES);
         });
         it("should export deprecated util items", () => {
-            expect(Loading).toEqual(ClrLoading);
+            expect(Loading.prototype instanceof ClrLoading).toBeTruthy();
             expect(LOADING_DIRECTIVES).toEqual(CLR_LOADING_DIRECTIVES);
         });
         it("should export deprecated wizard items", () => {
-            expect(Wizard).toEqual(ClrWizard);
-            expect(WizardPage).toEqual(ClrWizardPage);
-            expect(WizardStepnav).toEqual(ClrWizardStepnav);
-            expect(WizardStepnavItem).toEqual(ClrWizardStepnavItem);
-            expect(WizardButton).toEqual(ClrWizardButton);
-            expect(WizardHeaderAction).toEqual(ClrWizardHeaderAction);
-            expect(WizardCustomTags).toEqual(ClrWizardCustomTags);
-            expect(WizardPageTitleDirective).toEqual(ClrWizardPageTitle);
-            expect(WizardPageNavTitleDirective).toEqual(ClrWizardPageNavTitle);
-            expect(WizardPageButtonsDirective).toEqual(ClrWizardPageButtons);
-            expect(WizardPageHeaderActionsDirective).toEqual(ClrWizardPageHeaderActions);
+            expect(Wizard.prototype instanceof ClrWizard).toBeTruthy();
+            expect(WizardPage.prototype instanceof ClrWizardPage).toBeTruthy();
+            expect(WizardStepnav.prototype instanceof ClrWizardStepnav).toBeTruthy();
+            expect(WizardStepnavItem.prototype instanceof ClrWizardStepnavItem).toBeTruthy();
+            expect(WizardButton.prototype instanceof ClrWizardButton).toBeTruthy();
+            expect(WizardHeaderAction.prototype instanceof ClrWizardHeaderAction).toBeTruthy();
+            expect(WizardCustomTags.prototype instanceof ClrWizardCustomTags).toBeTruthy();
+            expect(WizardPageTitleDirective.prototype instanceof ClrWizardPageTitle).toBeTruthy();
+            expect(WizardPageNavTitleDirective.prototype instanceof ClrWizardPageNavTitle).toBeTruthy();
+            expect(WizardPageButtonsDirective.prototype instanceof ClrWizardPageButtons).toBeTruthy();
+            expect(WizardPageHeaderActionsDirective.prototype instanceof ClrWizardPageHeaderActions).toBeTruthy();
             expect(WIZARD_DIRECTIVES).toEqual(CLR_WIZARD_DIRECTIVES);
         });
     });

--- a/src/clr-angular/emphasis/alert/alert.module.ts
+++ b/src/clr-angular/emphasis/alert/alert.module.ts
@@ -26,13 +26,13 @@ export class ClrAlertModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export const Alert = ClrAlert;
+export class Alert extends ClrAlert {}
 /** @deprecated since 0.11 */
-export const AlertItem = ClrAlertItem;
+export class AlertItem extends ClrAlertItem {}
 /** @deprecated since 0.11 */
-export const Alerts = ClrAlerts;
+export class Alerts extends ClrAlerts {}
 /** @deprecated since 0.11 */
-export const AlertsPager = ClrAlertsPager;
+export class AlertsPager extends ClrAlertsPager {}
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const ALERT_DIRECTIVES = CLR_ALERT_DIRECTIVES;

--- a/src/clr-angular/forms/checkbox/checkbox.ts
+++ b/src/clr-angular/forms/checkbox/checkbox.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import {Component, EventEmitter, forwardRef, Input, Output, Type} from "@angular/core";
+import {Component, EventEmitter, forwardRef, Input, Output} from "@angular/core";
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from "@angular/forms";
 
 /**
@@ -145,12 +145,3 @@ export class ClrCheckbox implements ControlValueAccessor {
         }
     }
 }
-
-export const CLR_CHECKBOX_DIRECTIVES: Type<any>[] = [ClrCheckbox];
-
-/* tslint:disable variable-name */
-/** @deprecated since 0.11 */
-export const Checkbox = ClrCheckbox;
-/* tslint:enable variable-name */
-/** @deprecated since 0.11 */
-export const CHECKBOX_DIRECTIVES = CLR_CHECKBOX_DIRECTIVES;

--- a/src/clr-angular/forms/forms.module.ts
+++ b/src/clr-angular/forms/forms.module.ts
@@ -5,9 +5,17 @@
  */
 
 import {CommonModule} from "@angular/common";
-import {NgModule} from "@angular/core";
+import {NgModule, Type} from "@angular/core";
+import {ClrCheckbox} from "./checkbox";
 
-import {CLR_CHECKBOX_DIRECTIVES} from "./checkbox";
+export const CLR_CHECKBOX_DIRECTIVES: Type<any>[] = [ClrCheckbox];
 
 @NgModule({imports: [CommonModule], declarations: [CLR_CHECKBOX_DIRECTIVES], exports: [CLR_CHECKBOX_DIRECTIVES]})
 export class ClrFormsModule {}
+
+/* tslint:disable variable-name */
+/** @deprecated since 0.11 */
+export class Checkbox extends ClrCheckbox {}
+/* tslint:enable variable-name */
+/** @deprecated since 0.11 */
+export const CHECKBOX_DIRECTIVES = CLR_CHECKBOX_DIRECTIVES;

--- a/src/clr-angular/icon/icon.module.ts
+++ b/src/clr-angular/icon/icon.module.ts
@@ -15,7 +15,7 @@ export class ClrIconModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export const IconCustomTag = ClrIconCustomTag;
+export class IconCustomTag extends ClrIconCustomTag {}
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const ICON_DIRECTIVES = CLR_ICON_DIRECTIVES;

--- a/src/clr-angular/layout/nav/navigation.module.ts
+++ b/src/clr-angular/layout/nav/navigation.module.ts
@@ -34,9 +34,9 @@ export class ClrNavigationModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export const Header = ClrHeader;
+export class Header extends ClrHeader {}
 /** @deprecated since 0.11 */
-export const NavLevelDirective = ClrNavLevel;
+export class NavLevelDirective extends ClrNavLevel {}
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const NAVIGATION_DIRECTIVES = CLR_NAVIGATION_DIRECTIVES;

--- a/src/clr-angular/layout/tabs/tabs.module.ts
+++ b/src/clr-angular/layout/tabs/tabs.module.ts
@@ -32,15 +32,15 @@ export class ClrTabsModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export const Tab = ClrTab;
+export class Tab extends ClrTab {}
 /** @deprecated since 0.11 */
-export const Tabs = ClrTabs;
+export class Tabs extends ClrTabs {}
 /** @deprecated since 0.11 */
-export const TabContent = ClrTabContent;
+export class TabContent extends ClrTabContent {}
 /** @deprecated since 0.11 */
-export const TabOverflowContent = ClrTabOverflowContent;
+export class TabOverflowContent extends ClrTabOverflowContent {}
 /** @deprecated since 0.11 */
-export const TabLinkDirective = ClrTabLink;
+export class TabLinkDirective extends ClrTabLink {}
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const TABS_DIRECTIVES = CLR_TABS_DIRECTIVES;

--- a/src/clr-angular/layout/vertical-nav/index.ts
+++ b/src/clr-angular/layout/vertical-nav/index.ts
@@ -4,6 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
+export * from "./vertical-nav-group-children";
 export * from "./vertical-nav-group";
 export * from "./vertical-nav";
 export * from "./vertical-nav-link";

--- a/src/clr-angular/layout/vertical-nav/vertical-nav.module.ts
+++ b/src/clr-angular/layout/vertical-nav/vertical-nav.module.ts
@@ -25,3 +25,18 @@ export const CLR_VERTICAL_NAV_DIRECTIVES: Type<any>[] =
     exports: [CLR_VERTICAL_NAV_DIRECTIVES, ClrIfExpandModule, ClrIconModule]
 })
 export class ClrVerticalNavModule {}
+
+/* tslint:disable variable-name */
+/** @deprecated since 0.11 */
+export class VerticalNav extends ClrVerticalNav {}
+/** @deprecated since 0.11 */
+export class VerticalNavGroup extends ClrVerticalNavGroup {}
+/** @deprecated since 0.11 */
+export class VerticalNavGroupChildren extends ClrVerticalNavGroupChildren {}
+/** @deprecated since 0.11 */
+export class VerticalNavIcon extends ClrVerticalNavIcon {}
+/** @deprecated since 0.11 */
+export class VerticalNavLink extends ClrVerticalNavLink {}
+/* tslint:enable variable-name */
+/** @deprecated since 0.11 */
+export const VERTICAL_NAV_DIRECTIVES = CLR_VERTICAL_NAV_DIRECTIVES;

--- a/src/clr-angular/modal/modal.module.ts
+++ b/src/clr-angular/modal/modal.module.ts
@@ -22,7 +22,7 @@ export class ClrModalModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export const Modal = ClrModal;
+export class Modal extends ClrModal {}
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const MODAL_DIRECTIVES = CLR_MODAL_DIRECTIVES;

--- a/src/clr-angular/popover/dropdown/dropdown.module.ts
+++ b/src/clr-angular/popover/dropdown/dropdown.module.ts
@@ -29,13 +29,13 @@ export class ClrDropdownModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export const Dropdown = ClrDropdown;
+export class Dropdown extends ClrDropdown {}
 /** @deprecated since 0.11 */
-export const DropdownMenu = ClrDropdownMenu;
+export class DropdownMenu extends ClrDropdownMenu {}
 /** @deprecated since 0.11 */
-export const DropdownTrigger = ClrDropdownTrigger;
+export class DropdownTrigger extends ClrDropdownTrigger {}
 /** @deprecated since 0.11 */
-export const DropdownItem = ClrDropdownItem;
+export class DropdownItem extends ClrDropdownItem {}
 /** @deprecated since 0.11 */
 export const menuPositions = CLR_MENU_POSITIONS;
 /* tslint:enable variable-name */

--- a/src/clr-angular/popover/signpost/signpost.module.ts
+++ b/src/clr-angular/popover/signpost/signpost.module.ts
@@ -28,11 +28,11 @@ export class ClrSignpostModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export const Signpost = ClrSignpost;
+export class Signpost extends ClrSignpost {}
 /** @deprecated since 0.11 */
-export const SignpostContent = ClrSignpostContent;
+export class SignpostContent extends ClrSignpostContent {}
 /** @deprecated since 0.11 */
-export const SignpostTrigger = ClrSignpostTrigger;
+export class SignpostTrigger extends ClrSignpostTrigger {}
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const SIGNPOST_DIRECTIVES = CLR_SIGNPOST_DIRECTIVES;

--- a/src/clr-angular/popover/tooltip/tooltip.module.ts
+++ b/src/clr-angular/popover/tooltip/tooltip.module.ts
@@ -26,11 +26,11 @@ export class ClrTooltipModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export const Tooltip = ClrTooltip;
+export class Tooltip extends ClrTooltip {}
 /** @deprecated since 0.11 */
-export const TooltipContent = ClrTooltipContent;
+export class TooltipContent extends ClrTooltipContent {}
 /** @deprecated since 0.11 */
-export const TooltipTrigger = ClrTooltipTrigger;
+export class TooltipTrigger extends ClrTooltipTrigger {}
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const TOOLTIP_DIRECTIVES = CLR_TOOLTIP_DIRECTIVES;

--- a/src/clr-angular/utils/loading/loading.module.ts
+++ b/src/clr-angular/utils/loading/loading.module.ts
@@ -15,7 +15,7 @@ export class ClrLoadingModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export const Loading = ClrLoading;
+export class Loading extends ClrLoading {}
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const LOADING_DIRECTIVES = CLR_LOADING_DIRECTIVES;

--- a/src/clr-angular/wizard/wizard.module.ts
+++ b/src/clr-angular/wizard/wizard.module.ts
@@ -36,27 +36,27 @@ export class ClrWizardModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export const Wizard = ClrWizard;
+export class Wizard extends ClrWizard {}
 /** @deprecated since 0.11 */
-export const WizardPage = ClrWizardPage;
+export class WizardPage extends ClrWizardPage {}
 /** @deprecated since 0.11 */
-export const WizardStepnav = ClrWizardStepnav;
+export class WizardStepnav extends ClrWizardStepnav {}
 /** @deprecated since 0.11 */
-export const WizardStepnavItem = ClrWizardStepnavItem;
+export class WizardStepnavItem extends ClrWizardStepnavItem {}
 /** @deprecated since 0.11 */
-export const WizardButton = ClrWizardButton;
+export class WizardButton extends ClrWizardButton {}
 /** @deprecated since 0.11 */
-export const WizardHeaderAction = ClrWizardHeaderAction;
+export class WizardHeaderAction extends ClrWizardHeaderAction {}
 /** @deprecated since 0.11 */
-export const WizardCustomTags = ClrWizardCustomTags;
+export class WizardCustomTags extends ClrWizardCustomTags {}
 /** @deprecated since 0.11 */
-export const WizardPageTitleDirective = ClrWizardPageTitle;
+export class WizardPageTitleDirective extends ClrWizardPageTitle {}
 /** @deprecated since 0.11 */
-export const WizardPageNavTitleDirective = ClrWizardPageNavTitle;
+export class WizardPageNavTitleDirective extends ClrWizardPageNavTitle {}
 /** @deprecated since 0.11 */
-export const WizardPageButtonsDirective = ClrWizardPageButtons;
+export class WizardPageButtonsDirective extends ClrWizardPageButtons {}
 /** @deprecated since 0.11 */
-export const WizardPageHeaderActionsDirective = ClrWizardPageHeaderActions;
+export class WizardPageHeaderActionsDirective extends ClrWizardPageHeaderActions {}
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const WIZARD_DIRECTIVES = CLR_WIZARD_DIRECTIVES;

--- a/src/ks-app/package.json
+++ b/src/ks-app/package.json
@@ -12,15 +12,15 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^4.0.0",
-    "@angular/common": "^4.0.0",
-    "@angular/compiler": "^4.0.0",
-    "@angular/core": "^4.0.0",
-    "@angular/forms": "^4.0.0",
-    "@angular/http": "^4.0.0",
-    "@angular/platform-browser": "^4.0.0",
-    "@angular/platform-browser-dynamic": "^4.0.0",
-    "@angular/router": "^4.0.0",
+    "@angular/animations": "^5.0.0",
+    "@angular/common": "^5.0.0",
+    "@angular/compiler": "^5.0.0",
+    "@angular/core": "^5.0.0",
+    "@angular/forms": "^5.0.0",
+    "@angular/http": "^5.0.0",
+    "@angular/platform-browser": "^5.0.0",
+    "@angular/platform-browser-dynamic": "^5.0.0",
+    "@angular/router": "^5.0.0",
     "@webcomponents/custom-elements": "1.0.0",
     "@clr/angular": "file:../../dist/clr-angular/clr-angular-0.11.0-beta.1.tgz",
     "@clr/icons": "file:../../dist/clr-icons",
@@ -33,9 +33,9 @@
     "zone.js": "^0.8.16"
   },
   "devDependencies": {
-    "@angular/cli": "~1.4.0",
-    "@angular/compiler-cli": "^4.0.0",
-    "@angular/language-service": "^4.0.0",
+    "@angular/cli": "^1.6.3",
+    "@angular/compiler-cli": "^5.0.0",
+    "@angular/language-service": "^5.0.0",
     "@types/jasmine": "~2.5.53",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "~6.0.60",
@@ -52,6 +52,6 @@
     "protractor": "~5.1.2",
     "ts-node": "~3.0.4",
     "tslint": "~5.3.2",
-    "typescript": "~2.3.3"
+    "typescript": "^2.4.2"
   }
 }


### PR DESCRIPTION
It appears that something in the build chain tree-shakes unused variables. To address this, exporting a class that extends another does not tree-shake the objects. 