### PR TITLE
[Docs] Minor typos

### DIFF
--- a/latest/src/app/documentation/demos/button-group/button-group.demo.html
+++ b/latest/src/app/documentation/demos/button-group/button-group.demo.html
@@ -315,10 +315,10 @@
 
             <ul class="list">
                 <li>
-                    Overflow button is shown below as an ellipses button in the button
+                    Overflow button is shown below as an ellipsis button in the button
                     group and is the last position to the right
                 </li>
-                <li>Clicking on the ellipses will show the overflow dropdown menu</li>
+                <li>Clicking on the ellipsis will show the overflow dropdown menu</li>
             </ul>
 
             <div class="row">

--- a/latest/src/app/documentation/demos/datagrid/binding-properties/binding-properties.html
+++ b/latest/src/app/documentation/demos/datagrid/binding-properties/binding-properties.html
@@ -8,7 +8,7 @@
 
 <p>
     For an easy setup of datagrid column features, you can simply specify the property to bind it to
-    in your model. When you do, the column will benefit for all built-in features for this case:
+    in your model. When you do, the column will benefit from all built-in features for this case:
     sorting based on the natural comparison, filtering based on string value, and anything else we
     might add in the future. You can bind to as deep a property as you want in your model, using
     a standard dot-separated syntax:
@@ -16,7 +16,7 @@
 </p>
 <p>
     You can also see in the following example how every feature we offer is always opt-in:
-    we did not declare any binding on the "User ID" column, which means it is not sortable of
+    we did not declare any binding on the "User ID" column, which means it is not sortable or
     filterable.
 </p>
 

--- a/latest/src/app/documentation/demos/datagrid/single-action/single-action.html
+++ b/latest/src/app/documentation/demos/datagrid/single-action/single-action.html
@@ -9,8 +9,8 @@
     You can allow actions on an item in a single row, in the cases where batch operation is not
     applicable. You can use this pattern in both selectable and non-selectable datagrids.
     Add a <code class="clr-code">clr-dg-action-overflow</code> inside a <code class="clr-code">clr-dg-row</code>.
-    The content inside of it will be projected as action menu which will toggle when the user clicks on the
-    ellipses icon as shown below. We recommend that the menu items be buttons with a class
+    The content inside of it will be projected as an action menu which will toggle when the user clicks on the
+    ellipsis icon as shown below. We recommend that the menu items be buttons with a class
     <code class="clr-code">.action-item</code> as in the example.
 </p>
 

--- a/latest/src/app/documentation/demos/tabs/tabs.demo.html
+++ b/latest/src/app/documentation/demos/tabs/tabs.demo.html
@@ -60,8 +60,8 @@
             </p>
 
             <p>
-                Tab overflow is shown below as an ellipses button in the tab group and is the last
-                position to the right. Clicking on the ellipses will show the overflow dropdown menu.
+                Tab overflow is shown below as an ellipsis button in the tab group and is the last
+                position to the right. Clicking on the ellipsis will show the overflow dropdown menu.
             </p>
 
             <p>

--- a/latest/src/app/documentation/demos/vertical-nav/vertical-nav.demo.html
+++ b/latest/src/app/documentation/demos/vertical-nav/vertical-nav.demo.html
@@ -345,8 +345,8 @@
             <h3>Long Labels</h3>
 
             <p>
-                When labels get too long they will be trimmed and followed by an ellipses (…). We recommend 
-                that navigation labels remain short and concise to prevent an ellipses from showing.
+                When labels get too long they will be trimmed and followed by an ellipsis (…). We recommend 
+                that navigation labels remain short and concise to prevent an ellipsis from showing.
             </p>
 
 

--- a/latest/src/releases/0.8/0.8.5.html
+++ b/latest/src/releases/0.8/0.8.5.html
@@ -5,7 +5,7 @@
         <p>
             With 0.8.5, Clarity has introduced new icons such as
             <code class="clr-code">tags</code>, <code class="clr-code">clock</code>, <code class="clr-code">floppy</code>,
-            <code class="clr-code">ellipses-vertical</code>, <code class="clr-code">ellipses-horizontal</code>,
+            <code class="clr-code">ellipsis-vertical</code>, <code class="clr-code">ellipsis-horizontal</code>,
             and <code class="clr-code">bank</code>.
         </p>
     </li>

--- a/v0.10/src/app/documentation/demos/button-group/button-group.demo.html
+++ b/v0.10/src/app/documentation/demos/button-group/button-group.demo.html
@@ -315,10 +315,10 @@
 
             <ul class="list">
                 <li>
-                    Overflow button is shown below as an ellipses button in the button
+                    Overflow button is shown below as an ellipsis button in the button
                     group and is the last position to the right
                 </li>
-                <li>Clicking on the ellipses will show the overflow dropdown menu</li>
+                <li>Clicking on the ellipsis will show the overflow dropdown menu</li>
             </ul>
 
             <div class="row">

--- a/v0.10/src/app/documentation/demos/datagrid/binding-properties/binding-properties.html
+++ b/v0.10/src/app/documentation/demos/datagrid/binding-properties/binding-properties.html
@@ -8,7 +8,7 @@
 
 <p>
     For an easy setup of datagrid column features, you can simply specify the property to bind it to
-    in your model. When you do, the column will benefit for all built-in features for this case:
+    in your model. When you do, the column will benefit from all built-in features for this case:
     sorting based on the natural comparison, filtering based on string value, and anything else we
     might add in the future. You can bind to as deep a property as you want in your model, using
     a standard dot-separated syntax:
@@ -16,7 +16,7 @@
 </p>
 <p>
     You can also see in the following example how every feature we offer is always opt-in:
-    we did not declare any binding on the "User ID" column, which means it is not sortable of
+    we did not declare any binding on the "User ID" column, which means it is not sortable or
     filterable.
 </p>
 

--- a/v0.10/src/app/documentation/demos/datagrid/single-action/single-action.html
+++ b/v0.10/src/app/documentation/demos/datagrid/single-action/single-action.html
@@ -9,8 +9,8 @@
     You can allow actions on an item in a single row, in the cases where batch operation is not
     applicable. You can use this pattern in both selectable and non-selectable datagrids.
     Add a <code class="clr-code">clr-dg-action-overflow</code> inside a <code class="clr-code">clr-dg-row</code>.
-    The content inside of it will be projected as action menu which will toggle when the user clicks on the
-    ellipses icon as shown below. We recommend that the menu items be buttons with a class
+    The content inside of it will be projected as an action menu which will toggle when the user clicks on the
+    ellipsis icon as shown below. We recommend that the menu items be buttons with a class
     <code class="clr-code">.action-item</code> as in the example.
 </p>
 

--- a/v0.10/src/app/documentation/demos/tabs/tabs.demo.html
+++ b/v0.10/src/app/documentation/demos/tabs/tabs.demo.html
@@ -60,8 +60,8 @@
             </p>
 
             <p>
-                Tab overflow is shown below as an ellipses button in the tab group and is the last 
-                position to the right. Clicking on the ellipses will show the overflow dropdown menu.
+                Tab overflow is shown below as an ellipsis button in the tab group and is the last 
+                position to the right. Clicking on the ellipsis will show the overflow dropdown menu.
             </p>
 
             <p>

--- a/v0.10/src/app/documentation/demos/vertical-nav/vertical-nav.demo.html
+++ b/v0.10/src/app/documentation/demos/vertical-nav/vertical-nav.demo.html
@@ -345,8 +345,8 @@
             <h3>Long Labels</h3>
 
             <p>
-                When labels get too long they will be trimmed and followed by an ellipses (…). We recommend 
-                that navigation labels remain short and concise to prevent an ellipses from showing.
+                When labels get too long they will be trimmed and followed by an ellipsis (…). We recommend 
+                that navigation labels remain short and concise to prevent an ellipsis from showing.
             </p>
 
 


### PR DESCRIPTION
Correct several minor typos, mostly related to the Datagrid component documentation.

Signed-off-by: Alex Mellnik <a.r.mellnik@gmail.com>