### PR TITLE
[UI] fix: dark theme navigation subnav box-shadows

### DIFF
--- a/src/clr-angular/utils/_theme.dark.clarity.scss
+++ b/src/clr-angular/utils/_theme.dark.clarity.scss
@@ -538,7 +538,7 @@ $clr-sidenav-border-color: #152127;
 $clr-sidenav-link-hover-color: $clr-global-selection-color;
 
 $clr-subnav-bgColor: #17242b;
-$clr-nav-shadow: 0 -1px 0 $gray-light-midtone inset;
+$clr-nav-shadow: 0 -1px 0 #485764 inset;
 // END Nav
 
 /**************


### PR DESCRIPTION
- closes #1871

Tested in Chrome. 

Signed-off-by: Matt Hippely <mhippely@vmware.com>