### PR TITLE
[UI] Dategrid Action Overflow Fix

### DIFF
--- a/src/clr-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clr-angular/data/datagrid/_datagrid.clarity.scss
@@ -626,7 +626,8 @@
         // Datagrid has a margin top of 1 baseline. action bar is supposed to be 1/2 baseline from the datagrid
         // Had to use translate instead of negative margins to pull the
         // action bar down. negative margin screws up the click targets.
-        transform: translateY(0.5rem);
+        margin-bottom: -0.5rem;
+        margin-top: 0.5rem;
     }
 
     .datagrid-foot {

--- a/src/clr-angular/data/datagrid/providers/selection.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/selection.spec.ts
@@ -251,11 +251,13 @@ export default function(): void {
 
         describe("client-side selection and pagination", function() {
             const items = [{id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}, {id: 6}, {id: 7}, {id: 8}, {id: 9}, {id: 10}];
+
             function cloneItems() {
                 return items.map(item => {
                     return {...item};
                 });
             }
+
             function testSelectedItems(latestItems, selectedIndexes: any[]) {
                 latestItems.forEach((item, index) => {
                     const state = selectedIndexes.indexOf(index) > -1;
@@ -309,6 +311,18 @@ export default function(): void {
                     selectionInstance.currentSingle = items[5];
                     pageInstance.current = 3;
                     expect(selectionInstance.isSelected(items[5])).toBe(true);
+                });
+
+                it("does not apply trackBy to single selection with no items", () => {
+                    const emptyItems = new Items(filtersInstance, sortInstance, pageInstance);
+                    const selection: Selection = new Selection(emptyItems, filtersInstance);
+
+                    spyOn(emptyItems, "trackBy");
+
+                    expect(selection.currentSingle).toBeUndefined();
+                    selection.currentSingle = items[2];
+
+                    expect(emptyItems.trackBy).not.toHaveBeenCalled();
                 });
 
                 function testTrackBy(trackBy: TrackByFunction<{id: number}>) {

--- a/src/clr-angular/data/datagrid/providers/selection.ts
+++ b/src/clr-angular/data/datagrid/providers/selection.ts
@@ -133,7 +133,7 @@ export class Selection {
             return;
         }
         this._currentSingle = value;
-        if (this._items.trackBy && value) {
+        if (this._items.all && this._items.trackBy && value) {
             const lookup = this._items.all.findIndex(maybe => maybe === value);
             this.selectedSingle = this._items.trackBy(lookup, value);
         }


### PR DESCRIPTION
`translateY` was causing issues with dropdown menus and modals:

Before:
![screen shot 2018-03-19 at 4 18 51 pm](https://user-images.githubusercontent.com/1426805/37620199-e9203182-2b91-11e8-977b-d924cd2822b6.png)

After:
![screen shot 2018-03-19 at 4 18 33 pm](https://user-images.githubusercontent.com/1426805/37620202-ebf94344-2b91-11e8-9797-90d6d9cf169d.png)

Before:
<img width="309" alt="screen shot 2018-03-19 at 4 20 06 pm" src="https://user-images.githubusercontent.com/1426805/37620207-edbdd8de-2b91-11e8-9b74-54907e21d8f6.png">

After:
<img width="312" alt="screen shot 2018-03-19 at 4 19 51 pm" src="https://user-images.githubusercontent.com/1426805/37620212-ef8c30ca-2b91-11e8-878f-dfc554ac0dc5.png">
