### PR TITLE
[NG] fix to remove datagrid column toggle hard coded strings

### DIFF
--- a/src/app/datagrid/hide-show-columns/hide-show.html
+++ b/src/app/datagrid/hide-show-columns/hide-show.html
@@ -82,3 +82,73 @@
         <clr-dg-pagination #pagination [clrDgPageSize]="currentPageSize"></clr-dg-pagination>
     </clr-dg-footer>
 </clr-datagrid>
+
+<h2>Hide-show columns demo with custom buttons</h2>
+
+<clr-datagrid>
+    <clr-dg-column>
+        <ng-container *clrDgHideableColumn>
+            User ID
+        </ng-container>
+    </clr-dg-column>
+    <clr-dg-column>
+        <!--Name-->
+        <ng-container *clrDgHideableColumn>
+            Name
+        </ng-container>
+    </clr-dg-column>
+    <clr-dg-column>
+        <ng-container *clrDgHideableColumn>
+            Creation date
+        </ng-container>
+    </clr-dg-column>
+    <clr-dg-column>
+        <ng-container *clrDgHideableColumn>
+            Pokemon
+        </ng-container>
+    </clr-dg-column>
+    <clr-dg-column>
+        <ng-container *clrDgHideableColumn>
+            Favorite color
+        </ng-container>
+    </clr-dg-column>
+
+    <clr-dg-placeholder>No users found</clr-dg-placeholder>
+
+    <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
+        <clr-dg-cell>
+            {{user.id}}
+        </clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>
+            {{user.pokemon.name}}
+            <clr-signpost>
+                <button
+                    type="button"
+                    class="signpost-action btn btn-small btn-link"
+                    [class.active]="open"
+                    clrSignpostTrigger>
+                    <clr-icon shape="help-info"></clr-icon>
+                </button>
+                <clr-signpost-content *clrIfOpen [clrPosition]="'top-middle'">
+                    The pokemon is strong.
+                </clr-signpost-content>
+            </clr-signpost>
+        </clr-dg-cell>
+        <clr-dg-cell>
+            <span class="color-square" [style.backgroundColor]="user.color"></span>
+        </clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>
+        <clr-dg-column-toggle>
+            <clr-dg-column-toggle-title>Kolumne Herauschauen!</clr-dg-column-toggle-title>
+            <clr-dg-column-toggle-button clrType="selectAll">Alle auswählen!</clr-dg-column-toggle-button>
+            <clr-dg-column-toggle-button clrType="ok"><clr-icon shape="check"></clr-icon></clr-dg-column-toggle-button>
+        </clr-dg-column-toggle>
+        {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
+        of {{pagination.totalItems}} users
+        <clr-dg-pagination #pagination [clrDgPageSize]="currentPageSize"></clr-dg-pagination>
+    </clr-dg-footer>
+</clr-datagrid>

--- a/src/clr-angular/data/datagrid/all.spec.ts
+++ b/src/clr-angular/data/datagrid/all.spec.ts
@@ -18,7 +18,8 @@ import NestedPropertySpecs from "./built-in/nested-property.spec";
 import DatagridActionBarSpecs from "./datagrid-action-bar.spec";
 import DatagridActionOverflowSpecs from "./datagrid-action-overflow.spec";
 import DatagridCellSpecs from "./datagrid-cell.spec";
-import DatagridColumnToggle from "./datagrid-column-toggle.spec";
+import DatagridColumnToggleButtonSpecs from "./datagrid-column-toggle-button.spec";
+import DatagridColumnToggleSpecs from "./datagrid-column-toggle.spec";
 import DatagridColumnSpecs from "./datagrid-column.spec";
 import DatagridFilterSpecs from "./datagrid-filter.spec";
 import DatagridFooterSpecs from "./datagrid-footer.spec";
@@ -32,6 +33,7 @@ import DatagridRowDetailSpecs from "./datagrid-row-detail.spec";
 import DatagridRowSpecs from "./datagrid-row.spec";
 import DatagridSpecs from "./datagrid.spec";
 import {addHelpers} from "./helpers.spec";
+import ColumnToggleButtonsServiceSpecs from "./providers/column-toggle-buttons.service.spec";
 import FiltersProviderSpecs from "./providers/filters.spec";
 import DatagridHideableColumnServiceSpecs from "./providers/hideable-column.service.spec";
 import ItemsProviderSpecs from "./providers/items.spec";
@@ -60,6 +62,7 @@ describe("Datagrid", function() {
         ItemsProviderSpecs();
         SelectionProviderSpecs();
         DatagridHideableColumnServiceSpecs();
+        ColumnToggleButtonsServiceSpecs();
     });
     describe("Components", function() {
         DatagridActionBarSpecs();
@@ -76,7 +79,8 @@ describe("Datagrid", function() {
         DatagridPlaceholderSpecs();
         DatagridSpecs();
         DatagridHideableColumnSpec();
-        DatagridColumnToggle();
+        DatagridColumnToggleSpecs();
+        DatagridColumnToggleButtonSpecs();
         DatagridHideableColumnDirectiveSpec();
     });
     describe("Render", function() {

--- a/src/clr-angular/data/datagrid/datagrid-column-toggle-button.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-toggle-button.spec.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component, QueryList, TemplateRef, ViewChildren} from "@angular/core";
+
+import {ClrDatagridColumnToggle} from "./datagrid-column-toggle";
+import {ClrDatagridColumnToggleButton} from "./datagrid-column-toggle-button";
+import {DatagridHideableColumnModel} from "./datagrid-hideable-column.model";
+import {TestContext} from "./helpers.spec";
+import {ColumnToggleButtonsService} from "./providers/column-toggle-buttons.service";
+import {HideableColumnService} from "./providers/hideable-column.service";
+
+export default function(): void {
+    describe("Datagrid Column Toggle Button component", function() {
+        describe("Typescript API", function() {
+            let columnToggleButtons: ColumnToggleButtonsService;
+            let component: ClrDatagridColumnToggleButton;
+
+            beforeEach(function() {
+                columnToggleButtons = new ColumnToggleButtonsService();
+                component = new ClrDatagridColumnToggleButton(columnToggleButtons);
+            });
+
+            it("knows if the button isOk()", function() {
+                component.clrType = "ok";
+                expect(component.isOk()).toBe(true);
+                component.clrType = "selectAll";
+                expect(component.isOk()).toBe(false);
+            });
+
+            it("gets the correct classes", function() {
+                component.clrType = "ok";
+                expect(component.getClasses()).toEqual("btn btn-primary");
+                component.clrType = "selectAll";
+                expect(component.getClasses()).toEqual("btn btn-sm btn-link p6 text-uppercase");
+            });
+
+            it("calls the click method", function() {
+                component.clrType = "ok";
+                spyOn(columnToggleButtons, "buttonClicked");
+                component.click();
+                expect(columnToggleButtons.buttonClicked).toHaveBeenCalledWith(component.clrType);
+            });
+        });
+
+        describe("View", function() {
+            // Until we can properly type "this"
+            let context: TestContext<ClrDatagridColumnToggleButton, ButtonTest>;
+            let columnToggleButtons: ColumnToggleButtonsService;
+            let button;
+
+            beforeEach(function() {
+                context = this.create(ClrDatagridColumnToggleButton, ButtonTest, [ColumnToggleButtonsService]);
+                columnToggleButtons = context.getClarityProvider(ColumnToggleButtonsService);
+                button = context.clarityElement.querySelector("button");
+            });
+
+            it("has a button", function() {
+                expect(button).toBeDefined();
+                expect(button.className).toContain("btn btn-primary");
+                context.testComponent.type = "selectAll";
+                context.detectChanges();
+                expect(button.className).toContain("btn btn-sm");
+            });
+
+            it("projects content", function() {
+                expect(button.innerText).toEqual("Testing 1 2 3".toUpperCase());
+            });
+
+            it("should disable the button when all are active", function() {
+                context.testComponent.type = "selectAll";
+                columnToggleButtons.selectAllDisabled = true;
+                context.detectChanges();
+                expect(button.disabled).toBe(true);
+            });
+        });
+    });
+}
+
+@Component({
+    template: `
+        <clr-dg-column-toggle-button [clrType]="type">Testing 1 2 3</clr-dg-column-toggle-button>
+    `
+})
+class ButtonTest {
+    type = "ok";
+}

--- a/src/clr-angular/data/datagrid/datagrid-column-toggle-button.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-toggle-button.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component, Input} from "@angular/core";
+
+import {ColumnToggleButtons, ColumnToggleButtonsService} from "./providers/column-toggle-buttons.service";
+
+@Component({
+    selector: "clr-dg-column-toggle-button",
+    template: `
+        <button
+            (click)="click()"
+            [disabled]="toggleButtons.selectAllDisabled && !isOk()"
+            [ngClass]="getClasses()"
+            type="button">
+            <ng-content></ng-content>
+        </button>
+    `,
+    host: {"[class.action-right]": "isOk()", "[style.display]": "block"}
+})
+
+export class ClrDatagridColumnToggleButton {
+    @Input() clrType: ColumnToggleButtons;
+
+    constructor(public toggleButtons: ColumnToggleButtonsService) {}
+
+    getClasses() {
+        let classes = "btn ";
+        if (this.isOk()) {
+            classes += "btn-primary";
+        } else {
+            classes += "btn-sm btn-link p6 text-uppercase";
+        }
+        return classes;
+    }
+
+    isOk() {
+        return this.clrType === "ok";
+    }
+
+    click() {
+        this.toggleButtons.buttonClicked(this.clrType);
+    }
+}

--- a/src/clr-angular/data/datagrid/datagrid-column-toggle-title.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-toggle-title.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component} from "@angular/core";
+
+@Component({
+    selector: "clr-dg-column-toggle-title",
+    template: `<ng-content></ng-content>`,
+})
+export class ClrDatagridColumnToggleTitle {}

--- a/src/clr-angular/data/datagrid/datagrid-footer.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-footer.spec.ts
@@ -7,6 +7,7 @@ import {Component} from "@angular/core";
 
 import {ClrDatagridFooter} from "./datagrid-footer";
 import {TestContext} from "./helpers.spec";
+import {ColumnToggleButtonsService} from "./providers/column-toggle-buttons.service";
 import {FiltersProvider} from "./providers/filters";
 import {HideableColumnService} from "./providers/hideable-column.service";
 import {Items} from "./providers/items";
@@ -15,71 +16,104 @@ import {Selection, SelectionType} from "./providers/selection";
 import {Sort} from "./providers/sort";
 import {StateDebouncer} from "./providers/state-debouncer.provider";
 
-const PROVIDERS_NEEDED = [Selection, Items, FiltersProvider, Sort, Page, HideableColumnService, StateDebouncer];
+const PROVIDERS_NEEDED =
+    [Selection, Items, FiltersProvider, Sort, Page, HideableColumnService, StateDebouncer, ColumnToggleButtonsService];
 
 export default function(): void {
     describe("ClrDatagridFooter component", function() {
-        let context: TestContext<ClrDatagridFooter, SimpleTest>;
+        describe("View", function() {
+            let context: TestContext<ClrDatagridFooter, SimpleTest>;
 
-        beforeEach(function() {
-            context = this.create(ClrDatagridFooter, SimpleTest, PROVIDERS_NEEDED);
+            beforeEach(function() {
+                context = this.create(ClrDatagridFooter, SimpleTest, PROVIDERS_NEEDED);
+            });
+
+            it("projects content", function() {
+                expect(context.clarityElement.textContent.trim()).toMatch("Hello world");
+            });
+
+            it("adds the .datagrid-cell class to the host", function() {
+                expect(context.clarityElement.classList.contains("datagrid-foot")).toBeTruthy();
+            });
+
+            it("does not show the selection details when selection type is None", function() {
+                const clarityDirectiveSelection: Selection = context.clarityDirective.selection;
+                clarityDirectiveSelection.selectionType = SelectionType.None;
+
+                context.detectChanges();
+
+                expect(context.clarityElement.querySelector(".datagrid-foot-select")).toBeNull();
+            });
+
+            it("does not show the selection details when selection type is single", function() {
+                const clarityDirectiveSelection: Selection = context.clarityDirective.selection;
+                clarityDirectiveSelection.selectionType = SelectionType.Single;
+                clarityDirectiveSelection.current.push(1);
+
+                context.detectChanges();
+
+                expect(context.clarityElement.querySelector(".datagrid-foot-select")).toBeNull();
+            });
+
+            it("shows the selection details when more than one item is selected", function() {
+                const clarityDirectiveSelection: Selection = context.clarityDirective.selection;
+                clarityDirectiveSelection.selectionType = SelectionType.Multi;
+                clarityDirectiveSelection.current.push(1);
+
+                context.clarityDirective.cdr.markForCheck();
+                context.detectChanges();
+
+                expect(context.clarityElement.querySelector(".datagrid-foot-select")).not.toBeNull();
+                expect(context.clarityElement.querySelector(".datagrid-foot-select").textContent).toMatch("1");
+
+
+                clarityDirectiveSelection.current.push(1);
+                context.clarityDirective.cdr.markForCheck();
+                context.detectChanges();
+
+                expect(context.clarityElement.querySelector(".datagrid-foot-select")).not.toBeNull();
+                expect(context.clarityElement.querySelector(".datagrid-foot-select").textContent).toMatch("2");
+
+                clarityDirectiveSelection.current = [];
+
+                context.clarityDirective.cdr.markForCheck();
+                context.detectChanges();
+
+                expect(context.clarityElement.querySelector(".datagrid-foot-select")).toBeNull();
+            });
         });
 
-        it("projects content", function() {
-            expect(context.clarityElement.textContent.trim()).toMatch("Hello world");
-        });
+        describe("View with Custom Toggle Buttons", function() {
+            let context: TestContext<ClrDatagridFooter, ColumnTogglerTest>;
 
-        it("adds the .datagrid-cell class to the host", function() {
-            expect(context.clarityElement.classList.contains("datagrid-foot")).toBeTruthy();
-        });
+            beforeEach(function() {
+                context = this.create(ClrDatagridFooter, ColumnTogglerTest, PROVIDERS_NEEDED);
+            });
 
-        it("does not show the selection details when selection type is None", function() {
-            const clarityDirectiveSelection: Selection = context.clarityDirective.selection;
-            clarityDirectiveSelection.selectionType = SelectionType.None;
-
-            context.detectChanges();
-
-            expect(context.clarityElement.querySelector(".datagrid-foot-select")).toBeNull();
-        });
-
-        it("does not show the selection details when selection type is single", function() {
-            const clarityDirectiveSelection: Selection = context.clarityDirective.selection;
-            clarityDirectiveSelection.selectionType = SelectionType.Single;
-            clarityDirectiveSelection.current.push(1);
-
-            context.detectChanges();
-
-            expect(context.clarityElement.querySelector(".datagrid-foot-select")).toBeNull();
-        });
-
-        it("shows the selection details when more than one item is selected", function() {
-            const clarityDirectiveSelection: Selection = context.clarityDirective.selection;
-            clarityDirectiveSelection.selectionType = SelectionType.Multi;
-            clarityDirectiveSelection.current.push(1);
-
-            context.clarityDirective.cdr.markForCheck();
-            context.detectChanges();
-
-            expect(context.clarityElement.querySelector(".datagrid-foot-select")).not.toBeNull();
-            expect(context.clarityElement.querySelector(".datagrid-foot-select").textContent).toMatch("1");
-
-
-            clarityDirectiveSelection.current.push(1);
-            context.clarityDirective.cdr.markForCheck();
-            context.detectChanges();
-
-            expect(context.clarityElement.querySelector(".datagrid-foot-select")).not.toBeNull();
-            expect(context.clarityElement.querySelector(".datagrid-foot-select").textContent).toMatch("2");
-
-            clarityDirectiveSelection.current = [];
-
-            context.clarityDirective.cdr.markForCheck();
-            context.detectChanges();
-
-            expect(context.clarityElement.querySelector(".datagrid-foot-select")).toBeNull();
+            it("projects custom column toggler", function() {
+                context.clarityElement.querySelector(".column-toggle--action").click();
+                context.detectChanges();
+                expect(context.clarityElement.querySelector("clr-dg-column-toggle-title").innerText)
+                    .toMatch("Custom Title");
+                expect(context.clarityElement.querySelector(".switch-footer clr-dg-column-toggle-button").innerText)
+                    .toMatch("OK!!!");
+            });
         });
     });
 }
 
 @Component({template: `<clr-dg-footer>Hello world</clr-dg-footer>`})
 class SimpleTest {}
+
+@Component({
+    template: `        
+    <clr-dg-footer>
+        <clr-dg-column-toggle>
+            <clr-dg-column-toggle-title>Custom Title</clr-dg-column-toggle-title>
+            <clr-dg-column-toggle-button type="ok">OK!!!</clr-dg-column-toggle-button>
+            <clr-dg-column-toggle-button type="selectAll">Select All!!!</clr-dg-column-toggle-button>
+        </clr-dg-column-toggle>
+        Hello world
+    </clr-dg-footer>`
+})
+class ColumnTogglerTest {}

--- a/src/clr-angular/data/datagrid/datagrid-footer.ts
+++ b/src/clr-angular/data/datagrid/datagrid-footer.ts
@@ -3,9 +3,10 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import {ChangeDetectorRef, Component, OnInit} from "@angular/core";
+import {ChangeDetectorRef, Component, ContentChild, OnInit} from "@angular/core";
 import {Subscription} from "rxjs/Subscription";
 
+import {ClrDatagridColumnToggle} from "./datagrid-column-toggle";
 import {HideableColumnService} from "./providers/hideable-column.service";
 import {Selection, SelectionType} from "./providers/selection";
 
@@ -18,7 +19,8 @@ import {Selection, SelectionType} from "./providers/selection";
                 {{selection.current.length}}
             </clr-checkbox>
         </ng-container>
-        <clr-dg-column-toggle *ngIf="activeToggler"></clr-dg-column-toggle>
+        <ng-content select="clr-dg-column-toggle"></ng-content>
+        <clr-dg-column-toggle *ngIf="!toggle && activeToggler"></clr-dg-column-toggle>
         <div class="datagrid-foot-description">
             <ng-content></ng-content>
         </div>
@@ -37,6 +39,8 @@ export class ClrDatagridFooter implements OnInit {
 
     /* reference to the enum so that template can access */
     public SELECTION_TYPE = SelectionType;
+
+    @ContentChild(ClrDatagridColumnToggle) toggle: ClrDatagridColumnToggle;
 
     ngOnInit() {
         this.subscriptions.push(this.hideableColumnService.columnListChange.subscribe((change) => {

--- a/src/clr-angular/data/datagrid/datagrid.module.ts
+++ b/src/clr-angular/data/datagrid/datagrid.module.ts
@@ -26,6 +26,8 @@ import {ClrDatagridActionOverflow} from "./datagrid-action-overflow";
 import {ClrDatagridCell} from "./datagrid-cell";
 import {ClrDatagridColumn} from "./datagrid-column";
 import {ClrDatagridColumnToggle} from "./datagrid-column-toggle";
+import {ClrDatagridColumnToggleButton} from "./datagrid-column-toggle-button";
+import {ClrDatagridColumnToggleTitle} from "./datagrid-column-toggle-title";
 import {DatagridDetailRegisterer} from "./datagrid-detail-registerer";
 import {ClrDatagridFilter} from "./datagrid-filter";
 import {ClrDatagridFooter} from "./datagrid-footer";
@@ -55,7 +57,7 @@ export const CLR_DATAGRID_DIRECTIVES: Type<any>[] = [
     ClrDatagrid, ClrDatagridActionBar, ClrDatagridActionOverflow, ClrDatagridColumn, ClrDatagridColumnToggle,
     ClrDatagridHideableColumn, ClrDatagridFilter, ClrDatagridItems, ClrDatagridItemsTrackBy, ClrDatagridRow,
     ClrDatagridRowDetail, DatagridDetailRegisterer, ClrDatagridCell, ClrDatagridFooter, ClrDatagridPagination,
-    ClrDatagridPlaceholder,
+    ClrDatagridPlaceholder, ClrDatagridColumnToggleButton, ClrDatagridColumnToggleTitle,
 
     // Renderers
     DatagridMainRenderer, DatagridTableRenderer, DatagridHeadRenderer, DatagridHeaderRenderer, DatagridBodyRenderer,

--- a/src/clr-angular/data/datagrid/datagrid.ts
+++ b/src/clr-angular/data/datagrid/datagrid.ts
@@ -22,6 +22,7 @@ import {ClrDatagridItems} from "./datagrid-items";
 import {ClrDatagridPlaceholder} from "./datagrid-placeholder";
 import {ClrDatagridRow} from "./datagrid-row";
 import {ClrDatagridStateInterface} from "./interfaces/state.interface";
+import {ColumnToggleButtonsService} from "./providers/column-toggle-buttons.service";
 import {FiltersProvider} from "./providers/filters";
 import {ExpandableRowsCount} from "./providers/global-expandable-rows";
 import {HideableColumnService} from "./providers/hideable-column.service";
@@ -38,8 +39,18 @@ import {DatagridRenderOrganizer} from "./render/render-organizer";
     selector: "clr-datagrid",
     templateUrl: "./datagrid.html",
     providers: [
-        Selection, Sort, FiltersProvider, Page, Items, DatagridRenderOrganizer, RowActionService, ExpandableRowsCount,
-        HideableColumnService, StateDebouncer, StateProvider
+        Selection,
+        Sort,
+        FiltersProvider,
+        Page,
+        Items,
+        DatagridRenderOrganizer,
+        RowActionService,
+        ExpandableRowsCount,
+        HideableColumnService,
+        StateDebouncer,
+        StateProvider,
+        ColumnToggleButtonsService,
     ],
     host: {"[class.datagrid-host]": "true"}
 })

--- a/src/clr-angular/data/datagrid/providers/column-toggle-buttons.service.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/column-toggle-buttons.service.spec.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import {ColumnToggleButtonsService} from "./column-toggle-buttons.service";
+
+export default function(): void {
+    describe("ColumnToggleButtons provider", function() {
+        let service: ColumnToggleButtonsService;
+
+        beforeEach(function() {
+            service = new ColumnToggleButtonsService();
+        });
+
+        it("should have expected properties", function() {
+            expect(service.buttons).toBeNull();
+            expect(service.selectAllDisabled).toBe(false);
+            expect(service.okButtonClicked.subscribe).toBeDefined();
+            expect(service.selectAllButtonClicked.subscribe).toBeDefined();
+        });
+
+        it("should emit clicks", function() {
+            let calls = 0;
+            service.okButtonClicked.subscribe(() => {
+                calls++;
+            });
+            service.selectAllButtonClicked.subscribe(() => {
+                calls++;
+            });
+
+            service.buttonClicked("ok");
+            service.buttonClicked("selectAll");
+            expect(calls).toEqual(2);
+        });
+    });
+}

--- a/src/clr-angular/data/datagrid/providers/column-toggle-buttons.service.ts
+++ b/src/clr-angular/data/datagrid/providers/column-toggle-buttons.service.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Injectable, TemplateRef} from "@angular/core";
+import {Observable} from "rxjs/Observable";
+import {Subject} from "rxjs/Subject";
+
+export type ColumnToggleButtons = "ok"|"selectAll";
+
+@Injectable()
+export class ColumnToggleButtonsService {
+    buttons: TemplateRef<any> = null;
+    selectAllDisabled: boolean = false;
+
+    private _okButtonClicked = new Subject<any>();
+    public get okButtonClicked(): Observable<any> {
+        return this._okButtonClicked.asObservable();
+    }
+
+    private _selectAllButtonClicked = new Subject<any>();
+    public get selectAllButtonClicked(): Observable<any> {
+        return this._selectAllButtonClicked.asObservable();
+    }
+
+    public buttonClicked(type: ColumnToggleButtons): void {
+        switch (type.toLowerCase()) {
+            case "ok":
+                this._okButtonClicked.next();
+                break;
+            case "selectall":
+                this._selectAllButtonClicked.next();
+                break;
+            default:
+                break;
+        }
+    }
+}


### PR DESCRIPTION
Does not break compatibility because it will fall back to existing implementation. To use, just add the `clr-dg-column-toggle` component into the footer, and then project the `clr-dg-column-toggle-title` and `clr-dg-column-toggle-button` components into the footer.

This can be ported to 0.10 without a breaking change.

Fixes #1129 