### PR TITLE
[CORE] fix gemini reporter latest release

### DIFF
--- a/.gemini.conf.yml
+++ b/.gemini.conf.yml
@@ -8,8 +8,9 @@ browsers:
 
 system:
   plugins:
-    html-reporter:
+    'html-reporter/gemini': 
       enabled: true
+      path: 'gemini-report'
 
 
 #compositeImage: true

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ src/clr-angular/.ng_build
 *.launch
 .settings/
 *.sublime-workspace
+*.code-workspace
 
 # IDE - VSCode
 .vscode/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "7.0"
+  - "8"
 env:
   global:
     - CXX=g++-4.8
@@ -37,8 +37,8 @@ cache:
 before_install:
 
 before_script:
-  - npm install -g gemini
-  - npm install -g html-reporter
+  - npm install -g gemini@5.2.0
+  - npm install -g html-reporter@2.0.1
 
 script:
   - npm run $TEST_SUITE # run unit test and css regression test sets in parallel

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "clr-all",
-    "version": "0.11.1",
+    "version": "0.11.2-patch",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
The html-reporter released a breaking change and we don't version control it in Travis. This locks versions and updates to the current release.