### PR TITLE
[CORE] fix tests from loading files from directories other than src

### DIFF
--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -12,7 +12,7 @@
     "tests/tests.entry.ts"
   ],
   "include": [
-    "**/*.spec.ts",
-    "**/*.d.ts"
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
   ]
 }


### PR DESCRIPTION
If you had old build files in the `dist` directory (with d.ts files) it would pick them up when it shouldn't. Updated the paths to only load from `src/`.