### PR TITLE
Issue/core copyright date updates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Clarity
 
-Copyright © 2016 VMware, Inc.  All rights reserved				
+Copyright © 2016-2018 VMware, Inc.  All rights reserved
 
 The MIT license (the "License") set forth below applies to all parts of the Clarity project except for the fonts which are licensed under the SIL Open Font License version 1.1.  You may not use this file except in compliance with the License.
 

--- a/src/app/_utils/code-example.ts
+++ b/src/app/_utils/code-example.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/_utils/code.scss
+++ b/src/app/_utils/code.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 /* Vendor */
 

--- a/src/app/_utils/fake-loader.ts
+++ b/src/app/_utils/fake-loader.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/alert/alert.demo.html
+++ b/src/app/alert/alert.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/alert/alert.demo.module.ts
+++ b/src/app/alert/alert.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/alert/alert.demo.routing.ts
+++ b/src/app/alert/alert.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/alert/alert.demo.scss
+++ b/src/app/alert/alert.demo.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @import "../_utils/code";
 

--- a/src/app/alert/alert.demo.ts
+++ b/src/app/alert/alert.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/alert/angular/alert-angular-app-level.demo.html
+++ b/src/app/alert/angular/alert-angular-app-level.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/alert/angular/alert-angular-app-level.ts
+++ b/src/app/alert/angular/alert-angular-app-level.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/alert/angular/alert-angular-close-event.demo.html
+++ b/src/app/alert/angular/alert-angular-close-event.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/alert/angular/alert-angular-close-event.ts
+++ b/src/app/alert/angular/alert-angular-close-event.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/alert/angular/alert-angular-not-closable.demo.html
+++ b/src/app/alert/angular/alert-angular-not-closable.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/alert/angular/alert-angular-not-closable.ts
+++ b/src/app/alert/angular/alert-angular-not-closable.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/alert/angular/alert-angular-small.demo.html
+++ b/src/app/alert/angular/alert-angular-small.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/alert/angular/alert-angular-small.ts
+++ b/src/app/alert/angular/alert-angular-small.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/alert/angular/alert-angular-success.demo.html
+++ b/src/app/alert/angular/alert-angular-success.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/alert/angular/alert-angular-success.ts
+++ b/src/app/alert/angular/alert-angular-success.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/alert/angular/alert-angular.ts
+++ b/src/app/alert/angular/alert-angular.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/alert/static/alert-app-level.demo.html
+++ b/src/app/alert/static/alert-app-level.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/alert/static/alert-app-level.ts
+++ b/src/app/alert/static/alert-app-level.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/alert/static/alert-cards.demo.html
+++ b/src/app/alert/static/alert-cards.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/alert/static/alert-cards.ts
+++ b/src/app/alert/static/alert-cards.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/alert/static/alert-content-area.demo.html
+++ b/src/app/alert/static/alert-content-area.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/alert/static/alert-content-area.ts
+++ b/src/app/alert/static/alert-content-area.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/alert/static/alert-modals.demo.html
+++ b/src/app/alert/static/alert-modals.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/alert/static/alert-modals.ts
+++ b/src/app/alert/static/alert-modals.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/alert/static/alert-sizes.demo.html
+++ b/src/app/alert/static/alert-sizes.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/alert/static/alert-sizes.ts
+++ b/src/app/alert/static/alert-sizes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/alert/static/alert-static.ts
+++ b/src/app/alert/static/alert-static.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/alert/static/alert-styles.demo.html
+++ b/src/app/alert/static/alert-styles.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/alert/static/alert-styles.ts
+++ b/src/app/alert/static/alert-styles.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/angular/hide-show-overflow-toggle/hide-show-overflow-toggle.html
+++ b/src/app/button-group/angular/hide-show-overflow-toggle/hide-show-overflow-toggle.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h4>Toggle Overflow Menu</h4>
 
 <div class="clr-example example-min-height">

--- a/src/app/button-group/angular/menu-directions/menu-directions.html
+++ b/src/app/button-group/angular/menu-directions/menu-directions.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h4>Setting Menu Position using Angular</h4>
 
 <div class="clr-example space-below">

--- a/src/app/button-group/angular/move-all-in-menu/move-all-in-menu.html
+++ b/src/app/button-group/angular/move-all-in-menu/move-all-in-menu.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h4>Toggle Overflow Menu</h4>
 
 <div class="clr-example example-min-height">

--- a/src/app/button-group/static/basic-structure/basic-structure.html
+++ b/src/app/button-group/static/basic-structure/basic-structure.html
@@ -1,4 +1,10 @@
 
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <div class="clr-example" id="btn-group-test-1">
     <div class="btn-group btn-primary">
         <button class="btn">1</button>

--- a/src/app/button-group/static/cards/button-group-cards.html
+++ b/src/app/button-group/static/cards/button-group-cards.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h4>Button Groups in Cards</h4>
 <div class="clr-example" id="btn-group-test-1">
     <div class="row">

--- a/src/app/button-group/static/checkbox/button-group-checkboxes.html
+++ b/src/app/button-group/static/checkbox/button-group-checkboxes.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h4>Checkboxes</h4>
 <div class="clr-example" id="btn-group-test-1">
     <div class="btn-group">

--- a/src/app/button-group/static/icon-buttons/icon-button-group.html
+++ b/src/app/button-group/static/icon-buttons/icon-button-group.html
@@ -1,5 +1,11 @@
 
 
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h6>Icon Button Group</h6>
 <div class="clr-example">
     <div class="btn-group btn-icon btn-primary">

--- a/src/app/button-group/static/icons-with-text/button-group-icons-text.html
+++ b/src/app/button-group/static/icons-with-text/button-group-icons-text.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h4>Icon with Text</h4>
 <div class="clr-example example-min-height" id="btn-group-test-1">
     <div class="btn-group btn-primary">

--- a/src/app/button-group/static/icons/button-group-icons.html
+++ b/src/app/button-group/static/icons/button-group-icons.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h4>Icon Buttons</h4>
 
 <h6>Regular</h6>

--- a/src/app/button-group/static/menu-directions/menu-directions.html
+++ b/src/app/button-group/static/menu-directions/menu-directions.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h4>Static Menu Position</h4>
 
 <h6>Default / .bottom-left</h6>

--- a/src/app/button-group/static/radio/button-group-radios.html
+++ b/src/app/button-group/static/radio/button-group-radios.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h4>Radio Buttons</h4>
 <div class="clr-example" id="btn-group-test-1">
     <div class="btn-group">

--- a/src/app/button-group/static/types/button-group-types.html
+++ b/src/app/button-group/static/types/button-group-types.html
@@ -1,4 +1,10 @@
 
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h4>Primary</h4>
 <div class="clr-example" id="btn-group-test-1">
     <div class="btn-group btn-primary">

--- a/src/app/buttons/button-loading.html
+++ b/src/app/buttons/button-loading.html
@@ -1,6 +1,6 @@
 
 <!--
-  ~ Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/buttons/button-loading.ts
+++ b/src/app/buttons/button-loading.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/buttons/buttons-icons-sm.html
+++ b/src/app/buttons/buttons-icons-sm.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <button class="btn btn-sm btn-primary">
     <clr-icon shape="home"></clr-icon>
     Home

--- a/src/app/buttons/buttons-icons.html
+++ b/src/app/buttons/buttons-icons.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <button class="btn btn-primary">
     <clr-icon shape="home"></clr-icon>
     Home

--- a/src/app/color/color-contrast.demo.scss
+++ b/src/app/color/color-contrast.demo.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @import "./color-shared.demo";
 

--- a/src/app/color/color-luminance.demo.scss
+++ b/src/app/color/color-luminance.demo.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @import "./color-shared.demo";
 

--- a/src/app/color/color-palette.demo.html
+++ b/src/app/color/color-palette.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/color/color-palette.demo.scss
+++ b/src/app/color/color-palette.demo.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @import "./color-shared.demo";
 

--- a/src/app/color/color-palette.ts
+++ b/src/app/color/color-palette.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/color/color-shared.demo.scss
+++ b/src/app/color/color-shared.demo.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @import "../_utils/code";
 

--- a/src/app/color/color.demo.module.ts
+++ b/src/app/color/color.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/color/color.demo.routing.ts
+++ b/src/app/color/color.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/content-container.component.ts
+++ b/src/app/content-container.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/basic-structure/basic-structure.html
+++ b/src/app/datagrid/basic-structure/basic-structure.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/basic-structure/basic-structure.ts
+++ b/src/app/datagrid/basic-structure/basic-structure.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/binding-properties/binding-properties.html
+++ b/src/app/datagrid/binding-properties/binding-properties.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -11,7 +11,7 @@
     in your model. When you do, the column will benefit for all built-in features for this case:
     sorting based on the natural comparison, filtering based on string value, and anything else we
     might add in the future. Please note that the default sort order for strings will be case-insensitive.
-    If this isn't the desired behavior, you will have to write a custom comparator. You can bind to as deep 
+    If this isn't the desired behavior, you will have to write a custom comparator. You can bind to as deep
     a property as you want in your model, using a standard dot-separated syntax:
     <code class="clr-code">[clrDgField]=&quot;'my.deep.property'&quot;</code>
 </p>

--- a/src/app/datagrid/binding-properties/binding-properties.ts
+++ b/src/app/datagrid/binding-properties/binding-properties.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/column-sizing/column-sizing.html
+++ b/src/app/datagrid/column-sizing/column-sizing.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/column-sizing/column-sizing.ts
+++ b/src/app/datagrid/column-sizing/column-sizing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/compact/compact.html
+++ b/src/app/datagrid/compact/compact.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/compact/compact.ts
+++ b/src/app/datagrid/compact/compact.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/custom-rendering/custom-rendering.html
+++ b/src/app/datagrid/custom-rendering/custom-rendering.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/custom-rendering/custom-rendering.ts
+++ b/src/app/datagrid/custom-rendering/custom-rendering.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/datagrid.demo.html
+++ b/src/app/datagrid/datagrid.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/datagrid.demo.module.ts
+++ b/src/app/datagrid/datagrid.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/datagrid.demo.routing.ts
+++ b/src/app/datagrid/datagrid.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/datagrid.demo.scss
+++ b/src/app/datagrid/datagrid.demo.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @import "../_utils/code";
 

--- a/src/app/datagrid/datagrid.demo.ts
+++ b/src/app/datagrid/datagrid.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/expandable-rows/expandable-rows.html
+++ b/src/app/datagrid/expandable-rows/expandable-rows.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/expandable-rows/expandable-rows.ts
+++ b/src/app/datagrid/expandable-rows/expandable-rows.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/filtering/examples.ts
+++ b/src/app/datagrid/filtering/examples.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/filtering/filtering.html
+++ b/src/app/datagrid/filtering/filtering.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/filtering/filtering.ts
+++ b/src/app/datagrid/filtering/filtering.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/full/full.html
+++ b/src/app/datagrid/full/full.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/full/full.ts
+++ b/src/app/datagrid/full/full.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/hide-show-columns/hide-show.html
+++ b/src/app/datagrid/hide-show-columns/hide-show.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/inventory/inventory.ts
+++ b/src/app/datagrid/inventory/inventory.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/inventory/pokemon.ts
+++ b/src/app/datagrid/inventory/pokemon.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/inventory/user.ts
+++ b/src/app/datagrid/inventory/user.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/inventory/values.ts
+++ b/src/app/datagrid/inventory/values.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/kitchen-sink/kitchen-sink.html
+++ b/src/app/datagrid/kitchen-sink/kitchen-sink.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/kitchen-sink/kitchen-sink.ts
+++ b/src/app/datagrid/kitchen-sink/kitchen-sink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/pagination/pagination.html
+++ b/src/app/datagrid/pagination/pagination.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/pagination/pagination.ts
+++ b/src/app/datagrid/pagination/pagination.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/placeholder/placeholder.html
+++ b/src/app/datagrid/placeholder/placeholder.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/placeholder/placeholder.ts
+++ b/src/app/datagrid/placeholder/placeholder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/preserve-selection/preserve-selection.html
+++ b/src/app/datagrid/preserve-selection/preserve-selection.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <clr-datagrid [(clrDgSelected)]="selected">
     <clr-dg-column>User ID</clr-dg-column>
     <clr-dg-column [clrDgField]="'name'" [(clrFilterValue)]="nameFilter">Name</clr-dg-column>

--- a/src/app/datagrid/preserve-selection/preserve-selection.ts
+++ b/src/app/datagrid/preserve-selection/preserve-selection.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/scrolling/scrolling.html
+++ b/src/app/datagrid/scrolling/scrolling.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/scrolling/scrolling.ts
+++ b/src/app/datagrid/scrolling/scrolling.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/selection-row-mode/selection-row-mode.html
+++ b/src/app/datagrid/selection-row-mode/selection-row-mode.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/selection-row-mode/selection-row-mode.ts
+++ b/src/app/datagrid/selection-row-mode/selection-row-mode.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/selection-single/selection-single.html
+++ b/src/app/datagrid/selection-single/selection-single.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/selection-single/selection-single.ts
+++ b/src/app/datagrid/selection-single/selection-single.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/selection/selection.html
+++ b/src/app/datagrid/selection/selection.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/selection/selection.ts
+++ b/src/app/datagrid/selection/selection.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/server-driven/examples.ts
+++ b/src/app/datagrid/server-driven/examples.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/server-driven/server-driven.html
+++ b/src/app/datagrid/server-driven/server-driven.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/server-driven/server-driven.ts
+++ b/src/app/datagrid/server-driven/server-driven.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/smart-iterator/smart-iterator.html
+++ b/src/app/datagrid/smart-iterator/smart-iterator.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/smart-iterator/smart-iterator.ts
+++ b/src/app/datagrid/smart-iterator/smart-iterator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/sorting/examples.ts
+++ b/src/app/datagrid/sorting/examples.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/sorting/sorting.html
+++ b/src/app/datagrid/sorting/sorting.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/sorting/sorting.ts
+++ b/src/app/datagrid/sorting/sorting.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/string-filtering/examples.ts
+++ b/src/app/datagrid/string-filtering/examples.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/string-filtering/string-filtering.html
+++ b/src/app/datagrid/string-filtering/string-filtering.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/string-filtering/string-filtering.ts
+++ b/src/app/datagrid/string-filtering/string-filtering.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/utils/color-filter.ts
+++ b/src/app/datagrid/utils/color-filter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/utils/example.ts
+++ b/src/app/datagrid/utils/example.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/utils/pokemon-comparator.ts
+++ b/src/app/datagrid/utils/pokemon-comparator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/utils/pokemon-filter.ts
+++ b/src/app/datagrid/utils/pokemon-filter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/dropdown/dropdown-header.demo.html
+++ b/src/app/dropdown/dropdown-header.demo.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <div class="clr-example">
     <div class="main-container">
         <header class="header-6">

--- a/src/app/iconography/icon-selection.demo.html
+++ b/src/app/iconography/icon-selection.demo.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <div class="clr-icon-selection">
 
     <section>

--- a/src/app/iconography/iconography.demo.scss
+++ b/src/app/iconography/iconography.demo.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 @import "../_utils/code";
 
 

--- a/src/app/iconography/icons-view-box-test.demo.html
+++ b/src/app/iconography/icons-view-box-test.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/images/images.demo.scss
+++ b/src/app/images/images.demo.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @import "../_utils/code";
 

--- a/src/app/modal/modal-form.demo.html
+++ b/src/app/modal/modal-form.demo.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <p>
     <button class="btn btn-primary" (click)="basic = true;">Show modal</button>
     <span>Model Info: {{diagnostic}}</span>

--- a/src/app/modal/modal-max-height.html
+++ b/src/app/modal/modal-max-height.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/modal/modal-max-height.ts
+++ b/src/app/modal/modal-max-height.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/modal/modal-trap.demo.html
+++ b/src/app/modal/modal-trap.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/modal/modal-trap.ts
+++ b/src/app/modal/modal-trap.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/signpost/signpost.demo.html
+++ b/src/app/signpost/signpost.demo.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h4>Positions</h4>
 
 <div class="content-container">

--- a/src/app/signpost/signpost.demo.scss
+++ b/src/app/signpost/signpost.demo.scss
@@ -1,3 +1,9 @@
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 .signpost-demo {
     display: flex;
     justify-content: center;

--- a/src/app/signpost/signpost.demo.ts
+++ b/src/app/signpost/signpost.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/signpost/signpost.routing.ts
+++ b/src/app/signpost/signpost.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tooltips/tooltips-angular.html
+++ b/src/app/tooltips/tooltips-angular.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tooltips/tooltips-directions.html
+++ b/src/app/tooltips/tooltips-directions.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tooltips/tooltips-icons.html
+++ b/src/app/tooltips/tooltips-icons.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tooltips/tooltips-sizes.html
+++ b/src/app/tooltips/tooltips-sizes.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tooltips/tooltips.demo.html
+++ b/src/app/tooltips/tooltips.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tooltips/tooltips.demo.scss
+++ b/src/app/tooltips/tooltips.demo.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @import "../_utils/code";
 @import "../../clr-angular/image/icons.clarity";

--- a/src/app/typography/typography-font-char-test.html
+++ b/src/app/typography/typography-font-char-test.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <style>
     .p0,.p1,.p2,.p3,.p4,.p5,.p6,.p7,.p8 {
         margin: 0;

--- a/src/app/vertical-nav/all-cases/vertical-all-cases.demo.html
+++ b/src/app/vertical-nav/all-cases/vertical-all-cases.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/vertical-nav/all-cases/vertical-all-cases.demo.ts
+++ b/src/app/vertical-nav/all-cases/vertical-all-cases.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/basic/vertical-nav-basic.demo.html
+++ b/src/app/vertical-nav/basic/vertical-nav-basic.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/vertical-nav/basic/vertical-nav-basic.ts
+++ b/src/app/vertical-nav/basic/vertical-nav-basic.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/collapsible/vertical-nav-collapsible.demo.html
+++ b/src/app/vertical-nav/collapsible/vertical-nav-collapsible.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/vertical-nav/collapsible/vertical-nav-collapsible.ts
+++ b/src/app/vertical-nav/collapsible/vertical-nav-collapsible.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/direct-icon/vertical-nav-icon.demo.html
+++ b/src/app/vertical-nav/direct-icon/vertical-nav-icon.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/vertical-nav/direct-icon/vertical-nav-icon.ts
+++ b/src/app/vertical-nav/direct-icon/vertical-nav-icon.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/header-and-divider/vertical-nav-header-and-divider.demo.html
+++ b/src/app/vertical-nav/header-and-divider/vertical-nav-header-and-divider.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/vertical-nav/header-and-divider/vertical-nav-header-and-divider.ts
+++ b/src/app/vertical-nav/header-and-divider/vertical-nav-header-and-divider.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/nested-icon-menus/vertical-nav-nested-icon-menus.demo.html
+++ b/src/app/vertical-nav/nested-icon-menus/vertical-nav-nested-icon-menus.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/vertical-nav/nested-icon-menus/vertical-nav-nested-icon-menus.ts
+++ b/src/app/vertical-nav/nested-icon-menus/vertical-nav-nested-icon-menus.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/nested-menus/vertical-nav-nested-menus.demo.html
+++ b/src/app/vertical-nav/nested-menus/vertical-nav-nested-menus.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/vertical-nav/nested-menus/vertical-nav-nested-menus.ts
+++ b/src/app/vertical-nav/nested-menus/vertical-nav-nested-menus.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/partially-nested-icon-menu/vertical-nav-partial-nested-icon-menus.demo.html
+++ b/src/app/vertical-nav/partially-nested-icon-menu/vertical-nav-partial-nested-icon-menus.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/vertical-nav/partially-nested-icon-menu/vertical-nav-partial-nested-icon-menus.ts
+++ b/src/app/vertical-nav/partially-nested-icon-menu/vertical-nav-partial-nested-icon-menus.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/partially-nested-menu/vertical-nav-partial-nested-menus.demo.html
+++ b/src/app/vertical-nav/partially-nested-menu/vertical-nav-partial-nested-menus.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/vertical-nav/partially-nested-menu/vertical-nav-partial-nested-menus.ts
+++ b/src/app/vertical-nav/partially-nested-menu/vertical-nav-partial-nested-menus.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/routing/beatles/abbey-road.ts
+++ b/src/app/vertical-nav/routing/beatles/abbey-road.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/routing/beatles/beatles.ts
+++ b/src/app/vertical-nav/routing/beatles/beatles.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/routing/beatles/revolver.ts
+++ b/src/app/vertical-nav/routing/beatles/revolver.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/routing/beatles/rubber-soul.ts
+++ b/src/app/vertical-nav/routing/beatles/rubber-soul.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/routing/the-killers/day-and-age.ts
+++ b/src/app/vertical-nav/routing/the-killers/day-and-age.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/routing/the-killers/hot-fuss.ts
+++ b/src/app/vertical-nav/routing/the-killers/hot-fuss.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/routing/the-killers/sams-town.ts
+++ b/src/app/vertical-nav/routing/the-killers/sams-town.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/routing/the-killers/the-killers.ts
+++ b/src/app/vertical-nav/routing/the-killers/the-killers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/routing/vertical-nav-routing.demo.html
+++ b/src/app/vertical-nav/routing/vertical-nav-routing.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/vertical-nav/routing/vertical-nav-routing.ts
+++ b/src/app/vertical-nav/routing/vertical-nav-routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/routing/wikipedia.ts
+++ b/src/app/vertical-nav/routing/wikipedia.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/static/vertical-nav-static.demo.html
+++ b/src/app/vertical-nav/static/vertical-nav-static.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/vertical-nav/static/vertical-nav-static.demo.ts
+++ b/src/app/vertical-nav/static/vertical-nav-static.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/unstructured-routes/beatles/abbey-road.ts
+++ b/src/app/vertical-nav/unstructured-routes/beatles/abbey-road.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/unstructured-routes/beatles/beatles.ts
+++ b/src/app/vertical-nav/unstructured-routes/beatles/beatles.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/unstructured-routes/beatles/revolver.ts
+++ b/src/app/vertical-nav/unstructured-routes/beatles/revolver.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/unstructured-routes/beatles/rubber-soul.ts
+++ b/src/app/vertical-nav/unstructured-routes/beatles/rubber-soul.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/unstructured-routes/the-killers/day-and-age.ts
+++ b/src/app/vertical-nav/unstructured-routes/the-killers/day-and-age.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/unstructured-routes/the-killers/hot-fuss.ts
+++ b/src/app/vertical-nav/unstructured-routes/the-killers/hot-fuss.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/unstructured-routes/the-killers/sams-town.ts
+++ b/src/app/vertical-nav/unstructured-routes/the-killers/sams-town.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/unstructured-routes/the-killers/the-killers.ts
+++ b/src/app/vertical-nav/unstructured-routes/the-killers/the-killers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/unstructured-routes/unstructured-routes.html
+++ b/src/app/vertical-nav/unstructured-routes/unstructured-routes.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/vertical-nav/unstructured-routes/unstructured-routes.ts
+++ b/src/app/vertical-nav/unstructured-routes/unstructured-routes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/unstructured-routes/wikipedia.ts
+++ b/src/app/vertical-nav/unstructured-routes/wikipedia.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/vertical-nav-cases.ts
+++ b/src/app/vertical-nav/vertical-nav-cases.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/vertical-nav.demo.module.ts
+++ b/src/app/vertical-nav/vertical-nav.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/vertical-nav.demo.routing.ts
+++ b/src/app/vertical-nav/vertical-nav.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/vertical-nav.demo.scss
+++ b/src/app/vertical-nav/vertical-nav.demo.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @import "../_utils/code";
 

--- a/src/app/vertical-nav/vertical-nav.demo.ts
+++ b/src/app/vertical-nav/vertical-nav.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/without-expanded-directive/beatles/abbey-road.ts
+++ b/src/app/vertical-nav/without-expanded-directive/beatles/abbey-road.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/without-expanded-directive/beatles/beatles.ts
+++ b/src/app/vertical-nav/without-expanded-directive/beatles/beatles.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/without-expanded-directive/beatles/revolver.ts
+++ b/src/app/vertical-nav/without-expanded-directive/beatles/revolver.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/without-expanded-directive/beatles/rubber-soul.ts
+++ b/src/app/vertical-nav/without-expanded-directive/beatles/rubber-soul.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/without-expanded-directive/the-killers/day-and-age.ts
+++ b/src/app/vertical-nav/without-expanded-directive/the-killers/day-and-age.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/without-expanded-directive/the-killers/hot-fuss.ts
+++ b/src/app/vertical-nav/without-expanded-directive/the-killers/hot-fuss.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/without-expanded-directive/the-killers/sams-town.ts
+++ b/src/app/vertical-nav/without-expanded-directive/the-killers/sams-town.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/without-expanded-directive/the-killers/the-killers.ts
+++ b/src/app/vertical-nav/without-expanded-directive/the-killers/the-killers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/without-expanded-directive/wikipedia.ts
+++ b/src/app/vertical-nav/without-expanded-directive/wikipedia.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/without-expanded-directive/without-expanded-directive.html
+++ b/src/app/vertical-nav/without-expanded-directive/without-expanded-directive.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/vertical-nav/without-expanded-directive/without-expanded-directive.ts
+++ b/src/app/vertical-nav/without-expanded-directive/without-expanded-directive.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/virtual-scroll/slots.ts
+++ b/src/app/virtual-scroll/slots.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/virtual-scroll/virtual-scroll-array.ts
+++ b/src/app/virtual-scroll/virtual-scroll-array.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/virtual-scroll/virtual-scroll-infinite-generator.ts
+++ b/src/app/virtual-scroll/virtual-scroll-infinite-generator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/virtual-scroll/virtual-scroll-slot-machine.ts
+++ b/src/app/virtual-scroll/virtual-scroll-slot-machine.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/virtual-scroll/virtual-scroll.demo.module.ts
+++ b/src/app/virtual-scroll/virtual-scroll.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/virtual-scroll/virtual-scroll.demo.scss
+++ b/src/app/virtual-scroll/virtual-scroll.demo.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 .container  {
     height: 120px;

--- a/src/app/virtual-scroll/virtual-scroll.demo.ts
+++ b/src/app/virtual-scroll/virtual-scroll.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/wizard/wizard-alt-cancel.demo.html
+++ b/src/app/wizard/wizard-alt-cancel.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/wizard/wizard-alt-cancel.demo.ts
+++ b/src/app/wizard/wizard-alt-cancel.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/wizard/wizard-alt-next.demo.html
+++ b/src/app/wizard/wizard-alt-next.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/wizard/wizard-alt-next.demo.ts
+++ b/src/app/wizard/wizard-alt-next.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/wizard/wizard-async-validation.demo.html
+++ b/src/app/wizard/wizard-async-validation.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/wizard/wizard-async-validation.demo.ts
+++ b/src/app/wizard/wizard-async-validation.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/wizard/wizard-basic.demo.html
+++ b/src/app/wizard/wizard-basic.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/wizard/wizard-basic.demo.ts
+++ b/src/app/wizard/wizard-basic.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/wizard/wizard-custom-buttons.demo.html
+++ b/src/app/wizard/wizard-custom-buttons.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -22,56 +22,56 @@
         <ng-template clrPageNavTitle>Default buttons</ng-template> <!-- optional -->
 
         <p class="content-for-page-1">
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia, 
-            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur 
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia,
+            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur
             quas! Quaerat explicabo expedita placeat vero.
         </p>
         <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia, 
-            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur 
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia,
+            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur
             quas! Quaerat explicabo expedita placeat vero.
         </p>
         <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia, 
-            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur 
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia,
+            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur
             quas! Quaerat explicabo expedita placeat vero.
         </p>
         <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia, 
-            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur 
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia,
+            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur
             quas! Quaerat explicabo expedita placeat vero.
         </p>
     </clr-wizard-page>
 
-    <clr-wizard-page 
+    <clr-wizard-page
         (clrWizardPageCustomButton)="doCustomClick($event)">
 
         <ng-template clrPageTitle>Page 2 with custom buttons</ng-template> <!-- mandatory -->
         <ng-template clrPageNavTitle>Custom buttons</ng-template> <!-- optional -->
 
         <p class="content-for-page-2">
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia, 
-            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur 
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia,
+            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur
             quas! Quaerat explicabo expedita placeat vero.
         </p>
         <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia, 
-            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur 
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia,
+            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur
             quas! Quaerat explicabo expedita placeat vero.
         </p>
         <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia, 
-            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur 
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia,
+            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur
             quas! Quaerat explicabo expedita placeat vero.
         </p>
         <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia, 
-            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur 
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia,
+            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur
             quas! Quaerat explicabo expedita placeat vero.
         </p>
         <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia, 
-            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur 
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia,
+            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur
             quas! Quaerat explicabo expedita placeat vero.
         </p>
 
@@ -87,36 +87,36 @@
         <ng-template clrPageNavTitle>Default buttons</ng-template> <!-- optional -->
 
         <p class="content-for-page-3">
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia, 
-            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur 
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia,
+            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur
             quas! Quaerat explicabo expedita placeat vero.
         </p>
         <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia, 
-            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur 
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia,
+            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur
             quas! Quaerat explicabo expedita placeat vero.
         </p>
         <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia, 
-            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur 
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia,
+            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur
             quas! Quaerat explicabo expedita placeat vero.
         </p>
         <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia, 
-            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur 
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia,
+            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur
             quas! Quaerat explicabo expedita placeat vero.
         </p>
     </clr-wizard-page>
 
-    <clr-wizard-page 
+    <clr-wizard-page
         (clrWizardPageCustomButton)="doCustomClick($event)">
 
         <ng-template clrPageTitle>Page 4 with custom finish</ng-template> <!-- mandatory -->
         <ng-template clrPageNavTitle>Custom buttons</ng-template> <!-- optional -->
 
         <p *ngIf="!showWarning">
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia, 
-            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur 
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia,
+            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur
             quas! Quaerat explicabo expedita placeat vero.
         </p>
 

--- a/src/app/wizard/wizard-custom-buttons.demo.ts
+++ b/src/app/wizard/wizard-custom-buttons.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/wizard/wizard-force-forward.demo.html
+++ b/src/app/wizard/wizard-force-forward.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/wizard/wizard-force-forward.demo.ts
+++ b/src/app/wizard/wizard-force-forward.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/wizard/wizard-form-validation.demo.html
+++ b/src/app/wizard/wizard-form-validation.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -49,7 +49,7 @@
                     <label for="numberInput" aria-haspopup="true" role="tooltip"
                         [class.invalid]="number.touched && !number.valid"
                         class="tooltip tooltip-validation tooltip-md tooltip-bottom-right">
-                        <input type="number" id="numberInput" required [(ngModel)]="model.number" 
+                        <input type="number" id="numberInput" required [(ngModel)]="model.number"
                             name="number" #number="ngModel">
                         <span class="tooltip-content">
                             This field cannot be empty!

--- a/src/app/wizard/wizard-form-validation.demo.ts
+++ b/src/app/wizard/wizard-form-validation.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/wizard/wizard-ghosts.demo.html
+++ b/src/app/wizard/wizard-ghosts.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/wizard/wizard-ghosts.demo.ts
+++ b/src/app/wizard/wizard-ghosts.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/wizard/wizard-header-actions.demo.html
+++ b/src/app/wizard/wizard-header-actions.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -30,23 +30,23 @@
         <ng-template clrPageNavTitle>Default header actions</ng-template> <!-- optional -->
 
         <p class="content-for-page-1">
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia, 
-            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur 
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia,
+            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur
             quas! Quaerat explicabo expedita placeat vero.
         </p>
         <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia, 
-            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur 
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia,
+            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur
             quas! Quaerat explicabo expedita placeat vero.
         </p>
         <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia, 
-            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur 
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia,
+            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur
             quas! Quaerat explicabo expedita placeat vero.
         </p>
         <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia, 
-            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur 
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia,
+            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur
             quas! Quaerat explicabo expedita placeat vero.
         </p>
     </clr-wizard-page>
@@ -56,8 +56,8 @@
         <ng-template clrPageNavTitle>Custom header actions</ng-template> <!-- optional -->
 
         <p class="content-for-page-2">
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia, 
-            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur 
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia,
+            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur
             quas! Quaerat explicabo expedita placeat vero.
         </p>
 

--- a/src/app/wizard/wizard-header-actions.demo.ts
+++ b/src/app/wizard/wizard-header-actions.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/wizard/wizard-inline.demo.html
+++ b/src/app/wizard/wizard-inline.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -25,23 +25,23 @@
 
         <p>Content for page 1</p>
         <p class="content-for-page-1">
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia, 
-            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur 
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia,
+            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur
             quas! Quaerat explicabo expedita placeat vero.
         </p>
         <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia, 
-            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur 
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia,
+            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur
             quas! Quaerat explicabo expedita placeat vero.
         </p>
         <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia, 
-            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur 
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia,
+            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur
             quas! Quaerat explicabo expedita placeat vero.
         </p>
         <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia, 
-            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur 
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia,
+            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur
             quas! Quaerat explicabo expedita placeat vero.
         </p>
     </clr-wizard-page>
@@ -51,8 +51,8 @@
 
         <p>Content for page 2</p>
         <p class="content-for-page-2">
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia, 
-            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur 
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quae minima inventore quia,
+            officiis rem id explicabo incidunt, illum deleniti qui doloremque voluptatem, saepe tenetur
             quas! Quaerat explicabo expedita placeat vero.
         </p>
     </clr-wizard-page>

--- a/src/app/wizard/wizard-inline.demo.ts
+++ b/src/app/wizard/wizard-inline.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/wizard/wizard-jump-to.demo.html
+++ b/src/app/wizard/wizard-jump-to.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -19,12 +19,12 @@
     <clr-wizard-page>
         <ng-template clrPageTitle>Page 1</ng-template>
         <p>
-            If the wizard can navigate to the pages, you can click on the buttons 
+            If the wizard can navigate to the pages, you can click on the buttons
             above to have it open up at step three or step five. Try clicking through
             all the pages, closing the wizard, and clicking on the buttons.
         </p>
         <p>
-            Enabling a page for navigation entails setting the pages before it as 
+            Enabling a page for navigation entails setting the pages before it as
             both ready to complete and completed. This can be done programmatically as
             well.
         </p>

--- a/src/app/wizard/wizard-jump-to.demo.ts
+++ b/src/app/wizard/wizard-jump-to.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/wizard/wizard-not-closable.demo.html
+++ b/src/app/wizard/wizard-not-closable.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/wizard/wizard-not-closable.demo.ts
+++ b/src/app/wizard/wizard-not-closable.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/wizard/wizard-reset.demo.html
+++ b/src/app/wizard/wizard-reset.demo.html
@@ -1,12 +1,12 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
 
 <button class="btn btn-primary" (click)="wizard.open()">Reset Wizard</button>
 
-<clr-wizard #wizard 
+<clr-wizard #wizard
     [(clrWizardOpen)]="open"
     [clrWizardSize]="'md'"
     (clrWizardOnFinish)="doFinish()"

--- a/src/app/wizard/wizard-reset.demo.ts
+++ b/src/app/wizard/wizard-reset.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/wizard/wizard-skip-page.demo.html
+++ b/src/app/wizard/wizard-skip-page.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/wizard/wizard-skip-page.demo.ts
+++ b/src/app/wizard/wizard-skip-page.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/wizard/wizard-stop-navigation.demo.html
+++ b/src/app/wizard/wizard-stop-navigation.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/wizard/wizard-stop-navigation.demo.ts
+++ b/src/app/wizard/wizard-stop-navigation.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/wizard/wizard.demo.module.ts
+++ b/src/app/wizard/wizard.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/wizard/wizard.demo.ts
+++ b/src/app/wizard/wizard.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/button/_buttons.clarity.scss
+++ b/src/clr-angular/button/_buttons.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @mixin populateButtonProperties($button-type: default, $button-global-map: $clr-global-button-properties-map) {
     $button-property-map: map-get($button-global-map, $button-type);

--- a/src/clr-angular/button/_toggles.clarity.scss
+++ b/src/clr-angular/button/_toggles.clarity.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/button/_variables.button.scss
+++ b/src/clr-angular/button/_variables.button.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/button/_variables.toggles.scss
+++ b/src/clr-angular/button/_variables.toggles.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/button/button-group/_button-group.clarity.scss
+++ b/src/clr-angular/button/button-group/_button-group.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @include exports('button-group.clarity') {
 

--- a/src/clr-angular/button/button-group/button-group.html
+++ b/src/clr-angular/button/button-group/button-group.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <ng-container *ngFor="let inlineButton of inlineButtons">
     <ng-template [ngTemplateOutlet]="inlineButton.templateRef"></ng-template>
 </ng-container>

--- a/src/clr-angular/button/button-group/button-group.module.ts
+++ b/src/clr-angular/button/button-group/button-group.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/button/button-group/index.ts
+++ b/src/clr-angular/button/button-group/index.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/button/button-loading/index.ts
+++ b/src/clr-angular/button/button-loading/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/button/button-loading/loading-button.module.ts
+++ b/src/clr-angular/button/button-loading/loading-button.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/button/button-loading/loading-button.spec.ts
+++ b/src/clr-angular/button/button-loading/loading-button.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/button/button-loading/loading-button.ts
+++ b/src/clr-angular/button/button-loading/loading-button.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/button/button.module.ts
+++ b/src/clr-angular/button/button.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/button/index.ts
+++ b/src/clr-angular/button/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/clr-angular.module.ts
+++ b/src/clr-angular/clr-angular.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/code/code.module.ts
+++ b/src/clr-angular/code/code.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/code/index.ts
+++ b/src/clr-angular/code/index.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/code/syntax-highlight/_code.clarity.scss
+++ b/src/clr-angular/code/syntax-highlight/_code.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @include exports('code.clarity') {
     //Styles for Clarity Code Snippets

--- a/src/clr-angular/code/syntax-highlight/index.ts
+++ b/src/clr-angular/code/syntax-highlight/index.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/code/syntax-highlight/syntax-highlight.module.ts
+++ b/src/clr-angular/code/syntax-highlight/syntax-highlight.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/color/_color.clarity.scss
+++ b/src/clr-angular/color/_color.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @function clr-getColor($colorIndexOrBase: base, $colorType: grays) {
     $colorMap: _clr-lookupColorMap($colorType);

--- a/src/clr-angular/color/_variables.color.scss
+++ b/src/clr-angular/color/_variables.color.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/color/utils/_colors.clarity.scss
+++ b/src/clr-angular/color/utils/_colors.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 $clr-white: #fff !default;
 $clr-black: #000 !default;

--- a/src/clr-angular/color/utils/_contrast-cache.clarity.scss
+++ b/src/clr-angular/color/utils/_contrast-cache.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 // using cache for contrast lookup shaved 7 seconds off sass build. over 50% at this time.
 // using interpolation for cacheContrast keys increased build time almost 250%.

--- a/src/clr-angular/dark-theme.scss
+++ b/src/clr-angular/dark-theme.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  *

--- a/src/clr-angular/data/_tables.clarity.scss
+++ b/src/clr-angular/data/_tables.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 // Backgrounds
 $clr-table-bgcolor: $clr-white !default;

--- a/src/clr-angular/data/_variables.tables.scss
+++ b/src/clr-angular/data/_variables.tables.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/data.module.ts
+++ b/src/clr-angular/data/data.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clr-angular/data/datagrid/_datagrid.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @include exports('datagrid.clarity') {
     @include basic-table(".datagrid", ".datagrid-head", ".datagrid-body",

--- a/src/clr-angular/data/datagrid/_variables.datagrid.scss
+++ b/src/clr-angular/data/datagrid/_variables.datagrid.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/all.spec.ts
+++ b/src/clr-angular/data/datagrid/all.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/animation-hack/row-expand-animation.spec.ts
+++ b/src/clr-angular/data/datagrid/animation-hack/row-expand-animation.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/animation-hack/row-expand-animation.ts
+++ b/src/clr-angular/data/datagrid/animation-hack/row-expand-animation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/built-in/comparators/datagrid-property-comparator.spec.ts
+++ b/src/clr-angular/data/datagrid/built-in/comparators/datagrid-property-comparator.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/built-in/comparators/datagrid-property-comparator.ts
+++ b/src/clr-angular/data/datagrid/built-in/comparators/datagrid-property-comparator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/built-in/filters/datagrid-property-string-filter.spec.ts
+++ b/src/clr-angular/data/datagrid/built-in/filters/datagrid-property-string-filter.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/built-in/filters/datagrid-property-string-filter.ts
+++ b/src/clr-angular/data/datagrid/built-in/filters/datagrid-property-string-filter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/built-in/filters/datagrid-string-filter-impl.spec.ts
+++ b/src/clr-angular/data/datagrid/built-in/filters/datagrid-string-filter-impl.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/built-in/filters/datagrid-string-filter-impl.ts
+++ b/src/clr-angular/data/datagrid/built-in/filters/datagrid-string-filter-impl.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/built-in/filters/datagrid-string-filter.spec.ts
+++ b/src/clr-angular/data/datagrid/built-in/filters/datagrid-string-filter.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/built-in/filters/datagrid-string-filter.ts
+++ b/src/clr-angular/data/datagrid/built-in/filters/datagrid-string-filter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/built-in/nested-property.spec.ts
+++ b/src/clr-angular/data/datagrid/built-in/nested-property.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/built-in/nested-property.ts
+++ b/src/clr-angular/data/datagrid/built-in/nested-property.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/chocolate/actionable-oompa-loompa.ts
+++ b/src/clr-angular/data/datagrid/chocolate/actionable-oompa-loompa.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/chocolate/datagrid-willy-wonka.ts
+++ b/src/clr-angular/data/datagrid/chocolate/datagrid-willy-wonka.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/chocolate/expandable-oompa-loompa.ts
+++ b/src/clr-angular/data/datagrid/chocolate/expandable-oompa-loompa.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-action-bar.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-action-bar.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-action-bar.ts
+++ b/src/clr-angular/data/datagrid/datagrid-action-bar.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-action-overflow.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-action-overflow.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-action-overflow.ts
+++ b/src/clr-angular/data/datagrid/datagrid-action-overflow.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-cell.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-cell.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-cell.ts
+++ b/src/clr-angular/data/datagrid/datagrid-cell.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-column-toggle.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-toggle.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-column-toggle.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-toggle.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-column.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-column.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-detail-registerer.ts
+++ b/src/clr-angular/data/datagrid/datagrid-detail-registerer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-filter.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-filter.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-filter.ts
+++ b/src/clr-angular/data/datagrid/datagrid-filter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-footer.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-footer.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-footer.ts
+++ b/src/clr-angular/data/datagrid/datagrid-footer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-hideable-column.model.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-hideable-column.model.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-hideable-column.model.ts
+++ b/src/clr-angular/data/datagrid/datagrid-hideable-column.model.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-hideable-column.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-hideable-column.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-hideable-column.ts
+++ b/src/clr-angular/data/datagrid/datagrid-hideable-column.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-items.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-items.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-items.ts
+++ b/src/clr-angular/data/datagrid/datagrid-items.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-pagination.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-pagination.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-pagination.ts
+++ b/src/clr-angular/data/datagrid/datagrid-pagination.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-placeholder.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-placeholder.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-placeholder.ts
+++ b/src/clr-angular/data/datagrid/datagrid-placeholder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-row-detail.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-row-detail.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-row-detail.ts
+++ b/src/clr-angular/data/datagrid/datagrid-row-detail.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-row.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-row.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-row.ts
+++ b/src/clr-angular/data/datagrid/datagrid-row.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid.html
+++ b/src/clr-angular/data/datagrid/datagrid.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/clr-angular/data/datagrid/datagrid.module.ts
+++ b/src/clr-angular/data/datagrid/datagrid.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid.ts
+++ b/src/clr-angular/data/datagrid/datagrid.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/helpers.spec.ts
+++ b/src/clr-angular/data/datagrid/helpers.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/index.ts
+++ b/src/clr-angular/data/datagrid/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/interfaces/comparator.interface.ts
+++ b/src/clr-angular/data/datagrid/interfaces/comparator.interface.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/interfaces/filter.interface.ts
+++ b/src/clr-angular/data/datagrid/interfaces/filter.interface.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/interfaces/sort-order.ts
+++ b/src/clr-angular/data/datagrid/interfaces/sort-order.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/interfaces/state.interface.ts
+++ b/src/clr-angular/data/datagrid/interfaces/state.interface.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/interfaces/string-filter.interface.ts
+++ b/src/clr-angular/data/datagrid/interfaces/string-filter.interface.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/providers/custom-filter.ts
+++ b/src/clr-angular/data/datagrid/providers/custom-filter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/providers/drag-dispatcher.ts
+++ b/src/clr-angular/data/datagrid/providers/drag-dispatcher.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/providers/filters.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/filters.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/providers/filters.ts
+++ b/src/clr-angular/data/datagrid/providers/filters.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/providers/global-expandable-rows.ts
+++ b/src/clr-angular/data/datagrid/providers/global-expandable-rows.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/providers/hideable-column.service.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/hideable-column.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/providers/hideable-column.service.ts
+++ b/src/clr-angular/data/datagrid/providers/hideable-column.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/providers/items.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/items.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/providers/items.ts
+++ b/src/clr-angular/data/datagrid/providers/items.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/providers/page.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/page.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/providers/page.ts
+++ b/src/clr-angular/data/datagrid/providers/page.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/providers/row-action-service.ts
+++ b/src/clr-angular/data/datagrid/providers/row-action-service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/providers/selection.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/selection.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/providers/selection.ts
+++ b/src/clr-angular/data/datagrid/providers/selection.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/providers/sort.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/sort.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/providers/sort.ts
+++ b/src/clr-angular/data/datagrid/providers/sort.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/providers/state-debouncer.provider.ts
+++ b/src/clr-angular/data/datagrid/providers/state-debouncer.provider.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/providers/state.provider.ts
+++ b/src/clr-angular/data/datagrid/providers/state.provider.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/render/body-renderer.spec.ts
+++ b/src/clr-angular/data/datagrid/render/body-renderer.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/render/body-renderer.ts
+++ b/src/clr-angular/data/datagrid/render/body-renderer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/render/cell-renderer.spec.ts
+++ b/src/clr-angular/data/datagrid/render/cell-renderer.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/render/cell-renderer.ts
+++ b/src/clr-angular/data/datagrid/render/cell-renderer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/render/column-resizer.spec.ts
+++ b/src/clr-angular/data/datagrid/render/column-resizer.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/render/column-resizer.ts
+++ b/src/clr-angular/data/datagrid/render/column-resizer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/render/constants.ts
+++ b/src/clr-angular/data/datagrid/render/constants.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/render/dom-adapter.mock.ts
+++ b/src/clr-angular/data/datagrid/render/dom-adapter.mock.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/render/dom-adapter.spec.ts
+++ b/src/clr-angular/data/datagrid/render/dom-adapter.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/render/dom-adapter.ts
+++ b/src/clr-angular/data/datagrid/render/dom-adapter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/render/head-renderer.spec.ts
+++ b/src/clr-angular/data/datagrid/render/head-renderer.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/render/head-renderer.ts
+++ b/src/clr-angular/data/datagrid/render/head-renderer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/render/header-renderer.spec.ts
+++ b/src/clr-angular/data/datagrid/render/header-renderer.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/render/header-renderer.ts
+++ b/src/clr-angular/data/datagrid/render/header-renderer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/render/main-renderer.spec.ts
+++ b/src/clr-angular/data/datagrid/render/main-renderer.spec.ts
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/render/main-renderer.ts
+++ b/src/clr-angular/data/datagrid/render/main-renderer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/render/noop-dom-adapter.spec.ts
+++ b/src/clr-angular/data/datagrid/render/noop-dom-adapter.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/render/noop-dom-adapter.ts
+++ b/src/clr-angular/data/datagrid/render/noop-dom-adapter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/render/render-organizer.mock.ts
+++ b/src/clr-angular/data/datagrid/render/render-organizer.mock.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/render/render-organizer.spec.ts
+++ b/src/clr-angular/data/datagrid/render/render-organizer.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/render/render-organizer.ts
+++ b/src/clr-angular/data/datagrid/render/render-organizer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/render/row-renderer.spec.ts
+++ b/src/clr-angular/data/datagrid/render/row-renderer.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/render/row-renderer.ts
+++ b/src/clr-angular/data/datagrid/render/row-renderer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/render/table-renderer.spec.ts
+++ b/src/clr-angular/data/datagrid/render/table-renderer.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/render/table-renderer.ts
+++ b/src/clr-angular/data/datagrid/render/table-renderer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/utils/datagrid-filter-registrar.ts
+++ b/src/clr-angular/data/datagrid/utils/datagrid-filter-registrar.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/index.ts
+++ b/src/clr-angular/data/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/stack-view/_stack-view.clarity.scss
+++ b/src/clr-angular/data/stack-view/_stack-view.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @include exports('stack-view.clarity') {
     .stack-header {

--- a/src/clr-angular/data/stack-view/_variables.stack-view.scss
+++ b/src/clr-angular/data/stack-view/_variables.stack-view.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/stack-view/stack-view.module.ts
+++ b/src/clr-angular/data/stack-view/stack-view.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/tree-view/_tree-view.clarity.scss
+++ b/src/clr-angular/data/tree-view/_tree-view.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @include exports('tree-view.clarity') {
     .clr-tree-node {

--- a/src/clr-angular/data/tree-view/_variables.tree-view.scss
+++ b/src/clr-angular/data/tree-view/_variables.tree-view.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/tree-view/abstract-tree-selection.spec.ts
+++ b/src/clr-angular/data/tree-view/abstract-tree-selection.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/tree-view/abstract-tree-selection.ts
+++ b/src/clr-angular/data/tree-view/abstract-tree-selection.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/tree-view/all.spec.ts
+++ b/src/clr-angular/data/tree-view/all.spec.ts
@@ -1,4 +1,5 @@
-/* * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/tree-view/index.ts
+++ b/src/clr-angular/data/tree-view/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/tree-view/providers/tree-selection.provider.ts
+++ b/src/clr-angular/data/tree-view/providers/tree-selection.provider.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/tree-view/providers/tree-selection.service.ts
+++ b/src/clr-angular/data/tree-view/providers/tree-selection.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/tree-view/tree-node.html
+++ b/src/clr-angular/data/tree-view/tree-node.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <div class="clr-tree-node-content-container">
     <button
         type="button"

--- a/src/clr-angular/data/tree-view/tree-node.spec.ts
+++ b/src/clr-angular/data/tree-view/tree-node.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/tree-view/tree-node.ts
+++ b/src/clr-angular/data/tree-view/tree-node.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/tree-view/tree-view.module.ts
+++ b/src/clr-angular/data/tree-view/tree-view.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/deprecations.spec.ts
+++ b/src/clr-angular/deprecations.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/emphasis/_labels.clarity.scss
+++ b/src/clr-angular/emphasis/_labels.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 // TODO: Split badges and labels into separate files.
 

--- a/src/clr-angular/emphasis/_variables.badge.scss
+++ b/src/clr-angular/emphasis/_variables.badge.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/emphasis/_variables.label.scss
+++ b/src/clr-angular/emphasis/_variables.label.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/emphasis/alert/_alert.clarity.scss
+++ b/src/clr-angular/emphasis/alert/_alert.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @mixin generateAlertType($alertType: "info") {
     $propMap: map-get($clr-alert-colors, $alertType);

--- a/src/clr-angular/emphasis/alert/_variables.alert.scss
+++ b/src/clr-angular/emphasis/alert/_variables.alert.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/emphasis/alert/alert-item.ts
+++ b/src/clr-angular/emphasis/alert/alert-item.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/emphasis/alert/alert.html
+++ b/src/clr-angular/emphasis/alert/alert.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/clr-angular/emphasis/alert/alert.module.ts
+++ b/src/clr-angular/emphasis/alert/alert.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/emphasis/alert/alert.spec.ts
+++ b/src/clr-angular/emphasis/alert/alert.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/emphasis/alert/alert.ts
+++ b/src/clr-angular/emphasis/alert/alert.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/emphasis/alert/alerts-pager.html
+++ b/src/clr-angular/emphasis/alert/alerts-pager.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <div class="alerts-pager-control">
     <div class="alerts-page-down">
         <button class="alerts-pager-button" (click)="pageDown()">

--- a/src/clr-angular/emphasis/alert/alerts-pager.spec.ts
+++ b/src/clr-angular/emphasis/alert/alerts-pager.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/emphasis/alert/alerts-pager.ts
+++ b/src/clr-angular/emphasis/alert/alerts-pager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/emphasis/alert/alerts.html
+++ b/src/clr-angular/emphasis/alert/alerts.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <clr-alerts-pager
         *ngIf="multiAlertService.count > 1"
         [clrCurrentAlertIndex]="currentAlertIndex">

--- a/src/clr-angular/emphasis/alert/alerts.spec.ts
+++ b/src/clr-angular/emphasis/alert/alerts.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/emphasis/alert/alerts.ts
+++ b/src/clr-angular/emphasis/alert/alerts.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/emphasis/alert/all.spec.ts
+++ b/src/clr-angular/emphasis/alert/all.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/emphasis/alert/index.ts
+++ b/src/clr-angular/emphasis/alert/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/emphasis/alert/providers/icon-and-types-service.spec.ts
+++ b/src/clr-angular/emphasis/alert/providers/icon-and-types-service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/emphasis/alert/providers/icon-and-types-service.ts
+++ b/src/clr-angular/emphasis/alert/providers/icon-and-types-service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/emphasis/alert/providers/icon-and-types.service.spec.ts
+++ b/src/clr-angular/emphasis/alert/providers/icon-and-types.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/emphasis/alert/providers/icon-and-types.service.ts
+++ b/src/clr-angular/emphasis/alert/providers/icon-and-types.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/emphasis/alert/providers/multi-alert.service.spec.ts
+++ b/src/clr-angular/emphasis/alert/providers/multi-alert.service.spec.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/emphasis/alert/providers/multi-alert.service.ts
+++ b/src/clr-angular/emphasis/alert/providers/multi-alert.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/emphasis/alert/utils/alert-info-object.ts
+++ b/src/clr-angular/emphasis/alert/utils/alert-info-object.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/emphasis/alert/utils/alert-types.ts
+++ b/src/clr-angular/emphasis/alert/utils/alert-types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/emphasis/emphasis.module.ts
+++ b/src/clr-angular/emphasis/emphasis.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/emphasis/index.ts
+++ b/src/clr-angular/emphasis/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/forms/_forms.clarity.scss
+++ b/src/clr-angular/forms/_forms.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 //Validation Tooltips Arrow Color
 // TODO: color should be a variable

--- a/src/clr-angular/forms/_inputs.clarity.scss
+++ b/src/clr-angular/forms/_inputs.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @include exports("inputs.clarity") {
     #{$styledInputs} {

--- a/src/clr-angular/forms/_radio.clarity.scss
+++ b/src/clr-angular/forms/_radio.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @include exports('radio.clarity') {
 

--- a/src/clr-angular/forms/_select.clarity.scss
+++ b/src/clr-angular/forms/_select.clarity.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/forms/_variables.forms.scss
+++ b/src/clr-angular/forms/_variables.forms.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/forms/_variables.inputs.scss
+++ b/src/clr-angular/forms/_variables.inputs.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/forms/_variables.select.scss
+++ b/src/clr-angular/forms/_variables.select.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/forms/checkbox/_checkbox.clarity.scss
+++ b/src/clr-angular/forms/checkbox/_checkbox.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @include exports('checkbox.clarity') {
     .checkbox {

--- a/src/clr-angular/forms/checkbox/_variables.checkbox.scss
+++ b/src/clr-angular/forms/checkbox/_variables.checkbox.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/forms/forms.module.ts
+++ b/src/clr-angular/forms/forms.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/forms/index.ts
+++ b/src/clr-angular/forms/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/forms/utils/_form-variables.clarity.scss
+++ b/src/clr-angular/forms/utils/_form-variables.clarity.scss
@@ -1,5 +1,7 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 

--- a/src/clr-angular/image/_icons.clarity.scss
+++ b/src/clr-angular/image/_icons.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 //Background SVG Images work only when the svg is url encoded.
 //Use this encoder http://meyerweb.com/eric/tools/dencoder/ to encode the SVG.

--- a/src/clr-angular/image/_images.clarity.scss
+++ b/src/clr-angular/image/_images.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @mixin icon-background-styles() {
     background-repeat: no-repeat;

--- a/src/clr-angular/index.ts
+++ b/src/clr-angular/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/_card.clarity.scss
+++ b/src/clr-angular/layout/_card.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @include exports('card.clarity') {
 

--- a/src/clr-angular/layout/_grid.clarity.scss
+++ b/src/clr-angular/layout/_grid.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 .row {
     &.force-fit {

--- a/src/clr-angular/layout/_login.clarity.scss
+++ b/src/clr-angular/layout/_login.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @include exports('login.clarity') {
     .login-wrapper {

--- a/src/clr-angular/layout/_variables.card.scss
+++ b/src/clr-angular/layout/_variables.card.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/index.ts
+++ b/src/clr-angular/layout/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/layout.module.ts
+++ b/src/clr-angular/layout/layout.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/main-container/_layout.clarity.scss
+++ b/src/clr-angular/layout/main-container/_layout.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @include exports('layout.clarity') {
 

--- a/src/clr-angular/layout/main-container/_variables.header.scss
+++ b/src/clr-angular/layout/main-container/_variables.header.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/main-container/main-container.module.ts
+++ b/src/clr-angular/layout/main-container/main-container.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/nav/_nav.clarity.scss
+++ b/src/clr-angular/layout/nav/_nav.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @include exports('nav.clarity') {
     .nav {

--- a/src/clr-angular/layout/nav/_responsive-nav.clarity.scss
+++ b/src/clr-angular/layout/nav/_responsive-nav.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @mixin sliding-nav-positioning($top: 0, $right: auto, $bottom: 0, $left: 0) {
     display: flex;

--- a/src/clr-angular/layout/nav/_sidenav.clarity.scss
+++ b/src/clr-angular/layout/nav/_sidenav.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 
 

--- a/src/clr-angular/layout/nav/_subnav.clarity.scss
+++ b/src/clr-angular/layout/nav/_subnav.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 
 @include exports('subnav.clarity') {

--- a/src/clr-angular/layout/nav/_variables.nav.scss
+++ b/src/clr-angular/layout/nav/_variables.nav.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/nav/_variables.responsive-nav.scss
+++ b/src/clr-angular/layout/nav/_variables.responsive-nav.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/nav/_variables.sidenav.scss
+++ b/src/clr-angular/layout/nav/_variables.sidenav.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/nav/_variables.subnav.scss
+++ b/src/clr-angular/layout/nav/_variables.subnav.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/nav/chocolate/index.ts
+++ b/src/clr-angular/layout/nav/chocolate/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/nav/chocolate/main-container-willy-wonka.ts
+++ b/src/clr-angular/layout/nav/chocolate/main-container-willy-wonka.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/nav/chocolate/nav-detection-oompa-loompa.ts
+++ b/src/clr-angular/layout/nav/chocolate/nav-detection-oompa-loompa.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/nav/navigation.module.ts
+++ b/src/clr-angular/layout/nav/navigation.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/nav/providers/responsive-navigation.provider.ts
+++ b/src/clr-angular/layout/nav/providers/responsive-navigation.provider.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/tabs/_tabs.clarity.scss
+++ b/src/clr-angular/layout/tabs/_tabs.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 
 @include exports('tabs.clarity') {

--- a/src/clr-angular/layout/tabs/_variables.tabs.scss
+++ b/src/clr-angular/layout/tabs/_variables.tabs.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/tabs/chocolate/active-oompa-loompa.ts
+++ b/src/clr-angular/layout/tabs/chocolate/active-oompa-loompa.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/tabs/chocolate/tabs-willy-wonka.ts
+++ b/src/clr-angular/layout/tabs/chocolate/tabs-willy-wonka.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/tabs/providers/aria.service.ts
+++ b/src/clr-angular/layout/tabs/providers/aria.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/tabs/providers/tabs.service.ts
+++ b/src/clr-angular/layout/tabs/providers/tabs.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/tabs/tab-link.directive.ts
+++ b/src/clr-angular/layout/tabs/tab-link.directive.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/tabs/tab-overflow-content.ts
+++ b/src/clr-angular/layout/tabs/tab-overflow-content.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/tabs/tab.spec.ts
+++ b/src/clr-angular/layout/tabs/tab.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/tabs/tab.ts
+++ b/src/clr-angular/layout/tabs/tab.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/tabs/tabs-id.provider.ts
+++ b/src/clr-angular/layout/tabs/tabs-id.provider.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/tabs/tabs.module.ts
+++ b/src/clr-angular/layout/tabs/tabs.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/vertical-nav/_variables.vertical-nav.scss
+++ b/src/clr-angular/layout/vertical-nav/_variables.vertical-nav.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/vertical-nav/_vertical-nav.clarity.scss
+++ b/src/clr-angular/layout/vertical-nav/_vertical-nav.clarity.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/vertical-nav/all.spec.ts
+++ b/src/clr-angular/layout/vertical-nav/all.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/vertical-nav/index.ts
+++ b/src/clr-angular/layout/vertical-nav/index.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/vertical-nav/providers/vertical-nav-group-registration.service.spec.ts
+++ b/src/clr-angular/layout/vertical-nav/providers/vertical-nav-group-registration.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/vertical-nav/providers/vertical-nav-group-registration.service.ts
+++ b/src/clr-angular/layout/vertical-nav/providers/vertical-nav-group-registration.service.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/vertical-nav/providers/vertical-nav-group.service.ts
+++ b/src/clr-angular/layout/vertical-nav/providers/vertical-nav-group.service.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/vertical-nav/providers/vertical-nav-icon.service.spec.ts
+++ b/src/clr-angular/layout/vertical-nav/providers/vertical-nav-icon.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/vertical-nav/providers/vertical-nav-icon.service.ts
+++ b/src/clr-angular/layout/vertical-nav/providers/vertical-nav-icon.service.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/vertical-nav/providers/vertical-nav.service.spec.ts
+++ b/src/clr-angular/layout/vertical-nav/providers/vertical-nav.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/vertical-nav/providers/vertical-nav.service.ts
+++ b/src/clr-angular/layout/vertical-nav/providers/vertical-nav.service.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/vertical-nav/vertical-nav-group-children.ts
+++ b/src/clr-angular/layout/vertical-nav/vertical-nav-group-children.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/vertical-nav/vertical-nav-group.html
+++ b/src/clr-angular/layout/vertical-nav/vertical-nav-group.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <div class="nav-group-content">
     <ng-content select="[clrVerticalNavLink]"></ng-content>
     <button

--- a/src/clr-angular/layout/vertical-nav/vertical-nav-group.spec.ts
+++ b/src/clr-angular/layout/vertical-nav/vertical-nav-group.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/vertical-nav/vertical-nav-group.ts
+++ b/src/clr-angular/layout/vertical-nav/vertical-nav-group.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/vertical-nav/vertical-nav-icon.spec.ts
+++ b/src/clr-angular/layout/vertical-nav/vertical-nav-icon.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/vertical-nav/vertical-nav-icon.ts
+++ b/src/clr-angular/layout/vertical-nav/vertical-nav-icon.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/vertical-nav/vertical-nav-link.spec.ts
+++ b/src/clr-angular/layout/vertical-nav/vertical-nav-link.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/vertical-nav/vertical-nav-link.ts
+++ b/src/clr-angular/layout/vertical-nav/vertical-nav-link.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/vertical-nav/vertical-nav.html
+++ b/src/clr-angular/layout/vertical-nav/vertical-nav.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <button type="button" class="nav-trigger"
         [class.on-collapse]="collapsed"
         (click)="toggleByButton()"

--- a/src/clr-angular/layout/vertical-nav/vertical-nav.module.ts
+++ b/src/clr-angular/layout/vertical-nav/vertical-nav.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/vertical-nav/vertical-nav.spec.ts
+++ b/src/clr-angular/layout/vertical-nav/vertical-nav.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/vertical-nav/vertical-nav.ts
+++ b/src/clr-angular/layout/vertical-nav/vertical-nav.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/main.scss
+++ b/src/clr-angular/main.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  *
@@ -12,7 +12,6 @@
 // Dependencies import the clarity variables file.
 // for all intents and purposes we can consider the values there as the
 // OG Theme: This is for generating the OG Clarity Theme
-
 
 // Clarity component code (consumes the variables and theme overrides)
 @import "./utils/components.clarity";

--- a/src/clr-angular/modal/_modal.clarity.scss
+++ b/src/clr-angular/modal/_modal.clarity.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/modal/_variables.modal.scss
+++ b/src/clr-angular/modal/_variables.modal.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/modal/index.ts
+++ b/src/clr-angular/modal/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/modal/modal.html
+++ b/src/clr-angular/modal/modal.html
@@ -1,6 +1,6 @@
 
 <!--
-  ~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/clr-angular/modal/modal.module.ts
+++ b/src/clr-angular/modal/modal.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/modal/modal.spec.ts
+++ b/src/clr-angular/modal/modal.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/modal/modal.ts
+++ b/src/clr-angular/modal/modal.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/modal/utils/ghost-page-animations.ts
+++ b/src/clr-angular/modal/utils/ghost-page-animations.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/common/_popover.clarity.scss
+++ b/src/clr-angular/popover/common/_popover.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @include exports('popover.clarity') {
     .is-off-screen {

--- a/src/clr-angular/popover/common/abstract-popover.ts
+++ b/src/clr-angular/popover/common/abstract-popover.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/common/index.ts
+++ b/src/clr-angular/popover/common/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/common/popover-host-anchor.token.ts
+++ b/src/clr-angular/popover/common/popover-host-anchor.token.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/common/popover-old.directive.spec.ts
+++ b/src/clr-angular/popover/common/popover-old.directive.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/common/popover-old.directive.ts
+++ b/src/clr-angular/popover/common/popover-old.directive.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/common/popover-options.interface.ts
+++ b/src/clr-angular/popover/common/popover-options.interface.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/common/popover-positions.ts
+++ b/src/clr-angular/popover/common/popover-positions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/common/popover.module.ts
+++ b/src/clr-angular/popover/common/popover.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/common/popover.spec.ts
+++ b/src/clr-angular/popover/common/popover.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/common/popover.ts
+++ b/src/clr-angular/popover/common/popover.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/dropdown/_dropdown.clarity.scss
+++ b/src/clr-angular/popover/dropdown/_dropdown.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 %dropdown-content {
     overflow: hidden;

--- a/src/clr-angular/popover/dropdown/_variables.dropdown.scss
+++ b/src/clr-angular/popover/dropdown/_variables.dropdown.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/dropdown/all.spec.ts
+++ b/src/clr-angular/popover/dropdown/all.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/dropdown/dropdown-menu.spec.ts
+++ b/src/clr-angular/popover/dropdown/dropdown-menu.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/dropdown/dropdown-menu.ts
+++ b/src/clr-angular/popover/dropdown/dropdown-menu.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/dropdown/dropdown.module.ts
+++ b/src/clr-angular/popover/dropdown/dropdown.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/dropdown/menu-positions.ts
+++ b/src/clr-angular/popover/dropdown/menu-positions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/dropdown/providers/dropdown.service.ts
+++ b/src/clr-angular/popover/dropdown/providers/dropdown.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/index.ts
+++ b/src/clr-angular/popover/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/popover.module.ts
+++ b/src/clr-angular/popover/popover.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/signpost/_signposts.clarity.scss
+++ b/src/clr-angular/popover/signpost/_signposts.clarity.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/signpost/_variables.signpost.scss
+++ b/src/clr-angular/popover/signpost/_variables.signpost.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/signpost/all.spec.ts
+++ b/src/clr-angular/popover/signpost/all.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/signpost/index.ts
+++ b/src/clr-angular/popover/signpost/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/signpost/signpost-content.spec.ts
+++ b/src/clr-angular/popover/signpost/signpost-content.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/signpost/signpost-content.ts
+++ b/src/clr-angular/popover/signpost/signpost-content.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/signpost/signpost-positions.ts
+++ b/src/clr-angular/popover/signpost/signpost-positions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/signpost/signpost-trigger.spec.ts
+++ b/src/clr-angular/popover/signpost/signpost-trigger.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/signpost/signpost-trigger.ts
+++ b/src/clr-angular/popover/signpost/signpost-trigger.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/signpost/signpost.module.ts
+++ b/src/clr-angular/popover/signpost/signpost.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/signpost/signpost.spec.ts
+++ b/src/clr-angular/popover/signpost/signpost.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/signpost/signpost.ts
+++ b/src/clr-angular/popover/signpost/signpost.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/tooltip/_tooltips.clarity.scss
+++ b/src/clr-angular/popover/tooltip/_tooltips.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @mixin common-tooltip-styles {
     @include clr-getTypePropertiesForDomElement(tooltip_text, (font-size, font-weight, letter-spacing));

--- a/src/clr-angular/popover/tooltip/_variables.tooltip.scss
+++ b/src/clr-angular/popover/tooltip/_variables.tooltip.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/tooltip/index.ts
+++ b/src/clr-angular/popover/tooltip/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/tooltip/tooltip-content.spec.ts
+++ b/src/clr-angular/popover/tooltip/tooltip-content.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/tooltip/tooltip-content.ts
+++ b/src/clr-angular/popover/tooltip/tooltip-content.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/tooltip/tooltip-trigger.spec.ts
+++ b/src/clr-angular/popover/tooltip/tooltip-trigger.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/tooltip/tooltip.module.ts
+++ b/src/clr-angular/popover/tooltip/tooltip.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/tooltip/tooltip.spec.ts
+++ b/src/clr-angular/popover/tooltip/tooltip.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/tooltip/tooltip.ts
+++ b/src/clr-angular/popover/tooltip/tooltip.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/progress/progress-bars/_progress-bars.clarity.scss
+++ b/src/clr-angular/progress/progress-bars/_progress-bars.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @import "utils/mixins.clarity";
 

--- a/src/clr-angular/progress/progress-bars/_variables.progress-bars.scss
+++ b/src/clr-angular/progress/progress-bars/_variables.progress-bars.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/progress/progress-bars/utils/mixins.clarity.scss
+++ b/src/clr-angular/progress/progress-bars/utils/mixins.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @mixin clr-progress-color($color: $clr-action-blue) {
     // for IE...

--- a/src/clr-angular/progress/spinner/_spinner.clarity.scss
+++ b/src/clr-angular/progress/spinner/_spinner.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @mixin min-height($size){
     min-height: $size;

--- a/src/clr-angular/progress/spinner/_variables.spinner.scss
+++ b/src/clr-angular/progress/spinner/_variables.spinner.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/public_api.ts
+++ b/src/clr-angular/public_api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/typography/_lists.clarity.scss
+++ b/src/clr-angular/typography/_lists.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @include exports('lists.clarity') {
     %kill-list-styles {

--- a/src/clr-angular/typography/_typography.clarity.scss
+++ b/src/clr-angular/typography/_typography.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @function clr-mergeCommonKeys($elMap: (), $valMap: ()) {
     @return map-merge(map-get($elMap, $clr-typography-commonmap-key), $valMap);

--- a/src/clr-angular/typography/_variables.lists.scss
+++ b/src/clr-angular/typography/_variables.lists.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/typography/_variables.typography.scss
+++ b/src/clr-angular/typography/_variables.typography.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/typography/fonts.clarity.scss
+++ b/src/clr-angular/typography/fonts.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 //Metropolis Font Version that we use: r8 https://github.com/chrismsimpson/Metropolis/releases/tag/r8
 

--- a/src/clr-angular/utils/_components.clarity.scss
+++ b/src/clr-angular/utils/_components.clarity.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/_dependencies.clarity.scss
+++ b/src/clr-angular/utils/_dependencies.clarity.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/_helpers.clarity.scss
+++ b/src/clr-angular/utils/_helpers.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 @function baselineRem($remSize) {
     @return $remSize * $clr-baseline;

--- a/src/clr-angular/utils/_maps.clarity.scss
+++ b/src/clr-angular/utils/_maps.clarity.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/_theme.dark.clarity.scss
+++ b/src/clr-angular/utils/_theme.dark.clarity.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/_variables.clarity.scss
+++ b/src/clr-angular/utils/_variables.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 // Clarity Components
 //

--- a/src/clr-angular/utils/_variables.global.scss
+++ b/src/clr-angular/utils/_variables.global.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/animations/_animations.clarity.scss
+++ b/src/clr-angular/utils/animations/_animations.clarity.scss
@@ -1,6 +1,8 @@
-// Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-// This software is released under MIT license.
-// The full license information can be found in LICENSE in the root directory of this project.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
 
 /**
  * TODO: figure out if we want to include animate.css or if we prefer sticking to a few,

--- a/src/clr-angular/utils/animations/index.ts
+++ b/src/clr-angular/utils/animations/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/chocolate/oompa-loompa.ts
+++ b/src/clr-angular/utils/chocolate/oompa-loompa.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/chocolate/willy-wonka.ts
+++ b/src/clr-angular/utils/chocolate/willy-wonka.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/conditional/all.spec.ts
+++ b/src/clr-angular/utils/conditional/all.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/conditional/conditional.module.ts
+++ b/src/clr-angular/utils/conditional/conditional.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/conditional/if-active.directive.spec.ts
+++ b/src/clr-angular/utils/conditional/if-active.directive.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/conditional/if-active.directive.ts
+++ b/src/clr-angular/utils/conditional/if-active.directive.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/conditional/if-active.service.spec.ts
+++ b/src/clr-angular/utils/conditional/if-active.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/conditional/if-active.service.ts
+++ b/src/clr-angular/utils/conditional/if-active.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/conditional/if-open.directive.spec.ts
+++ b/src/clr-angular/utils/conditional/if-open.directive.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/conditional/if-open.directive.ts
+++ b/src/clr-angular/utils/conditional/if-open.directive.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/conditional/if-open.service.spec.ts
+++ b/src/clr-angular/utils/conditional/if-open.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/conditional/if-open.service.ts
+++ b/src/clr-angular/utils/conditional/if-open.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/expand/all.spec.ts
+++ b/src/clr-angular/utils/expand/all.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/expand/if-expand.module.ts
+++ b/src/clr-angular/utils/expand/if-expand.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/expand/if-expanded.spec.ts
+++ b/src/clr-angular/utils/expand/if-expanded.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/expand/if-expanded.ts
+++ b/src/clr-angular/utils/expand/if-expanded.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/expand/providers/expand.spec.ts
+++ b/src/clr-angular/utils/expand/providers/expand.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/expand/providers/expand.ts
+++ b/src/clr-angular/utils/expand/providers/expand.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/focus-trap/focus-trap-tracker.service.ts
+++ b/src/clr-angular/utils/focus-trap/focus-trap-tracker.service.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/focus-trap/focus-trap.directive.spec.ts
+++ b/src/clr-angular/utils/focus-trap/focus-trap.directive.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/focus-trap/focus-trap.directive.ts
+++ b/src/clr-angular/utils/focus-trap/focus-trap.directive.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/focus-trap/focus-trap.module.ts
+++ b/src/clr-angular/utils/focus-trap/focus-trap.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/focus-trap/index.ts
+++ b/src/clr-angular/utils/focus-trap/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/index.ts
+++ b/src/clr-angular/utils/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/loading/loading.module.ts
+++ b/src/clr-angular/utils/loading/loading.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/outside-click/outside-click.module.ts
+++ b/src/clr-angular/utils/outside-click/outside-click.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/outside-click/outside-click.ts
+++ b/src/clr-angular/utils/outside-click/outside-click.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/template-ref/index.ts
+++ b/src/clr-angular/utils/template-ref/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/template-ref/template-ref-container.ts
+++ b/src/clr-angular/utils/template-ref/template-ref-container.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/template-ref/template-ref.module.ts
+++ b/src/clr-angular/utils/template-ref/template-ref.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/testing/helpers.spec.ts
+++ b/src/clr-angular/utils/testing/helpers.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/testing/slow-specs.spec.ts
+++ b/src/clr-angular/utils/testing/slow-specs.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/vendor/decimalRounding.clarity.scss
+++ b/src/clr-angular/utils/vendor/decimalRounding.clarity.scss
@@ -1,3 +1,9 @@
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 
 // _decimal.scss | mIT license | gist.github.com/terkel/4373420
 

--- a/src/clr-angular/utils/vendor/mathPow.clarity.scss
+++ b/src/clr-angular/utils/vendor/mathPow.clarity.scss
@@ -1,3 +1,9 @@
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 // by Tobias Bengfort
 // http://www.sassmeister.com/gist/5bbe8480c48e2fc10ab5
 

--- a/src/clr-angular/utils/virtual-scroll/all.spec.ts
+++ b/src/clr-angular/utils/virtual-scroll/all.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/virtual-scroll/dom-helpers.spec.ts
+++ b/src/clr-angular/utils/virtual-scroll/dom-helpers.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/virtual-scroll/dom-helpers.ts
+++ b/src/clr-angular/utils/virtual-scroll/dom-helpers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/virtual-scroll/index.ts
+++ b/src/clr-angular/utils/virtual-scroll/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/virtual-scroll/non-ng-iterable.ts
+++ b/src/clr-angular/utils/virtual-scroll/non-ng-iterable.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/virtual-scroll/virtual-for-of.spec.ts
+++ b/src/clr-angular/utils/virtual-scroll/virtual-for-of.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/virtual-scroll/virtual-for-of.ts
+++ b/src/clr-angular/utils/virtual-scroll/virtual-for-of.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/virtual-scroll/virtual-scroll.module.ts
+++ b/src/clr-angular/utils/virtual-scroll/virtual-scroll.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/_variables.wizard.scss
+++ b/src/clr-angular/wizard/_variables.wizard.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/_wizard.clarity.scss
+++ b/src/clr-angular/wizard/_wizard.clarity.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/all.spec.ts
+++ b/src/clr-angular/wizard/all.spec.ts
@@ -1,9 +1,7 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights
- * Reserved. This software is released under MIT
- * license. The full license information can be
- * found in LICENSE in the root directory of this
- * project.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
  */
 import {NoopAnimationsModule} from "@angular/platform-browser/animations";
 

--- a/src/clr-angular/wizard/index.ts
+++ b/src/clr-angular/wizard/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/providers/button-hub.service.mock.ts
+++ b/src/clr-angular/wizard/providers/button-hub.service.mock.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/providers/button-hub.service.spec.ts
+++ b/src/clr-angular/wizard/providers/button-hub.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/providers/button-hub.service.ts
+++ b/src/clr-angular/wizard/providers/button-hub.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/providers/header-actions.service.spec.ts
+++ b/src/clr-angular/wizard/providers/header-actions.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/providers/header-actions.service.ts
+++ b/src/clr-angular/wizard/providers/header-actions.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/providers/page-collection.service.mock.ts
+++ b/src/clr-angular/wizard/providers/page-collection.service.mock.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/providers/page-collection.service.spec.ts
+++ b/src/clr-angular/wizard/providers/page-collection.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/providers/page-collection.service.ts
+++ b/src/clr-angular/wizard/providers/page-collection.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/providers/wizard-navigation.service.mock.ts
+++ b/src/clr-angular/wizard/providers/wizard-navigation.service.mock.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/providers/wizard-navigation.service.spec.ts
+++ b/src/clr-angular/wizard/providers/wizard-navigation.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/providers/wizard-navigation.service.ts
+++ b/src/clr-angular/wizard/providers/wizard-navigation.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/test-components/api-wizard.mock.ts
+++ b/src/clr-angular/wizard/test-components/api-wizard.mock.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/test-components/basic-wizard.mock.ts
+++ b/src/clr-angular/wizard/test-components/basic-wizard.mock.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/test-components/dynamic-wizard.mock.ts
+++ b/src/clr-angular/wizard/test-components/dynamic-wizard.mock.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/test-components/header-action-wizard.mock.ts
+++ b/src/clr-angular/wizard/test-components/header-action-wizard.mock.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/test-components/unopened-wizard.mock.ts
+++ b/src/clr-angular/wizard/test-components/unopened-wizard.mock.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/wizard-button.spec.ts
+++ b/src/clr-angular/wizard/wizard-button.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/wizard-button.ts
+++ b/src/clr-angular/wizard/wizard-button.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/wizard-custom-tags.ts
+++ b/src/clr-angular/wizard/wizard-custom-tags.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/wizard-header-action.spec.ts
+++ b/src/clr-angular/wizard/wizard-header-action.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/wizard-header-action.ts
+++ b/src/clr-angular/wizard/wizard-header-action.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/wizard-page-buttons.ts
+++ b/src/clr-angular/wizard/wizard-page-buttons.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/wizard-page-header-actions.ts
+++ b/src/clr-angular/wizard/wizard-page-header-actions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/wizard-page-navtitle.ts
+++ b/src/clr-angular/wizard/wizard-page-navtitle.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/wizard-page-title.ts
+++ b/src/clr-angular/wizard/wizard-page-title.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/wizard-page.mock.ts
+++ b/src/clr-angular/wizard/wizard-page.mock.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/wizard-page.spec.ts
+++ b/src/clr-angular/wizard/wizard-page.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/wizard-page.ts
+++ b/src/clr-angular/wizard/wizard-page.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/wizard-stepnav-item.spec.ts
+++ b/src/clr-angular/wizard/wizard-stepnav-item.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/wizard-stepnav-item.ts
+++ b/src/clr-angular/wizard/wizard-stepnav-item.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/wizard-stepnav.spec.ts
+++ b/src/clr-angular/wizard/wizard-stepnav.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/wizard-stepnav.ts
+++ b/src/clr-angular/wizard/wizard-stepnav.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/wizard.html
+++ b/src/clr-angular/wizard/wizard.html
@@ -1,8 +1,8 @@
 <!--
-~ Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
-~ This software is released under MIT license.
-~ The full license information can be found in LICENSE in the root directory of this project.
--->
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
 
 <clr-modal
     [clrModalOpen]="_open"

--- a/src/clr-angular/wizard/wizard.module.ts
+++ b/src/clr-angular/wizard/wizard.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/wizard.spec.ts
+++ b/src/clr-angular/wizard/wizard.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/wizard/wizard.ts
+++ b/src/clr-angular/wizard/wizard.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-icons/clr-icons.scss
+++ b/src/clr-icons/clr-icons.scss
@@ -1,10 +1,7 @@
 /*!
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
- *
- * Clarity v@VERSION | MIT license | https://github.com/vmware/clarity
- *
  */
 $clr-icon-size: 16px;
 $clr-icon-color-success: #318700;

--- a/src/clr-icons/helpers.spec.ts
+++ b/src/clr-icons/helpers.spec.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-icons/shapes/all-shapes.ts
+++ b/src/clr-icons/shapes/all-shapes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-icons/shapes/commerce-shapes.ts
+++ b/src/clr-icons/shapes/commerce-shapes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-icons/shapes/core-shapes.ts
+++ b/src/clr-icons/shapes/core-shapes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-icons/shapes/essential-shapes.ts
+++ b/src/clr-icons/shapes/essential-shapes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-icons/shapes/media-shapes.ts
+++ b/src/clr-icons/shapes/media-shapes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-icons/shapes/social-shapes.ts
+++ b/src/clr-icons/shapes/social-shapes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-icons/shapes/technology-shapes.ts
+++ b/src/clr-icons/shapes/technology-shapes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-icons/shapes/travel-shapes.ts
+++ b/src/clr-icons/shapes/travel-shapes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-icons/utils/descriptor-config.ts
+++ b/src/clr-icons/utils/descriptor-config.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/index.html
+++ b/src/index.html
@@ -1,4 +1,10 @@
 <!doctype html>
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <html lang="en">
 <head>
   <meta charset="utf-8">

--- a/src/ks-app/e2e/app.e2e-spec.ts
+++ b/src/ks-app/e2e/app.e2e-spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/e2e/app.po.ts
+++ b/src/ks-app/e2e/app.po.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/karma.conf.js
+++ b/src/ks-app/karma.conf.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 // Karma configuration file, see link for more information
 // https://karma-runner.github.io/0.13/config/configuration-file.html
 

--- a/src/ks-app/protractor.conf.js
+++ b/src/ks-app/protractor.conf.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 // Protractor configuration file, see link for more information
 // https://github.com/angular/protractor/blob/master/lib/config.ts
 

--- a/src/ks-app/src/app/app-routing.module.ts
+++ b/src/ks-app/src/app/app-routing.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/app.component.scss
+++ b/src/ks-app/src/app/app.component.scss
@@ -1,5 +1,5 @@
-/*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/app.component.spec.ts
+++ b/src/ks-app/src/app/app.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/app.component.ts
+++ b/src/ks-app/src/app/app.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/app.module.ts
+++ b/src/ks-app/src/app/app.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/buttons/button-groups.component.html
+++ b/src/ks-app/src/app/containers/buttons/button-groups.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>Button Groups</h1>
 <h3>Primary Button Groups</h3>
 <div class="content-wrapper">

--- a/src/ks-app/src/app/containers/buttons/button-groups.component.ts
+++ b/src/ks-app/src/app/containers/buttons/button-groups.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/buttons/buttons.component.html
+++ b/src/ks-app/src/app/containers/buttons/buttons.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>Buttons & Button Groups</h1>
 
 <p>Button groups are for creating collections of similar type action buttons. There are several styles of button</p>

--- a/src/ks-app/src/app/containers/buttons/buttons.component.ts
+++ b/src/ks-app/src/app/containers/buttons/buttons.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/cards/cards.component.html
+++ b/src/ks-app/src/app/containers/cards/cards.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>Cards</h1>
 <p>A card presents high-level information and can guide the user toward related actions and details.</p>
 <div class="row">

--- a/src/ks-app/src/app/containers/cards/cards.component.scss
+++ b/src/ks-app/src/app/containers/cards/cards.component.scss
@@ -1,1 +1,7 @@
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 

--- a/src/ks-app/src/app/containers/cards/cards.component.ts
+++ b/src/ks-app/src/app/containers/cards/cards.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/colors/colors.component.css
+++ b/src/ks-app/src/app/containers/colors/colors.component.css
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 /* Start  color-shared.demo.css */
 /* line 35, /Users/mhippely/Projects/clarity/fork/src/app/_utils/code.scss */
 .clr-example {

--- a/src/ks-app/src/app/containers/colors/colors.component.html
+++ b/src/ks-app/src/app/containers/colors/colors.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>Colors here</h1>
 <h3>The Clarity color palette is a full spectrum of bold hues and neutrals to meet all your design needs.</h3>
 <p>NOTE: when 2 "A"s are present, one black and white white, both should be accessible against the background color.

--- a/src/ks-app/src/app/containers/colors/colors.component.scss
+++ b/src/ks-app/src/app/containers/colors/colors.component.scss
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+

--- a/src/ks-app/src/app/containers/colors/colors.component.ts
+++ b/src/ks-app/src/app/containers/colors/colors.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/data/datagrid.component.html
+++ b/src/ks-app/src/app/containers/data/datagrid.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>Datagrids</h1>
 <p>Datagrids are for organizing large volumes of data that users can scan, compare, and perform actions on.</p>
 

--- a/src/ks-app/src/app/containers/data/datagrid.component.scss
+++ b/src/ks-app/src/app/containers/data/datagrid.component.scss
@@ -1,3 +1,9 @@
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 .color-square {
   display: inline-block;
   vertical-align: bottom;

--- a/src/ks-app/src/app/containers/data/datagrid.component.ts
+++ b/src/ks-app/src/app/containers/data/datagrid.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/data/fake-loader.ts
+++ b/src/ks-app/src/app/containers/data/fake-loader.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/data/inventory.ts
+++ b/src/ks-app/src/app/containers/data/inventory.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/data/pokemon-comparator.ts
+++ b/src/ks-app/src/app/containers/data/pokemon-comparator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/data/pokemon-filter.ts
+++ b/src/ks-app/src/app/containers/data/pokemon-filter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/data/pokemon.data.ts
+++ b/src/ks-app/src/app/containers/data/pokemon.data.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/data/pokemon.ts
+++ b/src/ks-app/src/app/containers/data/pokemon.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/data/stackview.component.html
+++ b/src/ks-app/src/app/containers/data/stackview.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>Stack View</h1>
 <clr-stack-view>
     <clr-stack-header>Angular stack view</clr-stack-header>

--- a/src/ks-app/src/app/containers/data/stackview.component.ts
+++ b/src/ks-app/src/app/containers/data/stackview.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/data/tree-view.component.html
+++ b/src/ks-app/src/app/containers/data/tree-view.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>Tree View</h1>
 <h3>Basic tree</h3>
 <clr-tree-node>

--- a/src/ks-app/src/app/containers/data/tree-view.component.ts
+++ b/src/ks-app/src/app/containers/data/tree-view.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/data/user.ts
+++ b/src/ks-app/src/app/containers/data/user.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/data/values.ts
+++ b/src/ks-app/src/app/containers/data/values.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/emphasis/alerts.component.html
+++ b/src/ks-app/src/app/containers/emphasis/alerts.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>Alerts</h1>
 <h5>Alerts are banners that communicate a message with a severity attached to it. They grab the user’s attention to
     provide critical information needed in context.</h5>

--- a/src/ks-app/src/app/containers/emphasis/alerts.component.ts
+++ b/src/ks-app/src/app/containers/emphasis/alerts.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/emphasis/badges.component.html
+++ b/src/ks-app/src/app/containers/emphasis/badges.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>Badges</h1>
 <h4>Color Options</h4>
 <div>

--- a/src/ks-app/src/app/containers/emphasis/badges.component.ts
+++ b/src/ks-app/src/app/containers/emphasis/badges.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/emphasis/labels.component.html
+++ b/src/ks-app/src/app/containers/emphasis/labels.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>labels</h1>
 <h3>Default Label</h3>
 <span class="label">Default</span>

--- a/src/ks-app/src/app/containers/emphasis/labels.component.ts
+++ b/src/ks-app/src/app/containers/emphasis/labels.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/forms/checkboxes.component.html
+++ b/src/ks-app/src/app/containers/forms/checkboxes.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>Checkboxes</h1>
 <form #testForm="ngForm">
     <section class="form-block">

--- a/src/ks-app/src/app/containers/forms/checkboxes.component.ts
+++ b/src/ks-app/src/app/containers/forms/checkboxes.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/forms/forms.component.html
+++ b/src/ks-app/src/app/containers/forms/forms.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>Forms</h1>
 <form class="form" [formGroup]="employeeAddressForm" (ngSubmit)="onSubmit()" [hidden]="submitted">
     <section class="form-block">

--- a/src/ks-app/src/app/containers/forms/forms.component.ts
+++ b/src/ks-app/src/app/containers/forms/forms.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/forms/inputs.component.html
+++ b/src/ks-app/src/app/containers/forms/inputs.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>Inputs</h1>
 <form>
     <section class="form-block">

--- a/src/ks-app/src/app/containers/forms/inputs.component.ts
+++ b/src/ks-app/src/app/containers/forms/inputs.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/forms/radios.component.html
+++ b/src/ks-app/src/app/containers/forms/radios.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>Radios</h1>
 <form>
     <section class="form-block">

--- a/src/ks-app/src/app/containers/forms/radios.component.ts
+++ b/src/ks-app/src/app/containers/forms/radios.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/forms/selects.component.html
+++ b/src/ks-app/src/app/containers/forms/selects.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>Selects</h1>
 <form class="test-select">
     <section class="form-block">

--- a/src/ks-app/src/app/containers/forms/selects.component.ts
+++ b/src/ks-app/src/app/containers/forms/selects.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/lists/lists.component.html
+++ b/src/ks-app/src/app/containers/lists/lists.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>Lists</h1>
 <div class="row">
     <div class="col-xs-12 col-lg-6">

--- a/src/ks-app/src/app/containers/lists/lists.component.ts
+++ b/src/ks-app/src/app/containers/lists/lists.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/login/login.component.html
+++ b/src/ks-app/src/app/containers/login/login.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>Login Form</h1>
 <div class="login-wrapper">
     <form class="login" [formGroup]="loginForm">

--- a/src/ks-app/src/app/containers/login/login.component.ts
+++ b/src/ks-app/src/app/containers/login/login.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/modal/modals.component.html
+++ b/src/ks-app/src/app/containers/modal/modals.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>Modals</h1>
 
 <h3>Default</h3>

--- a/src/ks-app/src/app/containers/modal/modals.component.ts
+++ b/src/ks-app/src/app/containers/modal/modals.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/nav/beatles/abbey-road.ts
+++ b/src/ks-app/src/app/containers/nav/beatles/abbey-road.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/nav/beatles/beatles.ts
+++ b/src/ks-app/src/app/containers/nav/beatles/beatles.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/nav/beatles/revolver.ts
+++ b/src/ks-app/src/app/containers/nav/beatles/revolver.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/nav/beatles/rubber-soul.ts
+++ b/src/ks-app/src/app/containers/nav/beatles/rubber-soul.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/nav/tabs.component.html
+++ b/src/ks-app/src/app/containers/nav/tabs.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>Tabs</h1>
 <h3>Standard</h3>
 <p>Tabs can optionally be configured to have overflow tabs in an additional menu.</p>

--- a/src/ks-app/src/app/containers/nav/tabs.component.ts
+++ b/src/ks-app/src/app/containers/nav/tabs.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/nav/the-killers/day-and-age.ts
+++ b/src/ks-app/src/app/containers/nav/the-killers/day-and-age.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/nav/the-killers/hot-fuss.ts
+++ b/src/ks-app/src/app/containers/nav/the-killers/hot-fuss.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/nav/the-killers/sams-town.ts
+++ b/src/ks-app/src/app/containers/nav/the-killers/sams-town.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/nav/the-killers/the-killers.ts
+++ b/src/ks-app/src/app/containers/nav/the-killers/the-killers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/nav/vertical-nav-cases.ts
+++ b/src/ks-app/src/app/containers/nav/vertical-nav-cases.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/nav/vertical-nav.component.html
+++ b/src/ks-app/src/app/containers/nav/vertical-nav.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/ks-app/src/app/containers/nav/vertical-nav.component.ts
+++ b/src/ks-app/src/app/containers/nav/vertical-nav.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/nav/wikipedia/wikipedia.ts
+++ b/src/ks-app/src/app/containers/nav/wikipedia/wikipedia.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/popover/dropdowns.component.html
+++ b/src/ks-app/src/app/containers/popover/dropdowns.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>Dropdowns</h1>
 <h3>Dropdown w/ nested menu</h3>
 <clr-dropdown>

--- a/src/ks-app/src/app/containers/popover/dropdowns.component.ts
+++ b/src/ks-app/src/app/containers/popover/dropdowns.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/popover/signposts.component.html
+++ b/src/ks-app/src/app/containers/popover/signposts.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>Signposts</h1>
 <div class="row">
     <div class="col-xs-12 col-lg-4"

--- a/src/ks-app/src/app/containers/popover/signposts.component.ts
+++ b/src/ks-app/src/app/containers/popover/signposts.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/popover/tooltips.component.html
+++ b/src/ks-app/src/app/containers/popover/tooltips.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>Tooltips</h1>
 <div class="row">
     <div class="col-xs-12 col-lg-6">

--- a/src/ks-app/src/app/containers/popover/tooltips.component.ts
+++ b/src/ks-app/src/app/containers/popover/tooltips.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/progress/progress-bar-example.ts
+++ b/src/ks-app/src/app/containers/progress/progress-bar-example.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/progress/progress-bars.component.html
+++ b/src/ks-app/src/app/containers/progress/progress-bars.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>Progress Bars</h1>
 <div class="row">
     <div *ngFor="let e of examples" class="col-xs-12 col-lg-4">

--- a/src/ks-app/src/app/containers/progress/progress-bars.component.ts
+++ b/src/ks-app/src/app/containers/progress/progress-bars.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/spinners/spinners.component.html
+++ b/src/ks-app/src/app/containers/spinners/spinners.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>Spinners</h1>
 <div class="content-wrapper">
     <div class="col">

--- a/src/ks-app/src/app/containers/spinners/spinners.component.ts
+++ b/src/ks-app/src/app/containers/spinners/spinners.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/tables/tables.component.html
+++ b/src/ks-app/src/app/containers/tables/tables.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>Tables</h1>
 <h3>Default</h3>
 <table class="table">

--- a/src/ks-app/src/app/containers/tables/tables.component.ts
+++ b/src/ks-app/src/app/containers/tables/tables.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/typography/typography.component.html
+++ b/src/ks-app/src/app/containers/typography/typography.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>Typography</h1>
 <h3>Font weight</h3>
 <table class="table">

--- a/src/ks-app/src/app/containers/typography/typography.component.ts
+++ b/src/ks-app/src/app/containers/typography/typography.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/containers/wizard/wizards.component.html
+++ b/src/ks-app/src/app/containers/wizard/wizards.component.html
@@ -1,3 +1,9 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <h1>Wizards</h1>
 <div class="row">
     <div class="col-xs-12 col-lg-6">

--- a/src/ks-app/src/app/containers/wizard/wizards.component.ts
+++ b/src/ks-app/src/app/containers/wizard/wizards.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/environments/environment.prod.ts
+++ b/src/ks-app/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/environments/environment.ts
+++ b/src/ks-app/src/environments/environment.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/index.html
+++ b/src/ks-app/src/index.html
@@ -1,4 +1,10 @@
 <!doctype html>
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
 <html lang="en">
 <head>
   <meta charset="utf-8">

--- a/src/ks-app/src/main.ts
+++ b/src/ks-app/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/polyfills.ts
+++ b/src/ks-app/src/polyfills.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/styles.scss
+++ b/src/ks-app/src/styles.scss
@@ -1,3 +1,9 @@
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 /* You can add global styles to this file, and also import other style files */
 @import "./styles/clarity-overrides";
 @import "./styles/app-style";

--- a/src/ks-app/src/styles/_app-style.scss
+++ b/src/ks-app/src/styles/_app-style.scss
@@ -1,5 +1,5 @@
-/*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/styles/_clarity-overrides.scss
+++ b/src/ks-app/src/styles/_clarity-overrides.scss
@@ -1,3 +1,9 @@
+/*!
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 // Style overrides for KS App
 .header {
     .branding {

--- a/src/ks-app/src/test.ts
+++ b/src/ks-app/src/test.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/typings.d.ts
+++ b/src/ks-app/src/typings.d.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */


### PR DESCRIPTION
This updates the project files (`ts`, `scss` & `html`) for 2018. 

Because I did it automatically with IntelliJ's Copyright tool copyright comments should be in a standard format across all filetypes (i.e same comment format for `ts`, `scss` and `html` files). 

There are also some trailing spaces that were removed (Side effect from the Copyright tool). 