### PR TITLE
[UI] Add no wrapping to the alert pager

### DIFF
--- a/src/clr-angular/emphasis/alert/_alert.clarity.scss
+++ b/src/clr-angular/emphasis/alert/_alert.clarity.scss
@@ -416,6 +416,7 @@
     .alerts-pager-control {
         display: flex;
         margin-top: $clr-alert-top-margin;
+        white-space: nowrap;
     }
 
     $clr-alerts-pager-item-width: 33.33%;


### PR DESCRIPTION
Fixed: https://github.com/vmware/clarity/issues/2030

Tested on Chrome, Safari, IE11, Edge, Firefox

Before:
![image](https://user-images.githubusercontent.com/1426805/37107831-612fcd2e-2203-11e8-9d17-10aa88ab8f5b.png)


After:
![screen shot 2018-03-07 at 12 24 41 pm](https://user-images.githubusercontent.com/1426805/37107800-534c925a-2203-11e8-815a-b8d7cd40c593.png)


Signed-off-by: Aditya Bhandari <adityab@vmware.com>