### PR TITLE
[WEB] Fixes Clarity v11 release notes

### DIFF
--- a/src/releases/0.11/0.11.0-beta.1.html
+++ b/src/releases/0.11/0.11.0-beta.1.html
@@ -10,21 +10,24 @@
         <h6>Scoped Clarity Packages</h6>
         <p>
             Clarity has changed to scoped packages starting at v0.11.0. There were several reasons for changing to
-            scoped packages. One important factor in this decision was the need to remove the word <code class="clr-code">clarity</code> from file-paths and filenames so that Clarity would not get blocked by Easylist (commonly used in ad blockers).
+            scoped packages. One important factor in this decision was the need to remove the word `clarity`
+            from file-paths and filenames so that Clarity would not get blocked by Easylist (commonly used in ad
+            blockers).
         </p>
+        <p>All Clarity packages have moved locations in the <code class="clr-code">npm</code> repository.</p>
         <p>All Clarity packages have moved locations in the <code class="clr-code">npm</code> repository.</p>
         <ul>
             <li breaking-change>
-                Clarity Angular is located here: <a href="https://www.npmjs.com/package/@clr/angular">@ng/angular</a>
+                Clarity Angular is located here: <a href="https://www.npmjs.com/package/@clr/angular">@clr/angular</a>
             </li>
             <li breaking-change>
-                Clarity Icons is located here: <a href="https://www.npmjs.com/package/@clr/icons">@ng/icons</a>
+                Clarity Icons is located here: <a href="https://www.npmjs.com/package/@clr/icons">@clr/icons</a>
             </li>
             <li breaking-change>
-                Clarity UI is located here: <a href="https://www.npmjs.com/package/@clr/ui">@ng/ui</a>
+                Clarity UI is located here: <a href="https://www.npmjs.com/package/@clr/ui">@clr/ui</a>
             </li>
+            <li breaking-change>Clarity <code class="clr-code">v0.11.0</code> requires a minimum version of Angular 5</li>
         </ul>
-        <h4></h4>
     </li>
 </ul>
 <h2>Upgrade Guide</h2>


### PR DESCRIPTION
- Fixed the scope name to the correct name `@clr`
- Adds a breaking change note for the peerDependency bump to Angular 5
- closes #1828

Signed-off-by: Matt Hippely <mhippely@vmware.com>