### PR TITLE
[NG] Support loading buttons in button groups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "clr-all",
-    "version": "0.11.4",
+    "version": "0.11.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/app/button-group/angular/button-group-angular.ts
+++ b/src/app/button-group/angular/button-group-angular.ts
@@ -10,22 +10,35 @@ import {Component} from "@angular/core";
     styleUrls: ["../button-group.demo.scss"],
     template: `
         <h4>Angular Styles</h4>
-        <ul>
-            <li><a [routerLink]="['./basic-structure']">Basic Structure</a></li>
-            <li><a [routerLink]="['./directions']">Menu Directions</a></li>
-            <li><a [routerLink]="['./icon-button']">Icons</a></li>
-            <li><a [routerLink]="['./hide-overflow']">Hide/Show Overflow Toggle</a></li>
-            <li><a [routerLink]="['./mixed-buttons']">Mixed Buttons</a></li>
-            <li><a [routerLink]="['./move-button-in-menu']">Move Button In Menu</a></li>
-            <li><a [routerLink]="['./move-multiple-buttons-in-menu']">Move Multiple Buttons In Menu</a></li>
-            <li><a [routerLink]="['./move-all-in-menu']">Move All Buttons In Menu</a></li>
-            <li><a [routerLink]="['./projection-update-test-1']">Projection Update Test 1</a></li>
-            <li><a [routerLink]="['./projection-update-test-2']">Projection Update Test 2</a></li>
-            <li><a [routerLink]="['./projection-update-test-3']">Projection Update Test 3</a></li>
-            <li><a [routerLink]="['./projection-update-test-4']">Projection Update Test 4</a></li>
-            <li><a [routerLink]="['./projection-update-test-5']">Projection Update Test 5</a></li>
-            <li><a [routerLink]="['./projection-update-test-6']">Projection Update Test 6</a></li>
-        </ul>
+        <div class="row">
+            <div class="col-xs-12 col-sm-12 col-md-4">
+                <ul>
+                    <li><a [routerLink]="['./basic-structure']">Basic Structure</a></li>
+                    <li><a [routerLink]="['./directions']">Menu Directions</a></li>
+                    <li><a [routerLink]="['./icon-button']">Icons</a></li>
+                    <li><a [routerLink]="['./loading-button']">Loading Button in Button Groups</a></li>
+                    <li><a [routerLink]="['./hide-overflow']">Hide/Show Overflow Toggle</a></li>
+                </ul>
+            </div>
+            <div class="col-xs-12 col-sm-12 col-md-4">
+                <ul>
+                    <li><a [routerLink]="['./mixed-buttons']">Mixed Buttons</a></li>
+                    <li><a [routerLink]="['./move-button-in-menu']">Move Button In Menu</a></li>
+                    <li><a [routerLink]="['./move-multiple-buttons-in-menu']">Move Multiple Buttons In Menu</a></li>
+                    <li><a [routerLink]="['./move-all-in-menu']">Move All Buttons In Menu</a></li>
+                    <li><a [routerLink]="['./projection-update-test-1']">Projection Update Test 1</a></li>
+                </ul>
+            </div>
+            <div class="col-xs-12 col-sm-12 col-md-4">
+                <ul>
+                    <li><a [routerLink]="['./projection-update-test-2']">Projection Update Test 2</a></li>
+                    <li><a [routerLink]="['./projection-update-test-3']">Projection Update Test 3</a></li>
+                    <li><a [routerLink]="['./projection-update-test-4']">Projection Update Test 4</a></li>
+                    <li><a [routerLink]="['./projection-update-test-5']">Projection Update Test 5</a></li>
+                    <li><a [routerLink]="['./projection-update-test-6']">Projection Update Test 6</a></li>
+                </ul>
+            </div>
+        </div>
         <router-outlet></router-outlet>
     `
 })

--- a/src/app/button-group/angular/loading-buttons/loading-button-group.html
+++ b/src/app/button-group/angular/loading-buttons/loading-button-group.html
@@ -1,0 +1,17 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<h4>Loading Buttons</h4>
+
+<clr-button-group>
+    <clr-button>Apples</clr-button>
+    <clr-button [clrLoading]="load">Oranges</clr-button>
+    <clr-button>Bananas</clr-button>
+</clr-button-group>
+
+<div>
+    <button class="btn btn-primary" (click)="startLoading()">Start Loading</button>
+</div>

--- a/src/app/button-group/angular/loading-buttons/loading-button-group.ts
+++ b/src/app/button-group/angular/loading-buttons/loading-button-group.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component} from "@angular/core";
+
+@Component({
+    selector: "clr-loading-button-group-demo",
+    templateUrl: "./loading-button-group.html",
+    styleUrls: ["../../button-group.demo.scss"]
+})
+export class LoadingButtonGroupDemo {
+    load: boolean = false;
+
+    startLoading(): void {
+        this.load = true;
+        setTimeout(() => {
+            this.load = false;
+        }, 2000);
+    }
+}

--- a/src/app/button-group/button-group.demo.module.ts
+++ b/src/app/button-group/button-group.demo.module.ts
@@ -12,6 +12,7 @@ import {BasicButtonGroupDemo} from "./angular/basic-structure/basic-button-group
 import {ButtonGroupAngularDemo} from "./angular/button-group-angular";
 import {HideShowOverflowToggleDemo} from "./angular/hide-show-overflow-toggle/hide-show-overflow-toggle";
 import {IconButtonGroupDemo} from "./angular/icon-buttons/icon-button-group";
+import {LoadingButtonGroupDemo} from "./angular/loading-buttons/loading-button-group";
 import {MenuDirectionsDemo} from "./angular/menu-directions/menu-directions";
 import {MixedButtonGroupDemo} from "./angular/mixed-buttons/mixed-button-group";
 import {MoveAllInMenuDemo} from "./angular/move-all-in-menu/move-all-in-menu";
@@ -54,6 +55,7 @@ import {ButtonGroupTypes} from "./static/types/button-group-types";
         ProjectionUpdateTest4Demo,
         ProjectionUpdateTest5Demo,
         ProjectionUpdateTest6Demo,
+        LoadingButtonGroupDemo,
 
         StaticButtonGroupBasicStructureDemo,
         ButtonGroupCheckboxesDemo,
@@ -85,6 +87,7 @@ import {ButtonGroupTypes} from "./static/types/button-group-types";
         ProjectionUpdateTest4Demo,
         ProjectionUpdateTest5Demo,
         ProjectionUpdateTest6Demo,
+        LoadingButtonGroupDemo,
 
         StaticButtonGroupBasicStructureDemo,
         ButtonGroupCheckboxesDemo,

--- a/src/app/button-group/button-group.demo.routing.ts
+++ b/src/app/button-group/button-group.demo.routing.ts
@@ -10,6 +10,7 @@ import {BasicButtonGroupDemo} from "./angular/basic-structure/basic-button-group
 import {ButtonGroupAngularDemo} from "./angular/button-group-angular";
 import {HideShowOverflowToggleDemo} from "./angular/hide-show-overflow-toggle/hide-show-overflow-toggle";
 import {IconButtonGroupDemo} from "./angular/icon-buttons/icon-button-group";
+import {LoadingButtonGroupDemo} from "./angular/loading-buttons/loading-button-group";
 import {MenuDirectionsDemo} from "./angular/menu-directions/menu-directions";
 import {MixedButtonGroupDemo} from "./angular/mixed-buttons/mixed-button-group";
 import {MoveAllInMenuDemo} from "./angular/move-all-in-menu/move-all-in-menu";
@@ -59,6 +60,7 @@ const ROUTES: Routes = [{
                 {path: "basic-structure", component: BasicButtonGroupDemo},
                 {path: "directions", component: MenuDirectionsDemo},
                 {path: "icon-button", component: IconButtonGroupDemo},
+                {path: "loading-button", component: LoadingButtonGroupDemo},
                 {path: "hide-overflow", component: HideShowOverflowToggleDemo},
                 {path: "mixed-buttons", component: MixedButtonGroupDemo},
                 {path: "move-button-in-menu", component: MoveButtonInMenuDemo},

--- a/src/clr-angular/button/button-group/button.spec.ts
+++ b/src/clr-angular/button/button-group/button.spec.ts
@@ -4,126 +4,267 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import {Component, DebugElement} from "@angular/core";
+import {Component, DebugElement, ViewChild} from "@angular/core";
 import {ComponentFixture, TestBed} from "@angular/core/testing";
 
+import {ClrLoadingModule} from "../../utils/loading";
 import {ButtonInGroupService} from "../providers/button-in-group.service";
+
 import {ClrButton} from "./button";
 import {ClrButtonGroupModule} from "./button-group.module";
 
-
-export default function(): void {
-    describe("Buttons", () => {
-        let fixture: ComponentFixture<any>;
-        const buttons: ClrButton[] = [];
-
-        beforeEach(() => {
-            TestBed.configureTestingModule({
-                imports: [ClrButtonGroupModule],
-                declarations: [TestButtonComponent],
-                providers: [ButtonInGroupService]
-            });
-
-            fixture = TestBed.createComponent(TestButtonComponent);
-            fixture.detectChanges();
-            const projection: DebugElement[] = fixture.debugElement.children;
-            projection.forEach((debugElement) => {
-                buttons.push(<ClrButton>debugElement.componentInstance);
-            });
-        });
-
-        afterEach(() => {
-            fixture.destroy();
-        });
-
-        it("registers content projection", () => {
-            expect(buttons.length).toBe(3);
-        });
-
-        it("supports the clrInMenu Input", () => {
-            expect(buttons[0].inMenu).toBe(false);
-            expect(buttons[1].inMenu).toBe(true);
-            expect(buttons[2].inMenu).toBe(true);
-        });
-
-        it("supports the class Input", () => {
-            expect(buttons[0].classNames).toBe("btn");
-            expect(buttons[1].classNames).toBe("btn");
-            expect(buttons[2].classNames).toBe("btn btn-primary");
-        });
-
-        it("registers the ButtonInGroupService if the parent is registered too", () => {
-            expect(buttons[0].buttonInGroupService).not.toBeNull();
-            expect(buttons[1].buttonInGroupService).not.toBeNull();
-            expect(buttons[2].buttonInGroupService).not.toBeNull();
-        });
-
-        it("notifies when the clrInMenu input is updated with the help of the service", () => {
-            let mockButton: ClrButton;
-            buttons.forEach((updatedButton) => {
-                updatedButton.buttonInGroupService.changes.subscribe((button) => {
-                    mockButton = button;
-                });
-            });
-
-            buttons[0].inMenu = true;
-            expect(mockButton.inMenu).toBe(true);
-
-            buttons[0].inMenu = false;
-            expect(mockButton.inMenu).toBe(false);
-
-            buttons[1].inMenu = true;
-            // Still expect false because the service method
-            // shouldn't be called as the inMenu input was already true.
-            // Its value did not change.
-            expect(mockButton.inMenu).toBe(false);
-
-            // Set to false because the input is true initially
-            buttons[1].inMenu = false;
-            expect(mockButton.inMenu).toBe(false);
-
-            buttons[1].inMenu = true;
-            expect(mockButton.inMenu).toBe(true);
-
-            // First set to false because the input is true initially
-            buttons[2].inMenu = false;
-            expect(mockButton.inMenu).toBe(false);
-
-            buttons[2].inMenu = true;
-            expect(mockButton.inMenu).toBe(true);
-        });
-
-        it("emits a click event", () => {
-            expect(fixture.componentInstance.flag).toBe(false);
-
-            const btn: any = fixture.nativeElement.querySelector("#testBtn");
-
-            btn.click();
-
-            fixture.detectChanges();
-
-            expect(fixture.componentInstance.flag).toBe(true);
-
-            btn.click();
-
-            fixture.detectChanges();
-
-            expect(fixture.componentInstance.flag).toBe(false);
-        });
-    });
-}
-
 @Component({
     template: `
-        <clr-button id="testBtn" (click)="toggleClick()">Test 1</clr-button>
-        <clr-button [clrInMenu]="true">Test 2</clr-button>
-        <clr-button [clrInMenu]="true" class="btn btn-primary">Test 3</clr-button>
+        <clr-button
+            #button1
+            id="button1"
+            type="button"
+            name="button1"
+            (click)="toggleClick()">Button 1
+        </clr-button>
+        <clr-button
+            #button2
+            [clrInMenu]="button2InMenu"
+            class="btn btn-primary">Button 2
+        </clr-button>
+        <clr-button
+            #button3
+            disabled
+            class="test">Button 3
+        </clr-button>
     `
 })
 class TestButtonComponent {
+    @ViewChild("button1") button1: ClrButton;
+    @ViewChild("button2") button2: ClrButton;
+    @ViewChild("button3") button3: ClrButton;
+
     flag: boolean = false;
+    button2InMenu: boolean = true;
 
     toggleClick(): void {
         this.flag = !this.flag;
     }
+}
+
+
+@Component({
+    template: `
+        <clr-button
+            #button1
+            [clrLoading]="load"
+        >Test Button 1
+        </clr-button>
+        <clr-button
+            disabled
+            class="btn btn-primary"
+            #button2
+        >Test Button 2
+        </clr-button>
+        <clr-button
+            class="test"
+            type="button"
+            name="button3"
+            #button3
+        >Test Button 3
+        </clr-button>
+        <div id="portal">
+            <ng-template [ngTemplateOutlet]="button1.templateRef"></ng-template>
+            <ng-template [ngTemplateOutlet]="button2.templateRef"></ng-template>
+            <ng-template [ngTemplateOutlet]="button3.templateRef"></ng-template>
+        </div>
+    `
+})
+export class ButtonViewTestComponent {
+    @ViewChild("button1") button1: ClrButton;
+    @ViewChild("button2") button2: ClrButton;
+    @ViewChild("button3") button3: ClrButton;
+
+    load: boolean = true;
+}
+
+export default function(): void {
+    describe("Buttons", () => {
+        let fixture: ComponentFixture<any>;
+        let debugEl: DebugElement;
+        let componentInstance: any;
+        let buttons: HTMLButtonElement[];
+
+        describe("Typescript API", () => {
+            beforeEach(() => {
+                TestBed.configureTestingModule({
+                    imports: [ClrButtonGroupModule],
+                    declarations: [TestButtonComponent],
+                    providers: [ButtonInGroupService]
+                });
+
+                fixture = TestBed.createComponent(TestButtonComponent);
+                fixture.detectChanges();
+                debugEl = fixture.debugElement;
+                componentInstance = debugEl.componentInstance;
+            });
+
+            afterEach(() => {
+                fixture.destroy();
+            });
+
+            it("adds a .btn class to the button when a class is not provided", () => {
+                expect(componentInstance.button1.classNames).toBe("btn");
+            });
+
+            it("supports a class input", () => {
+                expect(componentInstance.button2.classNames).toBe("btn btn-primary");
+            });
+
+            it("makes sure that the btn class is present. if absent, appends it at the end", () => {
+                expect(componentInstance.button3.classNames).toBe("test btn");
+            });
+
+            it("supports a type input", () => {
+                expect(componentInstance.button1.type).toBe("button");
+                expect(componentInstance.button2.type).toBeNull();
+                expect(componentInstance.button3.type).toBeNull();
+            });
+
+            it("supports a name input", () => {
+                expect(componentInstance.button1.name).toBe("button1");
+                expect(componentInstance.button2.name).toBeNull();
+                expect(componentInstance.button3.name).toBeNull();
+            });
+
+            it("supports a disabled input which is set to an empty string when the user passes a value", () => {
+                expect(componentInstance.button1.disabled).toBeNull();
+                expect(componentInstance.button2.disabled).toBeNull();
+                expect(componentInstance.button3.disabled).toBe("");
+            });
+
+            it("emits a click event", () => {
+                expect(componentInstance.flag).toBe(false);
+
+                componentInstance.button1.emitClick();
+
+                expect(componentInstance.flag).toBe(true);
+
+                componentInstance.button1.emitClick();
+
+                expect(componentInstance.flag).toBe(false);
+            });
+
+            it("implements LoadingListener", () => {
+                expect(componentInstance.button1.startLoading).toBeDefined();
+                expect(componentInstance.button1.doneLoading).toBeDefined();
+            });
+
+            it("sets loading to true on start loading", () => {
+                expect(componentInstance.button1.loading).toBeUndefined();
+
+                componentInstance.button1.startLoading();
+
+                expect(componentInstance.button1.loading).toBe(true);
+            });
+
+            it("sets loading to false on done loading", () => {
+                expect(componentInstance.button1.loading).toBeUndefined();
+
+                componentInstance.button1.doneLoading();
+
+                expect(componentInstance.button1.loading).toBe(false);
+            });
+
+            it("has access to the button in group service if the parent declares it", () => {
+                expect(componentInstance.button1.buttonInGroupService).not.toBeNull();
+                expect(componentInstance.button2.buttonInGroupService).not.toBeNull();
+                expect(componentInstance.button3.buttonInGroupService).not.toBeNull();
+            });
+
+            it("sets inMenu to false by default", () => {
+                expect(componentInstance.button1.inMenu).toBe(false);
+                expect(componentInstance.button3.inMenu).toBe(false);
+            });
+
+            it("supports a clrInMenu Input", () => {
+                expect(componentInstance.button2.inMenu).toBe(true);
+
+                componentInstance.button2InMenu = false;
+
+                expect(componentInstance.button1.inMenu).toBe(false);
+            });
+
+            it("populates the template ref", () => {
+                expect(componentInstance.button1.templateRef).not.toBeNull();
+                expect(componentInstance.button2.templateRef).not.toBeNull();
+                expect(componentInstance.button3.templateRef).not.toBeNull();
+            });
+
+            it("updates the button in group service when the inMenu input changes", () => {
+                const buttonInGroupService: ButtonInGroupService =
+                    debugEl.injector.get<ButtonInGroupService>(ButtonInGroupService);
+                spyOn(buttonInGroupService, "updateButtonGroup");
+
+                componentInstance.button1.inMenu = true;
+                expect(buttonInGroupService.updateButtonGroup).toHaveBeenCalled();
+
+                componentInstance.button1.inMenu = false;
+                expect(buttonInGroupService.updateButtonGroup).toHaveBeenCalled();
+            });
+        });
+
+        describe("View Test", () => {
+            beforeEach(() => {
+                TestBed.configureTestingModule({
+                    imports: [ClrButtonGroupModule, ClrLoadingModule],
+                    declarations: [ButtonViewTestComponent],
+                    providers: [ButtonInGroupService]
+                });
+
+                fixture = TestBed.createComponent(ButtonViewTestComponent);
+                fixture.detectChanges();
+                debugEl = fixture.debugElement;
+                componentInstance = debugEl.componentInstance;
+                buttons = debugEl.nativeElement.querySelectorAll("button");
+            });
+
+            afterEach(() => {
+                fixture.destroy();
+            });
+
+            it("projects the content correctly", () => {
+                expect(buttons[0].textContent).toMatch("Test Button 1");
+                expect(buttons[1].textContent).toMatch("Test Button 2");
+                expect(buttons[2].textContent).toMatch("Test Button 3");
+            });
+
+            it("sets the disabled flag correctly", () => {
+                expect(buttons[0].disabled).toBe(false);
+                expect(buttons[1].disabled).toBe(true);
+                expect(buttons[2].disabled).toBe(false);
+            });
+
+            it("sets the name correctly", () => {
+                expect(buttons[0].name).toBe("");
+                expect(buttons[1].name).toBe("");
+                expect(buttons[2].name).toBe("button3");
+            });
+
+            it("sets the type correctly", () => {
+                expect(buttons[0].type).toBe("submit");  // default
+                expect(buttons[1].type).toBe("submit");  // default
+                expect(buttons[2].type).toBe("button");
+            });
+
+            it("shows the spinner when clrLoading is set to true", () => {
+                expect(buttons[0].children.length).toBe(1);
+                expect(buttons[1].children.length).toBe(0);
+                expect(buttons[2].children.length).toBe(0);
+
+                expect(buttons[0].children[0].classList.contains("spinner")).toBe(true);
+
+                componentInstance.load = false;
+                fixture.detectChanges();
+
+                const newButtons: HTMLButtonElement[] = debugEl.nativeElement.querySelectorAll("button");
+                expect(newButtons[0].children.length).toBe(0);
+            });
+        });
+    });
 }

--- a/src/clr-angular/button/button-group/button.ts
+++ b/src/clr-angular/button/button-group/button.ts
@@ -7,6 +7,7 @@
 
 import {Component, EventEmitter, Input, Optional, Output, SkipSelf, TemplateRef, ViewChild} from "@angular/core";
 
+import {LoadingListener} from "../../utils/loading";
 import {ButtonInGroupService} from "../providers/button-in-group.service";
 
 @Component({
@@ -19,12 +20,14 @@ import {ButtonInGroupService} from "../providers/button-in-group.service";
                 [attr.type]="type"
                 [attr.name]="name"
                 [attr.disabled]="disabled">
+                <span class="spinner spinner-inline" *ngIf="loading"></span>
                 <ng-content></ng-content>
             </button>
         </ng-template>
-    `
+    `,
+    providers: [{provide: LoadingListener, useExisting: ClrButton}]
 })
-export class ClrButton {
+export class ClrButton implements LoadingListener {
     private _enableService: boolean = false;
 
     @ViewChild("buttonProjectedRef") templateRef: TemplateRef<ClrButton>;
@@ -106,6 +109,16 @@ export class ClrButton {
         } else {
             this._disabled = null;
         }
+    }
+
+    public loading: boolean;
+
+    startLoading(): void {
+        this.loading = true;
+    }
+
+    doneLoading(): void {
+        this.loading = false;
     }
 
     @Output("click") _click: EventEmitter<boolean> = new EventEmitter<boolean>(false);


### PR DESCRIPTION
Fixes: #1681

Adds tests to this PR: #1685
- Had to rewrite tests for the `clr-button` component as the previous tests were not testing everything.

Tested on Chrome
![test 1](https://user-images.githubusercontent.com/1426805/36759693-45d05dbe-1be6-11e8-858c-50deaeff2abd.gif)



Signed-off-by: Aditya Bhandari <adityab@vmware.com>