### PR TITLE
[UI] Datagrid Action Overflow Fix

### DIFF
--- a/src/clr-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clr-angular/data/datagrid/_datagrid.clarity.scss
@@ -16,6 +16,7 @@
     .datagrid-host {
         display: flex;
         flex-flow: column nowrap;
+        padding-top: 0.5rem; //TODO: Remove. Temp fix. Matt to follow new UX recommendations with pinned columns
     }
 
     .datagrid-overlay-wrapper {
@@ -47,6 +48,7 @@
         flex-flow: column nowrap;
         // IE & Firefox needs this
         min-height: 1px;
+        margin-top: 0.5rem; //TODO: Remove. Temp fix. Matt to follow new UX recommendations with pinned columns
     }
     .datagrid-head, .datagrid-body, .datagrid-row, .datagrid-column, .datagrid-cell, .datagrid-fixed-column {
         display: block;
@@ -622,11 +624,6 @@
         display: flex;
         flex-flow: row nowrap;
         align-items: stretch;
-
-        // Datagrid has a margin top of 1 baseline. action bar is supposed to be 1/2 baseline from the datagrid
-        // Had to use translate instead of negative margins to pull the
-        // action bar down. negative margin screws up the click targets.
-        transform: translateY(0.5rem);
     }
 
     .datagrid-foot {


### PR DESCRIPTION
Fixes: #1631

`translateY` was causing issues with dropdown menus and modals. Replaced that by a negative margin. @hippee-lee's PR will fix this better but this can be a temp fix until that goes in.

Before:
![screen shot 2018-03-19 at 4 18 51 pm](https://user-images.githubusercontent.com/1426805/37620199-e9203182-2b91-11e8-977b-d924cd2822b6.png)

After:
![screen shot 2018-03-19 at 4 18 33 pm](https://user-images.githubusercontent.com/1426805/37620202-ebf94344-2b91-11e8-9797-90d6d9cf169d.png)

Before:
<img width="309" alt="screen shot 2018-03-19 at 4 20 06 pm" src="https://user-images.githubusercontent.com/1426805/37620207-edbdd8de-2b91-11e8-9b74-54907e21d8f6.png">

After:
<img width="312" alt="screen shot 2018-03-19 at 4 19 51 pm" src="https://user-images.githubusercontent.com/1426805/37620212-ef8c30ca-2b91-11e8-878f-dfc554ac0dc5.png">

Signed-off-by: Aditya Bhandari <adityab@vmware.com>