### PR TITLE
[Docs] Add template generation to npm start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "angular-cli": {},
   "scripts": {
-    "start": "ng serve",
+    "start": "node generate-template.js; ng serve",
     "lint": "tslint \"src/**/*.ts\"",
     "test": "ng test",
     "pree2e": "webdriver-manager update",


### PR DESCRIPTION
Users should now be able to run npm start to serve up the documentation locally.  This is half of a proposed fix to the issue mentioned by @adityarb88 here: https://github.com/vmware/clarity/issues/1820#issuecomment-354438343