### PR TITLE
fix: [UI] Dark theme .btn font color

### DIFF
--- a/src/clr-angular/utils/_theme.dark.clarity.scss
+++ b/src/clr-angular/utils/_theme.dark.clarity.scss
@@ -219,7 +219,7 @@ $clr-btn-default-hover-bg-color: hsla(0, 0%, 100%, 0.1); // hover-background-col
 $clr-btn-default-hover-color: #57c7ea; // hover-color
 $clr-btn-default-box-shadow-color: $clr-black; // active-box-shadow-color
 $clr-btn-default-checked-color: $clr-white; // checked-color
-$clr-btn-default-disabled-color: $clr-btn-disabled-font-color;                  // disabled-color
+$clr-btn-default-disabled-color: $clr-btn-outline-disabled-font-color;                  // disabled-color
 $clr-btn-default-disabled-border-color: $clr-btn-disabled-border-color;             // disabled-border-color
 
 // Default button


### PR DESCRIPTION
Tested in Chrome. 

### Before
<img width="301" alt="screen shot 2018-02-13 at 4 50 09 pm" src="https://user-images.githubusercontent.com/433692/36182432-77919830-10de-11e8-96c9-4d3c96cd7df8.png">

### After
<img width="425" alt="screen shot 2018-02-13 at 4 48 53 pm" src="https://user-images.githubusercontent.com/433692/36182435-7cd6cacc-10de-11e8-8cef-f1046a449219.png">


- Fixes #1973

Signed-off-by: Matt Hippely <mhippely@vmware.com>