### PR TITLE
[NG] Enable Angular modals and wizards to support aria.

### DIFF
--- a/src/clr-angular/modal/modal.html
+++ b/src/clr-angular/modal/modal.html
@@ -12,7 +12,7 @@
          [class.modal-sm]="size == 'sm'"
          [class.modal-lg]="size == 'lg'"
          [class.modal-xl]="size == 'xl'"
-         role="dialog" aria-hidden="true">
+         role="dialog" aria-hidden="!_open">
 
         <div class="modal-outer-wrapper">
             <div class="modal-content-wrapper">


### PR DESCRIPTION
When using a screen reader (i.e. for visually-impaired users), other
portions of the application work fine, however readers ignore the
content inside of modals (clr-modal) and wizards (clr-wizard) due
to the aria-hidden="true" in the modal.html.  With this change, the
screen readers properly read just like the rest of the clr-angular
components currently do.

To reproduce the problem, use a browser with screen reading
capability, e.g. by installing ChromeVox extension into Chrome, and
using the kitchen-sink app open a model or wizard and tab/click
through.  Reader will not read the elements audibly.
After applying this simple fix, the reader will properly read
the elements, buttons, wizard steps, etc.
This does not address the demo pieces, since they do not use
clr-modal nor clr-wizard.

Issue: Screen readers don't read clr-modal nor clr-wizard contents.

Signed-off-by: Scott Strobel <sstrobel99@gmail.com>