### PR TITLE
[SCHEMATICS] update schematics to handle new config schemas

### DIFF
--- a/npm/clr-angular/package.json
+++ b/npm/clr-angular/package.json
@@ -19,14 +19,16 @@
         "@angular/platform-browser": "^5.0.0",
         "@angular/platform-browser-dynamic": "^5.0.0",
         "@angular/router": "^5.0.0",
-        "@angular-devkit/core": "^0.4.7",
-        "@angular-devkit/schematics": "^0.4.7",
         "@clr/ui": "@VERSION"
+    },
+    "dependencies": {
+        "@angular-devkit/core": "^0.5.5",
+        "@angular-devkit/schematics": "^0.5.5"
     },
     "author": "clarity",
     "license": "MIT",
     "bugs": {
         "url": "https://github.com/vmware/clarity/issues"
     },
-    "collection": "schematics/collection.json"
+    "schematics": "./schematics/collection.json"
 }

--- a/packages/schematics/package-lock.json
+++ b/packages/schematics/package-lock.json
@@ -5,23 +5,44 @@
   "requires": true,
   "dependencies": {
     "@angular-devkit/core": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.4.3.tgz",
-      "integrity": "sha512-M5J3GcgzEubytoRq8c5QvvBZvSpPouy+5QdspQPJzFSUOKJXO0I1s8pyaB3dCatmygU/DxlIK9nUn8n4Z8+wTw==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.5.5.tgz",
+      "integrity": "sha512-91JZwom/wcZQQcm4oPnF3z6/rlKfIRdwB9eUe6htOL20K4M+Bsog7ngNYQhmOVX0QJfBQJX372gItd6vTaM9zg==",
       "requires": {
         "ajv": "5.5.2",
         "chokidar": "1.7.0",
-        "rxjs": "5.5.6",
+        "rxjs": "6.0.0-terrific-rc.3",
         "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "6.0.0-terrific-rc.3",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.0.0-terrific-rc.3.tgz",
+          "integrity": "sha512-CRpXVpRbuBsgbnTi/KjgYJ8/C1IXaeFL8obHtbxQrPorfhRPGEkIvbuQ+sTQnw9slszhRLrPz9EhmuGrVP8kYQ==",
+          "requires": {
+            "tslib": "1.9.0"
+          }
+        }
       }
     },
     "@angular-devkit/schematics": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-0.4.3.tgz",
-      "integrity": "sha512-SO8Hxc5LdCkbab0KX+gyFd1iXMum7VvubJwRPyA11C28fHCV7DStXBKmW4lIle7NI3aqTyGd5ZupuLBIwuJ4ig==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-0.5.5.tgz",
+      "integrity": "sha512-l3Pf69BBoZ7T3ju5DMeYVPC6ANidcJuJ9xA0+GRVoHSvNxl/roxJsQ56ujOXEChq/1znBgv6Mh8QBFycJIOQjA==",
       "requires": {
+        "@angular-devkit/core": "0.5.5",
         "@ngtools/json-schema": "1.1.0",
-        "rxjs": "5.5.6"
+        "rxjs": "6.0.0-terrific-rc.3"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "6.0.0-terrific-rc.3",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.0.0-terrific-rc.3.tgz",
+          "integrity": "sha512-CRpXVpRbuBsgbnTi/KjgYJ8/C1IXaeFL8obHtbxQrPorfhRPGEkIvbuQ+sTQnw9slszhRLrPz9EhmuGrVP8kYQ==",
+          "requires": {
+            "tslib": "1.9.0"
+          }
+        }
       }
     },
     "@ngtools/json-schema": {
@@ -1342,14 +1363,6 @@
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
-    "rxjs": {
-      "version": "5.5.6",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.6.tgz",
-      "integrity": "sha512-v4Q5HDC0FHAQ7zcBX7T2IL6O5ltl1a2GX4ENjPXg6SjDY69Cmx9v4113C99a4wGF16ClPv5Z8mghuYorVkg/kg==",
-      "requires": {
-        "symbol-observable": "1.0.1"
-      }
-    },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
@@ -1373,10 +1386,10 @@
         "safe-buffer": "5.1.1"
       }
     },
-    "symbol-observable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
+    "tslib": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
     },
     "typescript": {
       "version": "2.6.2",

--- a/packages/schematics/package.json
+++ b/packages/schematics/package.json
@@ -23,8 +23,8 @@
     "license": "MIT",
     "schematics": "./src/collection.json",
     "dependencies": {
-        "@angular-devkit/core": "^0.4.3",
-        "@angular-devkit/schematics": "^0.4.3",
+        "@angular-devkit/core": "^0.5.5",
+        "@angular-devkit/schematics": "^0.5.5",
         "@schematics/angular": "^0.4.3",
         "@types/jasmine": "^2.6.0",
         "@types/node": "^8.0.31",

--- a/packages/schematics/src/add/index.ts
+++ b/packages/schematics/src/add/index.ts
@@ -13,6 +13,15 @@ import { Schema as ComponentOptions } from "./schema";
 
 import * as ts from "typescript";
 import * as fs from "fs";
+import {join} from "path";
+
+// Determine where to load the package.json, if doing local dev or not
+let corePackage: any;
+if (fs.existsSync(join(__dirname, "../../package.json"))) {
+    corePackage = require("../../package.json")
+ } else {
+    corePackage = require("../../../../package.json");
+ }
 
 // Looks up and finds the path to the app module (or other module if specified)
 function findModuleFromOptions(host: Tree, options: ComponentOptions): Path | undefined {
@@ -38,6 +47,12 @@ function updateJsonFile(path: string, callback: (a: any) => any) {
     const json = JSON.parse(fs.readFileSync(path, "utf-8"));
     callback(json);
     fs.writeFileSync(path, JSON.stringify(json, null, 2));
+}
+
+// Looks at the project for the correct CLI config file
+function findCliConfig() {
+    return ['angular.json', '.angular.json', 'angular-cli.json', '.angular-cli.json']
+        .find(file => fs.existsSync(file));
 }
 
 // Handles adding a module to the NgModule 
@@ -80,13 +95,13 @@ export default function(options: ComponentOptions): Rule {
         updateJsonFile("package.json", json => {
             const packages = Object.keys(json.dependencies);
             if (!packages.includes("@clr/angular")) {
-                json.dependencies["@clr/angular"] = "^0.11.0";
+                json.dependencies["@clr/angular"] = `^${corePackage.version}`;
             }
             if (!packages.includes("@clr/ui")) {
-                json.dependencies["@clr/ui"] = "^0.11.0";
+                json.dependencies["@clr/ui"] = `^${corePackage.version}`;
             }
             if (!packages.includes("@clr/icons")) {
-                json.dependencies["@clr/icons"] = "^0.11.0";
+                json.dependencies["@clr/icons"] = `^${corePackage.version}`;
             }
             if (!packages.includes("@webcomponents/custom-elements")) {
                 json.dependencies["@webcomponents/custom-elements"] = "^1.0.0";
@@ -94,25 +109,49 @@ export default function(options: ComponentOptions): Rule {
         });
 
         // Add Clarity assets to .angular-cli.json, if not found
-        updateJsonFile(".angular-cli.json", json => {
-            const scripts = json.apps[0].scripts;
-            const scriptsSearch = scripts.join("|");
-            const styles = json.apps[0].styles;
-            const stylesSearch = styles.join("|");
+        const config = findCliConfig();
+        if (config) {
+            updateJsonFile(config, json => {
+                // @TODO abstract this out to a utility, maybe schematics will provide one
+                let scripts, styles = [];
+                if (json.apps) {
+                    scripts = json.apps[0].scripts;
+                    styles = json.apps[0].styles;
+                } else if (json.projects) {
+                    const projects = Object.keys(json.projects);
+                    const project = projects.find(key => {
+                        if (json.projects[key].projectType === "application") {
+                            return true;
+                        }
+                        return false;
+                    });
+                    if (!project) {
+                        console.info(`Could not update CLI config file to add scripts and styles. You'll have to add them manually.`);
+                        return;
+                    }
+                    scripts = json.projects[project].architect.build.options.scripts;
+                    styles = json.projects[project].architect.build.options.styles;
+                }
 
-            if (stylesSearch.search("../node_modules/@clr/ui/clr-ui") < 0) {
-                styles.push("../node_modules/@clr/ui/clr-ui.min.css");
-            }
-            if (stylesSearch.search("../node_modules/@clr/icons/clr-icons") < 0) {
-                styles.push("../node_modules/@clr/icons/clr-icons.min.css");
-            }
-            if (scriptsSearch.search("../node_modules/@clr/icons/clr-icons.min.js") < 0) {
-                scripts.push("../node_modules/@clr/icons/clr-icons.min.js");
-            }
-            if (scriptsSearch.search("../node_modules/@webcomponents/custom-elements/custom-elements.min.js") < 0) {
-                scripts.push("../node_modules/@webcomponents/custom-elements/custom-elements.min.js");
-            }
-        });
+                const scriptsSearch = scripts.join("|");
+                const stylesSearch = styles.join("|");
+    
+                if (stylesSearch.search("../node_modules/@clr/ui/clr-ui") < 0) {
+                    styles.push("../node_modules/@clr/ui/clr-ui.min.css");
+                }
+                if (stylesSearch.search("../node_modules/@clr/icons/clr-icons") < 0) {
+                    styles.push("../node_modules/@clr/icons/clr-icons.min.css");
+                }
+                if (scriptsSearch.search("../node_modules/@clr/icons/clr-icons.min.js") < 0) {
+                    scripts.push("../node_modules/@clr/icons/clr-icons.min.js");
+                }
+                if (scriptsSearch.search("../node_modules/@webcomponents/custom-elements/custom-elements.min.js") < 0) {
+                    scripts.push("../node_modules/@webcomponents/custom-elements/custom-elements.min.js");
+                }
+            });
+        } else {
+            console.info(`No CLI config found, skipping`);
+        }
 
         // Chain a series of tasks to setup Clarity
         // 1. Add ClarityModule to NgModule

--- a/src/clr-angular/package.json
+++ b/src/clr-angular/package.json
@@ -19,14 +19,16 @@
         "@angular/platform-browser": "^5.0.0",
         "@angular/platform-browser-dynamic": "^5.0.0",
         "@angular/router": "^5.0.0",
-        "@angular-devkit/core": "^0.4.7",
-        "@angular-devkit/schematics": "^0.4.7",
         "@clr/ui": "0.11.12"
+    },
+    "dependencies": {
+        "@angular-devkit/core": "^0.5.5",
+        "@angular-devkit/schematics": "^0.5.5"
     },
     "author": "clarity",
     "license": "MIT",
     "bugs": {
         "url": "https://github.com/vmware/clarity/issues"
     },
-    "collection": "schematics/collection.json"
+    "schematics": "./schematics/collection.json"
 }


### PR DESCRIPTION
Schematics needs to handle both versions of the angular cli config files coming with Angular 6. This also moves the schematics dependencies from peerDependencies to dependencies to ensure they are installed and users don't get an unnecessary warning.

fixes #2181
