### PR TITLE
[UI] Add styling for button disabled attribute

### DIFF
--- a/src/app/dropdown/dropdown-angular-close-item-false.demo.html
+++ b/src/app/dropdown/dropdown-angular-close-item-false.demo.html
@@ -12,11 +12,12 @@
         </button>
         <clr-dropdown-menu *clrIfOpen clrPosition="bottom-right">
             <label class="dropdown-header">Dropdown header</label>
-            <a href="javascript://" clrDropdownItem>Action 1</a>
-            <a href="javascript://" clrDropdownItem>Action 2</a>
+            <button clrDropdownItem>Action 1</button>
+            <button clrDropdownItem>Action 2</button>
+            <button clrDropdownItem disabled>Disabled Action 1</button>
             <div class="dropdown-divider"></div>
-            <a href="javascript://" clrDropdownItem>Link 1</a>
-            <a href="javascript://" clrDropdownItem>Link 2</a>
+            <button clrDropdownItem>Link 1</button>
+            <button clrDropdownItem>Link 2</button>
         </clr-dropdown-menu>
     </clr-dropdown>
 </div>

--- a/src/app/dropdown/dropdown-static-positioning.demo.html
+++ b/src/app/dropdown/dropdown-static-positioning.demo.html
@@ -13,7 +13,7 @@
         <div class="dropdown-menu">
             <h4 class="dropdown-header">Dropdown header</h4>
             <button class="dropdown-item active">First Action</button>
-            <button class="dropdown-item disabled">Disabled Action</button>
+            <button class="dropdown-item" disabled>Disabled Action</button>
             <div class="dropdown-divider"></div>
             <button class="dropdown-item">Link 1</button>
             <button class="dropdown-item">Link 2</button>
@@ -30,7 +30,7 @@
         &lt;div class=&quot;dropdown-menu&quot;&gt;
             &lt;h4 class=&quot;dropdown-header&quot;&gt;Dropdown header&lt;/h4&gt;
             &lt;button class=&quot;dropdown-item active&quot;&gt;First Action&lt;/button&gt;
-            &lt;button class=&quot;dropdown-item disabled&quot;&gt;Disabled Action&lt;/button&gt;
+            &lt;button class=&quot;dropdown-item&quot; disabled&gt;Disabled Action&lt;/button&gt;
             &lt;div class=&quot;dropdown-divider&quot;&gt;&lt;/div&gt;
             &lt;button class=&quot;dropdown-item&quot;&gt;Link 1&lt;/button&gt;
             &lt;button class=&quot;dropdown-item&quot;&gt;Link 2&lt;/button&gt;

--- a/src/clr-angular/button/_buttons.clarity.scss
+++ b/src/clr-angular/button/_buttons.clarity.scss
@@ -218,6 +218,8 @@
         // TODO fix button types by refactoring the maps that hold attr values for all button types.
         $icon-props: map_get($clr-global-button-properties-map, icon);
         $disabled-icon-color: map_get($icon-props, disabled-color);
+
+        &.disabled,
         &:disabled {
             color: $disabled-icon-color;
         }

--- a/src/clr-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clr-angular/data/datagrid/_datagrid.clarity.scss
@@ -526,20 +526,21 @@
                         outline: 0;
                     }
 
-                    &.disabled, &:disabled {
+                    &.disabled,
+                    &:disabled {
                         cursor: not-allowed;
                         opacity: 0.4;
                         user-select: none;
-                    }
 
-                    &.disabled:hover {
-                        background: none;
-                    }
+                        &:hover {
+                            background: none;
+                        }
 
-                    &.disabled:active,
-                    &.disabled:focus {
-                        background: none;
-                        box-shadow: none;
+                        &:active,
+                        &:focus {
+                            background: none;
+                            box-shadow: none;
+                        }
                     }
 
                     clr-icon {

--- a/src/clr-angular/popover/dropdown/_dropdown.clarity.scss
+++ b/src/clr-angular/popover/dropdown/_dropdown.clarity.scss
@@ -160,20 +160,21 @@
                 outline: 0;
             }
 
-            &.disabled {
+            &.disabled,
+            &:disabled {
                 cursor: not-allowed;
                 opacity: 0.4;
                 user-select: none;
-            }
 
-            &.disabled:hover {
-                background: none;
-            }
+                &:hover {
+                    background: none;
+                }
 
-            &.disabled:active,
-            &.disabled:focus {
-                background: none;
-                box-shadow: none;
+                &:active,
+                &:focus {
+                    background: none;
+                    box-shadow: none;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes: #1128 

Issue addressed in:
Buttons
Dropdown Items
Datagrid Overflow Action Items

Disabled Button (Before):
![image](https://user-images.githubusercontent.com/1426805/34677435-1f32c2b4-f45e-11e7-9637-d3d3ccc0c054.png)

Disabled Button (After):
![image](https://user-images.githubusercontent.com/1426805/34677402-090933a6-f45e-11e7-97cb-52ed14cf70a3.png)


Tested on Chrome

Signed-off-by: Aditya Bhandari <adityab@vmware.com>
  