### PR TITLE
[UI] Fix spinners in small buttons

### DIFF
--- a/src/app/buttons/button-loading.html
+++ b/src/app/buttons/button-loading.html
@@ -15,3 +15,14 @@
     &lt;button [clrLoading]=&quot;submitLoading&quot; type=&quot;submit&quot; class=&quot;btn btn-success-outline&quot;&gt;Success&lt;/button&gt;
     </code>
 </pre>
+
+<h4>Small Loading Buttons</h4>
+<button [clrLoading]="validateSmLoading" class="btn btn-sm btn-info-outline" (click)="validateSmDemo()">Validate</button>
+<button [clrLoading]="submitSmLoading" type="submit" class="btn btn-sm btn-success-outline" (click)="submitSmDemo()">Submit</button>
+
+<pre>
+    <code clr-code-highlight="language-html">
+    &lt;button [clrLoading]=&quot;validateSmLoading&quot; class=&quot;btn btn-sm btn-info-outline&quot;&gt;Validate&lt;/button&gt;
+    &lt;button [clrLoading]=&quot;submitSmLoading&quot; type=&quot;submit&quot; class=&quot;btn btn-sm btn-success-outline&quot;&gt;Success&lt;/button&gt;
+    </code>
+</pre>

--- a/src/app/buttons/button-loading.ts
+++ b/src/app/buttons/button-loading.ts
@@ -13,6 +13,8 @@ import {Component} from "@angular/core";
 export class ButtonLoadingDemo {
     private validateLoading: boolean = false;
     private submitLoading: boolean = false;
+    private validateSmLoading: boolean = false;
+    private submitSmLoading: boolean = false;
 
     validateDemo() {
         this.validateLoading = true;
@@ -22,5 +24,15 @@ export class ButtonLoadingDemo {
     submitDemo() {
         this.submitLoading = true;
         setTimeout(() => this.submitLoading = false, 1500);
+    }
+
+    validateSmDemo() {
+        this.validateSmLoading = true;
+        setTimeout(() => this.validateSmLoading = false, 1500);
+    }
+
+    submitSmDemo() {
+        this.submitSmLoading = true;
+        setTimeout(() => this.submitSmLoading = false, 1500);
     }
 }

--- a/src/clr-angular/progress/spinner/_spinner.clarity.scss
+++ b/src/clr-angular/progress/spinner/_spinner.clarity.scss
@@ -43,6 +43,13 @@
         }
     }
 
+    //Spinners inside of small buttons
+    .btn-sm {
+        .spinner {
+            @include min-height(0.541667rem);
+        }
+    }
+
     @keyframes spin {
         0% {
             transform: rotate(0deg);


### PR DESCRIPTION
Fixes: #1836 

Spinner in small buttons changed to 13px according to the specs mentioned here: https://github.com/vmware/clarity/issues/1488

![smallbuttonspinner](https://user-images.githubusercontent.com/1426805/34623463-79d7e17c-f21f-11e7-9f2a-4343fef00c80.gif)

Tested on: IE, Edge, Safari, Chrome, Firefox

Firefox alignment is a bit off but we can't do anything about it. Noticeable only if you stare at the screen very closely.

Signed-off-by: Aditya Bhandari <adityab@vmware.com>
  
  