### PR TITLE
[NG] fix deprecation strategy for both IDE support and proper bundling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "clr-all",
-    "version": "0.11.0-alpha.1",
+    "version": "0.11.0-beta.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -2711,9 +2711,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30000784",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000784.tgz",
-            "integrity": "sha1-EpztdOmhKApEGIC2zSvOMO9Z5sA=",
+            "version": "1.0.30000785",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000785.tgz",
+            "integrity": "sha1-dxgZLoK1GK4w/nqPQbsZtH6qoEw=",
             "dev": true
         },
         "capture-stack-trace": {
@@ -4282,6 +4282,12 @@
             "version": "2.5.7",
             "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.7.tgz",
             "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo=",
+            "dev": true
+        },
+        "electron-releases": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/electron-releases/-/electron-releases-2.1.0.tgz",
+            "integrity": "sha512-cyKFD1bTE/UgULXfaueIN1k5EPFzs+FRc/rvCY5tIynefAPqopQEgjr0EzY+U3Dqrk/G4m9tXSPuZ77v6dL/Rw==",
             "dev": true
         },
         "electron-to-chromium": {
@@ -8631,14 +8637,14 @@
             }
         },
         "ng-packagr": {
-            "version": "2.0.0-rc.7",
-            "resolved": "https://registry.npmjs.org/ng-packagr/-/ng-packagr-2.0.0-rc.7.tgz",
-            "integrity": "sha512-lSkwDlVdSYOOsAH/9aFmlHvk5QTv7d9ijJPBz8pIn1Kg8Mzb9PXD3BtORZWVX7DLyFgzGNxJQ/CKqNP/HMUmJg==",
+            "version": "2.0.0-rc.9",
+            "resolved": "https://registry.npmjs.org/ng-packagr/-/ng-packagr-2.0.0-rc.9.tgz",
+            "integrity": "sha512-OPYrIHoOEx7rOfayd4w08GsUodf57j2csqTwPFhODu/EsEpq/c0p4s2uZKvm+9e+JCIsblE4yl1QBIncOKNdcg==",
             "dev": true,
             "requires": {
                 "@ngtools/json-schema": "1.1.0",
-                "autoprefixer": "7.2.3",
-                "browserslist": "2.10.0",
+                "autoprefixer": "7.2.4",
+                "browserslist": "2.11.0",
                 "commander": "2.12.2",
                 "cpx": "1.5.0",
                 "fs-extra": "5.0.0",
@@ -8646,39 +8652,48 @@
                 "less": "2.7.3",
                 "node-sass": "4.7.2",
                 "node-sass-tilde-importer": "1.0.0",
-                "postcss": "6.0.14",
+                "postcss": "6.0.15",
                 "postcss-url": "7.3.0",
                 "rimraf": "2.6.2",
-                "rollup": "0.52.3",
+                "rollup": "0.53.3",
                 "rollup-plugin-commonjs": "8.2.6",
                 "rollup-plugin-node-resolve": "3.0.0",
                 "sorcery": "0.10.0",
                 "stylus": "0.54.5",
-                "uglify-js": "3.2.2"
+                "uglify-js": "3.3.4"
             },
             "dependencies": {
                 "autoprefixer": {
-                    "version": "7.2.3",
-                    "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.3.tgz",
-                    "integrity": "sha512-dqzVGiz3v934+s3YZA6nk7tAs9xuTz5wMJbX1M+L4cY/MTNkOUqP61c1GWkEVlUL/PEy1pKRSCFuoRZrXYx9qA==",
+                    "version": "7.2.4",
+                    "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.4.tgz",
+                    "integrity": "sha512-am8jJ7Rbh1sy7FvLvNxxQScWvhv2FwLAS3bIhvrZpx9HbX5PEcc/7v6ecgpWuiu0Dwlj+p/z/1boHd8x60JFwA==",
                     "dev": true,
                     "requires": {
-                        "browserslist": "2.10.0",
-                        "caniuse-lite": "1.0.30000784",
+                        "browserslist": "2.11.0",
+                        "caniuse-lite": "1.0.30000785",
                         "normalize-range": "0.1.2",
                         "num2fraction": "1.2.2",
-                        "postcss": "6.0.14",
+                        "postcss": "6.0.15",
                         "postcss-value-parser": "3.3.0"
                     }
                 },
                 "browserslist": {
-                    "version": "2.10.0",
-                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.10.0.tgz",
-                    "integrity": "sha512-WyvzSLsuAVPOjbljXnyeWl14Ae+ukAT8MUuagKVzIDvwBxl4UAwD1xqtyQs2eWYPGUKMeC3Ol62goqYuKqTTcw==",
+                    "version": "2.11.0",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.0.tgz",
+                    "integrity": "sha512-mNYp0RNeu1xueGuJFSXkU+K0nH+dBE/gcjtyhtNKfU8hwdrVIfoA7i5iFSjOmzkGdL2QaO7YX9ExiVPE7AY9JA==",
                     "dev": true,
                     "requires": {
-                        "caniuse-lite": "1.0.30000784",
-                        "electron-to-chromium": "1.3.29"
+                        "caniuse-lite": "1.0.30000785",
+                        "electron-to-chromium": "1.3.30"
+                    }
+                },
+                "electron-to-chromium": {
+                    "version": "1.3.30",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.30.tgz",
+                    "integrity": "sha512-zx1Prv7kYLfc4OA60FhxGbSo4qrEjgSzpo1/37i7l9ltXPYOoQBtjQxY9KmsgfHnBxHlBGXwLlsbt/gub1w5lw==",
+                    "dev": true,
+                    "requires": {
+                        "electron-releases": "2.1.0"
                     }
                 },
                 "fs-extra": {
@@ -8699,14 +8714,14 @@
                     "dev": true
                 },
                 "postcss": {
-                    "version": "6.0.14",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-                    "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+                    "version": "6.0.15",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
+                    "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
                     "dev": true,
                     "requires": {
                         "chalk": "2.3.0",
                         "source-map": "0.6.1",
-                        "supports-color": "4.5.0"
+                        "supports-color": "5.1.0"
                     }
                 },
                 "postcss-url": {
@@ -8718,7 +8733,7 @@
                         "mime": "1.4.1",
                         "minimatch": "3.0.4",
                         "mkdirp": "0.5.1",
-                        "postcss": "6.0.14",
+                        "postcss": "6.0.15",
                         "xxhashjs": "0.2.1"
                     }
                 },
@@ -8729,18 +8744,18 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "4.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-                    "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+                    "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
                     "dev": true,
                     "requires": {
                         "has-flag": "2.0.0"
                     }
                 },
                 "uglify-js": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.2.2.tgz",
-                    "integrity": "sha512-++1NO/zZIEdWf6cDIGceSJQPX31SqIpbVAHwFG5+240MtZqPG/NIPoinj8zlXQtAfMBqEt1Jyv2FiLP3n9gVhQ==",
+                    "version": "3.3.4",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.4.tgz",
+                    "integrity": "sha512-hfIwuAQI5dlXP30UtdmWoYF9k+ypVqBXIdmd6ZKBiaNHHvA8ty7ZloMe3+7S5AEKVkxHbjByl4DfRHQ7QpZquw==",
                     "dev": true,
                     "requires": {
                         "commander": "2.12.2",
@@ -13786,9 +13801,9 @@
             }
         },
         "rollup": {
-            "version": "0.52.3",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.52.3.tgz",
-            "integrity": "sha512-cw+vb9NqaTXlwJyb8G+Ve+uhhlVTcl1NKBkfANdeQqVcpZFilQgeNnAnNiu7MwfeXrqiKEGz+3R03a3zeFkmEQ==",
+            "version": "0.53.3",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.53.3.tgz",
+            "integrity": "sha512-MADFV0jpoh1QDB6U0U6YamGihGetxHEYgwTcGsc7map6JFIydPEfGNshK+ozxv1RKeUOQKn1vRb85IAcdjL22Q==",
             "dev": true
         },
         "rollup-plugin-commonjs": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
         "karma-webpack": "^2.0.4",
         "lite-server": "^2.3.0",
         "loader-utils": "^1.1.0",
-        "ng-packagr": "^2.0.0-rc.5",
+        "ng-packagr": "^2.0.0-rc.9",
         "npm": "^4.6.1",
         "npm-run-all": "^4.1.1",
         "optimize-css-assets-webpack-plugin": "^3.2.0",

--- a/src/app/datagrid/sorting/sorting.ts
+++ b/src/app/datagrid/sorting/sorting.ts
@@ -5,7 +5,7 @@
  */
 import {Component} from "@angular/core";
 
-import {ClrDatagridSortOrder} from "../../../clr-angular";
+import {ClrDatagridSortOrder} from "../../../clr-angular/data/datagrid/interfaces/sort-order";
 import {Inventory} from "../inventory/inventory";
 import {User} from "../inventory/user";
 import {PokemonComparator} from "../utils/pokemon-comparator";

--- a/src/app/tree-view/utils/example.ts
+++ b/src/app/tree-view/utils/example.ts
@@ -5,7 +5,7 @@
  */
 import {AfterViewInit, Component, Input, ViewChild} from "@angular/core";
 
-import {ClrCodeHighlight} from "../../../clr-angular";
+import {ClrCodeHighlight} from "../../../clr-angular/code/syntax-highlight/syntax-highlight";
 
 @Component({
     selector: "clr-example",

--- a/src/clr-angular/button/button-group/button-group.module.ts
+++ b/src/clr-angular/button/button-group/button-group.module.ts
@@ -24,9 +24,13 @@ export class ClrButtonGroupModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export class Button extends ClrButton {}
+export interface Button extends ClrButton {}
 /** @deprecated since 0.11 */
-export class ButtonGroup extends ClrButtonGroup {}
+export const Button = ClrButton;
+/** @deprecated since 0.11 */
+export interface ButtonGroup extends ClrButtonGroup {}
+/** @deprecated since 0.11 */
+export const ButtonGroup = ClrButtonGroup;
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const BUTTON_GROUP_DIRECTIVES = CLR_BUTTON_GROUP_DIRECTIVES;

--- a/src/clr-angular/button/button-loading/loading-button.module.ts
+++ b/src/clr-angular/button/button-loading/loading-button.module.ts
@@ -21,7 +21,9 @@ export class ClrLoadingButtonModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export class LoadingButton extends ClrLoadingButton {}
+export interface LoadingButton extends ClrLoadingButton {}
+/** @deprecated since 0.11 */
+export const LoadingButton = ClrLoadingButton;
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const LOADING_BUTTON_DIRECTIVES = CLR_LOADING_BUTTON_DIRECTIVES;

--- a/src/clr-angular/button/index.ts
+++ b/src/clr-angular/button/index.ts
@@ -5,5 +5,5 @@
  */
 
 export * from "./button.module";
-export * from "./button-group";
-export * from "./button-loading";
+export * from "./button-group/index";
+export * from "./button-loading/index";

--- a/src/clr-angular/code/index.ts
+++ b/src/clr-angular/code/index.ts
@@ -5,4 +5,4 @@
  */
 
 export * from "./code.module";
-export * from "./syntax-highlight";
+export * from "./syntax-highlight/index";

--- a/src/clr-angular/code/syntax-highlight/syntax-highlight.module.ts
+++ b/src/clr-angular/code/syntax-highlight/syntax-highlight.module.ts
@@ -16,7 +16,9 @@ export class ClrSyntaxHighlightModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export class CodeHighlight extends ClrCodeHighlight {}
+export interface CodeHighlight extends ClrCodeHighlight {}
+/** @deprecated since 0.11 */
+export const CodeHighlight = ClrCodeHighlight;
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const CODE_HIGHLIGHT_DIRECTIVES = CLR_CODE_HIGHLIGHT_DIRECTIVES;

--- a/src/clr-angular/data/datagrid/datagrid.module.ts
+++ b/src/clr-angular/data/datagrid/datagrid.module.ts
@@ -83,33 +83,61 @@ export class ClrDatagridModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export class Datagrid extends ClrDatagrid {}
+export interface Datagrid extends ClrDatagrid {}
 /** @deprecated since 0.11 */
-export class DatagridActionBar extends ClrDatagridActionBar {}
+export const Datagrid = ClrDatagrid;
 /** @deprecated since 0.11 */
-export class DatagridActionOverflow extends ClrDatagridActionOverflow {}
+export interface DatagridActionBar extends ClrDatagridActionBar {}
 /** @deprecated since 0.11 */
-export class DatagridColumn extends ClrDatagridColumn {}
+export const DatagridActionBar = ClrDatagridActionBar;
 /** @deprecated since 0.11 */
-export class DatagridColumnToggle extends ClrDatagridColumnToggle {}
+export interface DatagridActionOverflow extends ClrDatagridActionOverflow {}
 /** @deprecated since 0.11 */
-export class DatagridHideableColumnDirective extends ClrDatagridHideableColumn {}
+export const DatagridActionOverflow = ClrDatagridActionOverflow;
 /** @deprecated since 0.11 */
-export class DatagridFilter extends ClrDatagridFilter {}
+export interface DatagridColumn extends ClrDatagridColumn {}
 /** @deprecated since 0.11 */
-export class DatagridItems extends ClrDatagridItems {}
+export const DatagridColumn = ClrDatagridColumn;
 /** @deprecated since 0.11 */
-export class DatagridRow extends ClrDatagridRow {}
+export interface DatagridColumnToggle extends ClrDatagridColumnToggle {}
 /** @deprecated since 0.11 */
-export class DatagridRowDetail extends ClrDatagridRowDetail {}
+export const DatagridColumnToggle = ClrDatagridColumnToggle;
 /** @deprecated since 0.11 */
-export class DatagridCell extends ClrDatagridCell {}
+export interface DatagridHideableColumnDirective extends ClrDatagridHideableColumn {}
 /** @deprecated since 0.11 */
-export class DatagridFooter extends ClrDatagridFooter {}
+export const DatagridHideableColumnDirective = ClrDatagridHideableColumn;
 /** @deprecated since 0.11 */
-export class DatagridPagination extends ClrDatagridPagination {}
+export interface DatagridFilter extends ClrDatagridFilter {}
 /** @deprecated since 0.11 */
-export class DatagridPlaceholder extends ClrDatagridPlaceholder {}
+export const DatagridFilter = ClrDatagridFilter;
+/** @deprecated since 0.11 */
+export interface DatagridItems extends ClrDatagridItems {}
+/** @deprecated since 0.11 */
+export const DatagridItems = ClrDatagridItems;
+/** @deprecated since 0.11 */
+export interface DatagridRow extends ClrDatagridRow {}
+/** @deprecated since 0.11 */
+export const DatagridRow = ClrDatagridRow;
+/** @deprecated since 0.11 */
+export interface DatagridRowDetail extends ClrDatagridRowDetail {}
+/** @deprecated since 0.11 */
+export const DatagridRowDetail = ClrDatagridRowDetail;
+/** @deprecated since 0.11 */
+export interface DatagridCell extends ClrDatagridCell {}
+/** @deprecated since 0.11 */
+export const DatagridCell = ClrDatagridCell;
+/** @deprecated since 0.11 */
+export interface DatagridFooter extends ClrDatagridFooter {}
+/** @deprecated since 0.11 */
+export const DatagridFooter = ClrDatagridFooter;
+/** @deprecated since 0.11 */
+export interface DatagridPagination extends ClrDatagridPagination {}
+/** @deprecated since 0.11 */
+export const DatagridPagination = ClrDatagridPagination;
+/** @deprecated since 0.11 */
+export interface DatagridPlaceholder extends ClrDatagridPlaceholder {}
+/** @deprecated since 0.11 */
+export const DatagridPlaceholder = ClrDatagridPlaceholder;
 /** @deprecated since 0.11 */
 export enum SortOrder {
     // Cannot extend an enum so have to redeclare it

--- a/src/clr-angular/data/index.ts
+++ b/src/clr-angular/data/index.ts
@@ -5,6 +5,6 @@
  */
 
 export * from "./data.module";
-export * from "./datagrid";
-export * from "./tree-view";
-export * from "./stack-view";
+export * from "./datagrid/index";
+export * from "./tree-view/index";
+export * from "./stack-view/index";

--- a/src/clr-angular/data/stack-view/stack-view.module.ts
+++ b/src/clr-angular/data/stack-view/stack-view.module.ts
@@ -35,17 +35,29 @@ export class ClrStackViewModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export class StackView extends ClrStackView {}
+export interface StackView extends ClrStackView {}
 /** @deprecated since 0.11 */
-export class StackHeader extends ClrStackHeader {}
+export const StackView = ClrStackView;
 /** @deprecated since 0.11 */
-export class StackBlock extends ClrStackBlock {}
+export interface StackHeader extends ClrStackHeader {}
 /** @deprecated since 0.11 */
-export class StackViewCustomTags extends ClrStackViewCustomTags {}
+export const StackHeader = ClrStackHeader;
 /** @deprecated since 0.11 */
-export class StackInput extends ClrStackInput {}
+export interface StackBlock extends ClrStackBlock {}
 /** @deprecated since 0.11 */
-export class StackSelect extends ClrStackSelect {}
+export const StackBlock = ClrStackBlock;
+/** @deprecated since 0.11 */
+export interface StackViewCustomTags extends ClrStackViewCustomTags {}
+/** @deprecated since 0.11 */
+export const StackViewCustomTags = ClrStackViewCustomTags;
+/** @deprecated since 0.11 */
+export interface StackInput extends ClrStackInput {}
+/** @deprecated since 0.11 */
+export const StackInput = ClrStackInput;
+/** @deprecated since 0.11 */
+export interface StackSelect extends ClrStackSelect {}
+/** @deprecated since 0.11 */
+export const StackSelect = ClrStackSelect;
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const STACK_VIEW_DIRECTIVES = CLR_STACK_VIEW_DIRECTIVES;

--- a/src/clr-angular/data/tree-view/tree-view.module.ts
+++ b/src/clr-angular/data/tree-view/tree-view.module.ts
@@ -24,7 +24,9 @@ export class ClrTreeViewModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export class TreeNode extends ClrTreeNode {}
+export interface TreeNode extends ClrTreeNode {}
+/** @deprecated since 0.11 */
+export const TreeNode = ClrTreeNode;
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const TREE_VIEW_DIRECTIVES = CLR_TREE_VIEW_DIRECTIVES;

--- a/src/clr-angular/deprecations.spec.ts
+++ b/src/clr-angular/deprecations.spec.ts
@@ -24,6 +24,7 @@ import {
     CLR_DATAGRID_DIRECTIVES,
     CLR_DROPDOWN_DIRECTIVES,
     CLR_ICON_DIRECTIVES,
+    CLR_LAYOUT_DIRECTIVES,
     CLR_LOADING_BUTTON_DIRECTIVES,
     CLR_LOADING_DIRECTIVES,
     CLR_MENU_POSITIONS,
@@ -68,6 +69,7 @@ import {
     ClrIconCustomTag,
     ClrLoading,
     ClrLoadingButton,
+    ClrMainContainer,
     ClrModal,
     ClrNavLevel,
     ClrSignpost,
@@ -131,10 +133,12 @@ import {
     Header,
     ICON_DIRECTIVES,
     IconCustomTag,
+    LAYOUT_DIRECTIVES,
     Loading,
     LOADING_BUTTON_DIRECTIVES,
     LOADING_DIRECTIVES,
     LoadingButton,
+    MainContainer,
     menuPositions,
     Modal,
     MODAL_DIRECTIVES,
@@ -190,39 +194,39 @@ describe("Deprecations", () => {
     describe("since v0.11", () => {
         it("should export deprecated buttons items", () => {
             expect(BUTTON_GROUP_DIRECTIVES).toEqual(CLR_BUTTON_GROUP_DIRECTIVES);
-            expect(Button.prototype instanceof ClrButton).toBeTruthy();
-            expect(ButtonGroup.prototype instanceof ClrButtonGroup).toBeTruthy();
+            expect(Button).toEqual(ClrButton);
+            expect(ButtonGroup).toEqual(ClrButtonGroup);
             expect(LOADING_BUTTON_DIRECTIVES).toEqual(CLR_LOADING_BUTTON_DIRECTIVES);
-            expect(LoadingButton.prototype instanceof ClrLoadingButton).toBeTruthy();
+            expect(LoadingButton).toEqual(ClrLoadingButton);
         });
         it("should export depecreated code highlight items", () => {
             expect(CODE_HIGHLIGHT_DIRECTIVES).toEqual(CLR_CODE_HIGHLIGHT_DIRECTIVES);
-            expect(CodeHighlight.prototype instanceof ClrCodeHighlight).toBeTruthy();
+            expect(CodeHighlight).toEqual(ClrCodeHighlight);
         });
         it("should export deprecated data items", () => {
-            expect(Datagrid.prototype instanceof ClrDatagrid).toBeTruthy();
-            expect(DatagridActionBar.prototype instanceof ClrDatagridActionBar).toBeTruthy();
-            expect(DatagridActionOverflow.prototype instanceof ClrDatagridActionOverflow).toBeTruthy();
-            expect(DatagridColumn.prototype instanceof ClrDatagridColumn).toBeTruthy();
-            expect(DatagridColumnToggle.prototype instanceof ClrDatagridColumnToggle).toBeTruthy();
-            expect(DatagridFilter.prototype instanceof ClrDatagridFilter).toBeTruthy();
-            expect(DatagridHideableColumnDirective.prototype instanceof ClrDatagridHideableColumn).toBeTruthy();
-            expect(DatagridItems.prototype instanceof ClrDatagridItems).toBeTruthy();
-            expect(DatagridRow.prototype instanceof ClrDatagridRow).toBeTruthy();
-            expect(DatagridRowDetail.prototype instanceof ClrDatagridRowDetail).toBeTruthy();
-            expect(DatagridCell.prototype instanceof ClrDatagridCell).toBeTruthy();
-            expect(DatagridFooter.prototype instanceof ClrDatagridFooter).toBeTruthy();
-            expect(DatagridPagination.prototype instanceof ClrDatagridPagination).toBeTruthy();
-            expect(DatagridPlaceholder.prototype instanceof ClrDatagridPlaceholder).toBeTruthy();
+            expect(Datagrid).toEqual(ClrDatagrid);
+            expect(DatagridActionBar).toEqual(ClrDatagridActionBar);
+            expect(DatagridActionOverflow).toEqual(ClrDatagridActionOverflow);
+            expect(DatagridColumn).toEqual(ClrDatagridColumn);
+            expect(DatagridColumnToggle).toEqual(ClrDatagridColumnToggle);
+            expect(DatagridFilter).toEqual(ClrDatagridFilter);
+            expect(DatagridHideableColumnDirective).toEqual(ClrDatagridHideableColumn);
+            expect(DatagridItems).toEqual(ClrDatagridItems);
+            expect(DatagridRow).toEqual(ClrDatagridRow);
+            expect(DatagridRowDetail).toEqual(ClrDatagridRowDetail);
+            expect(DatagridCell).toEqual(ClrDatagridCell);
+            expect(DatagridFooter).toEqual(ClrDatagridFooter);
+            expect(DatagridPagination).toEqual(ClrDatagridPagination);
+            expect(DatagridPlaceholder).toEqual(ClrDatagridPlaceholder);
             expect(DATAGRID_DIRECTIVES).toEqual(CLR_DATAGRID_DIRECTIVES);
-            expect(StackView.prototype instanceof ClrStackView).toBeTruthy();
-            expect(StackSelect.prototype instanceof ClrStackSelect).toBeTruthy();
-            expect(StackInput.prototype instanceof ClrStackInput).toBeTruthy();
-            expect(StackHeader.prototype instanceof ClrStackHeader).toBeTruthy();
-            expect(StackViewCustomTags.prototype instanceof ClrStackViewCustomTags).toBeTruthy();
-            expect(StackBlock.prototype instanceof ClrStackBlock).toBeTruthy();
+            expect(StackView).toEqual(ClrStackView);
+            expect(StackSelect).toEqual(ClrStackSelect);
+            expect(StackInput).toEqual(ClrStackInput);
+            expect(StackHeader).toEqual(ClrStackHeader);
+            expect(StackViewCustomTags).toEqual(ClrStackViewCustomTags);
+            expect(StackBlock).toEqual(ClrStackBlock);
             expect(STACK_VIEW_DIRECTIVES).toEqual(CLR_STACK_VIEW_DIRECTIVES);
-            expect(TreeNode.prototype instanceof ClrTreeNode).toBeTruthy();
+            expect(TreeNode).toEqual(ClrTreeNode);
             expect(TREE_VIEW_DIRECTIVES).toEqual(CLR_TREE_VIEW_DIRECTIVES);
             // Can't test interfaces directly, so just verify if they are exported and can be applied.
             class ComparatorTest implements Comparator<any> {
@@ -257,72 +261,74 @@ describe("Deprecations", () => {
         });
         it("should export deprecated emphasis items", () => {
             expect(ALERT_DIRECTIVES).toEqual(CLR_ALERT_DIRECTIVES);
-            expect(Alert.prototype instanceof ClrAlert).toBeTruthy();
-            expect(AlertItem.prototype instanceof ClrAlertItem).toBeTruthy();
-            expect(Alerts.prototype instanceof ClrAlerts).toBeTruthy();
-            expect(AlertsPager.prototype instanceof ClrAlertsPager).toBeTruthy();
+            expect(Alert).toEqual(ClrAlert);
+            expect(AlertItem).toEqual(ClrAlertItem);
+            expect(Alerts).toEqual(ClrAlerts);
+            expect(AlertsPager).toEqual(ClrAlertsPager);
         });
         it("should export deprecated form items", () => {
-            expect(Checkbox.prototype instanceof ClrCheckbox).toBeTruthy();
+            expect(Checkbox).toEqual(ClrCheckbox);
             expect(CHECKBOX_DIRECTIVES).toEqual(CLR_CHECKBOX_DIRECTIVES);
         });
         it("should export deprecated icon items", () => {
-            expect(IconCustomTag.prototype instanceof ClrIconCustomTag).toBeTruthy();
+            expect(IconCustomTag).toEqual(ClrIconCustomTag);
             expect(ICON_DIRECTIVES).toEqual(CLR_ICON_DIRECTIVES);
         });
         it("should export deprecated layout items", () => {
+            expect(MainContainer).toEqual(ClrMainContainer);
+            expect(LAYOUT_DIRECTIVES).toEqual(CLR_LAYOUT_DIRECTIVES);
             expect(NAVIGATION_DIRECTIVES).toEqual(CLR_NAVIGATION_DIRECTIVES);
-            expect(Header.prototype instanceof ClrHeader).toBeTruthy();
-            expect(NavLevelDirective.prototype instanceof ClrNavLevel).toBeTruthy();
+            expect(Header).toEqual(ClrHeader);
+            expect(NavLevelDirective).toEqual(ClrNavLevel);
             expect(TABS_DIRECTIVES).toEqual(CLR_TABS_DIRECTIVES);
-            expect(Tab.prototype instanceof ClrTab).toBeTruthy();
-            expect(Tabs.prototype instanceof ClrTabs).toBeTruthy();
-            expect(TabLinkDirective.prototype instanceof ClrTabLink).toBeTruthy();
-            expect(TabContent.prototype instanceof ClrTabContent).toBeTruthy();
-            expect(TabOverflowContent.prototype instanceof ClrTabOverflowContent).toBeTruthy();
+            expect(Tab).toEqual(ClrTab);
+            expect(Tabs).toEqual(ClrTabs);
+            expect(TabLinkDirective).toEqual(ClrTabLink);
+            expect(TabContent).toEqual(ClrTabContent);
+            expect(TabOverflowContent).toEqual(ClrTabOverflowContent);
             expect(VERTICAL_NAV_DIRECTIVES).toEqual(CLR_VERTICAL_NAV_DIRECTIVES);
-            expect(VerticalNav.prototype instanceof ClrVerticalNav).toBeTruthy();
-            expect(VerticalNavGroup.prototype instanceof ClrVerticalNavGroup).toBeTruthy();
-            expect(VerticalNavGroupChildren.prototype instanceof ClrVerticalNavGroupChildren).toBeTruthy();
-            expect(VerticalNavIcon.prototype instanceof ClrVerticalNavIcon).toBeTruthy();
-            expect(VerticalNavLink.prototype instanceof ClrVerticalNavLink).toBeTruthy();
+            expect(VerticalNav).toEqual(ClrVerticalNav);
+            expect(VerticalNavGroup).toEqual(ClrVerticalNavGroup);
+            expect(VerticalNavGroupChildren).toEqual(ClrVerticalNavGroupChildren);
+            expect(VerticalNavIcon).toEqual(ClrVerticalNavIcon);
+            expect(VerticalNavLink).toEqual(ClrVerticalNavLink);
         });
         it("should export deprecated modal items", () => {
-            expect(Modal.prototype instanceof ClrModal).toBeTruthy();
+            expect(Modal).toEqual(ClrModal);
             expect(MODAL_DIRECTIVES).toEqual(CLR_MODAL_DIRECTIVES);
         });
         it("should export deprecated popover items", () => {
-            expect(Dropdown.prototype instanceof ClrDropdown).toBeTruthy();
-            expect(DropdownItem.prototype instanceof ClrDropdownItem).toBeTruthy();
-            expect(DropdownMenu.prototype instanceof ClrDropdownMenu).toBeTruthy();
-            expect(DropdownTrigger.prototype instanceof ClrDropdownTrigger).toBeTruthy();
+            expect(Dropdown).toEqual(ClrDropdown);
+            expect(DropdownItem).toEqual(ClrDropdownItem);
+            expect(DropdownMenu).toEqual(ClrDropdownMenu);
+            expect(DropdownTrigger).toEqual(ClrDropdownTrigger);
             expect(menuPositions).toEqual(CLR_MENU_POSITIONS);
             expect(DROPDOWN_DIRECTIVES).toEqual(CLR_DROPDOWN_DIRECTIVES);
-            expect(Signpost.prototype instanceof ClrSignpost).toBeTruthy();
-            expect(SignpostContent.prototype instanceof ClrSignpostContent).toBeTruthy();
-            expect(SignpostTrigger.prototype instanceof ClrSignpostTrigger).toBeTruthy();
+            expect(Signpost).toEqual(ClrSignpost);
+            expect(SignpostContent).toEqual(ClrSignpostContent);
+            expect(SignpostTrigger).toEqual(ClrSignpostTrigger);
             expect(SIGNPOST_DIRECTIVES).toEqual(CLR_SIGNPOST_DIRECTIVES);
-            expect(Tooltip.prototype instanceof ClrTooltip).toBeTruthy();
-            expect(TooltipContent.prototype instanceof ClrTooltipContent).toBeTruthy();
-            expect(TooltipTrigger.prototype instanceof ClrTooltipTrigger).toBeTruthy();
+            expect(Tooltip).toEqual(ClrTooltip);
+            expect(TooltipContent).toEqual(ClrTooltipContent);
+            expect(TooltipTrigger).toEqual(ClrTooltipTrigger);
             expect(TOOLTIP_DIRECTIVES).toEqual(CLR_TOOLTIP_DIRECTIVES);
         });
         it("should export deprecated util items", () => {
-            expect(Loading.prototype instanceof ClrLoading).toBeTruthy();
+            expect(Loading).toEqual(ClrLoading);
             expect(LOADING_DIRECTIVES).toEqual(CLR_LOADING_DIRECTIVES);
         });
         it("should export deprecated wizard items", () => {
-            expect(Wizard.prototype instanceof ClrWizard).toBeTruthy();
-            expect(WizardPage.prototype instanceof ClrWizardPage).toBeTruthy();
-            expect(WizardStepnav.prototype instanceof ClrWizardStepnav).toBeTruthy();
-            expect(WizardStepnavItem.prototype instanceof ClrWizardStepnavItem).toBeTruthy();
-            expect(WizardButton.prototype instanceof ClrWizardButton).toBeTruthy();
-            expect(WizardHeaderAction.prototype instanceof ClrWizardHeaderAction).toBeTruthy();
-            expect(WizardCustomTags.prototype instanceof ClrWizardCustomTags).toBeTruthy();
-            expect(WizardPageTitleDirective.prototype instanceof ClrWizardPageTitle).toBeTruthy();
-            expect(WizardPageNavTitleDirective.prototype instanceof ClrWizardPageNavTitle).toBeTruthy();
-            expect(WizardPageButtonsDirective.prototype instanceof ClrWizardPageButtons).toBeTruthy();
-            expect(WizardPageHeaderActionsDirective.prototype instanceof ClrWizardPageHeaderActions).toBeTruthy();
+            expect(Wizard).toEqual(ClrWizard);
+            expect(WizardPage).toEqual(ClrWizardPage);
+            expect(WizardStepnav).toEqual(ClrWizardStepnav);
+            expect(WizardStepnavItem).toEqual(ClrWizardStepnavItem);
+            expect(WizardButton).toEqual(ClrWizardButton);
+            expect(WizardHeaderAction).toEqual(ClrWizardHeaderAction);
+            expect(WizardCustomTags).toEqual(ClrWizardCustomTags);
+            expect(WizardPageTitleDirective).toEqual(ClrWizardPageTitle);
+            expect(WizardPageNavTitleDirective).toEqual(ClrWizardPageNavTitle);
+            expect(WizardPageButtonsDirective).toEqual(ClrWizardPageButtons);
+            expect(WizardPageHeaderActionsDirective).toEqual(ClrWizardPageHeaderActions);
             expect(WIZARD_DIRECTIVES).toEqual(CLR_WIZARD_DIRECTIVES);
         });
     });

--- a/src/clr-angular/emphasis/alert/alert.module.ts
+++ b/src/clr-angular/emphasis/alert/alert.module.ts
@@ -26,13 +26,21 @@ export class ClrAlertModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export class Alert extends ClrAlert {}
+export interface Alert extends ClrAlert {}
 /** @deprecated since 0.11 */
-export class AlertItem extends ClrAlertItem {}
+export const Alert = ClrAlert;
 /** @deprecated since 0.11 */
-export class Alerts extends ClrAlerts {}
+export interface AlertItem extends ClrAlertItem {}
 /** @deprecated since 0.11 */
-export class AlertsPager extends ClrAlertsPager {}
+export const AlertItem = ClrAlertItem;
+/** @deprecated since 0.11 */
+export interface Alerts extends ClrAlerts {}
+/** @deprecated since 0.11 */
+export const Alerts = ClrAlerts;
+/** @deprecated since 0.11 */
+export interface AlertsPager extends ClrAlertsPager {}
+/** @deprecated since 0.11 */
+export const AlertsPager = ClrAlertsPager;
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const ALERT_DIRECTIVES = CLR_ALERT_DIRECTIVES;

--- a/src/clr-angular/emphasis/index.ts
+++ b/src/clr-angular/emphasis/index.ts
@@ -4,4 +4,4 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 export * from "./emphasis.module";
-export * from "./alert";
+export * from "./alert/index";

--- a/src/clr-angular/forms/checkbox/checkbox.module.ts
+++ b/src/clr-angular/forms/checkbox/checkbox.module.ts
@@ -3,21 +3,21 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
+
 import {CommonModule} from "@angular/common";
 import {NgModule, Type} from "@angular/core";
+import {ClrCheckbox} from "./checkbox";
 
-import {ClrLoading} from "./loading";
+export const CLR_CHECKBOX_DIRECTIVES: Type<any>[] = [ClrCheckbox];
 
-export const CLR_LOADING_DIRECTIVES: Type<any>[] = [ClrLoading];
-
-@NgModule({imports: [CommonModule], declarations: [CLR_LOADING_DIRECTIVES], exports: [CLR_LOADING_DIRECTIVES]})
-export class ClrLoadingModule {}
+@NgModule({imports: [CommonModule], declarations: [CLR_CHECKBOX_DIRECTIVES], exports: [CLR_CHECKBOX_DIRECTIVES]})
+export class ClrCheckboxModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export interface Loading extends ClrLoading {}
+export interface Checkbox extends ClrCheckbox {}
 /** @deprecated since 0.11 */
-export const Loading = ClrLoading;
+export const Checkbox = ClrCheckbox;
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
-export const LOADING_DIRECTIVES = CLR_LOADING_DIRECTIVES;
+export const CHECKBOX_DIRECTIVES = CLR_CHECKBOX_DIRECTIVES;

--- a/src/clr-angular/forms/checkbox/index.ts
+++ b/src/clr-angular/forms/checkbox/index.ts
@@ -3,5 +3,5 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-
 export * from "./checkbox";
+export * from "./checkbox.module";

--- a/src/clr-angular/forms/forms.module.ts
+++ b/src/clr-angular/forms/forms.module.ts
@@ -5,17 +5,8 @@
  */
 
 import {CommonModule} from "@angular/common";
-import {NgModule, Type} from "@angular/core";
-import {ClrCheckbox} from "./checkbox";
+import {NgModule} from "@angular/core";
+import {ClrCheckboxModule} from "./checkbox/checkbox.module";
 
-export const CLR_CHECKBOX_DIRECTIVES: Type<any>[] = [ClrCheckbox];
-
-@NgModule({imports: [CommonModule], declarations: [CLR_CHECKBOX_DIRECTIVES], exports: [CLR_CHECKBOX_DIRECTIVES]})
+@NgModule({imports: [CommonModule], exports: [ClrCheckboxModule]})
 export class ClrFormsModule {}
-
-/* tslint:disable variable-name */
-/** @deprecated since 0.11 */
-export class Checkbox extends ClrCheckbox {}
-/* tslint:enable variable-name */
-/** @deprecated since 0.11 */
-export const CHECKBOX_DIRECTIVES = CLR_CHECKBOX_DIRECTIVES;

--- a/src/clr-angular/forms/index.ts
+++ b/src/clr-angular/forms/index.ts
@@ -3,5 +3,5 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
+export * from "./checkbox/index";
 export * from "./forms.module";
-export * from "./checkbox";

--- a/src/clr-angular/icon/icon.module.ts
+++ b/src/clr-angular/icon/icon.module.ts
@@ -15,7 +15,9 @@ export class ClrIconModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export class IconCustomTag extends ClrIconCustomTag {}
+export interface IconCustomTag extends ClrIconCustomTag {}
+/** @deprecated since 0.11 */
+export const IconCustomTag = ClrIconCustomTag;
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const ICON_DIRECTIVES = CLR_ICON_DIRECTIVES;

--- a/src/clr-angular/index.ts
+++ b/src/clr-angular/index.ts
@@ -6,17 +6,17 @@
 
 export * from "./clr-angular.module";
 
-export * from "./button";
-export * from "./code";
-export * from "./data";
-export * from "./emphasis";
-export * from "./forms";
-export * from "./icon";
-export * from "./layout";
-export * from "./modal";
-export * from "./popover";
-export * from "./utils";
-export * from "./wizard";
+export * from "./button/index";
+export * from "./code/index";
+export * from "./data/index";
+export * from "./emphasis/index";
+export * from "./forms/index";
+export * from "./icon/index";
+export * from "./layout/index";
+export * from "./modal/index";
+export * from "./popover/index";
+export * from "./utils/index";
+export * from "./wizard/index";
 
 // Below are exported for internal use only and may change without notice
 export {FocusTrapTracker as ÇlrFocusTrapTracker} from "./utils/focus-trap/focus-trap-tracker.service";

--- a/src/clr-angular/layout/index.ts
+++ b/src/clr-angular/layout/index.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 export * from "./layout.module";
-export * from "./main-container";
-export * from "./nav";
-export * from "./tabs";
-export * from "./vertical-nav";
+export * from "./main-container/index";
+export * from "./nav/index";
+export * from "./tabs/index";
+export * from "./vertical-nav/index";

--- a/src/clr-angular/layout/layout.module.ts
+++ b/src/clr-angular/layout/layout.module.ts
@@ -5,10 +5,10 @@
  */
 import {NgModule} from "@angular/core";
 
-import {ClrMainContainerModule} from "./main-container";
-import {ClrNavigationModule} from "./nav";
-import {ClrTabsModule} from "./tabs";
-import {ClrVerticalNavModule} from "./vertical-nav";
+import {ClrMainContainerModule} from "./main-container/main-container.module";
+import {ClrNavigationModule} from "./nav/navigation.module";
+import {ClrTabsModule} from "./tabs/tabs.module";
+import {ClrVerticalNavModule} from "./vertical-nav/vertical-nav.module";
 
 @NgModule({exports: [ClrMainContainerModule, ClrNavigationModule, ClrTabsModule, ClrVerticalNavModule]})
 export class ClrLayoutModule {}

--- a/src/clr-angular/layout/main-container/main-container.module.ts
+++ b/src/clr-angular/layout/main-container/main-container.module.ts
@@ -18,6 +18,8 @@ export class ClrMainContainerModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
+export interface MainContainer extends ClrMainContainer {}
+/** @deprecated since 0.11 */
 export const MainContainer = ClrMainContainer;
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */

--- a/src/clr-angular/layout/nav/index.ts
+++ b/src/clr-angular/layout/nav/index.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-export * from "./chocolate";
+export * from "./chocolate/index";
 export * from "./header";
 export * from "./nav-level";
 export * from "./navigation.module";

--- a/src/clr-angular/layout/nav/navigation.module.ts
+++ b/src/clr-angular/layout/nav/navigation.module.ts
@@ -34,9 +34,13 @@ export class ClrNavigationModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export class Header extends ClrHeader {}
+export interface Header extends ClrHeader {}
 /** @deprecated since 0.11 */
-export class NavLevelDirective extends ClrNavLevel {}
+export const Header = ClrHeader;
+/** @deprecated since 0.11 */
+export interface NavLevelDirective extends ClrNavLevel {}
+/** @deprecated since 0.11 */
+export const NavLevelDirective = ClrNavLevel;
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const NAVIGATION_DIRECTIVES = CLR_NAVIGATION_DIRECTIVES;

--- a/src/clr-angular/layout/tabs/tabs.module.ts
+++ b/src/clr-angular/layout/tabs/tabs.module.ts
@@ -32,15 +32,25 @@ export class ClrTabsModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export class Tab extends ClrTab {}
+export interface Tab extends ClrTab {}
 /** @deprecated since 0.11 */
-export class Tabs extends ClrTabs {}
+export const Tab = ClrTab;
 /** @deprecated since 0.11 */
-export class TabContent extends ClrTabContent {}
+export interface Tabs extends ClrTabs {}
 /** @deprecated since 0.11 */
-export class TabOverflowContent extends ClrTabOverflowContent {}
+export const Tabs = ClrTabs;
 /** @deprecated since 0.11 */
-export class TabLinkDirective extends ClrTabLink {}
+export interface TabContent extends ClrTabContent {}
+/** @deprecated since 0.11 */
+export const TabContent = ClrTabContent;
+/** @deprecated since 0.11 */
+export interface TabOverflowContent extends ClrTabOverflowContent {}
+/** @deprecated since 0.11 */
+export const TabOverflowContent = ClrTabOverflowContent;
+/** @deprecated since 0.11 */
+export interface TabLinkDirective extends ClrTabLink {}
+/** @deprecated since 0.11 */
+export const TabLinkDirective = ClrTabLink;
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const TABS_DIRECTIVES = CLR_TABS_DIRECTIVES;

--- a/src/clr-angular/layout/vertical-nav/vertical-nav.module.ts
+++ b/src/clr-angular/layout/vertical-nav/vertical-nav.module.ts
@@ -28,15 +28,25 @@ export class ClrVerticalNavModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export class VerticalNav extends ClrVerticalNav {}
+export interface VerticalNav extends ClrVerticalNav {}
 /** @deprecated since 0.11 */
-export class VerticalNavGroup extends ClrVerticalNavGroup {}
+export const VerticalNav = ClrVerticalNav;
 /** @deprecated since 0.11 */
-export class VerticalNavGroupChildren extends ClrVerticalNavGroupChildren {}
+export interface VerticalNavGroup extends ClrVerticalNavGroup {}
 /** @deprecated since 0.11 */
-export class VerticalNavIcon extends ClrVerticalNavIcon {}
+export const VerticalNavGroup = ClrVerticalNavGroup;
 /** @deprecated since 0.11 */
-export class VerticalNavLink extends ClrVerticalNavLink {}
+export interface VerticalNavGroupChildren extends ClrVerticalNavGroupChildren {}
+/** @deprecated since 0.11 */
+export const VerticalNavGroupChildren = ClrVerticalNavGroupChildren;
+/** @deprecated since 0.11 */
+export interface VerticalNavIcon extends ClrVerticalNavIcon {}
+/** @deprecated since 0.11 */
+export const VerticalNavIcon = ClrVerticalNavIcon;
+/** @deprecated since 0.11 */
+export interface VerticalNavLink extends ClrVerticalNavLink {}
+/** @deprecated since 0.11 */
+export const VerticalNavLink = ClrVerticalNavLink;
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const VERTICAL_NAV_DIRECTIVES = CLR_VERTICAL_NAV_DIRECTIVES;

--- a/src/clr-angular/modal/modal.module.ts
+++ b/src/clr-angular/modal/modal.module.ts
@@ -22,7 +22,9 @@ export class ClrModalModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export class Modal extends ClrModal {}
+export interface Modal extends ClrModal {}
+/** @deprecated since 0.11 */
+export const Modal = ClrModal;
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const MODAL_DIRECTIVES = CLR_MODAL_DIRECTIVES;

--- a/src/clr-angular/popover/dropdown/dropdown.module.ts
+++ b/src/clr-angular/popover/dropdown/dropdown.module.ts
@@ -29,13 +29,21 @@ export class ClrDropdownModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export class Dropdown extends ClrDropdown {}
+export interface Dropdown extends ClrDropdown {}
 /** @deprecated since 0.11 */
-export class DropdownMenu extends ClrDropdownMenu {}
+export const Dropdown = ClrDropdown;
 /** @deprecated since 0.11 */
-export class DropdownTrigger extends ClrDropdownTrigger {}
+export interface DropdownMenu extends ClrDropdownMenu {}
 /** @deprecated since 0.11 */
-export class DropdownItem extends ClrDropdownItem {}
+export const DropdownMenu = ClrDropdownMenu;
+/** @deprecated since 0.11 */
+export interface DropdownTrigger extends ClrDropdownTrigger {}
+/** @deprecated since 0.11 */
+export const DropdownTrigger = ClrDropdownTrigger;
+/** @deprecated since 0.11 */
+export interface DropdownItem extends ClrDropdownItem {}
+/** @deprecated since 0.11 */
+export const DropdownItem = ClrDropdownItem;
 /** @deprecated since 0.11 */
 export const menuPositions = CLR_MENU_POSITIONS;
 /* tslint:enable variable-name */

--- a/src/clr-angular/popover/index.ts
+++ b/src/clr-angular/popover/index.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-export * from "./dropdown";
+export * from "./dropdown/index";
 export * from "./popover.module";
-export * from "./signpost";
-export * from "./tooltip";
+export * from "./signpost/index";
+export * from "./tooltip/index";

--- a/src/clr-angular/popover/signpost/signpost.module.ts
+++ b/src/clr-angular/popover/signpost/signpost.module.ts
@@ -28,11 +28,17 @@ export class ClrSignpostModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export class Signpost extends ClrSignpost {}
+export interface Signpost extends ClrSignpost {}
 /** @deprecated since 0.11 */
-export class SignpostContent extends ClrSignpostContent {}
+export const Signpost = ClrSignpost;
 /** @deprecated since 0.11 */
-export class SignpostTrigger extends ClrSignpostTrigger {}
+export interface SignpostContent extends ClrSignpostContent {}
+/** @deprecated since 0.11 */
+export const SignpostContent = ClrSignpostContent;
+/** @deprecated since 0.11 */
+export interface SignpostTrigger extends ClrSignpostTrigger {}
+/** @deprecated since 0.11 */
+export const SignpostTrigger = ClrSignpostTrigger;
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const SIGNPOST_DIRECTIVES = CLR_SIGNPOST_DIRECTIVES;

--- a/src/clr-angular/popover/tooltip/tooltip.module.ts
+++ b/src/clr-angular/popover/tooltip/tooltip.module.ts
@@ -26,11 +26,17 @@ export class ClrTooltipModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export class Tooltip extends ClrTooltip {}
+export interface Tooltip extends ClrTooltip {}
 /** @deprecated since 0.11 */
-export class TooltipContent extends ClrTooltipContent {}
+export const Tooltip = ClrTooltip;
 /** @deprecated since 0.11 */
-export class TooltipTrigger extends ClrTooltipTrigger {}
+export interface TooltipContent extends ClrTooltipContent {}
+/** @deprecated since 0.11 */
+export const TooltipContent = ClrTooltipContent;
+/** @deprecated since 0.11 */
+export interface TooltipTrigger extends ClrTooltipTrigger {}
+/** @deprecated since 0.11 */
+export const TooltipTrigger = ClrTooltipTrigger;
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const TOOLTIP_DIRECTIVES = CLR_TOOLTIP_DIRECTIVES;

--- a/src/clr-angular/utils/animations/index.ts
+++ b/src/clr-angular/utils/animations/index.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-export * from "./collapse";
-export * from "./fade";
-export * from "./fade-slide";
-export * from "./slide";
+export * from "./collapse/index";
+export * from "./fade/index";
+export * from "./fade-slide/index";
+export * from "./slide/index";

--- a/src/clr-angular/utils/index.ts
+++ b/src/clr-angular/utils/index.ts
@@ -4,5 +4,5 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-export * from "./animations";
-export * from "./loading";
+export * from "./animations/index";
+export * from "./loading/index";

--- a/src/clr-angular/wizard/wizard.module.ts
+++ b/src/clr-angular/wizard/wizard.module.ts
@@ -36,27 +36,49 @@ export class ClrWizardModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export class Wizard extends ClrWizard {}
+export interface Wizard extends ClrWizard {}
 /** @deprecated since 0.11 */
-export class WizardPage extends ClrWizardPage {}
+export const Wizard = ClrWizard;
 /** @deprecated since 0.11 */
-export class WizardStepnav extends ClrWizardStepnav {}
+export interface WizardPage extends ClrWizardPage {}
 /** @deprecated since 0.11 */
-export class WizardStepnavItem extends ClrWizardStepnavItem {}
+export const WizardPage = ClrWizardPage;
 /** @deprecated since 0.11 */
-export class WizardButton extends ClrWizardButton {}
+export interface WizardStepnav extends ClrWizardStepnav {}
 /** @deprecated since 0.11 */
-export class WizardHeaderAction extends ClrWizardHeaderAction {}
+export const WizardStepnav = ClrWizardStepnav;
 /** @deprecated since 0.11 */
-export class WizardCustomTags extends ClrWizardCustomTags {}
+export interface WizardStepnavItem extends ClrWizardStepnavItem {}
 /** @deprecated since 0.11 */
-export class WizardPageTitleDirective extends ClrWizardPageTitle {}
+export const WizardStepnavItem = ClrWizardStepnavItem;
 /** @deprecated since 0.11 */
-export class WizardPageNavTitleDirective extends ClrWizardPageNavTitle {}
+export interface WizardButton extends ClrWizardButton {}
 /** @deprecated since 0.11 */
-export class WizardPageButtonsDirective extends ClrWizardPageButtons {}
+export const WizardButton = ClrWizardButton;
 /** @deprecated since 0.11 */
-export class WizardPageHeaderActionsDirective extends ClrWizardPageHeaderActions {}
+export interface WizardHeaderAction extends ClrWizardHeaderAction {}
+/** @deprecated since 0.11 */
+export const WizardHeaderAction = ClrWizardHeaderAction;
+/** @deprecated since 0.11 */
+export interface WizardCustomTags extends ClrWizardCustomTags {}
+/** @deprecated since 0.11 */
+export const WizardCustomTags = ClrWizardCustomTags;
+/** @deprecated since 0.11 */
+export interface WizardPageTitleDirective extends ClrWizardPageTitle {}
+/** @deprecated since 0.11 */
+export const WizardPageTitleDirective = ClrWizardPageTitle;
+/** @deprecated since 0.11 */
+export interface WizardPageNavTitleDirective extends ClrWizardPageNavTitle {}
+/** @deprecated since 0.11 */
+export const WizardPageNavTitleDirective = ClrWizardPageNavTitle;
+/** @deprecated since 0.11 */
+export interface WizardPageButtonsDirective extends ClrWizardPageButtons {}
+/** @deprecated since 0.11 */
+export const WizardPageButtonsDirective = ClrWizardPageButtons;
+/** @deprecated since 0.11 */
+export interface WizardPageHeaderActionsDirective extends ClrWizardPageHeaderActions {}
+/** @deprecated since 0.11 */
+export const WizardPageHeaderActionsDirective = ClrWizardPageHeaderActions;
 /* tslint:enable variable-name */
 /** @deprecated since 0.11 */
 export const WIZARD_DIRECTIVES = CLR_WIZARD_DIRECTIVES;


### PR DESCRIPTION
This gets us past bundling and typescript issues, allowing us to avoid a breaking change.