### PR TITLE
[CORE] setup saucelabs with travis, fix code coverage

### DIFF
--- a/.gemini.conf.yml
+++ b/.gemini.conf.yml
@@ -10,7 +10,7 @@ system:
   plugins:
     'html-reporter/gemini': 
       enabled: true
-      path: 'gemini-report'
+      path: 'reports/gemini'
 
 
 #compositeImage: true

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 /.ng_build
 src/clr-angular/.ng_build
 
-/gemini-report/
+/reports
 
 # dependencies
 /node_modules
@@ -41,6 +41,7 @@ testem.log
 /typings
 /src/clr-angular/package.json
 /src/clr-angular/README.md
+sauceconnect.log
 
 # e2e
 /e2e/*.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
-node_js:
+node_js: 
   - "8"
+
 env:
   global:
     - CXX=g++-4.8
@@ -28,17 +29,17 @@ addons:
       - google-chrome-stable
   artifacts:
     paths:
-      - $TRAVIS_BUILD_DIR/gemini-report/
+      - "$TRAVIS_BUILD_DIR/reports/"
+
 cache:
   apt: true
   directories:
     - node_modules
 
-before_install:
+before_install: 
 
 before_script:
-  - npm install -g gemini@5.2.0
-  - npm install -g html-reporter@2.0.1
+  - npm install -g gemini@5.2.0 html-reporter@2.0.1
 
 script:
   - npm run $TEST_SUITE # run unit test and css regression test sets in parallel

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 [![Build Status](https://travis-ci.org/vmware/clarity.svg?branch=master)](https://travis-ci.org/vmware/clarity)
 
+[![Build Status](https://saucelabs.com/browser-matrix/claritydesignsystem.svg)](https://saucelabs.com/beta/builds/b16110e384ce459ab68f10da6e38a285)
+
 Project Clarity is an open source design system that brings together UX guidelines, an HTML/CSS framework, and Angular components. This repository includes everything you need to build, customize, test, and deploy Clarity.  For complete documentation, visit the [Clarity website](https://vmware.github.io/clarity/).
 
 ## Getting Started

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,43 +4,95 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
+const browsers = {
+    chrome_latest_win_10: {
+        base: "SauceLabs",
+        browserName: "chrome",
+        version: "latest",
+        platform: "Windows 10"
+    },
+    firefox_latest_win_10: {
+        base: "SauceLabs",
+        browserName: "firefox",
+        version: "latest",
+        platform: "Windows 10"
+    },
+    safari_latest_osx_11: {
+        base: "SauceLabs",
+        browserName: "safari",
+        version: "latest",
+        platform: "macOS 10.13"
+    },
+    ie_11_win_8_1: {
+        base: "SauceLabs",
+        browserName: "internet explorer",
+        version: "latest",
+        platform: "Windows 8.1"
+    },
+    edge_latest_win_10: {
+        base: "SauceLabs",
+        browserName: "MicrosoftEdge",
+        version: "latest",
+        platform: "Windows 10"
+    }
+};
+
 module.exports = function(karma) {
     "use strict";
 
-    karma.set({
+    const config = {
         autoWatch: true,
         basePath: "",
         frameworks: ["jasmine", "jasmine-matchers"],
         files: [
             //PrismJS
-            { pattern: './node_modules/prismjs/themes/prism.css', included: true, watched: false },
-            { pattern: './node_modules/prismjs/prism.js', included: true, watched: false },
-            { pattern: './node_modules/prismjs/components/prism-typescript.min.js', included: true, watched: false },
+            {
+                pattern: "./node_modules/prismjs/themes/prism.css",
+                included: true,
+                watched: false
+            },
+            {
+                pattern: "./node_modules/prismjs/prism.js",
+                included: true,
+                watched: false
+            },
+            {
+                pattern:
+                    "./node_modules/prismjs/components/prism-typescript.min.js",
+                included: true,
+                watched: false
+            },
 
             // Custom Elements
-            { pattern: './node_modules/@webcomponents/custom-elements/custom-elements.min.js', included: true, watched: false },
+            {
+                pattern:
+                    "./node_modules/@webcomponents/custom-elements/custom-elements.min.js",
+                included: true,
+                watched: false
+            },
 
             // Clarity
-            { pattern: './dist/clr-ui/clr-ui.min.css', included: true, watched: true },
+            {
+                pattern: "./dist/clr-ui/clr-ui.min.css",
+                included: true,
+                watched: true
+            },
 
             // Entry point to all our spec files
             { pattern: "./tests/tests.entry.ts", watched: false }
         ],
-        exclude: [ 'node_modules/**/*spec.js' ],
+        exclude: ["node_modules/**/*spec.js"],
         preprocessors: {
             "./tests/tests.entry.ts": ["webpack"]
         },
         mime: {
-            'text/x-typescript': ['ts','tsx']
+            "text/x-typescript": ["ts", "tsx"]
         },
-        reporters: ["mocha"],
-        coverageReporter: {
-            dir: "tests/coverage/",
-            reporters: [
-                { type: "text-summary" },
-                { type: "json" },
-                { type: "html" }
-            ]
+        reporters: ["mocha", "coverage-istanbul"],
+        coverageIstanbulReporter: {
+            dir: "./reports/coverage/",
+            fixWebpackSourcePaths: true,
+            reports: ["html", "lcovonly", "cobertura"]
         },
         browsers: ["Chrome_Headless"],
         browserNoActivityTimeout: 100000,
@@ -48,20 +100,46 @@ module.exports = function(karma) {
         runnerPort: 9101,
         colors: true,
         logLevel: karma.LOG_INFO,
-        singleRun: process.env.TRAVIS? true: false,
+        singleRun: process.env.TRAVIS ? true : false,
         concurrency: Infinity,
         webpackServer: { noInfo: true, quiet: true },
         webpackMiddleware: { noInfo: true, quiet: true },
         webpack: require("./webpack.test.config"),
         customLaunchers: {
             Chrome_Headless: {
-                base: 'Chrome',
-                flags: ['--headless', '--disable-gpu', '--remote-debugging-port=9222']
+                base: "Chrome",
+                flags: [
+                    "--headless",
+                    "--disable-gpu",
+                    "--remote-debugging-port=9222"
+                ]
             }
-
         },
         mochaReporter: {
             ignoreSkipped: true
         }
-    });
+    };
+
+    // We'll use saucelabs for testing if and only if the access key is set in ENV, and CI flag is set.
+    // We'll modify the config as necessary.
+    if (process.env.SAUCE_ACCESS_KEY && process.env.TRAVIS) {
+        config.reporters.push("saucelabs");
+        config.browsers = [
+            "chrome_latest_win_10",
+            "firefox_latest_win_10",
+            "safari_latest_osx_11"
+        ];
+        config.customLaunchers = browsers;
+        config.sauceLabs = {
+            testName: "Unit Tests",
+            startConnect: true,
+            // If you need to debug, here are some options
+            // connectOptions: {
+            //     verbose: true,
+            //     logfile: './sauceconnect.log'
+            // }
+        };
+    }
+
+    karma.set(config);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "clr-all",
-    "version": "0.11.4",
+    "version": "0.11.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -973,11 +973,35 @@
             "integrity": "sha1-UCGQ5HUM1XIWGDkyaLYaFXNm52U=",
             "dev": true
         },
+        "adm-zip": {
+            "version": "0.4.7",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
+            "integrity": "sha1-hgbCy/HEJs6MjsABdER/1Jtur8E=",
+            "dev": true
+        },
         "after": {
             "version": "0.8.2",
             "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
             "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
             "dev": true
+        },
+        "agent-base": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+            "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+            "dev": true,
+            "requires": {
+                "extend": "3.0.1",
+                "semver": "5.0.3"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.0.3",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+                    "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+                    "dev": true
+                }
+            }
         },
         "ajv": {
             "version": "5.5.2",
@@ -1129,6 +1153,37 @@
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
             "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
             "dev": true
+        },
+        "archiver": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
+            "integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI=",
+            "dev": true,
+            "requires": {
+                "archiver-utils": "1.3.0",
+                "async": "2.6.0",
+                "buffer-crc32": "0.2.13",
+                "glob": "7.1.2",
+                "lodash": "4.17.5",
+                "readable-stream": "2.3.4",
+                "tar-stream": "1.5.5",
+                "walkdir": "0.0.11",
+                "zip-stream": "1.2.0"
+            }
+        },
+        "archiver-utils": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
+            "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "lazystream": "1.0.0",
+                "lodash": "4.17.5",
+                "normalize-path": "2.1.1",
+                "readable-stream": "2.3.4"
+            }
         },
         "are-we-there-yet": {
             "version": "1.1.4",
@@ -1810,6 +1865,15 @@
             "version": "1.11.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
             "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+        },
+        "bl": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+            "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.4"
+            }
         },
         "blob": {
             "version": "0.0.4",
@@ -3354,6 +3418,18 @@
             "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
             "dev": true
         },
+        "compress-commons": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
+            "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
+            "dev": true,
+            "requires": {
+                "buffer-crc32": "0.2.13",
+                "crc32-stream": "2.0.0",
+                "normalize-path": "2.1.1",
+                "readable-stream": "2.3.4"
+            }
+        },
         "compressible": {
             "version": "2.0.12",
             "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz",
@@ -3684,6 +3760,22 @@
             "requires": {
                 "cpy": "4.0.1",
                 "meow": "3.7.0"
+            }
+        },
+        "crc": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/crc/-/crc-3.5.0.tgz",
+            "integrity": "sha1-mLi6fUiWZbo5efWbITgTdBAaGWQ=",
+            "dev": true
+        },
+        "crc32-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
+            "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+            "dev": true,
+            "requires": {
+                "crc": "3.5.0",
+                "readable-stream": "2.3.4"
             }
         },
         "create-ecdh": {
@@ -6853,6 +6945,17 @@
             "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
             "dev": true
         },
+        "https-proxy-agent": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+            "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+            "dev": true,
+            "requires": {
+                "agent-base": "2.1.1",
+                "debug": "2.6.9",
+                "extend": "3.0.1"
+            }
+        },
         "i": {
             "version": "0.3.6",
             "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
@@ -7904,6 +8007,18 @@
             "integrity": "sha1-lpgqLMR9BmquccVTursoMZEVos4=",
             "dev": true
         },
+        "karma-sauce-launcher": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/karma-sauce-launcher/-/karma-sauce-launcher-1.2.0.tgz",
+            "integrity": "sha512-lEhtGRGS+3Yw6JSx/vJY9iQyHNtTjcojrSwNzqNUOaDceKDu9dPZqA/kr69bUO9G2T6GKbu8AZgXqy94qo31Jg==",
+            "dev": true,
+            "requires": {
+                "q": "1.5.1",
+                "sauce-connect-launcher": "1.2.3",
+                "saucelabs": "1.4.0",
+                "wd": "1.5.0"
+            }
+        },
         "karma-source-map-support": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/karma-source-map-support/-/karma-source-map-support-1.2.0.tgz",
@@ -7999,6 +8114,15 @@
             "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
             "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
             "dev": true
+        },
+        "lazystream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.4"
+            }
         },
         "lcid": {
             "version": "1.0.0",
@@ -13962,6 +14086,28 @@
                 "pify": "3.0.0"
             }
         },
+        "sauce-connect-launcher": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-1.2.3.tgz",
+            "integrity": "sha1-0vkxrXro/avxlopEDnsgQXrKf4Y=",
+            "dev": true,
+            "requires": {
+                "adm-zip": "0.4.7",
+                "async": "2.6.0",
+                "https-proxy-agent": "1.0.0",
+                "lodash": "4.17.5",
+                "rimraf": "2.6.2"
+            }
+        },
+        "saucelabs": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.4.0.tgz",
+            "integrity": "sha1-uTSpr52ih0s/QKrh/N5QpEZvXzg=",
+            "dev": true,
+            "requires": {
+                "https-proxy-agent": "1.0.0"
+            }
+        },
         "sax": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -15153,6 +15299,18 @@
                 "inherits": "2.0.3"
             }
         },
+        "tar-stream": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+            "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
+            "dev": true,
+            "requires": {
+                "bl": "1.2.1",
+                "end-of-stream": "1.4.1",
+                "readable-stream": "2.3.4",
+                "xtend": "4.0.1"
+            }
+        },
         "term-size": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
@@ -15694,6 +15852,16 @@
             "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
             "dev": true
         },
+        "underscore.string": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
+            "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "1.0.3",
+                "util-deprecate": "1.0.2"
+            }
+        },
         "union-value": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
@@ -16122,6 +16290,12 @@
                 "spdx-expression-parse": "1.0.4"
             }
         },
+        "vargs": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/vargs/-/vargs-0.1.0.tgz",
+            "integrity": "sha1-a2GE2mUgzDIEzhtAfKwm2SYJ6/8=",
+            "dev": true
+        },
         "vary": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -16174,6 +16348,12 @@
             "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
             "dev": true
         },
+        "walkdir": {
+            "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
+            "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI=",
+            "dev": true
+        },
         "watchpack": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
@@ -16192,6 +16372,128 @@
             "dev": true,
             "requires": {
                 "minimalistic-assert": "1.0.0"
+            }
+        },
+        "wd": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/wd/-/wd-1.5.0.tgz",
+            "integrity": "sha512-e/KpzTlhtSG3Ek0AcRz4G6PhxGsc53Nro+GkI1er9p05tWQ7W9dpGZR5SqQzGUqvbaqJCThDSAGaY7LHgi6MiA==",
+            "dev": true,
+            "requires": {
+                "archiver": "1.3.0",
+                "async": "2.0.1",
+                "lodash": "4.16.2",
+                "mkdirp": "0.5.1",
+                "q": "1.4.1",
+                "request": "2.79.0",
+                "underscore.string": "3.3.4",
+                "vargs": "0.1.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "async": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+                    "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
+                    "dev": true,
+                    "requires": {
+                        "lodash": "4.16.2"
+                    }
+                },
+                "caseless": {
+                    "version": "0.11.0",
+                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+                    "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    }
+                },
+                "har-validator": {
+                    "version": "2.0.6",
+                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+                    "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "1.1.3",
+                        "commander": "2.14.1",
+                        "is-my-json-valid": "2.17.2",
+                        "pinkie-promise": "2.0.1"
+                    }
+                },
+                "lodash": {
+                    "version": "4.16.2",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.2.tgz",
+                    "integrity": "sha1-PmJtuCcEimmSgaihJSJjJs/A5lI=",
+                    "dev": true
+                },
+                "q": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+                    "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
+                    "dev": true
+                },
+                "qs": {
+                    "version": "6.3.2",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+                    "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+                    "dev": true
+                },
+                "request": {
+                    "version": "2.79.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+                    "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+                    "dev": true,
+                    "requires": {
+                        "aws-sign2": "0.6.0",
+                        "aws4": "1.6.0",
+                        "caseless": "0.11.0",
+                        "combined-stream": "1.0.6",
+                        "extend": "3.0.1",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.1.4",
+                        "har-validator": "2.0.6",
+                        "hawk": "3.1.3",
+                        "http-signature": "1.1.1",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.17",
+                        "oauth-sign": "0.8.2",
+                        "qs": "6.3.2",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.3",
+                        "tunnel-agent": "0.4.3",
+                        "uuid": "3.2.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                },
+                "tunnel-agent": {
+                    "version": "0.4.3",
+                    "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+                    "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+                    "dev": true
+                }
             }
         },
         "web-animations-js": {
@@ -16988,6 +17290,18 @@
             "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
             "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
             "dev": true
+        },
+        "zip-stream": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
+            "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+            "dev": true,
+            "requires": {
+                "archiver-utils": "1.3.0",
+                "compress-commons": "1.2.2",
+                "lodash": "4.17.5",
+                "readable-stream": "2.3.4"
+            }
         },
         "zone.js": {
             "version": "0.8.20",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
         "karma-jasmine-matchers": "^3.7.0",
         "karma-mocha-reporter": "^2.2.4",
         "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
         "karma-sourcemap-loader": "^0.3.7",
         "karma-webpack": "^2.0.4",
         "lite-server": "^2.3.0",

--- a/webpack.test.config.js
+++ b/webpack.test.config.js
@@ -40,6 +40,11 @@ module.exports = {
             {
                 test: /\.(png|jpe?g|gif|svg|woff|woff2|ttf|eot|ico)$/,
                 loader: 'null-loader'
+            },
+            {
+                test: /\.(js|ts)$/, loader: 'istanbul-instrumenter-loader',
+                enforce: 'post',
+                exclude: [ /\.(e2e|spec)\.ts$/, /node_modules/]
             }
         ]
     }


### PR DESCRIPTION
This improves our CI to use Saucelabs for running our unit tests, and runs it against Chrome, Firefox, and Safari. Code coverage now reports again.

I've enabled Chrome (Win 8), Safari (macOS), and Firefox (Win 8) latest versions to run tests. Our account has 5 concurrent sessions allowed, so I would like to eventually enable IE and Edge, but that means fixing some tests.

SauceLabs will only run after a PR is merged (from a fork), or for a PR made from a branch in this repo. This has to do with how private ENV vars are treated in Travis, where they aren't exposed when running the tests from a fork. See https://docs.travis-ci.com/user/pull-requests/#Pull-Requests-and-Security-Restrictions

You can see a build running on SauceLabs from this job (local branch `ci-unit-tests`) at https://travis-ci.org/vmware/clarity/jobs/341638600 and the result of this PR using only Headless Chrome (because its from a fork) https://travis-ci.org/vmware/clarity/jobs/341643683.