### PR TITLE
[NG] Preserve selection on items refresh for client-side datagrids

### DIFF
--- a/src/clr-angular/data/datagrid/datagrid-row.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-row.spec.ts
@@ -71,6 +71,7 @@ export default function(): void {
             beforeEach(function() {
                 context = this.create(ClrDatagridRow, FullTest, PROVIDERS);
                 selectionProvider = TestBed.get(Selection);
+                TestBed.get(Items).all = [{id: 1}, {id: 2}];
             });
 
             it("doesn't display a checkbox unless selection type is multi", function() {

--- a/src/clr-angular/data/datagrid/providers/items.ts
+++ b/src/clr-angular/data/datagrid/providers/items.ts
@@ -79,14 +79,16 @@ export class Items {
      * List of all items in the datagrid
      */
     private _all: any[];
+    public get all() {
+        return this._all;
+    }
     public set all(items: any[]) {
+        this._all = items;
+        this.emitAllChanges(items);
         if (this.smart) {
-            this._all = items;
-            this.emitAllChanges(items);
             this._filterItems();
         } else {
             this._displayed = items;
-            this.emitAllChanges(items);
             this.emitChange();
         }
     }

--- a/src/clr-angular/data/datagrid/providers/selection.ts
+++ b/src/clr-angular/data/datagrid/providers/selection.ts
@@ -61,7 +61,7 @@ export class Selection {
 
             // Filter out any unmatched items if we're using smart datagrids where we expect all items to be present
             if (this._items.smart) {
-                leftOver = this.current.filter(selected => updatedItems.indexOf(selected) > -1);
+                leftOver = leftOver.filter(selected => updatedItems.indexOf(selected) > -1);
             }
 
             // TODO: Discussed this with Eudes and this is fine for now.
@@ -134,7 +134,7 @@ export class Selection {
         }
         this._currentSingle = value;
         if (this._items.trackBy && value) {
-            const lookup = this._items.displayed.findIndex(maybe => maybe === value);
+            const lookup = this._items.all.findIndex(maybe => maybe === value);
             this.selectedSingle = this._items.trackBy(lookup, value);
         }
         this.emitChange();
@@ -212,8 +212,8 @@ export class Selection {
                     this.current.push(item);
                     if (trackBy) {
                         // Push selected ref onto array
-                        const lookup = this._items.displayed.findIndex(maybe => maybe === item);
-                        this.selected.push(this._items.trackBy(0, item));
+                        const lookup = this._items.all.findIndex(maybe => maybe === item);
+                        this.selected.push(this._items.trackBy(lookup, item));
                     }
                     this.emitChange();
                 }


### PR DESCRIPTION
Fixes several bugs at once where we used the wrong variables (or didn't use them at all) to try and preserve selection, which meant we cleared it every time.
Also fixes the corresponding spec, which were completely broken for two reasons: a nested `beforeEach()` that didn't do anything, and the fact that we tested synchronously that an asynchronous operation didn't change anything. In other words, we were testing that code that hasn't run yet did not have any effects...

Fixes #1593.