### PR TITLE
[Docs] Minor typo and mention new website branch

### DIFF
--- a/latest/README.md
+++ b/latest/README.md
@@ -4,9 +4,9 @@ The Clarity website is an Angular CLI project that has server-side rendering ena
 
 ### Setup
 
-Clone the repository, checkout the `new-website` branch, and install node modules.
+Clone the repository, checkout the `website` branch, and install node modules.
 
-    git clone https://github.com/vmware/clarity.git --branch new-website clarity-website
+    git clone https://github.com/vmware/clarity.git --branch website clarity-website
     cd clarity-website
     npm install
 

--- a/latest/src/app/documentation/demos/datagrid/datagrid.demo.html
+++ b/latest/src/app/documentation/demos/datagrid/datagrid.demo.html
@@ -127,7 +127,7 @@
 
             <h4 id="for-structured-content">For Structured Content</h4>
 
-            <p>Datagrids work best for structured, homogeneous content, where each object has the same attributes. Whenß
+            <p>Datagrids work best for structured, homogeneous content, where each object has the same attributes. When
                 common attributes are directly aligned in columns, users can quickly scan and compare them.</p>
 
             <p>For data sets with a blend of text, images, and data visualizations, or content with mixed formatting,

--- a/v0.10/README.md
+++ b/v0.10/README.md
@@ -4,9 +4,9 @@ The Clarity website is an Angular CLI project that has server-side rendering ena
 
 ### Setup
 
-Clone the repository, checkout the `new-website` branch, and install node modules.
+Clone the repository, checkout the `website` branch, and install node modules.
 
-    git clone https://github.com/vmware/clarity.git --branch new-website clarity-website
+    git clone https://github.com/vmware/clarity.git --branch website clarity-website
     cd clarity-website
     npm install
 

--- a/v0.10/src/app/documentation/demos/datagrid/datagrid.demo.html
+++ b/v0.10/src/app/documentation/demos/datagrid/datagrid.demo.html
@@ -6,7 +6,7 @@
             on.</h5>
 
         <div id="code-examples">
-            
+
             <p>
                 We have {{childRoutes.length}} datagrid demos. Starting with the basics, each demo shows
                 you one or more of the advanced Datagrid features.
@@ -127,7 +127,7 @@
 
             <h4 id="for-structured-content">For Structured Content</h4>
 
-            <p>Datagrids work best for structured, homogeneous content, where each object has the same attributes. Whenß
+            <p>Datagrids work best for structured, homogeneous content, where each object has the same attributes. When
                 common attributes are directly aligned in columns, users can quickly scan and compare them.</p>
 
             <p>For data sets with a blend of text, images, and data visualizations, or content with mixed formatting,


### PR DESCRIPTION
This supersedes https://github.com/vmware/clarity/pull/2035 and pushes against the correct branch, while also changing mentions of the old branch to the new one in the website.