### PR TITLE
[UI] Adds color to dark theme options in select elements

### DIFF
--- a/src/clr-angular/forms/_select.clarity.scss
+++ b/src/clr-angular/forms/_select.clarity.scss
@@ -28,6 +28,10 @@
             &:disabled {
                 @include disabled-form-fields();
             }
+
+            option {
+                color: $clr-option-font-color;
+            }
         }
 
         //Remove default arrow from IE

--- a/src/clr-angular/forms/_variables.inputs.scss
+++ b/src/clr-angular/forms/_variables.inputs.scss
@@ -4,6 +4,7 @@
 
 // Usage: ../forms/utils/_mixins.clarity.scss
 $clr-input-text-color: $clr-black;
+$clr-option-font-color: $clr-input-text-color;
 
 // Usage: ../forms/utils/_mixins.clarity.scss
 // Usage: ../forms/_select.clarity.scss

--- a/src/clr-angular/utils/_theme.dark.clarity.scss
+++ b/src/clr-angular/utils/_theme.dark.clarity.scss
@@ -381,6 +381,7 @@ $clr-dropdown-header-color: #ADBBC4;
  * - ../button/_toggles.clarity.scss
  */
 $clr-input-text-color: #e9ecef;
+$clr-option-font-color: $clr-black;
 
 $clr-textarea-border-color: #000000;
 $clr-textarea-bg-color: #17242b;


### PR DESCRIPTION
### NOTES
- @lil-kim - I chose black b/c it was by far the most accessible of the dark theme colors and we already use for font color for the sidnav. If you think it needs a different color I can update this. 
- Screenshots of open selects are difficult to capture on windows, some of them below were captured while it was closing (after the screenshot click)
- Tested in: IE11, Edge and Firefox (on macOS and Windows 10) 
- Closes #1853

### Before
- IE11 ![screen shot 2018-02-01 at 4 59 07 pm](https://user-images.githubusercontent.com/433692/35711325-3eff348a-0771-11e8-9b92-297e37e6aea0.png)
- Edge ![screen shot 2018-02-01 at 4 56 22 pm](https://user-images.githubusercontent.com/433692/35711288-0bda4194-0771-11e8-9d09-b1d4a5d9ee3d.png)
- Firefox <img width="663" alt="screen shot 2018-02-01 at 4 55 06 pm" src="https://user-images.githubusercontent.com/433692/35711281-01c950d2-0771-11e8-994c-6890ec24c175.png">

### After
- IE11 <img width="1552" alt="ie11" src="https://user-images.githubusercontent.com/433692/35711389-7a796404-0771-11e8-835e-b7926bfe1cfe.png">
- Edge <img width="1552" alt="edge" src="https://user-images.githubusercontent.com/433692/35711372-681be7b4-0771-11e8-94b1-be3d1eb52534.png">
- Firefox <img width="725" alt="screen shot 2018-02-01 at 4 46 36 pm" src="https://user-images.githubusercontent.com/433692/35711010-847e14d8-076f-11e8-9009-f19dab3b7da8.png">
Signed-off-by: Matt Hippely <mhippely@vmware.com>