### PR TITLE
[UI] Vertical Nav Top Padding Fix

### DIFF
--- a/src/clr-angular/layout/vertical-nav/_variables.vertical-nav.scss
+++ b/src/clr-angular/layout/vertical-nav/_variables.vertical-nav.scss
@@ -20,7 +20,7 @@ $clr-vertical-nav-item-color: $clr-dark-gray;
 $clr-vertical-nav-item-active-color: $clr-dark-gray;
 $clr-vertical-nav-bg-color: $clr-light-gray;
 $clr-vertical-nav-hover-bg-color: $clr-white;
-$clr-vertical-nav-top-padding:  1rem !default;
+$clr-vertical-nav-top-padding:  0.75rem !default;
 $clr-vertical-nav-trigger-icon-align-margin: ($clr-vertical-nav-item-height - $clr-vertical-nav-icon-size) / 2;
 //Vertical Nav: Trigger
 $clr-vertical-nav-toggle-icon-color: $clr-black;


### PR DESCRIPTION
@reddolan asked me to reduce the spacing before the links in the vertical nav. spacing reduced from 24px to 18px.

Before:
![image](https://user-images.githubusercontent.com/1426805/34745117-718ca070-f55d-11e7-9fea-37443c773acf.png)


After:
![image](https://user-images.githubusercontent.com/1426805/34745085-5eadc042-f55d-11e7-8b35-f1e7af7b8713.png)


Tested on: Chrome

Signed-off-by: Aditya Bhandari <adityab@vmware.com>