### PR TITLE
[UI] Breakpoints to be overwritable (#2195)

### DIFF
--- a/src/app/_utils/code.scss
+++ b/src/app/_utils/code.scss
@@ -15,6 +15,7 @@
 
 @import "../../clr-angular/utils/mixins.clarity";
 @import "../../clr-angular/utils/helpers.clarity";
+@import "../../clr-angular/utils/bs4-grid-breakpoint-overrides.clarity";
 
 //Color
 @import "../../clr-angular/color/utils/colors.clarity";

--- a/src/app/layout/layout.demo.scss
+++ b/src/app/layout/layout.demo.scss
@@ -11,7 +11,7 @@
         padding: 24px;
         border: 1px solid;
 
-        @media screen and (max-width: map-get($clr-breakpoints, small)) {
+        @media screen and (max-width: map-get($grid-breakpoints, sm)) {
             display: none;
         }
     }

--- a/src/app/vertical-nav/vertical-nav.demo.scss
+++ b/src/app/vertical-nav/vertical-nav.demo.scss
@@ -11,7 +11,7 @@
         padding: 24px;
         border: 1px solid;
 
-        @media screen and (max-width: map-get($clr-breakpoints, small)) {
+        @media screen and (max-width: map-get($grid-breakpoints, sm)) {
             display: none;
         }
     }

--- a/src/clr-angular/emphasis/alert/_alert.clarity.scss
+++ b/src/clr-angular/emphasis/alert/_alert.clarity.scss
@@ -321,7 +321,7 @@
         }
     }
 
-    @media screen and (max-width: map-get($clr-breakpoints, medium)) {
+    @media screen and (max-width: map-get($grid-breakpoints, md)) {
         .alert {
             .alert-item {
                 flex-wrap: wrap;

--- a/src/clr-angular/forms-deprecated/_forms.clarity.scss
+++ b/src/clr-angular/forms-deprecated/_forms.clarity.scss
@@ -186,7 +186,7 @@
         }
 
         //Media Queries for the form-group for small screens
-        @media screen and (max-width: map-get($clr-breakpoints, small)) {
+        @media screen and (max-width: map-get($grid-breakpoints, sm)) {
 
             .form-group {
                 padding-left: 0;

--- a/src/clr-angular/layout/_card.clarity.scss
+++ b/src/clr-angular/layout/_card.clarity.scss
@@ -237,7 +237,7 @@
     //Credit: Bootstrap 4 Card Masonry
     //Added some fixes to avoid flickering in Clickable cards
     //Added extra column classes to control the number of CSS columns
-    @media screen and (min-width: map-get($clr-breakpoints, small)) {
+    @media screen and (min-width: map-get($grid-breakpoints, sm)) {
         .card-columns {
             column-count: 3;
             column-gap: 0.5rem;

--- a/src/clr-angular/layout/_login.clarity.scss
+++ b/src/clr-angular/layout/_login.clarity.scss
@@ -120,7 +120,7 @@
         }
     }
 
-    @media screen and (max-width: map-get($clr-breakpoints, medium)) {
+    @media screen and (max-width: map-get($grid-breakpoints, md)) {
         .login-wrapper {
             justify-content: center;
             background: $clr-login-background-color;
@@ -137,7 +137,7 @@
         }
     }
 
-    @media screen and (max-width: map-get($clr-breakpoints, small)) {
+    @media screen and (max-width: map-get($grid-breakpoints, sm)) {
         .login-wrapper {
             .login {
                 padding: 1rem 15%;

--- a/src/clr-angular/layout/nav/_header.clarity.scss
+++ b/src/clr-angular/layout/nav/_header.clarity.scss
@@ -382,7 +382,7 @@
         }
     }
 
-    @media screen and (max-width: map-get($clr-breakpoints, medium)) {
+    @media screen and (max-width: map-get($grid-breakpoints, md)) {
         header,
         .header {
 

--- a/src/clr-angular/layout/nav/_responsive-nav.clarity.scss
+++ b/src/clr-angular/layout/nav/_responsive-nav.clarity.scss
@@ -156,7 +156,7 @@
         }
     }
 
-    @media screen and (max-width: map-get($clr-breakpoints, medium)) {
+    @media screen and (max-width: map-get($grid-breakpoints, md)) {
 
         .main-container {
             .header-hamburger-trigger,
@@ -467,7 +467,7 @@
         }
     }
 
-    @media screen and (max-width: map-get($clr-breakpoints, small)) {
+    @media screen and (max-width: map-get($grid-breakpoints, sm)) {
         .main-container {
 
             .header {

--- a/src/clr-angular/modal/_modal.clarity.scss
+++ b/src/clr-angular/modal/_modal.clarity.scss
@@ -15,7 +15,7 @@
     align-items: center;
     padding: 2rem;
 
-    @media screen and (max-width: map-get($clr-breakpoints, small)) {
+    @media screen and (max-width: map-get($grid-breakpoints, sm)) {
         padding: 0.5rem;
     }
 }
@@ -104,14 +104,14 @@
 }
 
 @media screen
-and (max-width: map-get($clr-breakpoints, medium))
+and (max-width: map-get($grid-breakpoints, md))
 and (orientation: landscape) {
     .modal-body {
         max-height: 55vh;
     }
 }
 
-@media screen and (max-width: map-get($clr-breakpoints, small)) {
+@media screen and (max-width: map-get($grid-breakpoints, sm)) {
     .modal-content {
         padding: 0.5rem 0 0.5rem 1rem;
     }

--- a/src/clr-angular/popover/dropdown/_dropdown.clarity.scss
+++ b/src/clr-angular/popover/dropdown/_dropdown.clarity.scss
@@ -185,7 +185,7 @@
             line-height: $adjusted_lineHeight;
         }
 
-        @media screen and (max-width: map-get($clr-breakpoints, small)) {
+        @media screen and (max-width: map-get($grid-breakpoints, sm)) {
             .btn,
             .dropdown-item {
                 $adjusted_lineHeight: 1.5rem;

--- a/src/clr-angular/typography/_typography.clarity.scss
+++ b/src/clr-angular/typography/_typography.clarity.scss
@@ -72,7 +72,7 @@
 }
 
 //Generates responsive typography based on the element style map in variables.clarity.scss
-@mixin clr-getTypeProperties($element, $whichTypeProperties: (), $breakpoint-property: min-width, $breakpoints-map: $clr-breakpoints) {
+@mixin clr-getTypeProperties($element, $whichTypeProperties: (), $breakpoint-property: min-width, $breakpoints-map: $grid-breakpoints) {
     //Check if the element exists in the $clr-elements style map
     @if map-has-key($clr-elements, $element) {
         $elMap: map-get($clr-elements, $element); //get the element style map
@@ -94,8 +94,8 @@
         //     }
         //     //Everything else except the common properties has a media query
         //     @else {
-        //         @if $breakpoint != "clr-common" and map-has-key($clr-breakpoints, $breakpoint) {
-        //             $breakpoint: map-get($clr-breakpoints, $breakpoint);
+        //         @if $breakpoint != "clr-common" and map-has-key($grid-breakpoints, $breakpoint) {
+        //             $breakpoint: map-get($grid-breakpoints, $breakpoint);
         //             @media screen and (# {$breakpoint-property}: $breakpoint) {
         //                 @include clr-getAllTypeKeys($val-map, $el-map);
         //             }

--- a/src/clr-angular/utils/_bs4-grid-breakpoint-overrides.clarity.scss
+++ b/src/clr-angular/utils/_bs4-grid-breakpoint-overrides.clarity.scss
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
+
+$grid-breakpoints: (
+    xs: 0,
+    sm: 576px,
+    md: 768px,
+    lg: 992px,
+    xl: 1200px
+);

--- a/src/clr-angular/utils/_components.clarity.scss
+++ b/src/clr-angular/utils/_components.clarity.scss
@@ -2,9 +2,11 @@
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
+// TODO: The BS4 imports were actually in dependencies.clarity.scss
+// We will get rid of BS4 so this should go away soon.
 
 // Bootstrap 4 Dependencies - Begin Part 2
-// NOTE: These are here b/c they need to be overwritable for the $clr-breakpoints map in a theme.
+// NOTE: These are here b/c they need to be overwritable for the $grid-breakpoints map in a theme.
 @import "~bootstrap/scss/media";
 @import "~bootstrap/scss/utilities";
 @import '~bootstrap/scss/images';
@@ -12,6 +14,9 @@
 @import "~bootstrap/scss/close";
 @import "~bootstrap/scss/grid";
 @import "~bootstrap/scss/responsive-embed";
+
+// Clarity scss maps w/ overridable variables per component
+@import "maps.clarity";
 
 //Reboot
 @import "../utils/reboot.clarity"; // depends on variables.clarity, mixins.clarity, color.clarity, helpers.clarity

--- a/src/clr-angular/utils/_dependencies.clarity.scss
+++ b/src/clr-angular/utils/_dependencies.clarity.scss
@@ -2,6 +2,8 @@
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
+// Bootstrap 4 Grid Overrides
+@import "../utils/bs4-grid-breakpoint-overrides.clarity";
 
 // Bootstrap 4 Dependencies - Begin Part 1
 @import "~bootstrap/scss/variables";
@@ -30,6 +32,3 @@
 
 // Component variables
 @import "../utils/variables.clarity"; // depends on helpers.clarity, color.clarity
-
-// Clarity scss maps w/ overridable variables per component
-@import "maps.clarity";

--- a/src/clr-angular/utils/_maps.clarity.scss
+++ b/src/clr-angular/utils/_maps.clarity.scss
@@ -306,13 +306,6 @@ $clr-button-appearance-map: (
 
 // Typography
 // Headers
-$clr-breakpoints: (
-    small : 544px,
-    medium: 768px,
-    large : 992px,
-    xlarge: 1200px
-) !default;
-
 $clr-h1: (
     clr-common: (
         color: $clr-h1-color,

--- a/src/clr-angular/utils/_overwrites.clarity.scss
+++ b/src/clr-angular/utils/_overwrites.clarity.scss
@@ -28,7 +28,7 @@ $clr-layers: null;
 
 
 // Breakpoints
-$clr-breakpoints: null; // (small: 544px, medium: 768px, large : 992px, xlarge: 1200px);
+$grid-breakpoints: null; // (small: 544px, medium: 768px, large : 992px, xlarge: 1200px);
 
 // Fonts Options
 $clr-font: null; // Metropolis, 'Avenir Next', 'Helvetica Neue', Arial, sans-serif; //Default font stack for Clarity


### PR DESCRIPTION
- moved _maps.clarity back to components so -breakpoints map can be overwritten
- fixes #2066

Signed-off-by: Aditya Bhandari <adityab@vmware.com>