### PR TITLE
[NG] Adds aria-labelledby to clr-checkboxes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1305,8 +1305,7 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
             "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "asn1": {
             "version": "0.2.3",
@@ -4244,6 +4243,16 @@
             "resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
             "integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA=",
             "dev": true
+        },
+        "dezalgo": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+            "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+            "dev": true,
+            "requires": {
+                "asap": "2.0.6",
+                "wrappy": "1.0.2"
+            }
         },
         "di": {
             "version": "0.0.1",
@@ -9333,6 +9342,12 @@
                 "osenv": "0.1.4"
             }
         },
+        "normalize-git-url": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/normalize-git-url/-/normalize-git-url-3.0.2.tgz",
+            "integrity": "sha1-jl8Uvgva7bc+ByADEKpBbCc1D8Q=",
+            "dev": true
+        },
         "normalize-package-data": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -9602,19 +9617,16 @@
                         }
                     }
                 },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                    "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                    "dev": true
+                },
                 "debuglog": {
                     "version": "1.0.1",
                     "bundled": true,
                     "dev": true
-                },
-                "dezalgo": {
-                    "version": "1.0.3",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "asap": "2.0.5",
-                        "wrappy": "1.0.2"
-                    }
                 },
                 "editor": {
                     "version": "1.0.0",
@@ -10236,11 +10248,6 @@
                         }
                     }
                 },
-                "normalize-git-url": {
-                    "version": "3.0.2",
-                    "bundled": true,
-                    "dev": true
-                },
                 "normalize-package-data": {
                     "version": "2.3.8",
                     "bundled": true,
@@ -10273,14 +10280,6 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true
-                },
-                "npm-install-checks": {
-                    "version": "3.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "semver": "5.3.0"
-                    }
                 },
                 "npm-package-arg": {
                     "version": "4.2.1",
@@ -10580,11 +10579,6 @@
                             "bundled": true,
                             "dev": true
                         },
-                        "core-util-is": {
-                            "version": "1.0.2",
-                            "bundled": true,
-                            "dev": true
-                        },
                         "isarray": {
                             "version": "1.0.0",
                             "bundled": true,
@@ -10619,15 +10613,6 @@
                         "dezalgo": "1.0.3",
                         "graceful-fs": "4.1.11",
                         "once": "1.4.0"
-                    }
-                },
-                "realize-package-specifier": {
-                    "version": "3.0.3",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "dezalgo": "1.0.3",
-                        "npm-package-arg": "4.2.1"
                     }
                 },
                 "request": {
@@ -11107,6 +11092,12 @@
                         }
                     }
                 },
+                "spdx-license-ids": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
+                    "integrity": "sha1-tUndD2Pct0Whfi6joHQC4OMy0eI=",
+                    "dev": true
+                },
                 "strip-ansi": {
                     "version": "3.0.1",
                     "bundled": true,
@@ -11156,16 +11147,15 @@
                     "dev": true,
                     "requires": {
                         "unique-slug": "2.0.0"
-                    },
-                    "dependencies": {
-                        "unique-slug": {
-                            "version": "2.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "imurmurhash": "0.1.4"
-                            }
-                        }
+                    }
+                },
+                "unique-slug": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+                    "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
+                    "dev": true,
+                    "requires": {
+                        "imurmurhash": "0.1.4"
                     }
                 },
                 "unpipe": {
@@ -11742,11 +11732,6 @@
                                     "version": "1.0.4",
                                     "bundled": true,
                                     "dev": true
-                                },
-                                "spdx-license-ids": {
-                                    "version": "1.2.0",
-                                    "bundled": true,
-                                    "dev": true
                                 }
                             }
                         }
@@ -11797,6 +11782,25 @@
                         "slide": "1.1.6"
                     }
                 }
+            }
+        },
+        "npm-install-checks": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.0.tgz",
+            "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
+            "dev": true,
+            "requires": {
+                "semver": "5.5.0"
+            }
+        },
+        "npm-package-arg": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.2.1.tgz",
+            "integrity": "sha1-WTMD/eqF98Qid18X+et2cPaA4+w=",
+            "dev": true,
+            "requires": {
+                "hosted-git-info": "2.5.0",
+                "semver": "5.5.0"
             }
         },
         "npm-run-all": {
@@ -13557,6 +13561,16 @@
                 "minimatch": "3.0.4",
                 "readable-stream": "2.3.4",
                 "set-immediate-shim": "1.0.1"
+            }
+        },
+        "realize-package-specifier": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/realize-package-specifier/-/realize-package-specifier-3.0.3.tgz",
+            "integrity": "sha1-0N74gpUrjeP2frpekRmWYScfQfQ=",
+            "dev": true,
+            "requires": {
+                "dezalgo": "1.0.3",
+                "npm-package-arg": "4.2.1"
             }
         },
         "recast": {

--- a/src/clr-angular/data/tree-view/tree-node.html
+++ b/src/clr-angular/data/tree-view/tree-node.html
@@ -25,7 +25,8 @@
         *ngIf="selectable"
         [(ngModel)]="selected"
         [(clrIndeterminate)]="indeterminate"></clr-checkbox>
-    <div class="clr-treenode-content">
+        [clrAriaLabeledBy]="nodeId"
+    <div class="clr-treenode-content" [id]="nodeId">
         <ng-content></ng-content>
     </div>
 </div>

--- a/src/clr-angular/data/tree-view/tree-node.html
+++ b/src/clr-angular/data/tree-view/tree-node.html
@@ -24,8 +24,8 @@
         class="clr-treenode-checkbox"
         *ngIf="selectable"
         [(ngModel)]="selected"
-        [(clrIndeterminate)]="indeterminate"></clr-checkbox>
-        [clrAriaLabeledBy]="nodeId"
+        [(clrIndeterminate)]="indeterminate"
+        [clrAriaLabeledBy]="nodeId"></clr-checkbox>
     <div class="clr-treenode-content" [id]="nodeId">
         <ng-content></ng-content>
     </div>

--- a/src/clr-angular/data/tree-view/tree-node.ts
+++ b/src/clr-angular/data/tree-view/tree-node.ts
@@ -5,9 +5,10 @@
  */
 
 import {animate, state, style, transition, trigger} from "@angular/animations";
-import {Component, EventEmitter, Input, OnDestroy, Optional, Output, SkipSelf} from "@angular/core";
+import {Component, EventEmitter, Inject, Input, OnDestroy, Optional, Output, SkipSelf} from "@angular/core";
 
 import {Expand} from "../../utils/expand/providers/expand";
+import {UNIQUE_ID, UNIQUE_ID_PROVIDER} from "../../utils/id-generator/id-generator.service";
 import {LoadingListener} from "../../utils/loading/loading-listener";
 
 import {AbstractTreeSelection} from "./abstract-tree-selection";
@@ -22,7 +23,8 @@ import {TreeSelectionService} from "./providers/tree-selection.service";
             provide: TreeSelectionService,
             useFactory: clrTreeSelectionProviderFactory,
             deps: [[new Optional(), new SkipSelf(), TreeSelectionService]]
-        }
+        },
+        UNIQUE_ID_PROVIDER
     ],
     animations: [trigger("childNodesState",
                          [
@@ -30,11 +32,11 @@ import {TreeSelectionService} from "./providers/tree-selection.service";
                              state("collapsed", style({"height": 0, "overflow-y": "hidden"})),
                              transition("expanded <=> collapsed", animate("0.2s ease-in-out"))
                          ])],
-    host: {"class": ".clr-tree-node"}
+    host: {"class": "clr-tree-node"}
 })
 export class ClrTreeNode extends AbstractTreeSelection implements OnDestroy {
     constructor(public nodeExpand: Expand, @Optional() @SkipSelf() public parent: ClrTreeNode,
-                public treeSelectionService: TreeSelectionService) {
+                public treeSelectionService: TreeSelectionService, @Inject(UNIQUE_ID) public nodeId: string) {
         super(parent);
         if (this.parent) {
             this.parent.register(this);

--- a/src/clr-angular/forms-deprecated/checkbox/checkbox.spec.ts
+++ b/src/clr-angular/forms-deprecated/checkbox/checkbox.spec.ts
@@ -17,6 +17,7 @@ abstract class CheckboxTest {
 
     checked = false;
     indeterminate = false;
+    ariaLabeledById = "clr-id-0";
 }
 
 @Component({
@@ -61,6 +62,13 @@ class InlineCheckbox extends CheckboxTest {}
 })
 class IndeterminateCheckbox extends CheckboxTest {}
 
+@Component({
+    template: `
+        <clr-checkbox [clrAriaLabeledBy]="ariaLabeledById"></clr-checkbox>
+    `
+})
+class AriaLabeledByCheckbox extends CheckboxTest {}
+
 describe("Checkbox", () => {
     let fixture: ComponentFixture<CheckboxTest>;
     let testInstance: CheckboxTest;
@@ -96,7 +104,7 @@ describe("Checkbox", () => {
             imports: [ClrFormsModule, FormsModule],
             declarations: [
                 BasicCheckbox, CheckboxWithNgModel, CheckboxWithLabel, CheckboxWithName, InlineCheckbox,
-                IndeterminateCheckbox
+                IndeterminateCheckbox, AriaLabeledByCheckbox
             ]
         });
     });
@@ -158,6 +166,11 @@ describe("Checkbox", () => {
         fixture.componentInstance.indeterminate = false;
         assertIndeterminate(false);
         assertChecked(false);
+    });
+
+    it("supports aria-labelledby on checkboxElements", () => {
+        createTestComponent(AriaLabeledByCheckbox);
+        expect(checkboxElement.getAttribute("aria-labelledby")).toEqual("clr-id-0");
     });
 
     it("sets indeterminate state to false when the checked state is toggled by user actions", () => {

--- a/src/clr-angular/forms-deprecated/checkbox/checkbox.ts
+++ b/src/clr-angular/forms-deprecated/checkbox/checkbox.ts
@@ -29,7 +29,8 @@ let latestId = 0;
             This works for cases when users toggle the checkbox using the keyboard too:
             https://stackoverflow.com/questions/27878940/spacebar-triggering-click-event-on-checkbox
         -->
-        <input type="checkbox" [id]="id" [name]="name" [checked]="checked"
+        <input type="checkbox" [attr.aria-labelledby]="clrAriaLabeledBy"
+               [id]="id" [name]="name" [checked]="checked"
                [indeterminate]="indeterminate" [disabled]="disabled"
                (blur)="touch()" (click)="checkIndeterminateState()">
         <label [attr.for]="id">
@@ -52,6 +53,9 @@ export class ClrCheckboxDeprecated implements ControlValueAccessor {
     public get id() {
         return `clr-checkbox-${this._id}`;
     }
+
+    // If host provides an clrAriaLabeledBy input, we apply it to the checkbox
+    @Input("clrAriaLabeledBy") public clrAriaLabeledBy: string = null;
 
     // If our host has a name attribute, we apply it to the checkbox.
     @Input("name") public name: string = null;

--- a/src/clr-angular/utils/id-generator/id-generator.service.ts
+++ b/src/clr-angular/utils/id-generator/id-generator.service.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import {InjectionToken} from "@angular/core";
+
+let NB_INSTANCES = 0;
+
+export const UNIQUE_ID = new InjectionToken<string>("UNIQUE_ID");
+
+export const UNIQUE_ID_PROVIDER = {
+    provide: UNIQUE_ID,
+    useFactory: () => "clr-id-" + (NB_INSTANCES++)
+};

--- a/src/clr-angular/utils/id-generator/id-generator.spec.ts
+++ b/src/clr-angular/utils/id-generator/id-generator.spec.ts
@@ -4,72 +4,51 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import {Component, Inject, NgModule, Type} from "@angular/core";
+import {Component, Inject, NgModule} from "@angular/core";
 import {ComponentFixture, TestBed} from "@angular/core/testing";
 import {By} from "@angular/platform-browser";
 
 import {UNIQUE_ID, UNIQUE_ID_PROVIDER} from "./id-generator.service";
 
 @Component({
-    selector: "test-zero",
+    selector: "id-test",
     template: `
         <div [id]="divId">My Div</div>`,
     providers: [UNIQUE_ID_PROVIDER]
 })
-class IdZero {
+class IdTest {
     constructor(@Inject(UNIQUE_ID) public divId: string) {}
 }
 
-@Component({
-    selector: "test-one",
-    template: `
-        <div [id]="divId">My Div</div>`,
-    providers: [UNIQUE_ID_PROVIDER]
-})
-class IdOne {
-    constructor(@Inject(UNIQUE_ID) public divId: string) {}
-}
-
-@Component({
-    selector: "test-two",
-    template: `
-        <div [id]="divId">My Div</div>`,
-    providers: [UNIQUE_ID_PROVIDER]
-})
-class IdTwo {
-    constructor(@Inject(UNIQUE_ID) public divId: string) {}
-}
-
-@NgModule({declarations: [IdZero, IdOne, IdTwo], exports: [IdZero, IdOne, IdTwo]})
+@NgModule({declarations: [IdTest], exports: [IdTest]})
 class IdTestingModule {}
 
 @Component({
     template: `
-        <test-zero></test-zero>
-        <test-one></test-one>
-        <test-two></test-two>`
+        <id-test></id-test>
+        <id-test></id-test>
+        <id-test></id-test>`
 })
 class UniqueIdTest {}
 
-interface TestContext<T extends UniqueIdTest|IdZero|IdOne|IdTwo> {
-    fixture: ComponentFixture<T>;
-    idZero: IdZero;
-    idOne: IdOne;
-    idTwo: IdTwo;
-}
-
-describe("Unique ID Generator Service", function() {
-    function setupTest<T>(testContext: TestContext<T>, testComponent: Type<T>) {
+describe("ID Generator Service", function() {
+    it("generates uniq id's", function() {
+        const fixture: ComponentFixture<UniqueIdTest>;
         TestBed.configureTestingModule(
-            {imports: [IdTestingModule], providers: [UNIQUE_ID_PROVIDER], declarations: [testComponent]});
-        testContext.fixture = TestBed.createComponent(testComponent);
-        testContext.idZero = testContext.fixture.debugElement.query(By.directive(IdZero)).componentInstance;
-        testContext.idOne = testContext.fixture.debugElement.query(By.directive(IdOne)).componentInstance;
-        testContext.idTwo = testContext.fixture.debugElement.query(By.directive(IdTwo)).componentInstance;
-    }
+            {imports: [IdTestingModule], providers: [UNIQUE_ID_PROVIDER], declarations: [UniqueIdTest]});
+        fixture = TestBed.createComponent(UniqueIdTest);
+        fixture.detectChanges();
 
-    it("generates uniq id's in the correct order", function() {
-        setupTest(this, UniqueIdTest);
-        expect(this.idZero !== this.idOne !== this.idTwo).toBe(true);
+        const elements = fixture.debugElement.queryAll(By.directive(IdTest));
+
+        for (const element of elements) {
+            // For each element, filter the array of elements and remove the ones w/ the same id
+            const unmatched = elements.filter(otherElement => otherElement.nativeElement.lastChild.id !==
+                                                  element.nativeElement.lastChild.id);
+
+            // Expect to have two unmatched elements (b/c we have three in UniqueIdTest template)
+            expect(unmatched.length).toBe(2);
+        }
+        fixture.destroy();
     });
 });

--- a/src/clr-angular/utils/id-generator/id-generator.spec.ts
+++ b/src/clr-angular/utils/id-generator/id-generator.spec.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import {Component, Inject, NgModule, Type} from "@angular/core";
+import {ComponentFixture, TestBed} from "@angular/core/testing";
+import {By} from "@angular/platform-browser";
+
+import {UNIQUE_ID, UNIQUE_ID_PROVIDER} from "./id-generator.service";
+
+@Component({
+    selector: "test-zero",
+    template: `
+        <div [id]="divId">My Div</div>`,
+    providers: [UNIQUE_ID_PROVIDER]
+})
+class IdZero {
+    constructor(@Inject(UNIQUE_ID) public divId: string) {}
+}
+
+@Component({
+    selector: "test-one",
+    template: `
+        <div [id]="divId">My Div</div>`,
+    providers: [UNIQUE_ID_PROVIDER]
+})
+class IdOne {
+    constructor(@Inject(UNIQUE_ID) public divId: string) {}
+}
+
+@Component({
+    selector: "test-two",
+    template: `
+        <div [id]="divId">My Div</div>`,
+    providers: [UNIQUE_ID_PROVIDER]
+})
+class IdTwo {
+    constructor(@Inject(UNIQUE_ID) public divId: string) {}
+}
+
+@NgModule({declarations: [IdZero, IdOne, IdTwo], exports: [IdZero, IdOne, IdTwo]})
+class IdTestingModule {}
+
+@Component({
+    template: `
+        <test-zero></test-zero>
+        <test-one></test-one>
+        <test-two></test-two>`
+})
+class UniqueIdTest {}
+
+interface TestContext<T extends UniqueIdTest|IdZero|IdOne|IdTwo> {
+    fixture: ComponentFixture<T>;
+    idZero: IdZero;
+    idOne: IdOne;
+    idTwo: IdTwo;
+}
+
+describe("Unique ID Generator Service", function() {
+    function setupTest<T>(testContext: TestContext<T>, testComponent: Type<T>) {
+        TestBed.configureTestingModule(
+            {imports: [IdTestingModule], providers: [UNIQUE_ID_PROVIDER], declarations: [testComponent]});
+        testContext.fixture = TestBed.createComponent(testComponent);
+        testContext.idZero = testContext.fixture.debugElement.query(By.directive(IdZero)).componentInstance;
+        testContext.idOne = testContext.fixture.debugElement.query(By.directive(IdOne)).componentInstance;
+        testContext.idTwo = testContext.fixture.debugElement.query(By.directive(IdTwo)).componentInstance;
+    }
+
+    it("generates uniq id's in the correct order", function() {
+        setupTest(this, UniqueIdTest);
+        expect(this.idZero !== this.idOne !== this.idTwo).toBe(true);
+    });
+});


### PR DESCRIPTION
- Adds a generic id-generator service
- Fixes #1926

@youdz - I'm not happy about the one test in `id-generator.spec`. I only really test that the ids generated are unique. The main thing I ran into is that `let NB_INSTANCES = 0;` seems to retain its state across tests and it felt hacky to write a second test expecting the starting value to be 'clr-id-4'.  I wasn't able to reset t` NB_INSTANCES` between the first and a second test's. I tried using the `TestBed`'s

```
static resetTestEnvironment()
Reset the providers for the test injector.
```

([docs](https://angular.io/api/core/testing/TestBed#resetTestEnvironment))

But that was resetting `this` to `{}`. If you have something specific that should be tested please advise. 

Signed-off-by: Matt Hippely <mhippely@vmware.com>