### PR TITLE
[CORE] Fixes orphaned webserver for gemini tests.

### DIFF
--- a/scripts/docker-cdc.js
+++ b/scripts/docker-cdc.js
@@ -56,7 +56,7 @@ if (program.update) {
  */
 function runGemini(config) {
     shell.exec("webpack");
-    shell.exec("node_modules/.bin/lite-server --baseDir=dist" , { async: true });
+    let server = shell.exec("node_modules/.bin/lite-server --baseDir=dist" , { async: true });
     let status = shell.exec("docker run --rm --name=clarity_chrome -d -p 4444:4444 selenium/standalone-chrome@sha256:b899f16b6d963600ef6da8a8dd49e311146033ed66cb5af71eccb78ab378e19a");
     let geminiStatus = 0;
     if (status.code === 0) {
@@ -68,5 +68,6 @@ function runGemini(config) {
     } else {
         console.warn("WARNING: Unable to start docker container for gemini. Is docker installed and running on your system?");
     }
+    server.kill();
     process.exit(geminiStatus); // this will kill the process so that the lite-server is killed with the exit code from gemini
 }


### PR DESCRIPTION
This is a core fix for running `npm run cssTest set#` so that the webserver running the demo app on port 3000 is killed before the Clarity Docker Control process exits.