### PR TITLE
[NG] Safari unit testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7716,6 +7716,12 @@
                 }
             }
         },
+        "karma-safari-launcher": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/karma-safari-launcher/-/karma-safari-launcher-1.0.0.tgz",
+            "integrity": "sha1-lpgqLMR9BmquccVTursoMZEVos4=",
+            "dev": true
+        },
         "karma-source-map-support": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/karma-source-map-support/-/karma-source-map-support-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
         "karma-jasmine-html-reporter": "^0.2.2",
         "karma-jasmine-matchers": "^3.7.0",
         "karma-mocha-reporter": "^2.2.4",
+        "karma-safari-launcher": "^1.0.0",
         "karma-sourcemap-loader": "^0.3.7",
         "karma-webpack": "^2.0.4",
         "lite-server": "^2.3.0",

--- a/src/clr-angular/utils/virtual-scroll/virtual-for-of.spec.ts
+++ b/src/clr-angular/utils/virtual-scroll/virtual-for-of.spec.ts
@@ -127,7 +127,8 @@ export default function(): void {
                expect(this.container.nativeElement.textContent.trim()).toEqual("40414243");
            }));
 
-        itIgnore(["firefox"], "can accept an NonNgIterable instead of an array", fakeAsync(function(this: TestContext) {
+        itIgnore(["firefox", "safari"], "can accept an NonNgIterable instead of an array",
+                 fakeAsync(function(this: TestContext) {
                      this.testComponent.numbers = {
                          get(index: number) {
                              return index;

--- a/tests/tests.helpers.ts
+++ b/tests/tests.helpers.ts
@@ -2,7 +2,7 @@ import * as Browser from "detect-browser";
 
 export const itIgnore = (browsers: string[], should: string, test: any, focus?: boolean) => {
   if (browsers.length && browsers.indexOf(Browser.name) >= 0) {
-    return;
+    return xit(should, test);
   }
 
   return (focus) ? fit(should, test) : it(should, test);


### PR DESCRIPTION
This adds the test organization needed to run against Safari. There is one test
that doesn't work properly with Safari and it is ignored for the moment.