### PR TITLE
[UI] Tooltip Content Break Work

### DIFF
--- a/src/app/tooltips/tooltips-angular.html
+++ b/src/app/tooltips/tooltips-angular.html
@@ -113,3 +113,14 @@
     </clr-dropdown>
 </div>
 
+<h6>Tooltip Break Word</h6>
+<div class="clr-example" style="margin-bottom:480px">
+    <clr-tooltip>
+        <clr-icon clrTooltipTrigger shape="home"></clr-icon>
+        <clr-tooltip-content [clrSize]="'sm'">
+            AlphaBetaThetaGammaAlphaBetaThetaGammaAlphaBetaThetaGammaAlphaBetaThetaGammaAlphaBetaThetaGammaAlphaBetaThetaGamma
+            AlphaBetaThetaGammaAlphaBetaThetaGammaAlphaBetaThetaGammaAlphaBetaThetaGammaAlphaBetaThetaGammaAlphaBetaThetaGamma
+        </clr-tooltip-content>
+    </clr-tooltip>
+</div>
+

--- a/src/clr-angular/popover/tooltip/_tooltips.clarity.scss
+++ b/src/clr-angular/popover/tooltip/_tooltips.clarity.scss
@@ -86,6 +86,7 @@
             opacity: 0;
             transition: opacity 0.3s linear;
             white-space: normal;
+            word-wrap: break-word;
             z-index: map-get($clr-layers, tooltips);
         }
 


### PR DESCRIPTION
Fixes: #2020

![image](https://user-images.githubusercontent.com/1426805/36790425-c628c42a-1c62-11e8-840b-23d7693be380.png)

 More info: https://developer.mozilla.org/en-US/docs/Web/CSS/word-break

Tested in Chrome, Firefox, Safari

Signed-off-by: Aditya Bhandari <adityab@vmware.com>