### PR TITLE
[UI] Remove z-index from datagrid column handle

### DIFF
--- a/src/clr-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clr-angular/data/datagrid/_datagrid.clarity.scss
@@ -238,7 +238,6 @@
                     top: -0.25rem;
                     cursor: col-resize;
                     height: calc(100% + 0.5rem - #{$clr-default-borderwidth});
-                    z-index: map-get($clr-layers, dropdown-menu);
                 }
                 .datagrid-column-handle-tracker {
                     position: absolute;


### PR DESCRIPTION
Same as #2270 but for 0.11 branch

Removed the z-index on the datagrid-column-handle

Tested on Chrome