### PR TITLE
[NG] Cal + Year Range Generation Optimizations

### DIFF
--- a/src/clr-angular/forms/datepicker/providers/date-navigation.service.spec.ts
+++ b/src/clr-angular/forms/datepicker/providers/date-navigation.service.spec.ts
@@ -127,6 +127,29 @@ export default function() {
                 expect(dateNavigationService.displayedCalendar.month).toBe(date.getMonth());
             });
 
+            it("does not regenerate the current calendar " +
+                   "when the displayed calendar is already current",
+               () => {
+                   let count: number = 0;
+                   const sub: Subscription = dateNavigationService.displayedCalendarChange.subscribe(() => {
+                       count++;
+                   });
+
+                   initalizeCalendar(new DayModel(2017, 0, 1));
+                   expect(count).toBe(0);
+
+                   dateNavigationService.moveToCurrentMonth();
+                   expect(count).toBe(1);
+
+                   dateNavigationService.moveToCurrentMonth();
+                   expect(count).toBe(1);
+
+                   dateNavigationService.moveToCurrentMonth();
+                   expect(count).toBe(1);
+
+                   sub.unsubscribe();
+               });
+
             it("supports the focused day property", () => {
                 expect(dateNavigationService.focusedDay).toBeUndefined();
                 dateNavigationService.focusedDay = new DayModel(2015, 2, 2);

--- a/src/clr-angular/forms/datepicker/providers/date-navigation.service.ts
+++ b/src/clr-angular/forms/datepicker/providers/date-navigation.service.ts
@@ -105,7 +105,9 @@ export class DateNavigationService {
      * Moves the displayed calendar to the current month and year.
      */
     moveToCurrentMonth(): void {
-        this.setDisplayedCalendar(new CalendarModel(this.today.year, this.today.month));
+        if (!this.displayedCalendar.isDayInCalendar(this.today)) {
+            this.setDisplayedCalendar(new CalendarModel(this.today.year, this.today.month));
+        }
         this._focusOnCalendarChange.next();
     }
 

--- a/src/clr-angular/forms/datepicker/yearpicker.spec.ts
+++ b/src/clr-angular/forms/datepicker/yearpicker.spec.ts
@@ -196,6 +196,17 @@ export default function() {
                 expect(context.clarityDirective.yearRangeModel.inRange(new Date().getFullYear())).toBe(true);
             });
 
+            it("does not regenerate the year range when its on the current decade", () => {
+                // Move to the current decade
+                context.clarityDirective.currentDecade();
+                expect(context.clarityDirective.yearRangeModel.inRange(new Date().getFullYear())).toBe(true);
+
+                // Move again and check
+                spyOn(context.clarityDirective.yearRangeModel, "currentDecade");
+                context.clarityDirective.currentDecade();
+                expect(context.clarityDirective.yearRangeModel.currentDecade).not.toHaveBeenCalled();
+            });
+
             it("gets the correct tab indices on initialization", () => {
                 const years: number[] = context.clarityDirective.yearRangeModel.yearRange;
 

--- a/src/clr-angular/forms/datepicker/yearpicker.ts
+++ b/src/clr-angular/forms/datepicker/yearpicker.ts
@@ -104,7 +104,9 @@ export class ClrYearpicker implements AfterViewInit {
      * Updates the YearRangeModel to the current decade.
      */
     currentDecade(): void {
-        this.yearRangeModel = this.yearRangeModel.currentDecade();
+        if (!this.yearRangeModel.inRange(this._dateNavigationService.today.year)) {
+            this.yearRangeModel = this.yearRangeModel.currentDecade();
+        }
         this._datepickerFocusService.focusCell(this._elRef);
     }
 


### PR DESCRIPTION
Calendar and Year Range Generation Optimizations

If on the current displayed calendar or current decade, dont generate the calendar or year range again.

Tested on Chrome.

Signed-off-by: Aditya Bhandari <adityab@vmware.com>