### PR TITLE
[NG] Fix stack view overflow-y issue with Angular universal

### DIFF
--- a/src/clr-angular/data/stack-view/_stack-view.clarity.scss
+++ b/src/clr-angular/data/stack-view/_stack-view.clarity.scss
@@ -59,6 +59,7 @@
             // Wrapping for nested stack-blocks
             flex-flow: row wrap;
             border-bottom: 1px solid $clr-stack-view-stack-block-border-bottom;
+            overflow-y: hidden;
         }
 
         // We have to handle potential nested elements, typically for web components

--- a/src/clr-angular/data/stack-view/stack-block.ts
+++ b/src/clr-angular/data/stack-view/stack-block.ts
@@ -26,15 +26,12 @@ import {Component, EventEmitter, HostBinding, Input, OnInit, Optional, Output, S
     `],
     // Make sure the host has the proper class for styling purposes
     host: {"[class.stack-block]": "true"},
-    animations:
-        [trigger("collapse",
-                 [
-                     state("true", style({"height": 0, "overflow-y": "hidden"})),
-                     transition("true => false",
-                                [animate("0.2s ease-in-out", style({"height": "*", "overflow-y": "hidden"}))]),
-                     transition("false => true",
-                                [style({"height": "*", "overflow-y": "hidden"}), animate("0.2s ease-in-out")])
-                 ])]
+    animations: [trigger("collapse",
+                         [
+                             state("true", style({"height": 0})),
+                             transition("true => false", [animate("0.2s ease-in-out", style({"height": "*"}))]),
+                             transition("false => true", [style({"height": "*"}), animate("0.2s ease-in-out")])
+                         ])]
 })
 export class ClrStackBlock implements OnInit {
     @HostBinding("class.stack-block-expanded") @Input("clrSbExpanded") expanded: boolean = false;


### PR DESCRIPTION
When using stack-view with angular universal, there is an error with the animation because overflow-y is not a supported CSS property for animations. This moves it from the animation to CSS.

Signed-off-by: Alyssa Brunswick <abrunswick@oriental.com>