### PR TITLE
[CORE] fix: adds four support links for light/dark themes and v10/v11 

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -19,8 +19,10 @@ PLEASE FILL OUT THE FOLLOWING. WE MAY CLOSE INCOMPLETE ISSUES.
 <!-- Include a working plunker link reproducing the behavior. -->
 <!-- Clarity Plunker Templates -->
 * Include a link to the reproduction scenario you created by forking one of the Clarity Plunker Templates:
-<!-- Clarity Version: [Latest](https://embed.plnkr.co/AuJuo5/) -->
-<!-- Clarity Version: [0.9.20](https://embed.plnkr.co/b6Deth/) -->
+<!-- Clarity Version: [Light Theme v11](https://stackblitz.com/edit/clarity-light-theme-v11) -->
+<!-- Clarity Version: [Dark Theme v11](https://stackblitz.com/edit/clarity-dark-theme-v11) -->
+<!-- Clarity Version: [Light Theme v10](https://stackblitz.com/edit/clarity-light-theme-v10) -->
+<!-- Clarity Version: [Dark Theme v10](https://stackblitz.com/edit/clarity-dark-theme-v10) -->
 
 ### Environment details
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,8 +129,10 @@ You can submit an issue or a bug to our [GitHub repository](https://github.com/v
 
 * The link to the reproduction scenario you created using one of the Clarity Plunker Templates
 * If possible please provide a minimal demo illustrating the issue by forking one of the Clarity Plunker Templates
-  - Clarity Version: [Latest - 0.9.x](https://plnkr.co/uNwwZe)
-  - Clarity Version: [Legacy - 0.8.15](https://plnkr.co/8TwwdL)
+  - [Light Theme v11](https://stackblitz.com/edit/clarity-light-theme-v11)
+  - [Dark Theme v11](https://stackblitz.com/edit/clarity-dark-theme-v11)
+  - [Light Theme v10](https://stackblitz.com/edit/clarity-light-theme-v10)
+  - [Dark Theme v10](https://stackblitz.com/edit/clarity-dark-theme-v10)
 * The version number of Angular
 * The version number of Clarity
 * The browser name and version number

--- a/README.md
+++ b/README.md
@@ -135,5 +135,7 @@ The Clarity project team welcomes contributions from the community. For more det
 
 If you find a bug or want to request a new feature, please open a [GitHub issue](https://github.com/vmware/clarity/issues).
 * Include a link to the reproduction scenario you created by forking one of the Clarity Plunker Templates:
-  - Clarity Version: [Latest - 0.10.x](https://plnkr.co/uNwwZe)
-  - Clarity Version: [Legacy - 0.8.15](https://plnkr.co/8TwwdL)
+  - [Light Theme v11](https://stackblitz.com/edit/clarity-light-theme-v11)
+  - [Dark Theme v11](https://stackblitz.com/edit/clarity-dark-theme-v11)
+  - [Light Theme v10](https://stackblitz.com/edit/clarity-light-theme-v10)
+  - [Dark Theme v10](https://stackblitz.com/edit/clarity-dark-theme-v10)


### PR DESCRIPTION
This is a maintenance commit that updates project files with new support links.  

Signed-off-by: Matt Hippely <mhippely@vmware.com>