### PR TITLE
Issue/1145 improve datagrid sorting docs

### DIFF
--- a/latest/src/app/documentation/demos/datagrid/sorting/examples.ts
+++ b/latest/src/app/documentation/demos/datagrid/sorting/examples.ts
@@ -3,6 +3,8 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
+import {ClrDatagridSortOrder} from "@clr/angular";
+
 export const EXAMPLES = {
     sortingTS: `
 import {ClrDatagridComparatorInterface} from "@clr/angular";
@@ -18,10 +20,17 @@ class MyComponent {
     private pokemonComparator = new PokemonComparator();
 }
 `,
-
     sortingHTML: `
 <-- In the columns declaration -->
 <clr-dg-column [clrDgField]="'pokemon.name'"
                [clrDgSortBy]="pokemonComparator">Pokemon</clr-dg-column>
+`,
+    preSortTS: `
+    import {ClrDatagridSortOrder} from '@clr/angular';
+    ...
+    this.descSort = ClrDatagridSortOrder.DESC;
+`,
+    preSortHTML: `
+    <clr-dg-column [clrDgField]="'name'" [clrDgSortOrder]="descSort">Name</clr-dg-column>
 `
 };

--- a/latest/src/app/documentation/demos/datagrid/sorting/examples.ts
+++ b/latest/src/app/documentation/demos/datagrid/sorting/examples.ts
@@ -26,9 +26,12 @@ class MyComponent {
                [clrDgSortBy]="pokemonComparator">Pokemon</clr-dg-column>
 `,
     preSortTS: `
-    import {ClrDatagridSortOrder} from '@clr/angular';
-    ...
+import {ClrDatagridSortOrder} from '@clr/angular';
+...
+@Component({ /* ... */ })
+class MyComponent {
     this.descSort = ClrDatagridSortOrder.DESC;
+}
 `,
     preSortHTML: `
     <clr-dg-column [clrDgField]="'name'" [clrDgSortOrder]="descSort">Name</clr-dg-column>

--- a/latest/src/app/documentation/demos/datagrid/sorting/sorting.html
+++ b/latest/src/app/documentation/demos/datagrid/sorting/sorting.html
@@ -137,3 +137,36 @@
 
 <clr-code-snippet [clrCode]="examples.sortingTS" clrLanguage="typescript"></clr-code-snippet>
 <clr-code-snippet [clrCode]="examples.sortingHTML" clrLanguage="html"></clr-code-snippet>
+
+<h4>Pre-Sorted Columns</h4>
+<p>Columns can be pre-sorted ascending or descending by declaring the <code class="clr-code">clrSortOrder</code>
+    input on <code class="clr-code">clr-dg-column</code>. You must also provide the
+    <code class="clr-code">[clrDgField]</code> so it knows what field in the provided object to sort on. Clarity
+    provides an enum for such a scenario: <code class="clr-code">ClrDatagridSortOrder</code></p>
+<p>Here is an example that presorts the <b>Name</b> column for descending sort order.</p>
+
+<clr-code-snippet [clrCode]="examples.preSortTS" clrLanguage="typescript"></clr-code-snippet>
+<clr-code-snippet [clrCode]="examples.preSortHTML" clrLanguage="html"></clr-code-snippet>
+
+<clr-datagrid>
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column [clrDgField]="'name'" [clrDgSortOrder]="descSort">Name</clr-dg-column>
+    <clr-dg-column>Creation date</clr-dg-column>
+    <clr-dg-column>
+        Pokemon
+    </clr-dg-column>
+    <clr-dg-column>Favorite color</clr-dg-column>
+
+    <clr-dg-row *clrDgItems="let user of users">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>
+            {{user.pokemon.name}} <span class="badge badge-5">#{{user.pokemon.number}}</span>
+        </clr-dg-cell>
+        <clr-dg-cell>
+            <span class="color-square" [style.backgroundColor]="user.color"></span>
+        </clr-dg-cell>
+    </clr-dg-row>
+    <clr-dg-footer>{{users.length}} users</clr-dg-footer>
+</clr-datagrid>

--- a/latest/src/app/documentation/demos/datagrid/sorting/sorting.ts
+++ b/latest/src/app/documentation/demos/datagrid/sorting/sorting.ts
@@ -6,7 +6,7 @@
 import {Component} from "@angular/core";
 import {Inventory} from "../inventory/inventory";
 import {User} from "../inventory/user";
-import {SortOrder} from "@clr/angular";
+import {ClrDatagridSortOrder} from "@clr/angular";
 import {PokemonComparator} from "../utils/pokemon-comparator";
 import {EXAMPLES} from "./examples";
 
@@ -20,9 +20,9 @@ export class DatagridSortingDemo {
     examples = EXAMPLES;
     users: User[];
     usersDeprecated: User[];
-    sortOrder: SortOrder = SortOrder.Unsorted;
+    sortOrder: ClrDatagridSortOrder = ClrDatagridSortOrder.DESC;
     sorted: boolean = false;
-
+    descSort: ClrDatagridSortOrder = ClrDatagridSortOrder.DESC;
 
     pokemonComparator = new PokemonComparator();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "website",
-  "version": "0.10.18",
+  "version": "0.11.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/v0.10/src/app/documentation/demos/datagrid/sorting/examples.ts
+++ b/v0.10/src/app/documentation/demos/datagrid/sorting/examples.ts
@@ -23,5 +23,16 @@ class MyComponent {
 <-- In the columns declaration -->
 <clr-dg-column [clrDgField]="'pokemon.name'"
                [clrDgSortBy]="pokemonComparator">Pokemon</clr-dg-column>
+`,
+    preSortTS: `
+    import {SortOrder} from 'clarity-angular';
+    ...
+    @Component({ /* ... */ })
+    class MyComponent {
+        this.descSort = SortOrder.Desc;
+    }
+`,
+    preSortHTML: `
+    <clr-dg-column [clrDgField]="'name'" [clrDgSortOrder]="descSort">Name</clr-dg-column>
 `
 };

--- a/v0.10/src/app/documentation/demos/datagrid/sorting/sorting.html
+++ b/v0.10/src/app/documentation/demos/datagrid/sorting/sorting.html
@@ -137,3 +137,36 @@
 
 <clr-code-snippet [clrCode]="examples.sortingTS" clrLanguage="typescript"></clr-code-snippet>
 <clr-code-snippet [clrCode]="examples.sortingHTML" clrLanguage="html"></clr-code-snippet>
+
+<h4>Pre-Sorted Columns</h4>
+<p>Columns can be pre-sorted ascending or descending by declaring the <code class="clr-code">clrSortOrder</code>
+    input on a <code class="clr-code">clr-dg-column<</code> . You must also provide the
+    <code class="clr-code">[clrDgField]</code> so it knows what field in the provided object to sort on. Clarity
+    provides an enum for such a scenario: <code class="clr-code">SortOrder</code></p>
+<p>Here is an example that presorts the <b>Name</b> column for descending sort order.</p>
+
+<clr-code-snippet [clrCode]="examples.preSortTS" clrLanguage="typescript"></clr-code-snippet>
+<clr-code-snippet [clrCode]="examples.preSortHTML" clrLanguage="html"></clr-code-snippet>
+
+<clr-datagrid>
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column [clrDgField]="'name'" [clrDgSortOrder]="descSort">Name</clr-dg-column>
+    <clr-dg-column>Creation date</clr-dg-column>
+    <clr-dg-column>
+        Pokemon
+    </clr-dg-column>
+    <clr-dg-column>Favorite color</clr-dg-column>
+
+    <clr-dg-row *clrDgItems="let user of users">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>
+            {{user.pokemon.name}} <span class="badge badge-5">#{{user.pokemon.number}}</span>
+        </clr-dg-cell>
+        <clr-dg-cell>
+            <span class="color-square" [style.backgroundColor]="user.color"></span>
+        </clr-dg-cell>
+    </clr-dg-row>
+    <clr-dg-footer>{{users.length}} users</clr-dg-footer>
+</clr-datagrid>

--- a/v0.10/src/app/documentation/demos/datagrid/sorting/sorting.ts
+++ b/v0.10/src/app/documentation/demos/datagrid/sorting/sorting.ts
@@ -22,6 +22,7 @@ export class DatagridSortingDemo {
     usersDeprecated: User[];
     sortOrder: SortOrder = SortOrder.Unsorted;
     sorted: boolean = false;
+    descSort: SortOrder = SortOrder.Desc;
 
 
     pokemonComparator = new PokemonComparator();


### PR DESCRIPTION
Adds an example for presorting on the 'Name' column for the `clrDgSortOrdder` Input. 