### PR TITLE
[NG] Bug Fix for Datepicker in Reactive Forms

### DIFF
--- a/src/app/datepicker/datepicker-in-reactive-forms.html
+++ b/src/app/datepicker/datepicker-in-reactive-forms.html
@@ -12,6 +12,10 @@
             <label for="dateControl">Date</label>
             <input id="dateControl" type="date" clrDate formControlName="date"/>
         </div>
+        <div class="form-group">
+            <label for="nameControl">Name</label>
+            <input type="text" id="nameControl" formControlName="name">
+        </div>
     </section>
 </form>
 

--- a/src/app/datepicker/datepicker-in-reactive-forms.ts
+++ b/src/app/datepicker/datepicker-in-reactive-forms.ts
@@ -12,4 +12,6 @@ import {FormControl, FormGroup} from "@angular/forms";
     styleUrls: ["./datepicker.demo.scss"],
     templateUrl: "./datepicker-in-reactive-forms.html"
 })
-export class DatepickerInReactiveForms { dateForm = new FormGroup({date: new FormControl()}); }
+export class DatepickerInReactiveForms {
+    dateForm = new FormGroup({date: new FormControl("03/05/2018"), name: new FormControl("Jane")});
+}

--- a/src/app/datepicker/datepicker-in-template-driven-forms.ts
+++ b/src/app/datepicker/datepicker-in-template-driven-forms.ts
@@ -12,7 +12,7 @@ import {Component} from "@angular/core";
     templateUrl: "./datepicker-in-template-driven-forms.html"
 })
 export class DatepickerInTemplateDrivenFormsDemo {
-    date1: string = "";
+    date1: string = "01/02/2015";
     date2: string = "";
 
     date1Changed(date: Date): void {

--- a/src/clr-angular/forms/datepicker/date-input.spec.ts
+++ b/src/clr-angular/forms/datepicker/date-input.spec.ts
@@ -6,7 +6,7 @@
 
 import {Component, DebugElement, ViewChild} from "@angular/core";
 import {ComponentFixture, fakeAsync, TestBed, tick} from "@angular/core/testing";
-import {FormsModule} from "@angular/forms";
+import {FormControl, FormsModule, ReactiveFormsModule} from "@angular/forms";
 import {By} from "@angular/platform-browser";
 
 import {TestContext} from "../../data/datagrid/helpers.spec";
@@ -179,6 +179,44 @@ export default function() {
                }));
         });
 
+        describe("Datepicker with Reactive Forms", () => {
+            let fixture: ComponentFixture<TestComponentWithReactiveForms>;
+            let compiled: any;
+
+            let dateContainerDebugElement: DebugElement;
+            let dateInputDebugElement: DebugElement;
+
+            beforeEach(function() {
+                TestBed.configureTestingModule(
+                    {imports: [ReactiveFormsModule, ClrFormsModule], declarations: [TestComponentWithReactiveForms]});
+
+                fixture = TestBed.createComponent(TestComponentWithReactiveForms);
+                fixture.detectChanges();
+                compiled = fixture.nativeElement;
+                dateContainerDebugElement = fixture.debugElement.query(By.directive(ClrDateContainer));
+                dateInputDebugElement = fixture.debugElement.query(By.directive(ClrDateInput));
+                dateNavigationService = dateContainerDebugElement.injector.get(DateNavigationService);
+            });
+
+            it("initializes the input and the selected day with the value set by the user", () => {
+                expect(fixture.componentInstance.date.value).not.toBeNull();
+
+                expect(dateInputDebugElement.nativeElement.value).toBe(fixture.componentInstance.dateInput);
+                expect(dateNavigationService.selectedDay.year).toBe(2015);
+                expect(dateNavigationService.selectedDay.month).toBe(0);
+                expect(dateNavigationService.selectedDay.date).toBe(1);
+            });
+
+            it("updates the input and the selected day when the value is updated by the user", () => {
+                fixture.componentInstance.date.setValue("05/05/2018");
+
+                expect(dateInputDebugElement.nativeElement.value).toBe("05/05/2018");
+                expect(dateNavigationService.selectedDay.year).toBe(2018);
+                expect(dateNavigationService.selectedDay.month).toBe(4);
+                expect(dateNavigationService.selectedDay.date).toBe(5);
+            });
+        });
+
         describe("Datepicker with clrDate", () => {
             let fixture: ComponentFixture<TestComponentWithClrDate>;
             let compiled: any;
@@ -277,4 +315,14 @@ class TestComponentWithNgModel {
 })
 class TestComponentWithClrDate {
     date: Date;
+}
+
+@Component({
+    template: `
+        <input id="dateControl" type="date" clrDate [formControl]="date">
+    `
+})
+class TestComponentWithReactiveForms {
+    dateInput: string = "01/01/2015";
+    date: FormControl = new FormControl(this.dateInput);
 }


### PR DESCRIPTION
Fixes: #2093

The initial value set by the user in Reactive Forms wasn't being processed by the Date Picker. Fixes that issue. For more details see #2093

Tested on Chrome

Signed-off-by: Aditya Bhandari <adityab@vmware.com>