### PR TITLE
[NG] use tilde to import bootstrap scss

### DIFF
--- a/src/clr-angular/utils/_dependencies.clarity.scss
+++ b/src/clr-angular/utils/_dependencies.clarity.scss
@@ -4,9 +4,9 @@
 
 
 // Bootstrap 4 Dependencies - Begin Part 1
-@import "node_modules/bootstrap/scss/variables";
-@import "node_modules/bootstrap/scss/mixins";
-@import "node_modules/bootstrap/scss/normalize";
+@import "~bootstrap/scss/variables";
+@import "~bootstrap/scss/mixins";
+@import "~bootstrap/scss/normalize";
 //Bootstrap 4 Dependencies - End Part 1
 
 
@@ -33,10 +33,10 @@
 
 // Bootstrap 4 Dependencies - Begin Part 2
 
-@import "node_modules/bootstrap/scss/media";
-@import "node_modules/bootstrap/scss/utilities";
-@import 'node_modules/bootstrap/scss/images';
-@import "node_modules/bootstrap/scss/list-group";
-@import "node_modules/bootstrap/scss/close";
-@import "node_modules/bootstrap/scss/grid";
-@import "node_modules/bootstrap/scss/responsive-embed";
+@import "~bootstrap/scss/media";
+@import "~bootstrap/scss/utilities";
+@import '~bootstrap/scss/images';
+@import "~bootstrap/scss/list-group";
+@import "~bootstrap/scss/close";
+@import "~bootstrap/scss/grid";
+@import "~bootstrap/scss/responsive-embed";


### PR DESCRIPTION
replace node_modules folder with ~ for more flexibility

 Signed-off-by: Gerd Jungbluth <gerd.jungbluth@engawa.de>