### PR TITLE
[CORE] Update Copyright (2nd pass)

### DIFF
--- a/gemini/tests/set1/alert.js
+++ b/gemini/tests/set1/alert.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set1/badges.js
+++ b/gemini/tests/set1/badges.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 
 gemini.suite('badges', (child) => {

--- a/gemini/tests/set1/button-group.js
+++ b/gemini/tests/set1/button-group.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set1/buttons.js
+++ b/gemini/tests/set1/buttons.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set1/card.js
+++ b/gemini/tests/set1/card.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set1/checkboxes.js
+++ b/gemini/tests/set1/checkboxes.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set1/code-highlight.js
+++ b/gemini/tests/set1/code-highlight.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set1/color.js
+++ b/gemini/tests/set1/color.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set2/datagrid-compact.js
+++ b/gemini/tests/set2/datagrid-compact.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 const WAIT_TIME = 10000;
 const WAIT_LOAD_TIME = 2000;
 

--- a/gemini/tests/set2/datagrid.js
+++ b/gemini/tests/set2/datagrid.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 10000;
 var WAIT_LOAD_TIME = 2000;
 

--- a/gemini/tests/set2/dropdown.js
+++ b/gemini/tests/set2/dropdown.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set2/forms.js
+++ b/gemini/tests/set2/forms.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set2/grid.js
+++ b/gemini/tests/set2/grid.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set2/iconography.js
+++ b/gemini/tests/set2/iconography.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set2/images.js
+++ b/gemini/tests/set2/images.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set3/input-fields.js
+++ b/gemini/tests/set3/input-fields.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set3/labels.js
+++ b/gemini/tests/set3/labels.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set3/landing-page.js
+++ b/gemini/tests/set3/landing-page.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 2000;
 

--- a/gemini/tests/set3/layout.js
+++ b/gemini/tests/set3/layout.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 2000;
 

--- a/gemini/tests/set3/lists.js
+++ b/gemini/tests/set3/lists.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set3/login.js
+++ b/gemini/tests/set3/login.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set3/modal.js
+++ b/gemini/tests/set3/modal.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set3/navigation.js
+++ b/gemini/tests/set3/navigation.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set3/progress-bars.js
+++ b/gemini/tests/set3/progress-bars.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 5000;
 
@@ -162,5 +168,5 @@ gemini.suite('progress-bar', (child) => {
             .setCaptureElements('.clr-example')
             .capture('default');
     });
-    
+
 });

--- a/gemini/tests/set3/radios.js
+++ b/gemini/tests/set3/radios.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set3/selects.js
+++ b/gemini/tests/set3/selects.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set3/signposts.js
+++ b/gemini/tests/set3/signposts.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set3/spinners.js
+++ b/gemini/tests/set3/spinners.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set3/stack-view.js
+++ b/gemini/tests/set3/stack-view.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set4/tables.js
+++ b/gemini/tests/set4/tables.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set4/tabs.js
+++ b/gemini/tests/set4/tabs.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set4/toggles.js
+++ b/gemini/tests/set4/toggles.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set4/tooltips.js
+++ b/gemini/tests/set4/tooltips.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 2000;
 

--- a/gemini/tests/set4/tree-view.js
+++ b/gemini/tests/set4/tree-view.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set4/typography.js
+++ b/gemini/tests/set4/typography.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set4/vertical-nav.js
+++ b/gemini/tests/set4/vertical-nav.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 

--- a/gemini/tests/set4/wizard.js
+++ b/gemini/tests/set4/wizard.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 var WAIT_TIME = 5000;
 
 gemini.suite('wizard', (child) => {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 module.exports = function(karma) {
     "use strict";
 

--- a/scripts/clr-icons-svg.js
+++ b/scripts/clr-icons-svg.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 const writeSVGIcons = require('./write-svg-icons');
 const shell = require("shelljs");
 

--- a/scripts/docker-cdc.js
+++ b/scripts/docker-cdc.js
@@ -1,5 +1,11 @@
 #!/usr/bin/env node
 
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 const program = require("commander");
 const shell = require("shelljs");
 const ip = require("ip");

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/scripts/write-svg-icons.js
+++ b/scripts/write-svg-icons.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/_utils/code.scss
+++ b/src/app/_utils/code.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 /* Vendor */
 

--- a/src/app/_utils/utils.module.ts
+++ b/src/app/_utils/utils.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/alert/alert.demo.scss
+++ b/src/app/alert/alert.demo.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @import "../_utils/code";
 

--- a/src/app/alert/angular/alert-angular-app-level-alerts.demo.html
+++ b/src/app/alert/angular/alert-angular-app-level-alerts.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/alert/angular/alert-angular-app-level-alerts.ts
+++ b/src/app/alert/angular/alert-angular-app-level-alerts.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/badges/badge-colors.demo.html
+++ b/src/app/badges/badge-colors.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/badges/badge-colors.ts
+++ b/src/app/badges/badge-colors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/badges/badge-statuses.demo.html
+++ b/src/app/badges/badge-statuses.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/badges/badge-statuses.ts
+++ b/src/app/badges/badge-statuses.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/badges/badges.demo.html
+++ b/src/app/badges/badges.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/badges/badges.demo.module.ts
+++ b/src/app/badges/badges.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/badges/badges.demo.routing.ts
+++ b/src/app/badges/badges.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/badges/badges.demo.scss
+++ b/src/app/badges/badges.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/badges/badges.demo.ts
+++ b/src/app/badges/badges.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/angular/basic-structure/basic-button-group.html
+++ b/src/app/button-group/angular/basic-structure/basic-button-group.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/button-group/angular/basic-structure/basic-button-group.ts
+++ b/src/app/button-group/angular/basic-structure/basic-button-group.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/angular/button-group-angular.ts
+++ b/src/app/button-group/angular/button-group-angular.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/angular/hide-show-overflow-toggle/hide-show-overflow-toggle.ts
+++ b/src/app/button-group/angular/hide-show-overflow-toggle/hide-show-overflow-toggle.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/angular/icon-buttons/icon-button-group.html
+++ b/src/app/button-group/angular/icon-buttons/icon-button-group.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/button-group/angular/icon-buttons/icon-button-group.ts
+++ b/src/app/button-group/angular/icon-buttons/icon-button-group.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/angular/menu-directions/menu-directions.ts
+++ b/src/app/button-group/angular/menu-directions/menu-directions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/angular/mixed-buttons/mixed-button-group.html
+++ b/src/app/button-group/angular/mixed-buttons/mixed-button-group.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/button-group/angular/mixed-buttons/mixed-button-group.ts
+++ b/src/app/button-group/angular/mixed-buttons/mixed-button-group.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/angular/move-all-in-menu/move-all-in-menu.ts
+++ b/src/app/button-group/angular/move-all-in-menu/move-all-in-menu.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/angular/move-button-in-menu/move-button-in-menu.html
+++ b/src/app/button-group/angular/move-button-in-menu/move-button-in-menu.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/button-group/angular/move-button-in-menu/move-button-in-menu.ts
+++ b/src/app/button-group/angular/move-button-in-menu/move-button-in-menu.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/angular/move-multiple-buttons-in-menu/move-multiple-button-in-menu.html
+++ b/src/app/button-group/angular/move-multiple-buttons-in-menu/move-multiple-button-in-menu.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/button-group/angular/move-multiple-buttons-in-menu/move-multiple-button-in-menu.ts
+++ b/src/app/button-group/angular/move-multiple-buttons-in-menu/move-multiple-button-in-menu.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/angular/projection-update-test-1/projection-update-test-1.html
+++ b/src/app/button-group/angular/projection-update-test-1/projection-update-test-1.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/button-group/angular/projection-update-test-1/projection-update-test-1.ts
+++ b/src/app/button-group/angular/projection-update-test-1/projection-update-test-1.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/angular/projection-update-test-2/projection-update-test-2.html
+++ b/src/app/button-group/angular/projection-update-test-2/projection-update-test-2.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/button-group/angular/projection-update-test-2/projection-update-test-2.ts
+++ b/src/app/button-group/angular/projection-update-test-2/projection-update-test-2.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/angular/projection-update-test-3/projection-update-test-3.html
+++ b/src/app/button-group/angular/projection-update-test-3/projection-update-test-3.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/button-group/angular/projection-update-test-3/projection-update-test-3.ts
+++ b/src/app/button-group/angular/projection-update-test-3/projection-update-test-3.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/angular/projection-update-test-4/projection-update-test-4.html
+++ b/src/app/button-group/angular/projection-update-test-4/projection-update-test-4.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/button-group/angular/projection-update-test-4/projection-update-test-4.ts
+++ b/src/app/button-group/angular/projection-update-test-4/projection-update-test-4.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/angular/projection-update-test-5/projection-update-test-5.html
+++ b/src/app/button-group/angular/projection-update-test-5/projection-update-test-5.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/button-group/angular/projection-update-test-5/projection-update-test-5.ts
+++ b/src/app/button-group/angular/projection-update-test-5/projection-update-test-5.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/angular/projection-update-test-6/projection-update-test-6.html
+++ b/src/app/button-group/angular/projection-update-test-6/projection-update-test-6.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/button-group/angular/projection-update-test-6/projection-update-test-6.ts
+++ b/src/app/button-group/angular/projection-update-test-6/projection-update-test-6.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/button-group.demo.module.ts
+++ b/src/app/button-group/button-group.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/button-group.demo.routing.ts
+++ b/src/app/button-group/button-group.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/button-group.demo.scss
+++ b/src/app/button-group/button-group.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/button-group/button-group.demo.ts
+++ b/src/app/button-group/button-group.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/static/basic-structure/basic-structure.ts
+++ b/src/app/button-group/static/basic-structure/basic-structure.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/static/button-group-static.ts
+++ b/src/app/button-group/static/button-group-static.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/static/cards/button-group-cards.ts
+++ b/src/app/button-group/static/cards/button-group-cards.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/static/checkbox/button-group-checkboxes.ts
+++ b/src/app/button-group/static/checkbox/button-group-checkboxes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/static/icon-buttons/icon-button-group.ts
+++ b/src/app/button-group/static/icon-buttons/icon-button-group.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/static/icons-with-text/button-group-icon-text.ts
+++ b/src/app/button-group/static/icons-with-text/button-group-icon-text.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/static/icons/button-group-icons.ts
+++ b/src/app/button-group/static/icons/button-group-icons.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/static/menu-directions/menu-directions.ts
+++ b/src/app/button-group/static/menu-directions/menu-directions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/static/radio/button-group-radios.ts
+++ b/src/app/button-group/static/radio/button-group-radios.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/button-group/static/types/button-group-types.ts
+++ b/src/app/button-group/static/types/button-group-types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/buttons/button-sizes.html
+++ b/src/app/buttons/button-sizes.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/buttons/button-sizes.ts
+++ b/src/app/buttons/button-sizes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/buttons/button-states.html
+++ b/src/app/buttons/button-states.html
@@ -1,6 +1,6 @@
 
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/buttons/button-states.ts
+++ b/src/app/buttons/button-states.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/buttons/buttons-icons-sm.ts
+++ b/src/app/buttons/buttons-icons-sm.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/buttons/buttons-icons.ts
+++ b/src/app/buttons/buttons-icons.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/buttons/buttons-test.html
+++ b/src/app/buttons/buttons-test.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/buttons/buttons-test.ts
+++ b/src/app/buttons/buttons-test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/buttons/buttons.demo.module.ts
+++ b/src/app/buttons/buttons.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/buttons/buttons.demo.routing.ts
+++ b/src/app/buttons/buttons.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/buttons/buttons.demo.scss
+++ b/src/app/buttons/buttons.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/buttons/buttons.demo.ts
+++ b/src/app/buttons/buttons.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/buttons/icon-buttons.html
+++ b/src/app/buttons/icon-buttons.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/buttons/icon-buttons.ts
+++ b/src/app/buttons/icon-buttons.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/buttons/inverse-button.html
+++ b/src/app/buttons/inverse-button.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/buttons/inverse-button.ts
+++ b/src/app/buttons/inverse-button.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/buttons/primary-button.html
+++ b/src/app/buttons/primary-button.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/buttons/primary-button.ts
+++ b/src/app/buttons/primary-button.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/buttons/real-button.html
+++ b/src/app/buttons/real-button.html
@@ -1,6 +1,6 @@
 
     <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/buttons/real-button.ts
+++ b/src/app/buttons/real-button.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/buttons/secondary-button.html
+++ b/src/app/buttons/secondary-button.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/buttons/secondary-button.ts
+++ b/src/app/buttons/secondary-button.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/buttons/tertiary-button.html
+++ b/src/app/buttons/tertiary-button.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/buttons/tertiary-button.ts
+++ b/src/app/buttons/tertiary-button.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/buttons/toggles.html
+++ b/src/app/buttons/toggles.html
@@ -1,6 +1,6 @@
 
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/buttons/toggles.ts
+++ b/src/app/buttons/toggles.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/card/card-clickable.html
+++ b/src/app/card/card-clickable.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/card/card-clickable.ts
+++ b/src/app/card/card-clickable.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/card/card-dropdown.html
+++ b/src/app/card/card-dropdown.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/card/card-dropdown.ts
+++ b/src/app/card/card-dropdown.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/card/card-grid.html
+++ b/src/app/card/card-grid.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/card/card-grid.ts
+++ b/src/app/card/card-grid.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/card/card-images.html
+++ b/src/app/card/card-images.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/card/card-images.ts
+++ b/src/app/card/card-images.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/card/card-layout.html
+++ b/src/app/card/card-layout.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/card/card-layout.ts
+++ b/src/app/card/card-layout.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/card/card-list-group.html
+++ b/src/app/card/card-list-group.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/card/card-list-group.ts
+++ b/src/app/card/card-list-group.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/card/card-masonry.html
+++ b/src/app/card/card-masonry.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/card/card-masonry.ts
+++ b/src/app/card/card-masonry.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/card/card-media-block.html
+++ b/src/app/card/card-media-block.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/card/card-media-block.ts
+++ b/src/app/card/card-media-block.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/card/card-old.html
+++ b/src/app/card/card-old.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/card/card-old.ts
+++ b/src/app/card/card-old.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/card/card.demo.html
+++ b/src/app/card/card.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/card/card.demo.module.ts
+++ b/src/app/card/card.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/card/card.demo.routing.ts
+++ b/src/app/card/card.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/card/card.demo.scss
+++ b/src/app/card/card.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/card/card.demo.ts
+++ b/src/app/card/card.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/checkboxes/checkboxes.demo.html
+++ b/src/app/checkboxes/checkboxes.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/checkboxes/checkboxes.demo.module.ts
+++ b/src/app/checkboxes/checkboxes.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/checkboxes/checkboxes.demo.routing.ts
+++ b/src/app/checkboxes/checkboxes.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/checkboxes/checkboxes.demo.scss
+++ b/src/app/checkboxes/checkboxes.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/checkboxes/checkboxes.demo.ts
+++ b/src/app/checkboxes/checkboxes.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/checkboxes/data/server.ts
+++ b/src/app/checkboxes/data/server.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/checkboxes/data/status.ts
+++ b/src/app/checkboxes/data/status.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/checkboxes/data/values.ts
+++ b/src/app/checkboxes/data/values.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/code/code-highlight-imports.html
+++ b/src/app/code/code-highlight-imports.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/code/code-highlight-imports.ts
+++ b/src/app/code/code-highlight-imports.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/code/code-highlight-snippet.html
+++ b/src/app/code/code-highlight-snippet.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/code/code-highlight-snippet.ts
+++ b/src/app/code/code-highlight-snippet.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/code/code-highlight.demo.module.ts
+++ b/src/app/code/code-highlight.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/code/code-highlight.demo.routing.ts
+++ b/src/app/code/code-highlight.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/code/code-highlight.demo.scss
+++ b/src/app/code/code-highlight.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/code/code-highlight.demo.ts
+++ b/src/app/code/code-highlight.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/color/color-contrast.demo.html
+++ b/src/app/color/color-contrast.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/color/color-contrast.demo.scss
+++ b/src/app/color/color-contrast.demo.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @import "./color-shared.demo";
 

--- a/src/app/color/color-contrast.ts
+++ b/src/app/color/color-contrast.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/color/color-luminance.demo.html
+++ b/src/app/color/color-luminance.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/color/color-luminance.demo.scss
+++ b/src/app/color/color-luminance.demo.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @import "./color-shared.demo";
 

--- a/src/app/color/color-luminance.ts
+++ b/src/app/color/color-luminance.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/color/color-palette.demo.scss
+++ b/src/app/color/color-palette.demo.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @import "./color-shared.demo";
 

--- a/src/app/color/color-shared.demo.scss
+++ b/src/app/color/color-shared.demo.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @import "../_utils/code";
 

--- a/src/app/color/color.demo.ts
+++ b/src/app/color/color.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/datagrid.demo.scss
+++ b/src/app/datagrid/datagrid.demo.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @import "../_utils/code";
 

--- a/src/app/datagrid/expandable-rows/detail-wrapper.ts
+++ b/src/app/datagrid/expandable-rows/detail-wrapper.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/hide-show-columns/hide-show.ts
+++ b/src/app/datagrid/hide-show-columns/hide-show.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/kitchen-sink/kitchen-sink-data.ts
+++ b/src/app/datagrid/kitchen-sink/kitchen-sink-data.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/pagination-scrolling/pagination-scrolling.html
+++ b/src/app/datagrid/pagination-scrolling/pagination-scrolling.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/pagination-scrolling/pagination-scrolling.ts
+++ b/src/app/datagrid/pagination-scrolling/pagination-scrolling.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/test-cases-async/test-cases-async.html
+++ b/src/app/datagrid/test-cases-async/test-cases-async.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/test-cases-async/test-cases-async.ts
+++ b/src/app/datagrid/test-cases-async/test-cases-async.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/datagrid/test-cases/test-cases.html
+++ b/src/app/datagrid/test-cases/test-cases.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/datagrid/test-cases/test-cases.ts
+++ b/src/app/datagrid/test-cases/test-cases.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/dropdown/dropdown-angular-close-item-false.demo.html
+++ b/src/app/dropdown/dropdown-angular-close-item-false.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/dropdown/dropdown-angular-close-item-false.ts
+++ b/src/app/dropdown/dropdown-angular-close-item-false.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/dropdown/dropdown-angular-nested.demo.html
+++ b/src/app/dropdown/dropdown-angular-nested.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/dropdown/dropdown-angular-nested.ts
+++ b/src/app/dropdown/dropdown-angular-nested.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/dropdown/dropdown-angular-positioning.demo.html
+++ b/src/app/dropdown/dropdown-angular-positioning.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/dropdown/dropdown-angular-positioning.ts
+++ b/src/app/dropdown/dropdown-angular-positioning.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/dropdown/dropdown-header.ts
+++ b/src/app/dropdown/dropdown-header.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/dropdown/dropdown-static-buttonlink-toggle.demo.html
+++ b/src/app/dropdown/dropdown-static-buttonlink-toggle.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/dropdown/dropdown-static-buttonlink-toggle.ts
+++ b/src/app/dropdown/dropdown-static-buttonlink-toggle.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/dropdown/dropdown-static-default.demo.html
+++ b/src/app/dropdown/dropdown-static-default.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/dropdown/dropdown-static-default.ts
+++ b/src/app/dropdown/dropdown-static-default.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/dropdown/dropdown-static-fontawesome-toggle.demo.html
+++ b/src/app/dropdown/dropdown-static-fontawesome-toggle.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/dropdown/dropdown-static-fontawesome-toggle.ts
+++ b/src/app/dropdown/dropdown-static-fontawesome-toggle.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/dropdown/dropdown-static-icon-toggle.demo.html
+++ b/src/app/dropdown/dropdown-static-icon-toggle.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/dropdown/dropdown-static-icon-toggle.ts
+++ b/src/app/dropdown/dropdown-static-icon-toggle.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/dropdown/dropdown-static-positioning.demo.html
+++ b/src/app/dropdown/dropdown-static-positioning.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/dropdown/dropdown-static-positioning.ts
+++ b/src/app/dropdown/dropdown-static-positioning.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/dropdown/dropdown.demo.module.ts
+++ b/src/app/dropdown/dropdown.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/dropdown/dropdown.demo.routing.ts
+++ b/src/app/dropdown/dropdown.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/dropdown/dropdown.demo.scss
+++ b/src/app/dropdown/dropdown.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/dropdown/dropdown.demo.ts
+++ b/src/app/dropdown/dropdown.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/forms/compact-forms/form-compact.demo.html
+++ b/src/app/forms/compact-forms/form-compact.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/forms/compact-forms/form-compact.demo.scss
+++ b/src/app/forms/compact-forms/form-compact.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/forms/compact-forms/form-compact.ts
+++ b/src/app/forms/compact-forms/form-compact.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/forms/form-fields/form-fields.demo.html
+++ b/src/app/forms/form-fields/form-fields.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/forms/form-fields/form-fields.demo.scss
+++ b/src/app/forms/form-fields/form-fields.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/forms/form-fields/form-fields.ts
+++ b/src/app/forms/form-fields/form-fields.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/forms/form-grid-validation/form-grid-validation.demo.html
+++ b/src/app/forms/form-grid-validation/form-grid-validation.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/forms/form-grid-validation/form-grid-validation.demo.scss
+++ b/src/app/forms/form-grid-validation/form-grid-validation.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/forms/form-grid-validation/form-grid-validation.ts
+++ b/src/app/forms/form-grid-validation/form-grid-validation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/forms/form-grid/form-grid.demo.html
+++ b/src/app/forms/form-grid/form-grid.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/forms/form-grid/form-grid.demo.scss
+++ b/src/app/forms/form-grid/form-grid.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/forms/form-grid/form-grid.ts
+++ b/src/app/forms/form-grid/form-grid.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/forms/form-test/form-test.demo.html
+++ b/src/app/forms/form-test/form-test.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/forms/form-test/form-test.demo.scss
+++ b/src/app/forms/form-test/form-test.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/forms/form-test/form-test.ts
+++ b/src/app/forms/form-test/form-test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/forms/form-validation-static/form-validation.demo.html
+++ b/src/app/forms/form-validation-static/form-validation.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/forms/form-validation-static/form-validation.demo.scss
+++ b/src/app/forms/form-validation-static/form-validation.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/forms/form-validation-static/form-validation.ts
+++ b/src/app/forms/form-validation-static/form-validation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/forms/forms.demo.module.ts
+++ b/src/app/forms/forms.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/forms/forms.demo.routing.ts
+++ b/src/app/forms/forms.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/forms/forms.demo.ts
+++ b/src/app/forms/forms.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/forms/model/employee.model.ts
+++ b/src/app/forms/model/employee.model.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/forms/reactive-forms/examples.ts
+++ b/src/app/forms/reactive-forms/examples.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/forms/reactive-forms/reactive-forms.html
+++ b/src/app/forms/reactive-forms/reactive-forms.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/forms/reactive-forms/reactive-forms.scss
+++ b/src/app/forms/reactive-forms/reactive-forms.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/forms/reactive-forms/reactive-forms.ts
+++ b/src/app/forms/reactive-forms/reactive-forms.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/forms/template-driven-forms/examples.ts
+++ b/src/app/forms/template-driven-forms/examples.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/forms/template-driven-forms/template-driven-forms.html
+++ b/src/app/forms/template-driven-forms/template-driven-forms.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/forms/template-driven-forms/template-driven-forms.scss
+++ b/src/app/forms/template-driven-forms/template-driven-forms.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/forms/template-driven-forms/template-driven-forms.ts
+++ b/src/app/forms/template-driven-forms/template-driven-forms.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/forms/utils/example.ts
+++ b/src/app/forms/utils/example.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/grid/grid-auto-layout-1.html
+++ b/src/app/grid/grid-auto-layout-1.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/grid/grid-auto-layout-1.ts
+++ b/src/app/grid/grid-auto-layout-1.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/grid/grid-auto-layout-2.html
+++ b/src/app/grid/grid-auto-layout-2.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/grid/grid-auto-layout-2.ts
+++ b/src/app/grid/grid-auto-layout-2.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/grid/grid-column-offsetting.html
+++ b/src/app/grid/grid-column-offsetting.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/grid/grid-column-offsetting.ts
+++ b/src/app/grid/grid-column-offsetting.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/grid/grid-column-pull.html
+++ b/src/app/grid/grid-column-pull.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/grid/grid-column-pull.ts
+++ b/src/app/grid/grid-column-pull.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/grid/grid-column-push.html
+++ b/src/app/grid/grid-column-push.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/grid/grid-column-push.ts
+++ b/src/app/grid/grid-column-push.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/grid/grid-column-stacking.html
+++ b/src/app/grid/grid-column-stacking.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/grid/grid-column-stacking.ts
+++ b/src/app/grid/grid-column-stacking.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/grid/grid-columns.html
+++ b/src/app/grid/grid-columns.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/grid/grid-columns.ts
+++ b/src/app/grid/grid-columns.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/grid/grid-items-horizontal-alignment.html
+++ b/src/app/grid/grid-items-horizontal-alignment.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/grid/grid-items-horizontal-alignment.ts
+++ b/src/app/grid/grid-items-horizontal-alignment.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/grid/grid-items-individual-vertical-alignment.html
+++ b/src/app/grid/grid-items-individual-vertical-alignment.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/grid/grid-items-individual-vertical-alignment.ts
+++ b/src/app/grid/grid-items-individual-vertical-alignment.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/grid/grid-items-vertical-alignment.html
+++ b/src/app/grid/grid-items-vertical-alignment.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/grid/grid-items-vertical-alignment.ts
+++ b/src/app/grid/grid-items-vertical-alignment.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/grid/grid.demo.module.ts
+++ b/src/app/grid/grid.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/grid/grid.demo.routing.ts
+++ b/src/app/grid/grid.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/grid/grid.demo.scss
+++ b/src/app/grid/grid.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/grid/grid.demo.ts
+++ b/src/app/grid/grid.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/iconography/icon-colors.demo.html
+++ b/src/app/iconography/icon-colors.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/iconography/icon-colors.ts
+++ b/src/app/iconography/icon-colors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/iconography/icon-inverse-color.demo.html
+++ b/src/app/iconography/icon-inverse-color.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/iconography/icon-inverse-color.ts
+++ b/src/app/iconography/icon-inverse-color.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/iconography/icon-orientation.demo.html
+++ b/src/app/iconography/icon-orientation.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/iconography/icon-orientation.ts
+++ b/src/app/iconography/icon-orientation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/iconography/icon-selection.ts
+++ b/src/app/iconography/icon-selection.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/iconography/icon-size.demo.html
+++ b/src/app/iconography/icon-size.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/iconography/icon-size.ts
+++ b/src/app/iconography/icon-size.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/iconography/icon-variants.demo.html
+++ b/src/app/iconography/icon-variants.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/iconography/icon-variants.ts
+++ b/src/app/iconography/icon-variants.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/iconography/iconography.demo.html
+++ b/src/app/iconography/iconography.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/iconography/iconography.demo.module.ts
+++ b/src/app/iconography/iconography.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/iconography/iconography.demo.routing.ts
+++ b/src/app/iconography/iconography.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/iconography/iconography.demo.scss
+++ b/src/app/iconography/iconography.demo.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 @import "../_utils/code";
 
 

--- a/src/app/iconography/iconography.demo.ts
+++ b/src/app/iconography/iconography.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/iconography/icons-view-box-test.demo.ts
+++ b/src/app/iconography/icons-view-box-test.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/images/images.demo.html
+++ b/src/app/images/images.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/images/images.demo.module.ts
+++ b/src/app/images/images.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/images/images.demo.routing.ts
+++ b/src/app/images/images.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/images/images.demo.scss
+++ b/src/app/images/images.demo.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @import "../_utils/code";
 

--- a/src/app/images/images.demo.ts
+++ b/src/app/images/images.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/index.html
+++ b/src/app/index.html
@@ -1,0 +1,6 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+

--- a/src/app/input-fields/input-fields.demo.html
+++ b/src/app/input-fields/input-fields.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/input-fields/input-fields.demo.module.ts
+++ b/src/app/input-fields/input-fields.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/input-fields/input-fields.demo.routing.ts
+++ b/src/app/input-fields/input-fields.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/input-fields/input-fields.demo.scss
+++ b/src/app/input-fields/input-fields.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/input-fields/input-fields.demo.ts
+++ b/src/app/input-fields/input-fields.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/labels/labels-clickable.demo.html
+++ b/src/app/labels/labels-clickable.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/labels/labels-clickable.ts
+++ b/src/app/labels/labels-clickable.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/labels/labels-color-options.demo.html
+++ b/src/app/labels/labels-color-options.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/labels/labels-color-options.ts
+++ b/src/app/labels/labels-color-options.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/labels/labels-default.demo.html
+++ b/src/app/labels/labels-default.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/labels/labels-default.ts
+++ b/src/app/labels/labels-default.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/labels/labels-status.demo.html
+++ b/src/app/labels/labels-status.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/labels/labels-status.ts
+++ b/src/app/labels/labels-status.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/labels/labels-with-badges.demo.html
+++ b/src/app/labels/labels-with-badges.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/labels/labels-with-badges.ts
+++ b/src/app/labels/labels-with-badges.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/labels/labels.demo.html
+++ b/src/app/labels/labels.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/labels/labels.demo.module.ts
+++ b/src/app/labels/labels.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/labels/labels.demo.routing.ts
+++ b/src/app/labels/labels.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/labels/labels.demo.scss
+++ b/src/app/labels/labels.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/labels/labels.demo.ts
+++ b/src/app/labels/labels.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/landing.component.ts
+++ b/src/app/landing.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/landing.html
+++ b/src/app/landing.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/layout/layout-additional-sections.html
+++ b/src/app/layout/layout-additional-sections.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/layout/layout-additional-sections.ts
+++ b/src/app/layout/layout-additional-sections.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/layout/layout-all.html
+++ b/src/app/layout/layout-all.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/layout/layout-all.ts
+++ b/src/app/layout/layout-all.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/layout/layout-no-sidenav.html
+++ b/src/app/layout/layout-no-sidenav.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/layout/layout-no-sidenav.ts
+++ b/src/app/layout/layout-no-sidenav.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/layout/layout-no-subnav.html
+++ b/src/app/layout/layout-no-subnav.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/layout/layout-no-subnav.ts
+++ b/src/app/layout/layout-no-subnav.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/layout/layout-only-header.html
+++ b/src/app/layout/layout-only-header.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/layout/layout-only-header.ts
+++ b/src/app/layout/layout-only-header.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/layout/layout-sidenav-primary.html
+++ b/src/app/layout/layout-sidenav-primary.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/layout/layout-sidenav-primary.ts
+++ b/src/app/layout/layout-sidenav-primary.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/layout/layout-subnav-primary.html
+++ b/src/app/layout/layout-subnav-primary.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/layout/layout-subnav-primary.ts
+++ b/src/app/layout/layout-subnav-primary.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/layout/layout.demo.module.ts
+++ b/src/app/layout/layout.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/layout/layout.demo.routing.ts
+++ b/src/app/layout/layout.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/layout/layout.demo.scss
+++ b/src/app/layout/layout.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/layout/layout.demo.ts
+++ b/src/app/layout/layout.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/lists/lists-compact.html
+++ b/src/app/lists/lists-compact.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/lists/lists-compact.ts
+++ b/src/app/lists/lists-compact.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/lists/lists-in-cards.html
+++ b/src/app/lists/lists-in-cards.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/lists/lists-in-cards.ts
+++ b/src/app/lists/lists-in-cards.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/lists/lists-mixed.html
+++ b/src/app/lists/lists-mixed.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/lists/lists-mixed.ts
+++ b/src/app/lists/lists-mixed.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/lists/lists-ol.html
+++ b/src/app/lists/lists-ol.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/lists/lists-ol.ts
+++ b/src/app/lists/lists-ol.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/lists/lists-ul.html
+++ b/src/app/lists/lists-ul.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/lists/lists-ul.ts
+++ b/src/app/lists/lists-ul.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/lists/lists-unstyled.html
+++ b/src/app/lists/lists-unstyled.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/lists/lists-unstyled.ts
+++ b/src/app/lists/lists-unstyled.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/lists/lists.demo.module.ts
+++ b/src/app/lists/lists.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/lists/lists.demo.routing.ts
+++ b/src/app/lists/lists.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/lists/lists.demo.scss
+++ b/src/app/lists/lists.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/lists/lists.demo.ts
+++ b/src/app/lists/lists.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/lists/old-lists-in-cards.html
+++ b/src/app/lists/old-lists-in-cards.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/lists/old-lists-in-cards.ts
+++ b/src/app/lists/old-lists-in-cards.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/login/login.demo.html
+++ b/src/app/login/login.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/login/login.demo.module.ts
+++ b/src/app/login/login.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/login/login.demo.routing.ts
+++ b/src/app/login/login.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/login/login.demo.scss
+++ b/src/app/login/login.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/login/login.demo.ts
+++ b/src/app/login/login.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/modal/modal-angular-not-closable.demo.html
+++ b/src/app/modal/modal-angular-not-closable.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/modal/modal-angular-not-closable.ts
+++ b/src/app/modal/modal-angular-not-closable.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/modal/modal-angular-show.demo.html
+++ b/src/app/modal/modal-angular-show.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/modal/modal-angular-show.ts
+++ b/src/app/modal/modal-angular-show.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/modal/modal-angular-size.demo.html
+++ b/src/app/modal/modal-angular-size.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/modal/modal-angular-size.ts
+++ b/src/app/modal/modal-angular-size.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/modal/modal-angular-static-backdrop.demo.html
+++ b/src/app/modal/modal-angular-static-backdrop.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/modal/modal-angular-static-backdrop.ts
+++ b/src/app/modal/modal-angular-static-backdrop.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/modal/modal-animation.demo.html
+++ b/src/app/modal/modal-animation.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/modal/modal-animation.ts
+++ b/src/app/modal/modal-animation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/modal/modal-backdrop.demo.html
+++ b/src/app/modal/modal-backdrop.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/modal/modal-backdrop.ts
+++ b/src/app/modal/modal-backdrop.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/modal/modal-form.demo.ts
+++ b/src/app/modal/modal-form.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/modal/modal-sizes.demo.html
+++ b/src/app/modal/modal-sizes.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/modal/modal-sizes.ts
+++ b/src/app/modal/modal-sizes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/modal/modal-static-old.demo.html
+++ b/src/app/modal/modal-static-old.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/modal/modal-static-old.ts
+++ b/src/app/modal/modal-static-old.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/modal/modal-static.demo.html
+++ b/src/app/modal/modal-static.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/modal/modal-static.ts
+++ b/src/app/modal/modal-static.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/modal/modal.demo.module.ts
+++ b/src/app/modal/modal.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/modal/modal.demo.routing.ts
+++ b/src/app/modal/modal.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/modal/modal.demo.scss
+++ b/src/app/modal/modal.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/modal/modal.demo.ts
+++ b/src/app/modal/modal.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/nav/header-colors.demo.html
+++ b/src/app/nav/header-colors.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/nav/header-colors.ts
+++ b/src/app/nav/header-colors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/nav/header-types-old.demo.html
+++ b/src/app/nav/header-types-old.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/nav/header-types-old.ts
+++ b/src/app/nav/header-types-old.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/nav/header-types.demo.html
+++ b/src/app/nav/header-types.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/nav/header-types.ts
+++ b/src/app/nav/header-types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/nav/headers.demo.scss
+++ b/src/app/nav/headers.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/nav/headers.ts
+++ b/src/app/nav/headers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/nav/nav.demo.module.ts
+++ b/src/app/nav/nav.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/nav/nav.demo.routing.ts
+++ b/src/app/nav/nav.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/nav/nav.demo.ts
+++ b/src/app/nav/nav.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/nav/navs.demo.html
+++ b/src/app/nav/navs.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/nav/navs.demo.scss
+++ b/src/app/nav/navs.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/nav/navs.ts
+++ b/src/app/nav/navs.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/nav/responsive-nav1.ts
+++ b/src/app/nav/responsive-nav1.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/nav/responsive-nav2.ts
+++ b/src/app/nav/responsive-nav2.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/nav/sidenav.demo.html
+++ b/src/app/nav/sidenav.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/nav/sidenav.demo.scss
+++ b/src/app/nav/sidenav.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/nav/sidenav.ts
+++ b/src/app/nav/sidenav.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/nav/sub-nav.demo.html
+++ b/src/app/nav/sub-nav.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/nav/sub-nav.demo.scss
+++ b/src/app/nav/sub-nav.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/nav/sub-nav.ts
+++ b/src/app/nav/sub-nav.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/progress-bars/old-progress-bar-cards.html
+++ b/src/app/progress-bars/old-progress-bar-cards.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/progress-bars/old-progress-bar-cards.ts
+++ b/src/app/progress-bars/old-progress-bar-cards.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/progress-bars/progbar-example.ts
+++ b/src/app/progress-bars/progbar-example.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/progress-bars/progress-bar-animations.html
+++ b/src/app/progress-bars/progress-bar-animations.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/progress-bars/progress-bar-animations.ts
+++ b/src/app/progress-bars/progress-bar-animations.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/progress-bars/progress-bar-cards.html
+++ b/src/app/progress-bars/progress-bar-cards.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/progress-bars/progress-bar-cards.ts
+++ b/src/app/progress-bars/progress-bar-cards.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/progress-bars/progress-bar-colors.html
+++ b/src/app/progress-bars/progress-bar-colors.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/progress-bars/progress-bar-colors.ts
+++ b/src/app/progress-bars/progress-bar-colors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/progress-bars/progress-bar-examples.html
+++ b/src/app/progress-bars/progress-bar-examples.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/progress-bars/progress-bar-examples.ts
+++ b/src/app/progress-bars/progress-bar-examples.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/progress-bars/progress-bar-inline-cards.html
+++ b/src/app/progress-bars/progress-bar-inline-cards.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/progress-bars/progress-bar-inline-cards.ts
+++ b/src/app/progress-bars/progress-bar-inline-cards.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/progress-bars/progress-bar-inline.html
+++ b/src/app/progress-bars/progress-bar-inline.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/progress-bars/progress-bar-inline.ts
+++ b/src/app/progress-bars/progress-bar-inline.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/progress-bars/progress-bar-loop.html
+++ b/src/app/progress-bars/progress-bar-loop.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/progress-bars/progress-bar-loop.ts
+++ b/src/app/progress-bars/progress-bar-loop.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/progress-bars/progress-bar-sidenav.html
+++ b/src/app/progress-bars/progress-bar-sidenav.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/progress-bars/progress-bar-sidenav.ts
+++ b/src/app/progress-bars/progress-bar-sidenav.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/progress-bars/progress-bar-static-cards.html
+++ b/src/app/progress-bars/progress-bar-static-cards.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/progress-bars/progress-bar-static-cards.ts
+++ b/src/app/progress-bars/progress-bar-static-cards.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/progress-bars/progress-bar-static.html
+++ b/src/app/progress-bars/progress-bar-static.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/progress-bars/progress-bar-static.ts
+++ b/src/app/progress-bars/progress-bar-static.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/progress-bars/progress-bars.demo.module.ts
+++ b/src/app/progress-bars/progress-bars.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/progress-bars/progress-bars.demo.routing.ts
+++ b/src/app/progress-bars/progress-bars.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/progress-bars/progress-bars.demo.scss
+++ b/src/app/progress-bars/progress-bars.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/progress-bars/progress-bars.demo.ts
+++ b/src/app/progress-bars/progress-bars.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/radios/radios.demo.html
+++ b/src/app/radios/radios.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/radios/radios.demo.module.ts
+++ b/src/app/radios/radios.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/radios/radios.demo.routing.ts
+++ b/src/app/radios/radios.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/radios/radios.demo.scss
+++ b/src/app/radios/radios.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/radios/radios.demo.ts
+++ b/src/app/radios/radios.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/selects/selects.demo.html
+++ b/src/app/selects/selects.demo.html
@@ -1,6 +1,6 @@
 
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/selects/selects.demo.module.ts
+++ b/src/app/selects/selects.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/selects/selects.demo.routing.ts
+++ b/src/app/selects/selects.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/selects/selects.demo.scss
+++ b/src/app/selects/selects.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/selects/selects.demo.ts
+++ b/src/app/selects/selects.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/signpost/signpost.demo.module.ts
+++ b/src/app/signpost/signpost.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/signpost/signpost.demo.scss
+++ b/src/app/signpost/signpost.demo.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 .signpost-demo {
     display: flex;

--- a/src/app/spinners/spinner-sizes.html
+++ b/src/app/spinners/spinner-sizes.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/spinners/spinner-sizes.ts
+++ b/src/app/spinners/spinner-sizes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/spinners/spinner-types.html
+++ b/src/app/spinners/spinner-types.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/spinners/spinner-types.ts
+++ b/src/app/spinners/spinner-types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/spinners/spinner.demo.scss
+++ b/src/app/spinners/spinner.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/spinners/spinner.demo.ts
+++ b/src/app/spinners/spinner.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/spinners/spinners.demo.module.ts
+++ b/src/app/spinners/spinners.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/spinners/spinners.demo.routing.ts
+++ b/src/app/spinners/spinners.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/stack-view/stack-view-angular-basic.html
+++ b/src/app/stack-view/stack-view-angular-basic.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/stack-view/stack-view-angular-basic.ts
+++ b/src/app/stack-view/stack-view-angular-basic.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/stack-view/stack-view-angular-lazyload.html
+++ b/src/app/stack-view/stack-view-angular-lazyload.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/stack-view/stack-view-angular-lazyload.ts
+++ b/src/app/stack-view/stack-view-angular-lazyload.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/stack-view/stack-view-angular-modal-edit.html
+++ b/src/app/stack-view/stack-view-angular-modal-edit.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/stack-view/stack-view-angular-modal-edit.ts
+++ b/src/app/stack-view/stack-view-angular-modal-edit.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/stack-view/stack-view-ng-demo.ts
+++ b/src/app/stack-view/stack-view-ng-demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/stack-view/stack-view-static.html
+++ b/src/app/stack-view/stack-view-static.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/stack-view/stack-view-static.ts
+++ b/src/app/stack-view/stack-view-static.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/stack-view/stack-view.demo.module.ts
+++ b/src/app/stack-view/stack-view.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/stack-view/stack-view.demo.routing.ts
+++ b/src/app/stack-view/stack-view.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/stack-view/stack-view.demo.scss
+++ b/src/app/stack-view/stack-view.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/stack-view/stack-view.demo.ts
+++ b/src/app/stack-view/stack-view.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tables/tables-basic.html
+++ b/src/app/tables/tables-basic.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tables/tables-basic.ts
+++ b/src/app/tables/tables-basic.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tables/tables-compact-noborder.html
+++ b/src/app/tables/tables-compact-noborder.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tables/tables-compact-noborder.ts
+++ b/src/app/tables/tables-compact-noborder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tables/tables-compact.html
+++ b/src/app/tables/tables-compact.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tables/tables-compact.ts
+++ b/src/app/tables/tables-compact.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tables/tables-leftcell.html
+++ b/src/app/tables/tables-leftcell.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tables/tables-leftcell.ts
+++ b/src/app/tables/tables-leftcell.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tables/tables-multiline.html
+++ b/src/app/tables/tables-multiline.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tables/tables-multiline.ts
+++ b/src/app/tables/tables-multiline.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tables/tables-noborder.html
+++ b/src/app/tables/tables-noborder.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tables/tables-noborder.ts
+++ b/src/app/tables/tables-noborder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tables/tables-vertical-noborder-compact.html
+++ b/src/app/tables/tables-vertical-noborder-compact.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tables/tables-vertical-noborder-compact.ts
+++ b/src/app/tables/tables-vertical-noborder-compact.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tables/tables-vertical.html
+++ b/src/app/tables/tables-vertical.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tables/tables-vertical.ts
+++ b/src/app/tables/tables-vertical.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tables/tables-width.html
+++ b/src/app/tables/tables-width.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tables/tables-width.ts
+++ b/src/app/tables/tables-width.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tables/tables.demo.module.ts
+++ b/src/app/tables/tables.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tables/tables.demo.routing.ts
+++ b/src/app/tables/tables.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tables/tables.demo.scss
+++ b/src/app/tables/tables.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/tables/tables.demo.ts
+++ b/src/app/tables/tables.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tabs/tabs-angular.demo.html
+++ b/src/app/tabs/tabs-angular.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tabs/tabs-angular.ts
+++ b/src/app/tabs/tabs-angular.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tabs/tabs-static.demo.html
+++ b/src/app/tabs/tabs-static.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tabs/tabs-static.ts
+++ b/src/app/tabs/tabs-static.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tabs/tabs.demo.html
+++ b/src/app/tabs/tabs.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tabs/tabs.demo.module.ts
+++ b/src/app/tabs/tabs.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tabs/tabs.demo.routing.ts
+++ b/src/app/tabs/tabs.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tabs/tabs.demo.scss
+++ b/src/app/tabs/tabs.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/tabs/tabs.demo.ts
+++ b/src/app/tabs/tabs.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/toggles/toggles.demo.html
+++ b/src/app/toggles/toggles.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/toggles/toggles.demo.module.ts
+++ b/src/app/toggles/toggles.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/toggles/toggles.demo.routing.ts
+++ b/src/app/toggles/toggles.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/toggles/toggles.demo.scss
+++ b/src/app/toggles/toggles.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/toggles/toggles.demo.ts
+++ b/src/app/toggles/toggles.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tooltips/tooltips-angular.ts
+++ b/src/app/tooltips/tooltips-angular.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tooltips/tooltips-buttons.html
+++ b/src/app/tooltips/tooltips-buttons.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tooltips/tooltips-buttons.ts
+++ b/src/app/tooltips/tooltips-buttons.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tooltips/tooltips-directions.ts
+++ b/src/app/tooltips/tooltips-directions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tooltips/tooltips-icons.ts
+++ b/src/app/tooltips/tooltips-icons.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tooltips/tooltips-sizes.ts
+++ b/src/app/tooltips/tooltips-sizes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tooltips/tooltips-text.html
+++ b/src/app/tooltips/tooltips-text.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tooltips/tooltips-text.ts
+++ b/src/app/tooltips/tooltips-text.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tooltips/tooltips.demo.module.ts
+++ b/src/app/tooltips/tooltips.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tooltips/tooltips.demo.routing.ts
+++ b/src/app/tooltips/tooltips.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tooltips/tooltips.demo.scss
+++ b/src/app/tooltips/tooltips.demo.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @import "../_utils/code";
 @import "../../clr-angular/image/icons.clarity";

--- a/src/app/tooltips/tooltips.demo.ts
+++ b/src/app/tooltips/tooltips.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tree-view/basic-selection-tree/basic-selection-tree.html
+++ b/src/app/tree-view/basic-selection-tree/basic-selection-tree.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tree-view/basic-selection-tree/basic-selection-tree.ts
+++ b/src/app/tree-view/basic-selection-tree/basic-selection-tree.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tree-view/basic-tree-node-expanded/tree-node-basic-expanded.html
+++ b/src/app/tree-view/basic-tree-node-expanded/tree-node-basic-expanded.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tree-view/basic-tree-node-expanded/tree-node-basic-expanded.ts
+++ b/src/app/tree-view/basic-tree-node-expanded/tree-node-basic-expanded.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tree-view/basic-tree-node/tree-node-basic.html
+++ b/src/app/tree-view/basic-tree-node/tree-node-basic.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tree-view/basic-tree-node/tree-node-basic.ts
+++ b/src/app/tree-view/basic-tree-node/tree-node-basic.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tree-view/child-node-selected/child-node-selected.html
+++ b/src/app/tree-view/child-node-selected/child-node-selected.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tree-view/child-node-selected/child-node-selected.ts
+++ b/src/app/tree-view/child-node-selected/child-node-selected.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tree-view/intedeterminate-node/indeterminate-node.html
+++ b/src/app/tree-view/intedeterminate-node/indeterminate-node.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tree-view/intedeterminate-node/indeterminate-node.ts
+++ b/src/app/tree-view/intedeterminate-node/indeterminate-node.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tree-view/label-change-on-expand/label-change-on-expand.html
+++ b/src/app/tree-view/label-change-on-expand/label-change-on-expand.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tree-view/label-change-on-expand/label-change-on-expand.ts
+++ b/src/app/tree-view/label-change-on-expand/label-change-on-expand.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tree-view/lazy-loading-tree-node/lazy-loading-tree-node.html
+++ b/src/app/tree-view/lazy-loading-tree-node/lazy-loading-tree-node.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tree-view/lazy-loading-tree-node/lazy-loading-tree-node.ts
+++ b/src/app/tree-view/lazy-loading-tree-node/lazy-loading-tree-node.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tree-view/recursive-lazy-load/recursive-lazy-load-structure.ts
+++ b/src/app/tree-view/recursive-lazy-load/recursive-lazy-load-structure.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tree-view/recursive-lazy-load/recursive-lazy-load.html
+++ b/src/app/tree-view/recursive-lazy-load/recursive-lazy-load.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tree-view/recursive-lazy-load/recursive-lazy-load.ts
+++ b/src/app/tree-view/recursive-lazy-load/recursive-lazy-load.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tree-view/recursive-selectable-tree/recursive-selectable-structure.ts
+++ b/src/app/tree-view/recursive-selectable-tree/recursive-selectable-structure.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tree-view/recursive-selectable-tree/recursive-selectable-tree.html
+++ b/src/app/tree-view/recursive-selectable-tree/recursive-selectable-tree.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tree-view/recursive-selectable-tree/recursive-selectable-tree.ts
+++ b/src/app/tree-view/recursive-selectable-tree/recursive-selectable-tree.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tree-view/recursive-tree/recursive-structure.ts
+++ b/src/app/tree-view/recursive-tree/recursive-structure.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tree-view/recursive-tree/recursive-tree.html
+++ b/src/app/tree-view/recursive-tree/recursive-tree.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tree-view/recursive-tree/recursive-tree.ts
+++ b/src/app/tree-view/recursive-tree/recursive-tree.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tree-view/tree-node-routing/tree-node-routing-abbey-road.ts
+++ b/src/app/tree-view/tree-node-routing/tree-node-routing-abbey-road.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tree-view/tree-node-routing/tree-node-routing-revolver.ts
+++ b/src/app/tree-view/tree-node-routing/tree-node-routing-revolver.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tree-view/tree-node-routing/tree-node-routing-rubber-soul.ts
+++ b/src/app/tree-view/tree-node-routing/tree-node-routing-rubber-soul.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tree-view/tree-node-routing/tree-node-routing.html
+++ b/src/app/tree-view/tree-node-routing/tree-node-routing.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tree-view/tree-node-routing/tree-node-routing.ts
+++ b/src/app/tree-view/tree-node-routing/tree-node-routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tree-view/tree-view-dynamic/tree-view-dynamic-test.html
+++ b/src/app/tree-view/tree-view-dynamic/tree-view-dynamic-test.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tree-view/tree-view-dynamic/tree-view-dynamic-test.ts
+++ b/src/app/tree-view/tree-view-dynamic/tree-view-dynamic-test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tree-view/tree-view-dynamic/tree-view-dynamic.html
+++ b/src/app/tree-view/tree-view-dynamic/tree-view-dynamic.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tree-view/tree-view-dynamic/tree-view-dynamic.ts
+++ b/src/app/tree-view/tree-view-dynamic/tree-view-dynamic.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tree-view/tree-view.demo.module.ts
+++ b/src/app/tree-view/tree-view.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tree-view/tree-view.demo.routing.ts
+++ b/src/app/tree-view/tree-view.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tree-view/tree-view.demo.scss
+++ b/src/app/tree-view/tree-view.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/tree-view/tree-view.demo.ts
+++ b/src/app/tree-view/tree-view.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tree-view/trees-10k/tree-10k.demo.html
+++ b/src/app/tree-view/trees-10k/tree-10k.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/tree-view/trees-10k/tree-10k.demo.ts
+++ b/src/app/tree-view/trees-10k/tree-10k.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/tree-view/utils/example.ts
+++ b/src/app/tree-view/utils/example.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/typography/typography-font-char-test.ts
+++ b/src/app/typography/typography-font-char-test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/typography/typography-font-weight.html
+++ b/src/app/typography/typography-font-weight.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/typography/typography-font-weight.ts
+++ b/src/app/typography/typography-font-weight.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/typography/typography-headers.html
+++ b/src/app/typography/typography-headers.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/typography/typography-headers.ts
+++ b/src/app/typography/typography-headers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/typography/typography-links.html
+++ b/src/app/typography/typography-links.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/typography/typography-links.ts
+++ b/src/app/typography/typography-links.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/typography/typography-text.html
+++ b/src/app/typography/typography-text.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/app/typography/typography-text.ts
+++ b/src/app/typography/typography-text.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/typography/typography.demo.module.ts
+++ b/src/app/typography/typography.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/typography/typography.demo.routing.ts
+++ b/src/app/typography/typography.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/typography/typography.demo.scss
+++ b/src/app/typography/typography.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/app/typography/typography.demo.ts
+++ b/src/app/typography/typography.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/vertical-nav/vertical-nav.demo.scss
+++ b/src/app/vertical-nav/vertical-nav.demo.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @import "../_utils/code";
 

--- a/src/app/virtual-scroll/virtual-scroll.demo.routing.ts
+++ b/src/app/virtual-scroll/virtual-scroll.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/virtual-scroll/virtual-scroll.demo.scss
+++ b/src/app/virtual-scroll/virtual-scroll.demo.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 .container  {
     height: 120px;

--- a/src/app/wizard/wizard.demo.routing.ts
+++ b/src/app/wizard/wizard.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/app/wizard/wizard.demo.scss
+++ b/src/app/wizard/wizard.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/clr-angular/button/_buttons.clarity.scss
+++ b/src/clr-angular/button/_buttons.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @mixin populateButtonProperties($button-type: default, $button-global-map: $clr-global-button-properties-map) {
     $button-property-map: map-get($button-global-map, $button-type);

--- a/src/clr-angular/button/_toggles.clarity.scss
+++ b/src/clr-angular/button/_toggles.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
  @include exports('toggles.clarity') {
     //Remove the default checkbox appearance

--- a/src/clr-angular/button/_variables.button.scss
+++ b/src/clr-angular/button/_variables.button.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 
 // General

--- a/src/clr-angular/button/_variables.toggles.scss
+++ b/src/clr-angular/button/_variables.toggles.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Usage: ../button/_toggles.clarity.scss
 // Toggle

--- a/src/clr-angular/button/all.spec.ts
+++ b/src/clr-angular/button/all.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/button/button-group/_button-group.clarity.scss
+++ b/src/clr-angular/button/button-group/_button-group.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @include exports('button-group.clarity') {
 

--- a/src/clr-angular/button/button-group/button-group.spec.ts
+++ b/src/clr-angular/button/button-group/button-group.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/button/button-group/button-group.ts
+++ b/src/clr-angular/button/button-group/button-group.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/button/button-group/button.spec.ts
+++ b/src/clr-angular/button/button-group/button.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/button/button-group/button.ts
+++ b/src/clr-angular/button/button-group/button.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/button/providers/button-in-group.service.spec.ts
+++ b/src/clr-angular/button/providers/button-in-group.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/button/providers/button-in-group.service.ts
+++ b/src/clr-angular/button/providers/button-in-group.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/code/syntax-highlight/_code.clarity.scss
+++ b/src/clr-angular/code/syntax-highlight/_code.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @include exports('code.clarity') {
     //Styles for Clarity Code Snippets

--- a/src/clr-angular/code/syntax-highlight/syntax-highlight.spec.ts
+++ b/src/clr-angular/code/syntax-highlight/syntax-highlight.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/code/syntax-highlight/syntax-highlight.ts
+++ b/src/clr-angular/code/syntax-highlight/syntax-highlight.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/color/_color.clarity.scss
+++ b/src/clr-angular/color/_color.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @function clr-getColor($colorIndexOrBase: base, $colorType: grays) {
     $colorMap: _clr-lookupColorMap($colorType);

--- a/src/clr-angular/color/_variables.color.scss
+++ b/src/clr-angular/color/_variables.color.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Color usage (Needs to be declared before usage in the OG Clarity theme
 // Grays

--- a/src/clr-angular/color/utils/_colors.clarity.scss
+++ b/src/clr-angular/color/utils/_colors.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 $clr-white: #fff !default;
 $clr-black: #000 !default;

--- a/src/clr-angular/color/utils/_contrast-cache.clarity.scss
+++ b/src/clr-angular/color/utils/_contrast-cache.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // using cache for contrast lookup shaved 7 seconds off sass build. over 50% at this time.
 // using interpolation for cacheContrast keys increased build time almost 250%.

--- a/src/clr-angular/color/utils/_helpers.clarity.scss
+++ b/src/clr-angular/color/utils/_helpers.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/clr-angular/dark-theme.scss
+++ b/src/clr-angular/dark-theme.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  *

--- a/src/clr-angular/data/_tables.clarity.scss
+++ b/src/clr-angular/data/_tables.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Backgrounds
 $clr-table-bgcolor: $clr-white !default;

--- a/src/clr-angular/data/_variables.tables.scss
+++ b/src/clr-angular/data/_variables.tables.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Theme variables
 // Usage: ./data/_tables.clarity.scss

--- a/src/clr-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clr-angular/data/datagrid/_datagrid.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @include exports('datagrid.clarity') {
     @include basic-table(".datagrid", ".datagrid-head", ".datagrid-body",

--- a/src/clr-angular/data/datagrid/_variables.datagrid.scss
+++ b/src/clr-angular/data/datagrid/_variables.datagrid.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Usage: ../data/datagrid/_datagrid.clarity.scss
 $clr-datagrid-icon-size: 0.583333rem;

--- a/src/clr-angular/data/datagrid/datagrid-items-trackby.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-items-trackby.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/datagrid-items-trackby.ts
+++ b/src/clr-angular/data/datagrid/datagrid-items-trackby.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/stack-view/_stack-view.clarity.scss
+++ b/src/clr-angular/data/stack-view/_stack-view.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @include exports('stack-view.clarity') {
     .stack-header {

--- a/src/clr-angular/data/stack-view/_variables.stack-view.scss
+++ b/src/clr-angular/data/stack-view/_variables.stack-view.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Usage: ../stack-view/_stack-view.clarity.scss
 $clr-stack-view-border-color: $gray-light-midtone; // Border for stack view container

--- a/src/clr-angular/data/stack-view/all.spec.ts
+++ b/src/clr-angular/data/stack-view/all.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/stack-view/index.ts
+++ b/src/clr-angular/data/stack-view/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/stack-view/stack-block.spec.ts
+++ b/src/clr-angular/data/stack-view/stack-block.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/stack-view/stack-block.ts
+++ b/src/clr-angular/data/stack-view/stack-block.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/stack-view/stack-control.ts
+++ b/src/clr-angular/data/stack-view/stack-control.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/stack-view/stack-header.spec.ts
+++ b/src/clr-angular/data/stack-view/stack-header.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/stack-view/stack-header.ts
+++ b/src/clr-angular/data/stack-view/stack-header.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/stack-view/stack-input.ts
+++ b/src/clr-angular/data/stack-view/stack-input.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/stack-view/stack-select.ts
+++ b/src/clr-angular/data/stack-view/stack-select.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/stack-view/stack-view-custom-tags.ts
+++ b/src/clr-angular/data/stack-view/stack-view-custom-tags.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/stack-view/stack-view.spec.ts
+++ b/src/clr-angular/data/stack-view/stack-view.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/stack-view/stack-view.ts
+++ b/src/clr-angular/data/stack-view/stack-view.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/tree-view/_tree-view.clarity.scss
+++ b/src/clr-angular/data/tree-view/_tree-view.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @include exports('tree-view.clarity') {
     .clr-tree-node {

--- a/src/clr-angular/data/tree-view/_variables.tree-view.scss
+++ b/src/clr-angular/data/tree-view/_variables.tree-view.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Usage: ../data/tree-view/_tree-vioew.clarity.scss
 $clr-tree-border-radius: $clr-global-borderradius;

--- a/src/clr-angular/emphasis/_labels.clarity.scss
+++ b/src/clr-angular/emphasis/_labels.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // TODO: Split badges and labels into separate files.
 

--- a/src/clr-angular/emphasis/_variables.badge.scss
+++ b/src/clr-angular/emphasis/_variables.badge.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Usage:
 // - ./_labels.clarity.scss

--- a/src/clr-angular/emphasis/_variables.label.scss
+++ b/src/clr-angular/emphasis/_variables.label.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Usage: ./_labels.clarity.scss
 $clr-label-padding-top-bottom: 0.125rem !default;

--- a/src/clr-angular/emphasis/alert/_alert.clarity.scss
+++ b/src/clr-angular/emphasis/alert/_alert.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @mixin generateAlertType($alertType: "info") {
     $propMap: map-get($clr-alert-colors, $alertType);

--- a/src/clr-angular/emphasis/alert/_variables.alert.scss
+++ b/src/clr-angular/emphasis/alert/_variables.alert.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Alert font color
 // Usage: This file only

--- a/src/clr-angular/forms/_forms.clarity.scss
+++ b/src/clr-angular/forms/_forms.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 //Validation Tooltips Arrow Color
 // TODO: color should be a variable

--- a/src/clr-angular/forms/_inputs.clarity.scss
+++ b/src/clr-angular/forms/_inputs.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @include exports("inputs.clarity") {
     #{$styledInputs} {

--- a/src/clr-angular/forms/_radio.clarity.scss
+++ b/src/clr-angular/forms/_radio.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @include exports('radio.clarity') {
 

--- a/src/clr-angular/forms/_select.clarity.scss
+++ b/src/clr-angular/forms/_select.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @include exports("select.clarity") {
     .select {

--- a/src/clr-angular/forms/_variables.forms.scss
+++ b/src/clr-angular/forms/_variables.forms.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Usage: ../forms/_forms.clarity.scss
 $clr-form-text-color: $clr-black;

--- a/src/clr-angular/forms/_variables.inputs.scss
+++ b/src/clr-angular/forms/_variables.inputs.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Usage: ../forms/utils/_mixins.clarity.scss
 $clr-input-text-color: $clr-black;

--- a/src/clr-angular/forms/_variables.select.scss
+++ b/src/clr-angular/forms/_variables.select.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Usage: ../forms/_select.clarity.scss
 $clr-select-hover-background: rgba(221, 221, 221, 0.5);

--- a/src/clr-angular/forms/checkbox/_checkbox.clarity.scss
+++ b/src/clr-angular/forms/checkbox/_checkbox.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @include exports('checkbox.clarity') {
     .checkbox {

--- a/src/clr-angular/forms/checkbox/_variables.checkbox.scss
+++ b/src/clr-angular/forms/checkbox/_variables.checkbox.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Usage: ../forms/checkbox/_checkbox.clarity.scss
 $clr-checkbox-checkmark-color: $clr-white;

--- a/src/clr-angular/forms/checkbox/checkbox.module.ts
+++ b/src/clr-angular/forms/checkbox/checkbox.module.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/forms/checkbox/checkbox.spec.ts
+++ b/src/clr-angular/forms/checkbox/checkbox.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/forms/checkbox/checkbox.ts
+++ b/src/clr-angular/forms/checkbox/checkbox.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/forms/checkbox/index.ts
+++ b/src/clr-angular/forms/checkbox/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/forms/utils/_form-variables.clarity.scss
+++ b/src/clr-angular/forms/utils/_form-variables.clarity.scss
@@ -1,7 +1,5 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 

--- a/src/clr-angular/forms/utils/_mixins.clarity.scss
+++ b/src/clr-angular/forms/utils/_mixins.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/clr-angular/icon/icon.module.ts
+++ b/src/clr-angular/icon/icon.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/icon/icon.ts
+++ b/src/clr-angular/icon/icon.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/icon/index.ts
+++ b/src/clr-angular/icon/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/image/_icons.clarity.scss
+++ b/src/clr-angular/image/_icons.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 //Background SVG Images work only when the svg is url encoded.
 //Use this encoder http://meyerweb.com/eric/tools/dencoder/ to encode the SVG.

--- a/src/clr-angular/image/_images.clarity.scss
+++ b/src/clr-angular/image/_images.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @mixin icon-background-styles() {
     background-repeat: no-repeat;

--- a/src/clr-angular/layout/_card.clarity.scss
+++ b/src/clr-angular/layout/_card.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @include exports('card.clarity') {
 

--- a/src/clr-angular/layout/_grid.clarity.scss
+++ b/src/clr-angular/layout/_grid.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 .row {
     &.force-fit {

--- a/src/clr-angular/layout/_login.clarity.scss
+++ b/src/clr-angular/layout/_login.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @include exports('login.clarity') {
     .login-wrapper {

--- a/src/clr-angular/layout/_variables.card.scss
+++ b/src/clr-angular/layout/_variables.card.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Usages: This file
 $card-light: $gray-light;

--- a/src/clr-angular/layout/_variables.login.scss
+++ b/src/clr-angular/layout/_variables.login.scss
@@ -1,4 +1,4 @@
-/*!
+/**
  * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.

--- a/src/clr-angular/layout/main-container/_layout.clarity.scss
+++ b/src/clr-angular/layout/main-container/_layout.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @include exports('layout.clarity') {
 

--- a/src/clr-angular/layout/main-container/_variables.header.scss
+++ b/src/clr-angular/layout/main-container/_variables.header.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Usage: ../layout/main-containter/_layout.clarity.scss
 // Usage: ../layout/nav/_header.clarity.scss

--- a/src/clr-angular/layout/main-container/index.ts
+++ b/src/clr-angular/layout/main-container/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/main-container/main-container.spec.ts
+++ b/src/clr-angular/layout/main-container/main-container.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/main-container/main-container.ts
+++ b/src/clr-angular/layout/main-container/main-container.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/nav/_header.clarity.scss
+++ b/src/clr-angular/layout/nav/_header.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/clr-angular/layout/nav/_nav.clarity.scss
+++ b/src/clr-angular/layout/nav/_nav.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @include exports('nav.clarity') {
     .nav {

--- a/src/clr-angular/layout/nav/_responsive-nav.clarity.scss
+++ b/src/clr-angular/layout/nav/_responsive-nav.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @mixin sliding-nav-positioning($top: 0, $right: auto, $bottom: 0, $left: 0) {
     display: flex;

--- a/src/clr-angular/layout/nav/_sidenav.clarity.scss
+++ b/src/clr-angular/layout/nav/_sidenav.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 
 

--- a/src/clr-angular/layout/nav/_subnav.clarity.scss
+++ b/src/clr-angular/layout/nav/_subnav.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 
 @include exports('subnav.clarity') {

--- a/src/clr-angular/layout/nav/_variables.nav.scss
+++ b/src/clr-angular/layout/nav/_variables.nav.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Usage: ../utils/_reboot.scss
 // Link colors

--- a/src/clr-angular/layout/nav/_variables.responsive-nav.scss
+++ b/src/clr-angular/layout/nav/_variables.responsive-nav.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Usage: ../layout/nav/_responsive-nav.clarity.scss
 // Responsive Nav

--- a/src/clr-angular/layout/nav/_variables.sidenav.scss
+++ b/src/clr-angular/layout/nav/_variables.sidenav.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Usage: ../layout/nav/_sidenav.clarity.scss
 // Sidenav

--- a/src/clr-angular/layout/nav/_variables.subnav.scss
+++ b/src/clr-angular/layout/nav/_variables.subnav.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Usage: ../layout/main-container/_sidenav.clarity.scss
 // TODO: would be nice to key text color in subnav off of the bgColor...

--- a/src/clr-angular/layout/nav/header.spec.ts
+++ b/src/clr-angular/layout/nav/header.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/nav/header.ts
+++ b/src/clr-angular/layout/nav/header.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/nav/index.ts
+++ b/src/clr-angular/layout/nav/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/nav/nav-level.spec.ts
+++ b/src/clr-angular/layout/nav/nav-level.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/nav/nav-level.ts
+++ b/src/clr-angular/layout/nav/nav-level.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/nav/providers/responsive-navigation.service.spec.ts
+++ b/src/clr-angular/layout/nav/providers/responsive-navigation.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/nav/providers/responsive-navigation.service.ts
+++ b/src/clr-angular/layout/nav/providers/responsive-navigation.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/nav/responsive-nav-codes.ts
+++ b/src/clr-angular/layout/nav/responsive-nav-codes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/nav/responsive-nav-control-message.ts
+++ b/src/clr-angular/layout/nav/responsive-nav-control-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/tabs/_tabs.clarity.scss
+++ b/src/clr-angular/layout/tabs/_tabs.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 
 @include exports('tabs.clarity') {

--- a/src/clr-angular/layout/tabs/_variables.tabs.scss
+++ b/src/clr-angular/layout/tabs/_variables.tabs.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Usage: ../layout/nav/_nav.clarity.scss
 $clr-nav-box-shadow-color: $gray-light-midtone;

--- a/src/clr-angular/layout/tabs/index.ts
+++ b/src/clr-angular/layout/tabs/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/tabs/tab-content.spec.ts
+++ b/src/clr-angular/layout/tabs/tab-content.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/tabs/tab-content.ts
+++ b/src/clr-angular/layout/tabs/tab-content.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/tabs/tab-link.directive.spec.ts
+++ b/src/clr-angular/layout/tabs/tab-link.directive.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/tabs/tab-overflow-content.spec.ts
+++ b/src/clr-angular/layout/tabs/tab-overflow-content.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/tabs/tabs.spec.ts
+++ b/src/clr-angular/layout/tabs/tabs.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/tabs/tabs.ts
+++ b/src/clr-angular/layout/tabs/tabs.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/layout/vertical-nav/_variables.vertical-nav.scss
+++ b/src/clr-angular/layout/vertical-nav/_variables.vertical-nav.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Usage: ./_vertical-nav.clarity.scss
 //Vertical Nav: Icons

--- a/src/clr-angular/layout/vertical-nav/_vertical-nav.clarity.scss
+++ b/src/clr-angular/layout/vertical-nav/_vertical-nav.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @mixin vertical-nav-link-colors($color: $clr-vertical-nav-hover-bg-color) {
     color: $clr-vertical-nav-item-color;

--- a/src/clr-angular/main.scss
+++ b/src/clr-angular/main.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  *

--- a/src/clr-angular/modal/_modal.clarity.scss
+++ b/src/clr-angular/modal/_modal.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 .modal {
     position: fixed;

--- a/src/clr-angular/modal/_variables.modal.scss
+++ b/src/clr-angular/modal/_variables.modal.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Usage: ../modal/_modal.clarity.scss
 $clr-modal-content-padding-top: 1rem !default;

--- a/src/clr-angular/popover/common/_popover.clarity.scss
+++ b/src/clr-angular/popover/common/_popover.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @include exports('popover.clarity') {
     .is-off-screen {

--- a/src/clr-angular/popover/dropdown/_dropdown.clarity.scss
+++ b/src/clr-angular/popover/dropdown/_dropdown.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 %dropdown-content {
     overflow: hidden;

--- a/src/clr-angular/popover/dropdown/_variables.dropdown.scss
+++ b/src/clr-angular/popover/dropdown/_variables.dropdown.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Usage:  ../data/stack-view/_stack-view.clarity.scss
 // Usage: ../forms/_select.clarity.scss

--- a/src/clr-angular/popover/dropdown/dropdown-item.ts
+++ b/src/clr-angular/popover/dropdown/dropdown-item.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/dropdown/dropdown-trigger.ts
+++ b/src/clr-angular/popover/dropdown/dropdown-trigger.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/dropdown/dropdown.spec.ts
+++ b/src/clr-angular/popover/dropdown/dropdown.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/dropdown/dropdown.ts
+++ b/src/clr-angular/popover/dropdown/dropdown.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/dropdown/index.ts
+++ b/src/clr-angular/popover/dropdown/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/popover/signpost/_signposts.clarity.scss
+++ b/src/clr-angular/popover/signpost/_signposts.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @include exports('signpost.clarity') {
     .signpost {

--- a/src/clr-angular/popover/signpost/_variables.signpost.scss
+++ b/src/clr-angular/popover/signpost/_variables.signpost.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 
 

--- a/src/clr-angular/popover/tooltip/_tooltips.clarity.scss
+++ b/src/clr-angular/popover/tooltip/_tooltips.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @mixin common-tooltip-styles {
     @include clr-getTypePropertiesForDomElement(tooltip_text, (font-size, font-weight, letter-spacing));

--- a/src/clr-angular/popover/tooltip/_variables.tooltip.scss
+++ b/src/clr-angular/popover/tooltip/_variables.tooltip.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 
 // Usage: ../popover/tooltip/_tooltips.clarity.scss

--- a/src/clr-angular/popover/tooltip/tooltip-trigger.ts
+++ b/src/clr-angular/popover/tooltip/tooltip-trigger.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/progress/progress-bars/_progress-bars.clarity.scss
+++ b/src/clr-angular/progress/progress-bars/_progress-bars.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @import "utils/mixins.clarity";
 

--- a/src/clr-angular/progress/progress-bars/_variables.progress-bars.scss
+++ b/src/clr-angular/progress/progress-bars/_variables.progress-bars.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Usage: ../progress/progress-bars/_progress-bars.clarity.scss
 $clr-progress-defaultBarColor: $clr-action-blue;

--- a/src/clr-angular/progress/progress-bars/utils/mixins.clarity.scss
+++ b/src/clr-angular/progress/progress-bars/utils/mixins.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @mixin clr-progress-color($color: $clr-action-blue) {
     // for IE...

--- a/src/clr-angular/progress/spinner/_spinner.clarity.scss
+++ b/src/clr-angular/progress/spinner/_spinner.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @mixin min-height($size){
     min-height: $size;

--- a/src/clr-angular/progress/spinner/_variables.spinner.scss
+++ b/src/clr-angular/progress/spinner/_variables.spinner.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Usage: ../progress/spinner/_spinner.clarity.scss
 $clr-spinner-color: $action-blues-dark-midtone;

--- a/src/clr-angular/providers.ts
+++ b/src/clr-angular/providers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/typography/_lists.clarity.scss
+++ b/src/clr-angular/typography/_lists.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @include exports('lists.clarity') {
     %kill-list-styles {

--- a/src/clr-angular/typography/_typography.clarity.scss
+++ b/src/clr-angular/typography/_typography.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @function clr-mergeCommonKeys($elMap: (), $valMap: ()) {
     @return map-merge(map-get($elMap, $clr-typography-commonmap-key), $valMap);

--- a/src/clr-angular/typography/_variables.lists.scss
+++ b/src/clr-angular/typography/_variables.lists.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Usage: ../typography/_lists.clarity.scss
 $clr-list-style-padding: 1.1em;

--- a/src/clr-angular/typography/_variables.typography.scss
+++ b/src/clr-angular/typography/_variables.typography.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Usage: ../typography/_typography.clarity.scss
 $clr-font: Metropolis, 'Avenir Next', 'Helvetica Neue', Arial, sans-serif !default; //Default font stack for Clarity

--- a/src/clr-angular/typography/fonts.clarity.scss
+++ b/src/clr-angular/typography/fonts.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 //Metropolis Font Version that we use: r8 https://github.com/chrismsimpson/Metropolis/releases/tag/r8
 

--- a/src/clr-angular/typography/typography.spec.ts
+++ b/src/clr-angular/typography/typography.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/_close.clarity.scss
+++ b/src/clr-angular/utils/_close.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/clr-angular/utils/_components.clarity.scss
+++ b/src/clr-angular/utils/_components.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 
 // Clarity scss maps w/ overridable variables per component

--- a/src/clr-angular/utils/_dependencies.clarity.scss
+++ b/src/clr-angular/utils/_dependencies.clarity.scss
@@ -1,23 +1,21 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 
-/* Bootstrap 4 Dependencies - Begin Part 1 */
+// Bootstrap 4 Dependencies - Begin Part 1
 @import "node_modules/bootstrap/scss/variables";
 @import "node_modules/bootstrap/scss/mixins";
 @import "node_modules/bootstrap/scss/normalize";
-/* Bootstrap 4 Dependencies - End Part 1 */
+//Bootstrap 4 Dependencies - End Part 1
 
 
-/* Vendor */
+// Vendor
 @import "../utils/vendor/decimalRounding.clarity";
 @import "../utils/vendor/mathPow.clarity";
-/* End Vendor */
+// End Vendor
 
-/* Clarity Internal Dependencies- Begin Part 1 */
+// Clarity Internal Dependencies- Begin Part 1
 @import "../utils/mixins.clarity";
 @import "../utils/helpers.clarity";
 
@@ -33,7 +31,7 @@
 // Component variables
 @import "../utils/variables.clarity"; // depends on helpers.clarity, color.clarity
 
-/* Bootstrap 4 Dependencies - Begin Part 2 */
+// Bootstrap 4 Dependencies - Begin Part 2
 
 @import "node_modules/bootstrap/scss/media";
 @import "node_modules/bootstrap/scss/utilities";

--- a/src/clr-angular/utils/_helpers.clarity.scss
+++ b/src/clr-angular/utils/_helpers.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 @function baselineRem($remSize) {
     @return $remSize * $clr-baseline;

--- a/src/clr-angular/utils/_layers.clarity.scss
+++ b/src/clr-angular/utils/_layers.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/clr-angular/utils/_maps.clarity.scss
+++ b/src/clr-angular/utils/_maps.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 // TODO - write better documentation for why and how these maps are used as well as where the $clr-variable-names are declared.
 
 // ALERTS

--- a/src/clr-angular/utils/_mixins.clarity.scss
+++ b/src/clr-angular/utils/_mixins.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/clr-angular/utils/_overwrites.clarity.scss
+++ b/src/clr-angular/utils/_overwrites.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/clr-angular/utils/_reboot.clarity.scss
+++ b/src/clr-angular/utils/_reboot.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/clr-angular/utils/_theme.dark.clarity.scss
+++ b/src/clr-angular/utils/_theme.dark.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // - Global
 // - Alerts

--- a/src/clr-angular/utils/_variables.clarity.scss
+++ b/src/clr-angular/utils/_variables.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Clarity Components
 //
@@ -30,74 +28,52 @@
 // Typography
 // Vertical Nav
 
-/**********
- * Global
- */
+//Global
 @import "../color/variables.color";
 @import "../utils/variables.global";
 // END Global
 
-/**********
- * Alert
- */
+// Alert
 @import "../emphasis/alert/variables.alert";
 // End Alert
 
-/*********
- * Label
- * Has code sharing with badges
- */
+// Label
+// Has code sharing with badges
 @import "../emphasis/variables.label";
 // END: Label
 
-/*****************
- * Badge
- * Has code sharing with labels
- */
+// Badge
+//Has code sharing with labels
 @import "../emphasis/variables.badge";
 // END: Badge
 
-/**********
- * Button
- * Disabled states are global for all buttons, independent of status or type
-*/
+// Button
+// Disabled states are global for all buttons, independent of status or type
 @import "../button/variables.button";
 // BUTTON END
 
-/**********
- * Card
- */
+// Card
 @import "../layout/variables.card";
 // END CARD
 
-/*********
- * Dropdown
- */
+// Dropdown
 @import "../popover/dropdown/variables.dropdown";
 // END: Dropdown
 
-/**********
- * List
- */
+// List
 @import "../typography/variables.lists";
 // END: List
 
-/**********
- * Table
- * NOTE: Datagrid depends on these
- */
+// Table
+// NOTE: Datagrid depends on these
 @import "../data/variables.tables";
 // END Table
 
-/**********
- * Datagrid
- */
+// Datagrid
 @import "../data/datagrid/variables.datagrid";
 // End Datagrid
 
-/*************************************************
- * Form, Toggle, Input, Checkbox, & Radio
- */
+// Form, Toggle, Input, Checkbox, & Radio
 @import "../forms/variables.forms";
 @import "../forms/checkbox/variables.checkbox";
 @import "../forms/variables.inputs";
@@ -105,33 +81,25 @@
 @import "../button/variables.toggles";
 // END Form, Toggle, Input, Checkbox, & Radio
 
-/**********
- * Header
- */
+// Header
 @import "../layout/main-container/variables.header";
 // END Header
 
-/********
- * Login
- */
+// Login
 @import "../layout/variables.login";
 // END: Login
 
-/*************************************************
- * Modal and Wizard (They are genetically related)
- */
+// Modal and Wizard (They are genetically related)
 @import "../modal/variables.modal";
 @import "../wizard/variables.wizard";
 // END: Modal and Wizard
 
-/***************
- * Nav
- * There are several components grouped under Nav:
- * 1. Links
- * 2. Responsive Nav
- * 3. Sidenav
- * 4. Vertical Nav
- */
+// Nav
+// There are several components grouped under Nav:
+// Links
+// Responsive Nav
+// Sidenav
+// Vertical Nav
 // Responsive Nav
 // Global nav variables
 @import "../layout/nav/variables.nav";
@@ -144,47 +112,31 @@
 @import "../layout/vertical-nav/variables.vertical-nav";
 // END: Nav variables
 
-/**************
- * Progress Bars
- */
+// Progress Bars
 @import "../progress/progress-bars/variables.progress-bars";
 // END Progress bars
 
-/*********
- * Signpost
- */
+// Signpost
 @import "../popover/signpost/variables.signpost";
 // END Signpost variables
 
 
-/*********
- * Spinners
- */
+// Spinners
 @import "../progress/spinner/variables.spinner";
 // END Spinners
 
-/*********
- * Stack View
- */
+// Stack View
 @import "../data/stack-view/variables.stack-view";
 
-/**********
- * Tabs
- */
+// Tabs
 @import "../layout/tabs/variables.tabs";
 
-/**********
- * Tree View
- */
+// Tree View
 @import "../data/tree-view/variables.tree-view";
 
-/**********
- * Tooltip
- */
+// Tooltip
 @import "../popover/tooltip/variables.tooltip";
 
-/**********
- * Typography
- */
+// Typography
 @import "../typography/variables.typography";
 // End Typography

--- a/src/clr-angular/utils/_variables.global.scss
+++ b/src/clr-angular/utils/_variables.global.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // App border radus
 $clr-default-borderradius: 0.125rem !default; // deprecated and will be removed.

--- a/src/clr-angular/utils/animations/_animations.clarity.scss
+++ b/src/clr-angular/utils/animations/_animations.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 /**
  * TODO: figure out if we want to include animate.css or if we prefer sticking to a few,

--- a/src/clr-angular/utils/animations/collapse/collapse.spec.ts
+++ b/src/clr-angular/utils/animations/collapse/collapse.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/animations/collapse/collapse.ts
+++ b/src/clr-angular/utils/animations/collapse/collapse.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/animations/collapse/index.ts
+++ b/src/clr-angular/utils/animations/collapse/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/animations/fade-slide/fade-slide.spec.ts
+++ b/src/clr-angular/utils/animations/fade-slide/fade-slide.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/animations/fade-slide/fade-slide.ts
+++ b/src/clr-angular/utils/animations/fade-slide/fade-slide.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/animations/fade-slide/index.ts
+++ b/src/clr-angular/utils/animations/fade-slide/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/animations/fade/fade.spec.ts
+++ b/src/clr-angular/utils/animations/fade/fade.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/animations/fade/fade.ts
+++ b/src/clr-angular/utils/animations/fade/fade.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/animations/fade/index.ts
+++ b/src/clr-angular/utils/animations/fade/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/animations/slide/index.ts
+++ b/src/clr-angular/utils/animations/slide/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/animations/slide/slide.spec.ts
+++ b/src/clr-angular/utils/animations/slide/slide.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/animations/slide/slide.ts
+++ b/src/clr-angular/utils/animations/slide/slide.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/chocolate/chocolate-factory.spec.ts
+++ b/src/clr-angular/utils/chocolate/chocolate-factory.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/conditional/index.ts
+++ b/src/clr-angular/utils/conditional/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/expand/index.ts
+++ b/src/clr-angular/utils/expand/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/loading/index.ts
+++ b/src/clr-angular/utils/loading/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/loading/loading-listener.ts
+++ b/src/clr-angular/utils/loading/loading-listener.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/loading/loading.spec.ts
+++ b/src/clr-angular/utils/loading/loading.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/loading/loading.ts
+++ b/src/clr-angular/utils/loading/loading.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/outside-click/index.ts
+++ b/src/clr-angular/utils/outside-click/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/outside-click/outside-click.spec.ts
+++ b/src/clr-angular/utils/outside-click/outside-click.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/scrolling/scrolling-service.spec.ts
+++ b/src/clr-angular/utils/scrolling/scrolling-service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/scrolling/scrolling-service.ts
+++ b/src/clr-angular/utils/scrolling/scrolling-service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/utils/vendor/decimalRounding.clarity.scss
+++ b/src/clr-angular/utils/vendor/decimalRounding.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 
 // _decimal.scss | mIT license | gist.github.com/terkel/4373420

--- a/src/clr-angular/utils/vendor/mathPow.clarity.scss
+++ b/src/clr-angular/utils/vendor/mathPow.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // by Tobias Bengfort
 // http://www.sassmeister.com/gist/5bbe8480c48e2fc10ab5

--- a/src/clr-angular/wizard/_variables.wizard.scss
+++ b/src/clr-angular/wizard/_variables.wizard.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // TODO: optimize the component default variables for theming
 $clr-wizard-main-bgcolor: clr-getColor(1);

--- a/src/clr-angular/wizard/_wizard.clarity.scss
+++ b/src/clr-angular/wizard/_wizard.clarity.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // NOTE THAT THE MIN-WIDTH OF THE BUTTONS WILL PUSH OUT THE DIALOG IF
 // SET UP IMPROPERLY. THIS IS A KNOWN ISSUE AND USERS SHOULD USE THEIR

--- a/src/clr-icons/clr-icons-api.ts
+++ b/src/clr-icons/clr-icons-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-icons/clr-icons-element.ts
+++ b/src/clr-icons/clr-icons-element.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-icons/clr-icons-sfx.ts
+++ b/src/clr-icons/clr-icons-sfx.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-icons/clr-icons.scss
+++ b/src/clr-icons/clr-icons.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 $clr-icon-size: 16px;
 $clr-icon-color-success: #318700;
 $clr-icon-color-danger: #e62700;

--- a/src/clr-icons/clr-icons.spec.ts
+++ b/src/clr-icons/clr-icons.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-icons/index.ts
+++ b/src/clr-icons/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-icons/interfaces/icon-alias.ts
+++ b/src/clr-icons/interfaces/icon-alias.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-icons/interfaces/icon-template.ts
+++ b/src/clr-icons/interfaces/icon-template.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/app/app.component.html
+++ b/src/ks-app/src/app/app.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/ks-app/src/app/app.component.scss
+++ b/src/ks-app/src/app/app.component.scss
@@ -1,6 +1,4 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/ks-app/src/app/containers/cards/cards.component.scss
+++ b/src/ks-app/src/app/containers/cards/cards.component.scss
@@ -1,7 +1,5 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 

--- a/src/ks-app/src/app/containers/colors/colors.component.css
+++ b/src/ks-app/src/app/containers/colors/colors.component.css
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
+ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ This software is released under MIT license.
+ The full license information can be found in LICENSE in the root directory of this project.
  */
 
 /* Start  color-shared.demo.css */

--- a/src/ks-app/src/app/containers/colors/colors.component.scss
+++ b/src/ks-app/src/app/containers/colors/colors.component.scss
@@ -1,6 +1,4 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 

--- a/src/ks-app/src/app/containers/data/datagrid.component.scss
+++ b/src/ks-app/src/app/containers/data/datagrid.component.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 .color-square {
   display: inline-block;

--- a/src/ks-app/src/app/containers/data/pokemon-data.ts
+++ b/src/ks-app/src/app/containers/data/pokemon-data.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/ks-app/src/styles.scss
+++ b/src/ks-app/src/styles.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 /* You can add global styles to this file, and also import other style files */
 @import "./styles/clarity-overrides";

--- a/src/ks-app/src/styles/_app-style.scss
+++ b/src/ks-app/src/styles/_app-style.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 .ks-demo-wrapper {
   margin-bottom: 24px;

--- a/src/ks-app/src/styles/_clarity-overrides.scss
+++ b/src/ks-app/src/styles/_clarity-overrides.scss
@@ -1,8 +1,6 @@
-/*!
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
 // Style overrides for KS App
 .header {

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/tests/tests.entry.ts
+++ b/tests/tests.entry.ts
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 import "core-js";
 import "core-js/es7/reflect";
 import "zone.js/dist/zone";
@@ -8,10 +14,12 @@ import "zone.js/dist/sync-test";
 import "zone.js/dist/proxy";
 import "zone.js/dist/jasmine-patch";
 
+/* tslint:disable no-var-requires no-require-imports */
 const browserTesting = require("@angular/platform-browser-dynamic/testing");
 const coreTesting = require("@angular/core/testing");
 // include every .spec.ts file inside src, except for those in ks-app folder
 const context = (require as any).context("../src/", true, /^((?![\\/]ks-app[\\/]).)*\.spec\.ts$/);
+/* tslint:enable no-var-requires no-require-imports*/
 
 Error.stackTraceLimit = Infinity;
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 2000;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 const fs = require('fs');
 const path = require('path');
 const ConcatPlugin = require('webpack-concat-plugin');

--- a/webpack.dark-theme.config.js
+++ b/webpack.dark-theme.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/webpack.icons.config.js
+++ b/webpack.icons.config.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 const path = require("path");
 const {UglifyJsPlugin} = require('webpack').optimize;
 

--- a/webpack.test.config.js
+++ b/webpack.test.config.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 const path = require("path");
 
 module.exports = {


### PR DESCRIPTION
## Changes

- Removes `loud` scss comments from previous Copyright update
- Removes multiline scss comments that were polluting the generated css
- Adds missing copyright to script files outside of the `src/` folder
- Generated CSS Filesize
     - clarity-ui-dark.css = 428KB
     - clarity-ui-dark.min.css = 367KB
     - clarity-ui.css = 463KB
     - clarity-ui.min.css = 402KB

##  Note

1. I found regular multi line comments in our generated scss from how I documented things for dark theme. That's the reason for removing the multi line comments from the `dependencies.clarity.scss` It seems there is a flag that we can enable to compress which will remove them while preserving the `loud` comments but I didn't want to add that to this changeset. 
2. I only ran the Copyright tool on `src/clr-angular` in the first pass

Signed-off-by: Matt Hippely <mhippely@vmware.com>
  
  