### PR TITLE
[UI] Remove z-index from datagrid column handle

### DIFF
--- a/src/clr-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clr-angular/data/datagrid/_datagrid.clarity.scss
@@ -238,7 +238,6 @@
                     top: -0.25rem;
                     cursor: col-resize;
                     height: calc(100% + 0.5rem - #{$clr-default-borderwidth});
-                    z-index: map-get($clr-layers, dropdown-menu);
                 }
                 .datagrid-column-handle-tracker {
                     position: absolute;


### PR DESCRIPTION
Fixes: #2269

Removed the z-index on the datagrid-column-handle

Needs to be reviewed by @Shijir 

Tested on Chrome

Signed-off-by: Aditya Bhandari <adityab@vmware.com>