### PR TITLE
[NG] fix: clDgRowSelection attribute naming (#2019)

### DIFF
--- a/src/app/datagrid/selection-row-mode/selection-row-mode.html
+++ b/src/app/datagrid/selection-row-mode/selection-row-mode.html
@@ -15,7 +15,7 @@
 </p>
 <ul>
     <li>
-        For row selection mode add <code class="clr-code">[(clDgRowSelection)]</code> and set it to <code class="clr-code">true</code>.
+        For row selection mode add <code class="clr-code">[(clrDgRowSelection)]</code> and set it to <code class="clr-code">true</code>.
     </li>
 </ul>
 
@@ -33,7 +33,7 @@
 
 <h3>Single selection</h3>
 
-<clr-datagrid [(clrDgSingleSelected)]="singleSelected" [clDgRowSelection]="true">
+<clr-datagrid [(clrDgSingleSelected)]="singleSelected" [clrDgRowSelection]="true">
 
     <clr-dg-column>User ID</clr-dg-column>
     <clr-dg-column>Name</clr-dg-column>
@@ -64,7 +64,7 @@
     </p>
 </div>
 
-<clr-datagrid [(clrDgSelected)]="multiSelected" [clDgRowSelection]="true">
+<clr-datagrid [(clrDgSelected)]="multiSelected" [clrDgRowSelection]="true">
     <clr-dg-column>User ID</clr-dg-column>
     <clr-dg-column>Name</clr-dg-column>
     <clr-dg-column>Creation date</clr-dg-column>

--- a/src/app/datagrid/selection-row-mode/selection-row-mode.ts
+++ b/src/app/datagrid/selection-row-mode/selection-row-mode.ts
@@ -9,7 +9,7 @@ import {Inventory} from "../inventory/inventory";
 import {User} from "../inventory/user";
 
 const SINGLE_SELECTION_EXAMPLE = `
-<clr-datagrid [(clrDgSingleSelected)]="selectedUser" [clDgRowSelection]="true">
+<clr-datagrid [(clrDgSingleSelected)]="selectedUser" [clrDgRowSelection]="true">
     <-- ... -->
     <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
         <-- ... -->
@@ -21,7 +21,7 @@ Selected user: <span class="username" *ngIf="selectedUser">{{selectedUser.name}}
 `;
 
 const MULTI_SELECTION_EXAMPLE = `
-<clr-datagrid [(clrDgSelected)]="selected" [clDgRowSelection]="true">
+<clr-datagrid [(clrDgSelected)]="selected" [clrDgRowSelection]="true">
     <-- ... -->
     <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
         <-- ... -->

--- a/src/clr-angular/data/datagrid/datagrid.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid.spec.ts
@@ -317,6 +317,14 @@ export default function(): void {
                     context.detectChanges();
                     expect(context.testComponent.selected).toEqual(2);
                 });
+
+                it("sets deprecated attribute 'clDgRowSelection' as expected `rowSelectionMode` is enabled",
+                   function() {
+                       expect(selection.rowSelectionMode).toBe(false);
+                       context.clarityDirective.rowSelectionModeDeprecated = true;
+                       context.detectChanges();
+                       expect(selection.rowSelectionMode).toBe(true);
+                   });
             });
 
             describe("View", function() {
@@ -401,12 +409,12 @@ export default function(): void {
             <clr-dg-filter *ngIf="filter" [clrDgFilter]="testFilter"></clr-dg-filter>
         </clr-dg-column>
         <clr-dg-column>Second</clr-dg-column>
-    
+
         <clr-dg-row *clrDgItems="let item of items">
             <clr-dg-cell>{{item}}</clr-dg-cell>
             <clr-dg-cell>{{item * item}}</clr-dg-cell>
         </clr-dg-row>
-    
+
         <clr-dg-footer>{{items.length}} items</clr-dg-footer>
     </clr-datagrid>
 `
@@ -440,12 +448,12 @@ class FullTest {
     <clr-datagrid>
         <clr-dg-column>First</clr-dg-column>
         <clr-dg-column>Second</clr-dg-column>
-    
+
         <clr-dg-row *ngFor="let item of items">
             <clr-dg-cell>{{item}}</clr-dg-cell>
             <clr-dg-cell>{{item * item}}</clr-dg-cell>
         </clr-dg-row>
-    
+
         <clr-dg-footer>{{items.length}} items</clr-dg-footer>
     </clr-datagrid>
 `
@@ -459,12 +467,12 @@ class NgForTest {
     <clr-datagrid>
         <clr-dg-column>First</clr-dg-column>
         <clr-dg-column>Second</clr-dg-column>
-    
+
         <clr-dg-row *clrDgItems="let item of items; trackBy: trackByIndex">
             <clr-dg-cell>{{item}}</clr-dg-cell>
             <clr-dg-cell>{{item * item}}</clr-dg-cell>
         </clr-dg-row>
-    
+
         <clr-dg-footer>{{items.length}} items</clr-dg-footer>
     </clr-datagrid>
 `
@@ -495,7 +503,7 @@ class OnPushTest {
     <clr-datagrid [(clrDgSelected)]="selected">
         <clr-dg-column>First</clr-dg-column>
         <clr-dg-column>Second</clr-dg-column>
-    
+
         <clr-dg-row *clrDgItems="let item of items;" [clrDgItem]="item">
             <clr-dg-cell>{{item}}</clr-dg-cell>
             <clr-dg-cell>{{item * item}}</clr-dg-cell>
@@ -513,12 +521,12 @@ class MultiSelectionTest {
     <clr-datagrid [(clrDgSingleSelected)]="selected">
         <clr-dg-column>First</clr-dg-column>
         <clr-dg-column>Second</clr-dg-column>
-    
+
         <clr-dg-row *clrDgItems="let item of items;" [clrDgItem]="item">
             <clr-dg-cell>{{item}}</clr-dg-cell>
             <clr-dg-cell>{{item * item}}</clr-dg-cell>
         </clr-dg-row>
-    
+
         <clr-dg-footer (click)="selected = null">{{selected}}</clr-dg-footer>
     </clr-datagrid>
 `
@@ -533,17 +541,17 @@ class SingleSelectionTest {
     <clr-datagrid>
         <clr-dg-column>First</clr-dg-column>
         <clr-dg-column>Second</clr-dg-column>
-    
+
         <clr-dg-row *clrDgItems="let item of items;">
-        
+
             <clr-dg-action-overflow *ngIf="item > showIfGreaterThan">
                 <button class="action-item">Edit</button>
             </clr-dg-action-overflow>
-                
+
             <clr-dg-cell>{{item}}</clr-dg-cell>
             <clr-dg-cell>{{item * item}}</clr-dg-cell>
         </clr-dg-row>
-    
+
         <clr-dg-footer>{{items.length}} items</clr-dg-footer>
     </clr-datagrid>
 `
@@ -558,7 +566,7 @@ class ActionableRowTest {
     <clr-datagrid>
         <clr-dg-column>First</clr-dg-column>
         <clr-dg-column>Second</clr-dg-column>
-    
+
         <clr-dg-row *clrDgItems="let item of items;" [clrDgItem]="item">
             <clr-dg-cell>{{item}}</clr-dg-cell>
             <clr-dg-cell>{{item * item}}</clr-dg-cell>
@@ -566,7 +574,7 @@ class ActionableRowTest {
                 <clr-dg-row-detail *clrIfExpanded>Detail</clr-dg-row-detail>
             </ng-template>
         </clr-dg-row>
-    
+
         <clr-dg-footer>{{items.length}} items</clr-dg-footer>
     </clr-datagrid>
 `
@@ -666,7 +674,7 @@ class TestStringFilter implements ClrDatagridStringFilterInterface<number> {
             </ng-container>
         </clr-dg-column>
         <clr-dg-column>Second</clr-dg-column>
-    
+
         <clr-dg-row *ngFor="let item of items;">
             <clr-dg-cell>{{item}}</clr-dg-cell>
             <clr-dg-cell>{{item * item}}</clr-dg-cell>

--- a/src/clr-angular/data/datagrid/datagrid.ts
+++ b/src/clr-angular/data/datagrid/datagrid.ts
@@ -124,9 +124,18 @@ export class ClrDatagrid implements AfterContentInit, AfterViewInit, OnDestroy {
     /**
      * Selection/Deselection on row click mode
      */
-    @Input("clDgRowSelection")
+    @Input("clrDgRowSelection")
     set rowSelectionMode(value: boolean) {
         this.selection.rowSelectionMode = value;
+    }
+
+    /**
+     * stay backwards compatible , will be renamed to clrDgRowSelection
+     * @deprecated since 0.12
+     */
+    @Input("clDgRowSelection")
+    set rowSelectionModeDeprecated(value: boolean) {
+        this.rowSelectionMode = value;
     }
 
     /**


### PR DESCRIPTION
- Fix data grid row selection attribute typo.

- I can't run **npm install** , then i use yarn to install but run **npm test** fail , package missed `@ngtools/webpack `

**NPM version : 5.6.0**

![image](https://user-images.githubusercontent.com/3501899/38595142-914f9af4-3d7c-11e8-89fa-403f8effeebd.png)


Signed-off-by: Jewway jewway@gmail.com