### PR TITLE
[NG] Datagrid Pagination Bug Fix

### DIFF
--- a/src/app/datagrid/datagrid.demo.html
+++ b/src/app/datagrid/datagrid.demo.html
@@ -17,6 +17,7 @@
     <li><a [routerLink]="['./string-filtering']">Built-in filters</a></li>
     <li><a [routerLink]="['./pagination']">Pagination</a></li>
     <li><a [routerLink]="['./pagination-scrolling']">Pagination & Scrolling</a></li>
+    <li><a [routerLink]="['./pagination-conditional']">Conditional Pagination</a></li>
     <li><a [routerLink]="['./selection']">Selection</a></li>
     <li><a [routerLink]="['./selection-single']">Selection (Single)</a></li>
     <li><a [routerLink]="['./selection-row-mode']">Selection (Row Mode)</a></li>

--- a/src/app/datagrid/datagrid.demo.module.ts
+++ b/src/app/datagrid/datagrid.demo.module.ts
@@ -23,6 +23,7 @@ import {DatagridFilteringDemo} from "./filtering/filtering";
 import {DatagridFullDemo} from "./full/full";
 import {DatagridHideShowDemo} from "./hide-show-columns/hide-show";
 import {DatagridKitchenSinkDemo} from "./kitchen-sink/kitchen-sink";
+import {DatagridConditionalPaginationDemo} from "./pagination-conditional/pagination-conditional";
 import {DatagridPaginationScrollingDemo} from "./pagination-scrolling/pagination-scrolling";
 import {DatagridPaginationDemo} from "./pagination/pagination";
 import {DatagridPlaceholderDemo} from "./placeholder/placeholder";
@@ -53,6 +54,7 @@ import {Example} from "./utils/example";
         DatagridHideShowDemo,
         DatagridPaginationDemo,
         DatagridPaginationScrollingDemo,
+        DatagridConditionalPaginationDemo,
         DatagridSelectionDemo,
         DatagridSelectionSingleDemo,
         DatagridSelectionRowModeDemo,
@@ -82,6 +84,7 @@ import {Example} from "./utils/example";
         DatagridFullDemo,
         DatagridPaginationDemo,
         DatagridPaginationScrollingDemo,
+        DatagridConditionalPaginationDemo,
         DatagridSelectionDemo,
         DatagridSelectionSingleDemo,
         DatagridSelectionRowModeDemo,

--- a/src/app/datagrid/datagrid.demo.routing.ts
+++ b/src/app/datagrid/datagrid.demo.routing.ts
@@ -17,6 +17,7 @@ import {DatagridFilteringDemo} from "./filtering/filtering";
 import {DatagridFullDemo} from "./full/full";
 import {DatagridHideShowDemo} from "./hide-show-columns/hide-show";
 import {DatagridKitchenSinkDemo} from "./kitchen-sink/kitchen-sink";
+import {DatagridConditionalPaginationDemo} from "./pagination-conditional/pagination-conditional";
 import {DatagridPaginationScrollingDemo} from "./pagination-scrolling/pagination-scrolling";
 import {DatagridPaginationDemo} from "./pagination/pagination";
 import {DatagridPlaceholderDemo} from "./placeholder/placeholder";
@@ -47,6 +48,7 @@ const ROUTES: Routes = [{
         {path: "string-filtering", component: DatagridStringFilteringDemo},
         {path: "pagination", component: DatagridPaginationDemo},
         {path: "pagination-scrolling", component: DatagridPaginationScrollingDemo},
+        {path: "pagination-conditional", component: DatagridConditionalPaginationDemo},
         {path: "selection", component: DatagridSelectionDemo},
         {path: "selection-single", component: DatagridSelectionSingleDemo},
         {path: "selection-row-mode", component: DatagridSelectionRowModeDemo},

--- a/src/app/datagrid/datagrid.demo.scss
+++ b/src/app/datagrid/datagrid.demo.scss
@@ -50,3 +50,7 @@
 #vertical-scrolling {
     height: 500px;
 }
+
+.conditional-datagrid {
+    height: 300px;
+}

--- a/src/app/datagrid/pagination-conditional/pagination-conditional.html
+++ b/src/app/datagrid/pagination-conditional/pagination-conditional.html
@@ -1,0 +1,40 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<h2>Conditional Pagination</h2>
+
+<p>
+    Test to conditional activate/deactivate pagination in a datagrid
+</p>
+
+<clr-datagrid [class.conditional-datagrid]="!paginationEnabled">
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column>Name</clr-dg-column>
+    <clr-dg-column>Creation date</clr-dg-column>
+    <clr-dg-column>Favorite color</clr-dg-column>
+
+    <clr-dg-row *clrDgItems="let user of users">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>
+            <span class="color-square" [style.backgroundColor]="user.color"></span>
+        </clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>
+        <ng-container *ngIf="!paginationEnabled">
+            {{users.length}} users
+        </ng-container>
+        <clr-dg-pagination #pagination [clrDgPageSize]="5" *ngIf="paginationEnabled">
+            {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}} of {{pagination.totalItems}} users
+        </clr-dg-pagination>
+    </clr-dg-footer>
+</clr-datagrid>
+
+<button class="btn" type="button" (click)="toggle()">Toggle Pagination</button>
+
+<clr-example [clrCode]="example" clrLanguage="html"></clr-example>

--- a/src/app/datagrid/pagination-conditional/pagination-conditional.ts
+++ b/src/app/datagrid/pagination-conditional/pagination-conditional.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component} from "@angular/core";
+
+import {Inventory} from "../inventory/inventory";
+import {User} from "../inventory/user";
+
+const EXAMPLE = `
+<-- Inside the full datagrid declaration -->
+<clr-dg-footer>
+    <ng-container *ngIf="!paginationEnabled">
+        {{users.length}} users
+    </ng-container>
+    <clr-dg-pagination #pagination [clrDgPageSize]="5" *ngIf="paginationEnabled">
+        {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}} of {{pagination.totalItems}} users
+    </clr-dg-pagination>
+</clr-dg-footer>
+`;
+
+@Component({
+    selector: "clr-datagrid-conditional-pagination-demo",
+    providers: [Inventory],
+    templateUrl: "pagination-conditional.html",
+    styleUrls: ["../datagrid.demo.scss"]
+})
+export class DatagridConditionalPaginationDemo {
+    example = EXAMPLE;
+    users: User[];
+    paginationEnabled: boolean = false;
+
+    constructor(private inventory: Inventory) {
+        inventory.size = 103;
+        inventory.reset();
+        this.users = inventory.all;
+    }
+
+    toggle(): void {
+        this.paginationEnabled = !this.paginationEnabled;
+    }
+}

--- a/src/clr-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clr-angular/data/datagrid/_datagrid.clarity.scss
@@ -645,8 +645,18 @@
         border-radius: 0 0 $clr-global-borderradius $clr-global-borderradius;
 
         .pagination {
-            margin-left: 1.5rem;
-            height: calc(1.5rem - #{2 * $clr-default-borderwidth});
+            display: flex;
+            align-items: center;
+
+            &-description {
+                white-space: nowrap;
+            }
+
+            &-list {
+                margin-left: 1.5rem;
+                height: calc(1.5rem - #{2 * $clr-default-borderwidth});
+            }
+
         }
 
         .column-switch-wrapper {
@@ -733,7 +743,7 @@
 
     // Yes, this is not .datagrid-pagination on purpose.
     // I've been told to consider a potential separate pagination component.
-    .pagination {
+    .pagination-list {
         list-style: none;
         display: flex;
         flex-flow: row nowrap;
@@ -855,7 +865,7 @@
             height: 1rem;
             padding: 0 $clr-table-cellpadding;
             line-height: calc(1rem - 1px);
-            .pagination {
+            .pagination-list {
                 height: calc(1rem - #{2 * $clr-default-borderwidth});
             }
             .column-switch-wrapper .column-toggle--action {

--- a/src/clr-angular/data/datagrid/datagrid-pagination.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-pagination.spec.ts
@@ -69,6 +69,12 @@ export default function(): void {
                 expect(component.firstItem).toBe(pageService.firstItem);
                 expect(component.lastItem).toBe(pageService.lastItem);
             });
+
+            it("resets the page size to 0 when pagination is destroyed", () => {
+                pageService.size = 7;
+                component.ngOnDestroy();
+                expect(pageService.size).toBe(0);
+            });
         });
 
         describe("Template API", function() {

--- a/src/clr-angular/data/datagrid/datagrid-pagination.ts
+++ b/src/clr-angular/data/datagrid/datagrid-pagination.ts
@@ -11,7 +11,10 @@ import {Page} from "./providers/page";
 @Component({
     selector: "clr-dg-pagination",
     template: `
-        <ul class="pagination" *ngIf="page.last > 1">
+        <div class="pagination-description">
+            <ng-content></ng-content>
+        </div>
+        <ul class="pagination-list" *ngIf="page.last > 1">
             <li *ngIf="page.current > 1">
                 <button 
                     class="pagination-previous" 
@@ -43,8 +46,7 @@ import {Page} from "./providers/page";
             </li>
         </ul>
     `,
-    // IE10 comes to pollute even our components declaration
-    styles: [`:host { display: block; }`]
+    host: {"[class.pagination]": "true"}
 })
 export class ClrDatagridPagination implements OnDestroy, OnInit {
     constructor(public page: Page) {
@@ -69,6 +71,7 @@ export class ClrDatagridPagination implements OnDestroy, OnInit {
      */
     private _pageSubscription: Subscription;
     ngOnDestroy() {
+        this.pageSize = 0;
         if (this._pageSubscription) {
             this._pageSubscription.unsubscribe();
         }

--- a/src/clr-angular/data/datagrid/datagrid-pagination.ts
+++ b/src/clr-angular/data/datagrid/datagrid-pagination.ts
@@ -71,7 +71,7 @@ export class ClrDatagridPagination implements OnDestroy, OnInit {
      */
     private _pageSubscription: Subscription;
     ngOnDestroy() {
-        this.pageSize = 0;
+        this.page.resetPageSize();
         if (this._pageSubscription) {
             this._pageSubscription.unsubscribe();
         }

--- a/src/clr-angular/data/datagrid/providers/page.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/page.spec.ts
@@ -55,6 +55,8 @@ export default function(): void {
             expect(this.pageInstance.current).toBe(2);
             this.pageInstance.size = 10;
             expect(this.pageInstance.current).toBe(3);
+            this.pageInstance.size = 0;
+            expect(this.pageInstance.current).toBe(1);
         });
 
         it("correctly uses the last item's index if the last page is not full", function() {

--- a/src/clr-angular/data/datagrid/providers/page.ts
+++ b/src/clr-angular/data/datagrid/providers/page.ts
@@ -143,4 +143,11 @@ export class Page {
         }
         return lastInPage;
     }
+
+    /**
+     * Resets the page size to 0
+     */
+    public resetPageSize(): void {
+        this.size = 0;
+    }
 }

--- a/src/clr-angular/data/datagrid/providers/page.ts
+++ b/src/clr-angular/data/datagrid/providers/page.ts
@@ -23,9 +23,13 @@ export class Page {
         const oldSize = this._size;
         if (size !== oldSize) {
             this._size = size;
-            // Yeap. That's the formula to keep the first item from the old page still
-            // displayed in the new one.
-            this._current = Math.floor(oldSize / size * (this._current - 1)) + 1;
+            if (size === 0) {
+                this._current = 1;
+            } else {
+                // Yeap. That's the formula to keep the first item from the old page still
+                // displayed in the new one.
+                this._current = Math.floor(oldSize / size * (this._current - 1)) + 1;
+            }
             // We always emit an event even if the current page index didn't change, because
             // the size changing means the items inside the page are different
             this._change.next(this._current);


### PR DESCRIPTION
Fixes: #1838

1. Resets the page size when the pagination is destroyed.
2. Introduced a pagination description section.

![pagination](https://user-images.githubusercontent.com/1426805/34838657-f72070ac-f6cc-11e7-9832-30925269d816.gif)

Note: In case the datagrid height is restricted, it has to be restricted via a class. Adding a style attribute doesn't work because when you enable and then disable pagination, the height is reset when added through the style attribute. Works when you have a class though.

Tested on Chrome, IE, Edge, Safari, Firefox

Signed-off-by: Aditya Bhandari <adityab@vmware.com>