### PR TITLE
[NG] v11 clr-datagrid height not calculated correctly on IE

### DIFF
--- a/src/clr-angular/data/datagrid/render/dom-adapter.ts
+++ b/src/clr-angular/data/datagrid/render/dom-adapter.ts
@@ -33,6 +33,10 @@ export class DomAdapter {
         return parseInt(getComputedStyle(element).getPropertyValue("height"), 10);
     }
 
+    clientRectHeight(element: any): number {
+        return parseInt(element.getBoundingClientRect().height, 10);
+    }
+
     clientRectRight(element: any): number {
         return parseInt(element.getBoundingClientRect().right, 10);
     }

--- a/src/clr-angular/data/datagrid/render/main-renderer.ts
+++ b/src/clr-angular/data/datagrid/render/main-renderer.ts
@@ -94,7 +94,8 @@ export class DatagridMainRenderer implements AfterContentInit, AfterViewChecked,
      * Refer: http://stackoverflow.com/questions/24396205/flex-grow-not-working-in-internet-explorer-11-0
      */
     private computeDatagridHeight() {
-        const value: number = this.domAdapter.computedHeight(this.el.nativeElement);
+        // IE doesn't return correct value for getComputedStyle(element).getPropertyValue("height")
+        const value: number = this.domAdapter.clientRectHeight(this.el.nativeElement);
         this.renderer.setStyle(this.el.nativeElement, "height", value + "px");
         this._heightSet = true;
     }


### PR DESCRIPTION
Use getBoundingClientRect().height to determine clr-datagrid height rather than getComputedStyle(element).getPropertyValue("height"), since IE11 returns the latter incorrectly.

Refer to issue #2256.

Signed-off-by: Your Name <sstrobel99@gmail.com>