### PR TITLE
[UI] Vertical Nav Bottom Nav Trigger

### DIFF
--- a/src/app/vertical-nav/collapsible/vertical-nav-collapsible.demo.html
+++ b/src/app/vertical-nav/collapsible/vertical-nav-collapsible.demo.html
@@ -63,3 +63,55 @@
         </div>
     </div>
 </div>
+
+<h3>Bottom Nav Trigger</h3>
+<div class="clr-example">
+    <div class="main-container">
+        <header class="header header-6">
+            <div class="branding">
+                <a href="#">
+                    <clr-icon shape="vm-bug"></clr-icon>
+                    <span class="title">Project Clarity</span>
+                </a>
+            </div>
+            <form class="search">
+                <label for="search_input1">
+                    <input id="search_input1" type="text" placeholder="Search for keywords...">
+                </label>
+            </form>
+            <div class="settings">
+                <a href="javascript://" class="nav-link nav-icon">
+                    <clr-icon shape="cog"></clr-icon>
+                </a>
+            </div>
+        </header>
+        <div class="content-container">
+            <div class="content-area">
+                <h4>
+                    {{case.title}}
+                </h4>
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum dignissim
+                    eget massa sit amet feugiat. Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat
+                    vitae sem at, tincidunt elementum magna. Phasellus tristique posuere dui, ut tempus felis sagittis
+                    quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus interdum semper velit eget gravida.
+                    Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie cursus, sapien purus
+                    volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat purus
+                    non, imperdiet ipsum.
+                </p>
+            </div>
+            <clr-vertical-nav
+                class="nav-trigger--bottom"
+                [clrVerticalNavCollapsible]="true">
+                <ng-container *ngFor="let item of case.items">
+
+                    <a clrVerticalNavLink href="javascript:void(0)" *ngIf="!item['children']">
+                        <clr-icon [attr.shape]="item.icon" *ngIf="item['icon']" clrVerticalNavIcon></clr-icon>
+                        {{item.label}}
+                    </a>
+
+                </ng-container>
+            </clr-vertical-nav>
+        </div>
+    </div>
+</div>

--- a/src/clr-angular/layout/vertical-nav/_vertical-nav.clarity.scss
+++ b/src/clr-angular/layout/vertical-nav/_vertical-nav.clarity.scss
@@ -388,5 +388,19 @@
                 }
             }
         }
+
+        &.nav-trigger--bottom {
+            .nav-trigger {
+                order: 2;
+                margin-top: 0;
+            }
+
+            .nav-trigger + .nav-content {
+                //Dims
+                border-bottom: $clr-global-borderwidth solid rgba($gray-darker, 0.2);
+                border-top: none;
+                padding-top: 0;
+            }
+        }
     }
 }


### PR DESCRIPTION
Partially Addresses #1328

Added a class (`.nav-trigger--bottom`) which can be used with the existing `.clr-vertical-nav` class. This will render the nav trigger at the bottom of the vertical nav instead of the top (default).

![image](https://user-images.githubusercontent.com/1426805/34631383-180c1958-f23e-11e7-9885-d1da62ded5f8.png)


Tested on Firefox, IE, Edge, Safari, Chrome


Signed-off-by: Aditya Bhandari <adityab@vmware.com>
  