### PR TITLE
[NG] emitting on string filter value change

### DIFF
--- a/src/clr-angular/data/datagrid/datagrid-column.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column.spec.ts
@@ -219,6 +219,7 @@ export default function(): void {
                 this.context.testComponent.filterValue = "M";
                 this.context.detectChanges();
                 expect(this.context.clarityDirective.filterValue).toBe("M");
+
                 this.context.clarityDirective.filterValue = "t";
                 this.context.detectChanges();
                 expect(this.context.testComponent.filterValue).toBe("t");
@@ -236,6 +237,12 @@ export default function(): void {
 
                 stringFilterComponent.value = "T";
                 expect(this.context.testComponent.filterValue).toBe("T");
+
+                stringFilterComponent.value = "";
+                expect(this.context.testComponent.filterValue).toBe("");
+
+                stringFilterComponent.value = "m";
+                expect(this.context.testComponent.filterValue).toBe("m");
             });
 
             it("accepts a custom filter in the projected content", function() {
@@ -484,7 +491,7 @@ class StringFilterTest {
 
 @Component({
     template: `
-        <clr-dg-column [clrDgField]="field" [(clrFilterValue)]="filterValue">
+        <clr-dg-column [(clrFilterValue)]="filterValue" [clrDgField]="field" >
             Column Title
         </clr-dg-column>
     `

--- a/src/clr-angular/data/datagrid/datagrid-column.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column.spec.ts
@@ -5,6 +5,7 @@
  */
 import {Component, ViewChild} from "@angular/core";
 import {TestBed} from "@angular/core/testing";
+import {By} from "@angular/platform-browser";
 import {Subject} from "rxjs/Subject";
 
 import {DatagridPropertyComparator} from "./built-in/comparators/datagrid-property-comparator";
@@ -212,7 +213,7 @@ export default function(): void {
                 expect(this.context.testComponent.sortOrder).toBe(ClrDatagridSortOrder.ASC);
             });
 
-            it("offers two way binding on the filtered state", function() {
+            it("offers two-way binding on the filtered state", function() {
                 this.context = this.create(ClrDatagridColumn, PreFilterTest, PROVIDERS_NEEDED);
                 this.context.testComponent.field = "test";
                 this.context.testComponent.filterValue = "M";
@@ -221,6 +222,20 @@ export default function(): void {
                 this.context.clarityDirective.filterValue = "t";
                 this.context.detectChanges();
                 expect(this.context.testComponent.filterValue).toBe("t");
+            });
+
+            it("should emit on string filter value changes", function() {
+                this.context = this.create(ClrDatagridColumn, PreFilterTest, PROVIDERS_NEEDED);
+                this.context.testComponent.field = "test";
+
+                this.context.detectChanges();
+
+                const stringFilterDebugElement =
+                    this.context.fixture.debugElement.query(By.directive(DatagridStringFilter));
+                const stringFilterComponent = stringFilterDebugElement.injector.get(DatagridStringFilter);
+
+                stringFilterComponent.value = "T";
+                expect(this.context.testComponent.filterValue).toBe("T");
             });
 
             it("accepts a custom filter in the projected content", function() {
@@ -453,7 +468,7 @@ class FilterTest {
 
 @Component({
     template: `
-        <clr-dg-column [clrDgField]="field">
+        <clr-dg-column [clrDgField]="field" [(clrFilterValue)]="filterValue">
             Hello world
             <clr-dg-string-filter class="my-string-filter" [clrDgStringFilter]="filter"></clr-dg-string-filter>
         </clr-dg-column>

--- a/src/clr-angular/data/datagrid/datagrid-column.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column.ts
@@ -20,7 +20,6 @@ import {DatagridFilterRegistrar} from "./utils/datagrid-filter-registrar";
 
 let nbCount: number = 0;
 
-
 @Component({
     selector: "clr-dg-column",
     template: `
@@ -31,7 +30,7 @@ let nbCount: number = 0;
             <clr-dg-string-filter
                     *ngIf="field && !customFilter"
                     [clrDgStringFilter]="registered"
-                    (clrFilterValueChange)="filterValueChange.emit($event)"></clr-dg-string-filter>
+                    [(clrFilterValue)]="filterValue"></clr-dg-string-filter>
 
             <ng-template #columnTitle><ng-content></ng-content></ng-template>
 
@@ -51,7 +50,6 @@ let nbCount: number = 0;
     `,
     host: {"[class.datagrid-column]": "true", "[class.datagrid-column--hidden]": "hidden"}
 })
-
 export class ClrDatagridColumn extends DatagridFilterRegistrar<DatagridStringFilterImpl> {
     constructor(private _sort: Sort, filters: FiltersProvider, private _dragDispatcher: DragDispatcher) {
         super(filters);
@@ -307,7 +305,7 @@ export class ClrDatagridColumn extends DatagridFilterRegistrar<DatagridStringFil
     }
 
     @Input("clrFilterValue")
-    public set filterValue(newValue: string) {
+    public set updateFilterValue(newValue: string) {
         if (!this.filter) {
             return;
         }
@@ -316,8 +314,12 @@ export class ClrDatagridColumn extends DatagridFilterRegistrar<DatagridStringFil
         }
         if (newValue !== this.filter.value) {
             this.filter.value = newValue;
-            this.filterValueChange.emit(newValue);
         }
+    }
+
+    public set filterValue(newValue: string) {
+        this.updateFilterValue = newValue;
+        this.filterValueChange.emit(this.filter.value);
     }
 
     @Output("clrFilterValueChange") filterValueChange = new EventEmitter();

--- a/src/clr-angular/data/datagrid/datagrid-column.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column.ts
@@ -31,7 +31,7 @@ let nbCount: number = 0;
             <clr-dg-string-filter
                     *ngIf="field && !customFilter"
                     [clrDgStringFilter]="registered"
-                    [(clrFilterValue)]="filterValue"></clr-dg-string-filter>
+                    (clrFilterValueChange)="filterValueChange.emit($event)"></clr-dg-string-filter>
 
             <ng-template #columnTitle><ng-content></ng-content></ng-template>
 

--- a/src/ks-app/src/app/containers/data/datagrid.component.html
+++ b/src/ks-app/src/app/containers/data/datagrid.component.html
@@ -31,6 +31,13 @@
 </clr-datagrid>
 
 <h3>Sort and Filter</h3>
+<div id="sort-and-filter">
+  <div class="card card-block">
+    <p class="card-text username-list">
+      Name filter value: {{nameFilter}}
+    </p>
+  </div>
+</div>
 <clr-datagrid [class.datagrid-compact]="isCompact">
   <clr-dg-column>User ID</clr-dg-column>
   <clr-dg-column [clrDgField]="'name'" [(clrFilterValue)]="nameFilter">Name</clr-dg-column>


### PR DESCRIPTION
When a user types in to filter, `clr-dg-string-filter` emits value through the `clrFilterValueChange` output. However, `clr-dg-column` was merely setting its `filterValue` property on those filter value changes sourced from `clr-dg-string-filter`, but wasn't emitting them from itself. 

So this fix lets `clr-dg-column` emit the filter value changes, that are first emitted from `clr-dg-string-filter`.

The demo of this fix (in the "Sort and Filter" section): http://2004-after-fix.surge.sh/datagrids

- Fixes #2004

Signed-off-by: Shijir Tsogoo <stsogoo@vmware.com>