### PR TITLE
[Docs] Add note on serving documentation locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,8 @@ These documents provide guidance creating a well-crafted commit message:
 
 The [Clarity documentation website](https://vmware.github.io/clarity/documentation) is also housed in this repository under the `new-website` branch.  You can contribute to the documentation by submitting pull requests against that branch.
 
+The documentation website is written in Angular using angular-cli.  You can serve the documentation by [installing](https://github.com/angular/angular-cli#installation) angular-cli, checking out the `new-website` branch, and running `npm start`.   
+
 ## Reporting Bugs and Creating Issues
 
 You can submit an issue or a bug to our [GitHub repository](https://github.com/vmware/clarity/issues).  You must provide:


### PR DESCRIPTION
This adds brief instructions to CONTRIBUTING.md on how to serve up the documentation website locally. 
 This is half of a proposed fix to the issue mentioned by @adityarb88 here: https://github.com/vmware/clarity/issues/1820#issuecomment-354438343 

The other half is a pull request against the `new-website` branch here: https://github.com/vmware/clarity/pull/1823