### PR TITLE
[NG] Closes a Popover on ESC

### DIFF
--- a/src/clr-angular/popover/common/abstract-popover.spec.ts
+++ b/src/clr-angular/popover/common/abstract-popover.spec.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import {Component, ElementRef, Injector, Optional} from "@angular/core";
+import {ComponentFixture, TestBed} from "@angular/core/testing";
+
+import {IfOpenService} from "../../utils/conditional/if-open.service";
+import {ESC} from "../../utils/key-codes/key-codes";
+
+import {AbstractPopover} from "./abstract-popover";
+
+describe("Abstract Popover", function() {
+    let fixture: ComponentFixture<any>;
+    let compiled: any;
+    let ifOpenService: IfOpenService;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({declarations: [TestPopover], providers: [IfOpenService]});
+        fixture = TestBed.createComponent(TestPopover);
+        compiled = fixture.nativeElement;
+        ifOpenService = fixture.debugElement.injector.get(IfOpenService);
+        fixture.detectChanges();
+    });
+
+    it("adds a binding for keydown events", () => {
+        spyOn(fixture.componentInstance, "onKeyDown").and.callThrough();
+
+        fixture.debugElement.triggerEventHandler("keydown", {keyCode: ESC});
+
+        expect(fixture.componentInstance.onKeyDown).toHaveBeenCalled();
+    });
+
+    it("closes the popover when ESC is pressed", () => {
+        ifOpenService.open = true;
+
+        fixture.debugElement.triggerEventHandler("keydown", {keyCode: ESC});
+
+        expect(ifOpenService.open).toBe(false);
+    });
+});
+
+@Component({
+    template: `
+        <div>Popover</div>
+    `
+})
+class TestPopover extends AbstractPopover {
+    constructor(injector: Injector, @Optional() parent: ElementRef) {
+        super(injector, parent);
+    }
+}

--- a/src/clr-angular/popover/common/abstract-popover.ts
+++ b/src/clr-angular/popover/common/abstract-popover.ts
@@ -7,6 +7,7 @@ import {
     AfterViewChecked,
     ElementRef,
     HostBinding,
+    HostListener,
     Injectable,
     Injector,
     OnDestroy,
@@ -16,6 +17,7 @@ import {
 import {Subscription} from "rxjs/Subscription";
 
 import {IfOpenService} from "../../utils/conditional/if-open.service";
+import {ESC} from "../../utils/key-codes/key-codes";
 
 import {Point, Popover} from "./popover";
 import {PopoverOptions} from "./popover-options.interface";
@@ -88,6 +90,13 @@ export abstract class AbstractPopover implements AfterViewChecked, OnDestroy {
     @HostBinding("class.is-off-screen")
     get isOffScreen() {
         return this.ifOpenService.open ? false : true;
+    }
+
+    @HostListener("keydown", ["$event"])
+    onKeyDown(event: KeyboardEvent) {
+        if (event && event.keyCode === ESC && this.ifOpenService.open) {
+            this.ifOpenService.open = false;
+        }
     }
 
     /*

--- a/src/clr-angular/utils/key-codes/key-codes.ts
+++ b/src/clr-angular/utils/key-codes/key-codes.ts
@@ -11,3 +11,4 @@ export const LEFT_ARROW: number = 37;
 export const ENTER: number = 13;
 export const SPACE: number = 32;
 export const TAB: number = 9;
+export const ESC: number = 27;


### PR DESCRIPTION
Fixes: #2062

Closes a popover when the `ESC` key is pressed.

Tested on Chrome

Note: For some reason `abstract-popover.ts` didn't have any tests. I have added tests related to this change in this PR. Will add the remaining tests in a separate PR.

Signed-off-by: Aditya Bhandari <adityab@vmware.com>