### PR TITLE
[NG] Fix #1642

### DIFF
--- a/src/clr-angular/popover/dropdown/dropdown-item.ts
+++ b/src/clr-angular/popover/dropdown/dropdown-item.ts
@@ -3,16 +3,20 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import {Directive, ElementRef, HostListener} from "@angular/core";
+import {AfterViewInit, Directive, ElementRef, Renderer2} from "@angular/core";
 
 import {ClrDropdown} from "./dropdown";
 import {RootDropdownService} from "./providers/dropdown.service";
 
 @Directive({selector: "[clrDropdownItem]", host: {"[class.dropdown-item]": "true"}})
-export class ClrDropdownItem {
-    constructor(private dropdown: ClrDropdown, private el: ElementRef, private _dropdownService: RootDropdownService) {}
+export class ClrDropdownItem implements AfterViewInit {
+    constructor(private dropdown: ClrDropdown, private el: ElementRef, private _dropdownService: RootDropdownService,
+                private renderer: Renderer2) {}
 
-    @HostListener("click")
+    ngAfterViewInit() {
+        this.renderer.listen(this.el.nativeElement, "click", () => this.onDropdownItemClick());
+    }
+
     onDropdownItemClick(): void {
         if (this.dropdown.isMenuClosable && !this.el.nativeElement.classList.contains("disabled")) {
             this._dropdownService.closeMenus();


### PR DESCRIPTION
We now wait until the view for each dropdown item is ready before
attaching the click listener. This lets us register our event listener
last, which means the custom ones provided by the consumer will
execute before ours.

Signed-off-by: Eudes Petonnet-Vincent <epetonnetvince@vmware.com>