### PR TITLE
[UI] Enhancement for tooltip (#1955)

### DIFF
--- a/src/clr-angular/forms-deprecated/_forms.clarity.scss
+++ b/src/clr-angular/forms-deprecated/_forms.clarity.scss
@@ -255,6 +255,7 @@
             //Show on input focus
             & > input:focus + .tooltip-content {
                 background: $clr-forms-input-invalid-color;
+                border: $arrow-border-width solid $clr-forms-input-invalid-color;
                 visibility: visible;
                 opacity: 1;
             }
@@ -266,7 +267,7 @@
             &.tooltip-bottom-right > input:focus + .tooltip-content {
                 left: 100%;
                 right: auto;
-                //6px to the right & left of the error icon + 8px for half width of the error icon
+                ////6px to the right & left of the error icon + 8px for half width of the error icon
                 margin-left: -1 * ($error-icon-margin + $error-icon-width / 2);
             }
 
@@ -279,20 +280,32 @@
             }
 
             //Set arrow colors to red :(
-            & > .tooltip-content::before, &.tooltip-top-right > .tooltip-content::before {
+            & > .tooltip-content::before, .tooltip-content::after {
                 @include vertical-tooltip-arrow-color(top, right, $clr-forms-input-invalid-color);
             }
 
-            &.tooltip-top-left > .tooltip-content::before {
-                @include vertical-tooltip-arrow-color(top, left, $clr-forms-input-invalid-color);
+            &.tooltip-top-right > .tooltip-content {
+                &::before, &::after {
+                    @include vertical-tooltip-arrow-color(top, right, $clr-forms-input-invalid-color);
+                }
             }
 
-            &.tooltip-bottom-right > .tooltip-content::before {
-                @include vertical-tooltip-arrow-color(bottom, right, $clr-forms-input-invalid-color);
+            &.tooltip-top-left > .tooltip-content {
+                &::before, &::after {
+                    @include vertical-tooltip-arrow-color(top, left, $clr-forms-input-invalid-color);
+                }
             }
 
-            &.tooltip-bottom-left > .tooltip-content::before {
-                @include vertical-tooltip-arrow-color(bottom, left, $clr-forms-input-invalid-color);
+            &.tooltip-bottom-right > .tooltip-content {
+                &::before, &::after {
+                    @include vertical-tooltip-arrow-color(bottom, right, $clr-forms-input-invalid-color);
+                }
+            }
+
+            &.tooltip-bottom-left > .tooltip-content {
+                &::before, &::after {
+                    @include vertical-tooltip-arrow-color(bottom, left, $clr-forms-input-invalid-color);
+                }
             }
 
             &.tooltip-left > input:focus + .tooltip-content {
@@ -300,7 +313,7 @@
                 left: auto;
                 margin: 0 ($error-icon-margin + $error-icon-width/2) 0 0;
 
-                &::before {
+                &::before, &::after {
                     @include horizontal-tooltip-arrow-color(top, left, $clr-forms-input-invalid-color);
                 }
             }
@@ -310,7 +323,7 @@
                 right: auto;
                 margin: 0 0 0 ($error-icon-margin + $error-icon-width/2);
 
-                &::before {
+                &::before, &::after {
                     @include horizontal-tooltip-arrow-color(top, right, $clr-forms-input-invalid-color);
                 }
             }

--- a/src/clr-angular/popover/tooltip/_tooltips.clarity.scss
+++ b/src/clr-angular/popover/tooltip/_tooltips.clarity.scss
@@ -12,6 +12,7 @@
     margin: 0; //Resetting any margin that might be applied to span/div elements inside forms
     padding: 0.375rem 0.5rem;
     width: $clr-tooltip-default-width;
+    border: $arrow-border-width solid $clr-tooltip-border-color;
 }
 
 @mixin vertical-tooltip-generator($dirA:top, $dirB:right) {
@@ -29,18 +30,32 @@
     border-#{$oppA}-#{$oppB}-radius: 0;
     margin-#{$oppA}: $clr-tooltip-adjusted-margin;
 
-    &::before {
+    &::before, &::after {
         position: absolute;
-        #{$oppA}: -0.375rem;
-        #{$oppB}: 0;
         #{$dirA}: auto;
         #{$dirB}: auto;
         content: '';
+    }
+
+    &::before {
+        #{$oppB}: -$arrow-border-width;
+        #{$oppA}: -0.4175rem;
+        border-#{$oppB}: $arrow-height solid $clr-tooltip-border-color;
+        border-#{$dirA}: $arrow-width solid $clr-tooltip-border-color;
+        border-#{$dirB}: $arrow-height solid transparent;
+        border-#{$oppA}: $arrow-width solid transparent;
+    }
+
+    &::after {
+        #{$oppB}: -0.24px;
+        #{$oppA}: -0.375rem;
         border-#{$oppB}: $arrow-height solid $clr-tooltip-background-color;
         border-#{$dirA}: $arrow-width solid $clr-tooltip-background-color;
         border-#{$dirB}: $arrow-height solid transparent;
         border-#{$oppA}: $arrow-width solid transparent;
     }
+
+
 }
 
 @mixin horizontal-tooltip-generator($dirA:right) {
@@ -57,15 +72,27 @@
     border-top-#{$oppA}-radius: 0;
     margin-#{$oppA}: $clr-tooltip-adjusted-margin;
 
-    &::before {
+    &::before, &::after {
         position: absolute;
-        top: 0;
-        #{$oppA}: -0.375rem;
         bottom: auto;
         #{$dirA}: auto;
         content: '';
-        border-top: $arrow-height solid $clr-tooltip-background-color;
-        border-#{$dirA}: $arrow-width solid $clr-tooltip-background-color;
+    }
+
+    &::before {
+        top: -$arrow-border-width;
+        #{$oppA}: -0.4175rem;
+        border-top: $arrow-height solid $clr-tooltip-border-color;
+        border-#{$dirA}: $arrow-width solid $clr-tooltip-border-color;
+        border-bottom: $arrow-height solid transparent;
+        border-#{$oppA}: $arrow-width solid transparent;
+    }
+
+    &::after {
+        top: -0.28px;
+        #{$oppA}: -0.375rem;
+        border-top: ($arrow-height) solid $clr-tooltip-background-color;
+        border-#{$dirA}: ($arrow-width) solid $clr-tooltip-background-color;
         border-bottom: $arrow-height solid transparent;
         border-#{$oppA}: $arrow-width solid transparent;
     }

--- a/src/clr-angular/popover/tooltip/_variables.tooltip.scss
+++ b/src/clr-angular/popover/tooltip/_variables.tooltip.scss
@@ -6,7 +6,9 @@
 // Usage: ../popover/tooltip/_tooltips.clarity.scss
 $clr-tooltip-font-color: $clr-white !default;
 $clr-tooltip-background-color: $clr-black !default;
+$clr-tooltip-border-color: $clr-black !default;
 $clr-tooltip-default-width: 10rem !default;
-$arrow-height: 0.25rem !default;
+$arrow-height: 0.208333rem !default;
 $arrow-width: 0.208333rem !default; //I wanted the arrow width to be 9. If I use 4.5/24 it still rounds up to 10.
+$arrow-border-width: 0.03541rem !default;
 $clr-tooltip-adjusted-margin: 0.666667rem !default;

--- a/src/clr-angular/utils/_overwrites.clarity.scss
+++ b/src/clr-angular/utils/_overwrites.clarity.scss
@@ -163,6 +163,7 @@ $clr-green-darkest: null; //  #0f2900;
 
 $clr-tooltip-font-color: null; // $clr-white;
 $clr-tooltip-background-color: null; // $clr-black;
+$clr-tooltip-border-color: null; // $clr-black;
 $clr-tooltip-default-width: null; // 10*$clr-baseline;
 $margin-value: null; // $clr-baseline*0.25;
 $arrow-height: null; // $clr-baseline*0.25;

--- a/src/clr-angular/utils/_theme.dark.clarity.scss
+++ b/src/clr-angular/utils/_theme.dark.clarity.scss
@@ -660,6 +660,7 @@ $clr-nav-link-color: #adbbc4;
  */
 $clr-tooltip-font-color: $clr-black;
 $clr-tooltip-background-color: $clr-white;
+$clr-tooltip-border-color: $clr-white;
 // END: Tooltip
 
 /**********


### PR DESCRIPTION
Provide a SASS variable to control the borders of a tooltip (including the arrow). In order to implement the border for the arrow, we implemented using before, after pseudo elements. One triangle is created with the background color and other triangle is created using border color. The values are adjusted for all the variant of toolips
We have tested 
1) Different variant Tooltips such as top-right,  top-left, bottom right, bottom-left, right and left
2) Different browsers such as Chrome, Mozilla, and Edge
3) Tested signposts and dont see any dependencies
4) Tested form validation in wizard tooltip-top-right, tooltip-top-left, tooltip-bottom-right, tooltip-bottom-left, tooltip-left, tooltip-right 

In order to adjust different tooltips in different browsers we have adjusted the values as much as possible with best possible outcomes. Please find attached the images for the same. 

![bottom-left](https://user-images.githubusercontent.com/4607437/38927230-b6440b00-4322-11e8-8734-e6303e23f9e3.png)
![bottom-right](https://user-images.githubusercontent.com/4607437/38927231-b675fd5e-4322-11e8-9d66-c00ea45cbf6a.png)
![left](https://user-images.githubusercontent.com/4607437/38927232-b6a3353a-4322-11e8-9db1-0121b485e8c6.png)
![right](https://user-images.githubusercontent.com/4607437/38927233-b6d17544-4322-11e8-9331-9c49c9c69aae.png)
![top-left](https://user-images.githubusercontent.com/4607437/38927234-b6ff3fb0-4322-11e8-9fa5-c8cade86c8fc.png)
![top-right](https://user-images.githubusercontent.com/4607437/38927236-b72d1ffc-4322-11e8-8f32-1b24dd75cb0b.png)

Fixes #1955

Signed-off-by: Uttam Agarwal <uttamagarwal.slg@gmail.com>