### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ If you already have an Angular application, you can follow the installation step
     @NgModule({
         imports: [
             BrowserModule,
-            ClarityModule.forRoot(),
+            ClarityModule,
             ....
          ],
          declarations: [ AppComponent ],


### PR DESCRIPTION
The `forRoot()` method is `@deprecated` and should not be used anymore.