### PR TITLE
[NG] Remove @private annotation

### DIFF
--- a/src/clr-angular/utils/host-wrapping/host-wrapping.module.ts
+++ b/src/clr-angular/utils/host-wrapping/host-wrapping.module.ts
@@ -10,8 +10,6 @@ import {EmptyAnchor} from "./empty-anchor";
 
 
 /**
- * @private
- *
  * Internal module, please do not export!
  */
 @NgModule({declarations: [EmptyAnchor], exports: [EmptyAnchor], entryComponents: [EmptyAnchor]})


### PR DESCRIPTION
Fixed an issue with the build.

<img width="400" alt="screen shot 2018-03-07 at 2 32 37 pm" src="https://user-images.githubusercontent.com/1426805/37113855-9c21c6f6-2214-11e8-8dc4-2a1fd18c29c0.png">

Without this fix `npm run build` fails.

Signed-off-by: Aditya Bhandari <adityab@vmware.com>