### PR TITLE
[NG] clrDragHandle directive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "clr-all",
-    "version": "0.11.7-patch.1",
+    "version": "0.11.8",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/clr-angular/utils/drag-and-drop/all.spec.ts
+++ b/src/clr-angular/utils/drag-and-drop/all.spec.ts
@@ -4,10 +4,12 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import ClrDragHandleSpecs from "./drag-handle.spec";
+import ClrDraggableSpecs from "./draggable.spec";
 import ClrIfDraggedSpecs from "./if-dragged.spec";
 import ClrDragAndDropEventBusSpecs from "./providers/drag-and-drop-event-bus.spec";
 import ClrDragEventListenerSpecs from "./providers/drag-event-listener.spec";
 import ClrDragHandleRegistrarSpecs from "./providers/drag-handle-registrar.spec";
+
 
 describe("Drag And Drop", function() {
     describe("Providers", function() {
@@ -18,5 +20,6 @@ describe("Drag And Drop", function() {
     describe("Components And Directives", function() {
         ClrIfDraggedSpecs();
         ClrDragHandleSpecs();
+        ClrDraggableSpecs();
     });
 });

--- a/src/clr-angular/utils/drag-and-drop/all.spec.ts
+++ b/src/clr-angular/utils/drag-and-drop/all.spec.ts
@@ -3,16 +3,20 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
+import ClrDragHandleSpecs from "./drag-handle.spec";
 import ClrIfDraggedSpecs from "./if-dragged.spec";
 import ClrDragAndDropEventBusSpecs from "./providers/drag-and-drop-event-bus.spec";
 import ClrDragEventListenerSpecs from "./providers/drag-event-listener.spec";
+import ClrDragHandleRegistrarSpecs from "./providers/drag-handle-registrar.spec";
 
 describe("Drag And Drop", function() {
     describe("Providers", function() {
         ClrDragAndDropEventBusSpecs();
         ClrDragEventListenerSpecs();
+        ClrDragHandleRegistrarSpecs();
     });
     describe("Components And Directives", function() {
         ClrIfDraggedSpecs();
+        ClrDragHandleSpecs();
     });
 });

--- a/src/clr-angular/utils/drag-and-drop/drag-handle.spec.ts
+++ b/src/clr-angular/utils/drag-and-drop/drag-handle.spec.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component} from "@angular/core";
+import {TestBed} from "@angular/core/testing";
+import {By} from "@angular/platform-browser";
+import {ClrDragHandle} from "./drag-handle";
+import {ClrDragHandleRegistrar} from "./providers/drag-handle-registrar";
+import {MOCK_DRAG_HANDLE_REGISTRAR_PROVIDER} from "./providers/drag-handle-registrar.mock";
+
+export default function(): void {
+    describe("ClrDragHandle", function() {
+        describe("Without ClrDragHandleRegistrar", function() {
+            it("should throw an error with a message", function() {
+                TestBed.configureTestingModule({declarations: [NoDragHandleRegistrar, ClrDragHandle]});
+
+                expect(function() {
+                    this.fixture = TestBed.createComponent(NoDragHandleRegistrar);
+                }).toThrowError("The clrDragHandle directive can only be used inside of a clrDraggable directive.");
+            });
+        });
+        describe("With ClrDragHandleRegistrar", function() {
+            beforeEach(function() {
+                TestBed.configureTestingModule(
+                    {declarations: [ClrDragHandle, DragHandleTest], providers: [MOCK_DRAG_HANDLE_REGISTRAR_PROVIDER]});
+
+                this.fixture = TestBed.createComponent(DragHandleTest);
+                this.testComponent = this.fixture.componentInstance;
+                this.fixture.detectChanges();
+
+                this.dragHandleRegistrar = TestBed.get(ClrDragHandleRegistrar);
+                this.testElement = this.fixture.nativeElement;
+            });
+
+            afterEach(function() {
+                this.fixture.destroy();
+            });
+
+            it("should register its element as a custom drag handle", function() {
+                const dragHandleEl = this.fixture.debugElement.query(By.directive(ClrDragHandle)).nativeElement;
+                expect(this.dragHandleRegistrar.customHandle).toBe(dragHandleEl);
+            });
+
+            it("should unregister its element if it gets removed", function() {
+                this.testComponent.display = false;
+                this.fixture.detectChanges();
+                expect(this.dragHandleRegistrar.customHandle).toBeUndefined();
+            });
+        });
+    });
+}
+
+@Component({template: `<div *ngIf="display" clrDragHandle>Test</div>`})
+class DragHandleTest {
+    display = true;
+}
+
+@Component({template: `<div clrDragHandle>Test</div>`})
+class NoDragHandleRegistrar {}

--- a/src/clr-angular/utils/drag-and-drop/drag-handle.ts
+++ b/src/clr-angular/utils/drag-and-drop/drag-handle.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import {Directive, ElementRef, OnDestroy, Optional} from "@angular/core";
+import {ClrDragHandleRegistrar} from "./providers/drag-handle-registrar";
+
+@Directive({selector: "[clrDragHandle]", host: {class: "drag-handle"}})
+export class ClrDragHandle<T> implements OnDestroy {
+    constructor(private el: ElementRef, @Optional() private dragHandleRegistrar: ClrDragHandleRegistrar<T>) {
+        if (!this.dragHandleRegistrar) {
+            // ClrDragHandleRegistrar is provided in ClrDraggable so we expect it to be present here
+            // as clrDragHandle is required to be used only inside of a clrDraggable directive.
+            throw new Error("The clrDragHandle directive can only be used inside of a clrDraggable directive.");
+        }
+        this.dragHandleRegistrar.registerCustomHandle(this.el.nativeElement);
+    }
+
+    ngOnDestroy() {
+        this.dragHandleRegistrar.unregisterCustomHandle();
+    }
+}

--- a/src/clr-angular/utils/drag-and-drop/draggable.spec.ts
+++ b/src/clr-angular/utils/drag-and-drop/draggable.spec.ts
@@ -24,8 +24,8 @@ export default function(): void {
                 this.fixture = TestBed.createComponent(NestedHandleTest);
                 this.testComponent = this.fixture.componentInstance;
                 this.draggable = this.fixture.debugElement.query(By.directive(ClrDraggable));
-                this.dragEvenListener = this.draggable.injector.get(ClrDragEventListener);
-                this.dragDragRegistrar = this.draggable.injector.get(ClrDragHandleRegistrar);
+                this.dragEventListener = this.draggable.injector.get(ClrDragEventListener);
+                this.dragHandleRegistrar = this.draggable.injector.get(ClrDragHandleRegistrar);
             });
 
             afterEach(function() {
@@ -36,9 +36,9 @@ export default function(): void {
                 this.fixture.detectChanges();
 
                 expect(this.draggable.nativeElement.classList.contains("drag-handle")).toBeTruthy();
-                expect(this.dragEvenListener.draggableEl).toBe(this.draggable.nativeElement);
-                expect(this.dragDragRegistrar._defaultHandleEl).toBe(this.draggable.nativeElement);
-                expect(this.dragDragRegistrar.customHandle).toBeUndefined();
+                expect(this.dragEventListener.draggableEl).toBe(this.draggable.nativeElement);
+                expect(this.dragHandleRegistrar.defaultHandleEl).toBe(this.draggable.nativeElement);
+                expect(this.dragHandleRegistrar.customHandleEl).toBeUndefined();
             });
 
             it("should have its nested handle as drag handle if it is present", function() {
@@ -47,9 +47,9 @@ export default function(): void {
                 this.dragHandle = this.fixture.debugElement.query(By.directive(ClrDragHandle));
                 expect(this.draggable.nativeElement.classList.contains("drag-handle")).toBeFalsy();
                 expect(this.dragHandle.nativeElement.classList.contains("drag-handle")).toBeTruthy();
-                expect(this.dragEvenListener.draggableEl).toBe(this.dragHandle.nativeElement);
-                expect(this.dragDragRegistrar.customHandle).toBe(this.dragHandle.nativeElement);
-                expect(this.dragDragRegistrar._defaultHandleEl)
+                expect(this.dragEventListener.draggableEl).toBe(this.dragHandle.nativeElement);
+                expect(this.dragHandleRegistrar.customHandleEl).toBe(this.dragHandle.nativeElement);
+                expect(this.dragHandleRegistrar.defaultHandleEl)
                     .toBe(
                         this.draggable.nativeElement,
                         `The default handle should be still set to the draggable element even though it's not made an active drag handle.`);

--- a/src/clr-angular/utils/drag-and-drop/draggable.spec.ts
+++ b/src/clr-angular/utils/drag-and-drop/draggable.spec.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component} from "@angular/core";
+import {TestBed} from "@angular/core/testing";
+import {By} from "@angular/platform-browser";
+import {ClrDragHandle} from "./drag-handle";
+import {ClrDraggable} from "./draggable";
+import {ClrDragAndDropEventBus} from "./providers/drag-and-drop-event-bus";
+import {ClrDragEventListener} from "./providers/drag-event-listener";
+import {ClrDragHandleRegistrar} from "./providers/drag-handle-registrar";
+
+export default function(): void {
+    describe("ClrDraggable", function() {
+        describe("ClrDragHandle", function() {
+            beforeEach(function() {
+                TestBed.configureTestingModule({
+                    declarations: [NestedHandleTest, ClrDraggable, ClrDragHandle],
+                    providers: [ClrDragAndDropEventBus]
+                });
+
+                this.fixture = TestBed.createComponent(NestedHandleTest);
+                this.testComponent = this.fixture.componentInstance;
+                this.draggable = this.fixture.debugElement.query(By.directive(ClrDraggable));
+                this.dragEvenListener = this.draggable.injector.get(ClrDragEventListener);
+                this.dragDragRegistrar = this.draggable.injector.get(ClrDragHandleRegistrar);
+            });
+
+            afterEach(function() {
+                this.fixture.destroy();
+            });
+
+            it("should have its own element as default drag handle when there is no nested drag handle", function() {
+                this.fixture.detectChanges();
+
+                expect(this.draggable.nativeElement.classList.contains("drag-handle")).toBeTruthy();
+                expect(this.dragEvenListener.draggableEl).toBe(this.draggable.nativeElement);
+                expect(this.dragDragRegistrar._defaultHandleEl).toBe(this.draggable.nativeElement);
+                expect(this.dragDragRegistrar.customHandle).toBeUndefined();
+            });
+
+            it("should have its nested handle as drag handle if it is present", function() {
+                this.testComponent.display = true;
+                this.fixture.detectChanges();
+                this.dragHandle = this.fixture.debugElement.query(By.directive(ClrDragHandle));
+                expect(this.draggable.nativeElement.classList.contains("drag-handle")).toBeFalsy();
+                expect(this.dragHandle.nativeElement.classList.contains("drag-handle")).toBeTruthy();
+                expect(this.dragEvenListener.draggableEl).toBe(this.dragHandle.nativeElement);
+                expect(this.dragDragRegistrar.customHandle).toBe(this.dragHandle.nativeElement);
+                expect(this.dragDragRegistrar._defaultHandleEl)
+                    .toBe(
+                        this.draggable.nativeElement,
+                        `The default handle should be still set to the draggable element even though it's not made an active drag handle.`);
+            });
+        });
+    });
+}
+
+@Component({template: `<div clrDraggable><button *ngIf="display" clrDragHandle></button></div>`})
+class NestedHandleTest {
+    display = false;
+}

--- a/src/clr-angular/utils/drag-and-drop/draggable.ts
+++ b/src/clr-angular/utils/drag-and-drop/draggable.ts
@@ -3,24 +3,27 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import {Directive, ElementRef, OnDestroy, OnInit} from "@angular/core";
+import {AfterContentInit, Directive, ElementRef, OnDestroy} from "@angular/core";
 import {Subscription} from "rxjs/Subscription";
-
 import {ClrDragEvent} from "./interfaces/drag-event";
 import {ClrDragEventListener} from "./providers/drag-event-listener";
+import {ClrDragHandleRegistrar} from "./providers/drag-handle-registrar";
 
-@Directive({selector: "[clrDraggable]", providers: [ClrDragEventListener], host: {class: "draggable"}})
-export class ClrDraggable<T> implements OnInit, OnDestroy {
+
+@Directive(
+    {selector: "[clrDraggable]", providers: [ClrDragEventListener, ClrDragHandleRegistrar], host: {class: "draggable"}})
+export class ClrDraggable<T> implements AfterContentInit, OnDestroy {
     private draggableEl: Node;
 
     private subscriptions: Subscription[] = [];
 
-    constructor(private el: ElementRef, private dragEventListener: ClrDragEventListener<T>) {
+    constructor(private el: ElementRef, private dragEventListener: ClrDragEventListener<T>,
+                private dragHandleRegistrar: ClrDragHandleRegistrar<T>) {
         this.draggableEl = this.el.nativeElement;
     }
 
-    ngOnInit() {
-        this.dragEventListener.attachDragListeners(this.draggableEl);
+    ngAfterContentInit() {
+        this.dragHandleRegistrar.defaultHandleEl = this.draggableEl;
 
         this.subscriptions.push(
             this.dragEventListener.dragStarted.subscribe((event: ClrDragEvent<T>) => {

--- a/src/clr-angular/utils/drag-and-drop/index.ts
+++ b/src/clr-angular/utils/drag-and-drop/index.ts
@@ -5,6 +5,7 @@
  */
 import {Type} from "@angular/core";
 
+import {ClrDragHandle} from "./drag-handle";
 import {ClrDraggable} from "./draggable";
 import {ClrDroppable} from "./droppable";
 import {ClrIfDragged} from "./if-dragged";
@@ -12,5 +13,6 @@ import {ClrIfDragged} from "./if-dragged";
 export * from "./draggable";
 export * from "./droppable";
 export * from "./if-dragged";
+export * from "./drag-handle";
 
-export const DRAG_AND_DROP_DIRECTIVES: Type<any>[] = [ClrDraggable, ClrDroppable, ClrIfDragged];
+export const DRAG_AND_DROP_DIRECTIVES: Type<any>[] = [ClrDraggable, ClrDroppable, ClrIfDragged, ClrDragHandle];

--- a/src/clr-angular/utils/drag-and-drop/providers/drag-event-listener.mock.ts
+++ b/src/clr-angular/utils/drag-and-drop/providers/drag-event-listener.mock.ts
@@ -6,12 +6,31 @@
 import {Subject} from "rxjs/Subject";
 import {ClrDragEventListener} from "./drag-event-listener";
 
+interface Node {
+    hasListener: boolean;
+}
+
+// This mock service is necessary because the real service uses Renderer2 and attaches complex event listeners.
+// This class mocks that as setting ".hasListener" to true
+// when attachDragListener() is called and removes it when detachDragListener() is called.
 export class MockDragEventListener {
+    private listeners: (() => void)[];
     public draggableEl: Node;
     public dragStarted: Subject<any> = new Subject<any>();
     public dragEnded: Subject<any> = new Subject<any>();
+
     public attachDragListeners(draggableEl: Node) {
         this.draggableEl = draggableEl;
+        this.draggableEl.hasListener = true;
+        this.listeners = [() => {
+            delete this.draggableEl.hasListener;
+        }];
+    }
+
+    public detachDragListeners() {
+        if (this.listeners) {
+            this.listeners.map(event => event());
+        }
     }
 }
 

--- a/src/clr-angular/utils/drag-and-drop/providers/drag-event-listener.mock.ts
+++ b/src/clr-angular/utils/drag-and-drop/providers/drag-event-listener.mock.ts
@@ -7,8 +7,12 @@ import {Subject} from "rxjs/Subject";
 import {ClrDragEventListener} from "./drag-event-listener";
 
 export class MockDragEventListener {
+    public draggableEl: Node;
     public dragStarted: Subject<any> = new Subject<any>();
     public dragEnded: Subject<any> = new Subject<any>();
+    public attachDragListeners(draggableEl: Node) {
+        this.draggableEl = draggableEl;
+    }
 }
 
 export const MOCK_DRAG_EVENT_LISTENER_PROVIDER = {

--- a/src/clr-angular/utils/drag-and-drop/providers/drag-handle-registrar.mock.ts
+++ b/src/clr-angular/utils/drag-and-drop/providers/drag-handle-registrar.mock.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {ClrDragHandleRegistrar} from "./drag-handle-registrar";
+
+export class MockDragHandleRegistrar {
+    private _customHandleEl: Node;
+
+    get customHandle() {
+        return this._customHandleEl;
+    }
+
+    public registerCustomHandle(handleElement: Node) {
+        this._customHandleEl = handleElement;
+    }
+
+    public unregisterCustomHandle() {
+        delete this._customHandleEl;
+    }
+}
+
+export const MOCK_DRAG_HANDLE_REGISTRAR_PROVIDER = {
+    provide: ClrDragHandleRegistrar,
+    useClass: MockDragHandleRegistrar
+};

--- a/src/clr-angular/utils/drag-and-drop/providers/drag-handle-registrar.spec.ts
+++ b/src/clr-angular/utils/drag-and-drop/providers/drag-handle-registrar.spec.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Component} from "@angular/core";
+import {ComponentFixture, TestBed} from "@angular/core/testing";
+import {ClrDragAndDropEventBus} from "./drag-and-drop-event-bus";
+import {ClrDragEventListener} from "./drag-event-listener";
+import {MOCK_DRAG_EVENT_LISTENER_PROVIDER} from "./drag-event-listener.mock";
+import {ClrDragHandleRegistrar} from "./drag-handle-registrar";
+
+export default function(): void {
+    describe("Drag Handle Registrar", function() {
+        let fixture: ComponentFixture<any>;
+        let testComponent: DragHandleTestComponent;
+
+        const draggableEl = document.createElement("div");
+        const customHandleEl = document.createElement("button");
+
+        // Providers
+        let dragHandleRegistrar: any;
+        let dragEventListener: any;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule(
+                {declarations: [DragHandleTestComponent], providers: [ClrDragAndDropEventBus]});
+            fixture = TestBed.createComponent(DragHandleTestComponent);
+            testComponent = fixture.componentInstance;
+            dragHandleRegistrar = fixture.debugElement.injector.get(ClrDragHandleRegistrar);
+            dragEventListener = fixture.debugElement.injector.get(ClrDragEventListener);
+        });
+
+        afterEach(() => {
+            fixture.destroy();
+        });
+
+        it("should be able to register element as default handle", function() {
+            dragHandleRegistrar.draggableEl = draggableEl;
+            expect(dragHandleRegistrar.customHandle).toBeUndefined();
+            expect(draggableEl.classList.contains("drag-handle")).toBeTruthy();
+            expect(dragEventListener.draggableEl).toBe(draggableEl);
+        });
+
+        it("should be able to register custom element as drag handle", function() {
+            dragHandleRegistrar.draggableEl = draggableEl;
+            dragHandleRegistrar.registerCustomHandle(customHandleEl);
+            expect(draggableEl.classList.contains("drag-handle")).toBeFalsy();
+            expect(dragHandleRegistrar.customHandle).toBe(customHandleEl);
+            expect(dragEventListener.draggableEl).toBe(customHandleEl);
+        });
+
+        it("should be able to unregister custom element and fallback to default handle", function() {
+            dragHandleRegistrar.draggableEl = draggableEl;
+            dragHandleRegistrar.registerCustomHandle(customHandleEl);
+
+            dragHandleRegistrar.unregisterCustomHandle();
+            expect(dragHandleRegistrar.customHandle).toBeUndefined();
+            expect(draggableEl.classList.contains("drag-handle")).toBeTruthy();
+            expect(dragEventListener.draggableEl).toBe(draggableEl);
+        });
+    });
+}
+
+@Component({
+    providers: [
+        MOCK_DRAG_EVENT_LISTENER_PROVIDER,
+        ClrDragHandleRegistrar
+    ],  // Should be declared here in a component level, not in the TestBed because Renderer2 wouldn't be present
+    template: "<div>Test</div>"
+})
+class DragHandleTestComponent {}

--- a/src/clr-angular/utils/drag-and-drop/providers/drag-handle-registrar.spec.ts
+++ b/src/clr-angular/utils/drag-and-drop/providers/drag-handle-registrar.spec.ts
@@ -45,7 +45,7 @@ export default function(): void {
         it("registers custom element as handle", function() {
             dragHandleRegistrar.registerCustomHandle(customHandleEl);
 
-            expect(dragHandleRegistrar.customHandle).toBe(customHandleEl);
+            expect(dragHandleRegistrar.customHandleEl).toBe(customHandleEl);
             expect(dragEventListener.draggableEl).toBe(customHandleEl);
 
             expect(customHandleEl.hasListener).toBeTruthy();
@@ -59,7 +59,7 @@ export default function(): void {
             expect(draggableEl.hasListener).toBeFalsy();
             expect(draggableEl.classList.contains("drag-handle")).toBeFalsy();
 
-            expect(dragHandleRegistrar.customHandle).toBe(customHandleEl);
+            expect(dragHandleRegistrar.customHandleEl).toBe(customHandleEl);
             expect(dragEventListener.draggableEl).toBe(customHandleEl);
 
             expect(customHandleEl.hasListener).toBeTruthy();
@@ -68,12 +68,12 @@ export default function(): void {
 
         it("unregisters custom handle", function() {
             dragHandleRegistrar.registerCustomHandle(customHandleEl);
-            expect(dragHandleRegistrar.customHandle).toBe(customHandleEl);
+            expect(dragHandleRegistrar.customHandleEl).toBe(customHandleEl);
             expect(customHandleEl.hasListener).toBeTruthy();
             expect(customHandleEl.classList.contains("drag-handle")).toBeTruthy();
             dragHandleRegistrar.unregisterCustomHandle();
 
-            expect(dragHandleRegistrar.customHandle).toBeUndefined();
+            expect(dragHandleRegistrar.customHandleEl).toBeUndefined();
             expect(customHandleEl.hasListener).toBeFalsy();
             expect(customHandleEl.classList.contains("drag-handle")).toBeFalsy();
         });
@@ -83,7 +83,7 @@ export default function(): void {
                dragHandleRegistrar.defaultHandleEl = draggableEl;
                dragHandleRegistrar.registerCustomHandle(customHandleEl);
                dragHandleRegistrar.unregisterCustomHandle();
-               expect(dragHandleRegistrar.customHandle).toBeUndefined();
+               expect(dragHandleRegistrar.customHandleEl).toBeUndefined();
                expect(dragEventListener.draggableEl).toBe(draggableEl);
                expect(draggableEl.hasListener).toBeTruthy();
                expect(draggableEl.classList.contains("drag-handle")).toBeTruthy();
@@ -93,7 +93,7 @@ export default function(): void {
             dragHandleRegistrar.registerCustomHandle(customHandleEl);
             dragHandleRegistrar.defaultHandleEl = draggableEl;
 
-            expect(dragHandleRegistrar.customHandle).toBe(customHandleEl);
+            expect(dragHandleRegistrar.customHandleEl).toBe(customHandleEl);
             expect(customHandleEl.hasListener).toBeTruthy();
             expect(customHandleEl.classList.contains("drag-handle")).toBeTruthy();
         });
@@ -103,7 +103,7 @@ export default function(): void {
                dragHandleRegistrar.registerCustomHandle(customHandleEl);
                dragHandleRegistrar.defaultHandleEl = draggableEl;
                dragHandleRegistrar.unregisterCustomHandle();
-               expect(dragHandleRegistrar.customHandle).toBeUndefined();
+               expect(dragHandleRegistrar.customHandleEl).toBeUndefined();
                expect(dragEventListener.draggableEl).toBe(draggableEl);
                expect(draggableEl.hasListener).toBeTruthy();
                expect(draggableEl.classList.contains("drag-handle")).toBeTruthy();

--- a/src/clr-angular/utils/drag-and-drop/providers/drag-handle-registrar.spec.ts
+++ b/src/clr-angular/utils/drag-and-drop/providers/drag-handle-registrar.spec.ts
@@ -35,30 +35,79 @@ export default function(): void {
             fixture.destroy();
         });
 
-        it("should be able to register element as default handle", function() {
-            dragHandleRegistrar.draggableEl = draggableEl;
-            expect(dragHandleRegistrar.customHandle).toBeUndefined();
-            expect(draggableEl.classList.contains("drag-handle")).toBeTruthy();
+        it("registers element as default handle on assignment", function() {
+            dragHandleRegistrar.defaultHandleEl = draggableEl;
             expect(dragEventListener.draggableEl).toBe(draggableEl);
+            expect(draggableEl.hasListener).toBeTruthy();
+            expect(draggableEl.classList.contains("drag-handle")).toBeTruthy();
         });
 
-        it("should be able to register custom element as drag handle", function() {
-            dragHandleRegistrar.draggableEl = draggableEl;
+        it("registers custom element as handle", function() {
             dragHandleRegistrar.registerCustomHandle(customHandleEl);
-            expect(draggableEl.classList.contains("drag-handle")).toBeFalsy();
+
             expect(dragHandleRegistrar.customHandle).toBe(customHandleEl);
             expect(dragEventListener.draggableEl).toBe(customHandleEl);
+
+            expect(customHandleEl.hasListener).toBeTruthy();
+            expect(customHandleEl.classList.contains("drag-handle")).toBeTruthy();
         });
 
-        it("should be able to unregister custom element and fallback to default handle", function() {
-            dragHandleRegistrar.draggableEl = draggableEl;
+        it("registers custom element as drag handle after default handle is set", function() {
+            dragHandleRegistrar.defaultHandleEl = draggableEl;
             dragHandleRegistrar.registerCustomHandle(customHandleEl);
+            // Once custom handle gets registered, listeners and drag styles should be removed from default element.
+            expect(draggableEl.hasListener).toBeFalsy();
+            expect(draggableEl.classList.contains("drag-handle")).toBeFalsy();
 
-            dragHandleRegistrar.unregisterCustomHandle();
-            expect(dragHandleRegistrar.customHandle).toBeUndefined();
-            expect(draggableEl.classList.contains("drag-handle")).toBeTruthy();
-            expect(dragEventListener.draggableEl).toBe(draggableEl);
+            expect(dragHandleRegistrar.customHandle).toBe(customHandleEl);
+            expect(dragEventListener.draggableEl).toBe(customHandleEl);
+
+            expect(customHandleEl.hasListener).toBeTruthy();
+            expect(customHandleEl.classList.contains("drag-handle")).toBeTruthy();
         });
+
+        it("unregisters custom handle", function() {
+            dragHandleRegistrar.registerCustomHandle(customHandleEl);
+            expect(dragHandleRegistrar.customHandle).toBe(customHandleEl);
+            expect(customHandleEl.hasListener).toBeTruthy();
+            expect(customHandleEl.classList.contains("drag-handle")).toBeTruthy();
+            dragHandleRegistrar.unregisterCustomHandle();
+
+            expect(dragHandleRegistrar.customHandle).toBeUndefined();
+            expect(customHandleEl.hasListener).toBeFalsy();
+            expect(customHandleEl.classList.contains("drag-handle")).toBeFalsy();
+        });
+
+        it("unregisters custom handle and fall back to default handle if default handle is set before custom handle",
+           function() {
+               dragHandleRegistrar.defaultHandleEl = draggableEl;
+               dragHandleRegistrar.registerCustomHandle(customHandleEl);
+               dragHandleRegistrar.unregisterCustomHandle();
+               expect(dragHandleRegistrar.customHandle).toBeUndefined();
+               expect(dragEventListener.draggableEl).toBe(draggableEl);
+               expect(draggableEl.hasListener).toBeTruthy();
+               expect(draggableEl.classList.contains("drag-handle")).toBeTruthy();
+           });
+
+        it("keeps custom element as drag handle even after default handle is set", function() {
+            dragHandleRegistrar.registerCustomHandle(customHandleEl);
+            dragHandleRegistrar.defaultHandleEl = draggableEl;
+
+            expect(dragHandleRegistrar.customHandle).toBe(customHandleEl);
+            expect(customHandleEl.hasListener).toBeTruthy();
+            expect(customHandleEl.classList.contains("drag-handle")).toBeTruthy();
+        });
+
+        it("unregisters custom handle and fall back to default handle if default handle is set after custom handle",
+           function() {
+               dragHandleRegistrar.registerCustomHandle(customHandleEl);
+               dragHandleRegistrar.defaultHandleEl = draggableEl;
+               dragHandleRegistrar.unregisterCustomHandle();
+               expect(dragHandleRegistrar.customHandle).toBeUndefined();
+               expect(dragEventListener.draggableEl).toBe(draggableEl);
+               expect(draggableEl.hasListener).toBeTruthy();
+               expect(draggableEl.classList.contains("drag-handle")).toBeTruthy();
+           });
     });
 }
 

--- a/src/clr-angular/utils/drag-and-drop/providers/drag-handle-registrar.ts
+++ b/src/clr-angular/utils/drag-and-drop/providers/drag-handle-registrar.ts
@@ -15,6 +15,10 @@ export class ClrDragHandleRegistrar<T> {
     private _customHandleEl: Node;
     private _defaultHandleEl: Node;
 
+    get defaultHandleEl() {
+        return this._defaultHandleEl;
+    }
+
     set defaultHandleEl(value: Node) {
         this._defaultHandleEl = value;  // defaultHandleEl will be usually the clrDraggable element.
 
@@ -37,7 +41,7 @@ export class ClrDragHandleRegistrar<T> {
         this.renderer.addClass(el, "drag-handle");
     }
 
-    get customHandle() {
+    get customHandleEl() {
         return this._customHandleEl;
     }
 

--- a/src/clr-angular/utils/drag-and-drop/providers/drag-handle-registrar.ts
+++ b/src/clr-angular/utils/drag-and-drop/providers/drag-handle-registrar.ts
@@ -19,8 +19,8 @@ export class ClrDragHandleRegistrar<T> {
         return this._defaultHandleEl;
     }
 
-    set defaultHandleEl(value: Node) {
-        this._defaultHandleEl = value;  // defaultHandleEl will be usually the clrDraggable element.
+    set defaultHandleEl(el: Node) {
+        this._defaultHandleEl = el;  // defaultHandleEl will be usually the clrDraggable element.
 
         // If the customHandleEl has been registered,
         // don't make the defaultHandleEl the drag handle yet until the customHandleEl is unregistered.
@@ -45,9 +45,9 @@ export class ClrDragHandleRegistrar<T> {
         return this._customHandleEl;
     }
 
-    public registerCustomHandle(handleElement: Node) {
+    public registerCustomHandle(el: Node) {
         this.dragEventListener.detachDragListeners();  // removes the existing listeners
-        this._customHandleEl = handleElement;
+        this._customHandleEl = el;
         this.makeElementHandle(this._customHandleEl);
     }
 

--- a/src/clr-angular/utils/drag-and-drop/providers/drag-handle-registrar.ts
+++ b/src/clr-angular/utils/drag-and-drop/providers/drag-handle-registrar.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {Injectable, Renderer2} from "@angular/core";
+
+import {ClrDragEventListener} from "./drag-event-listener";
+
+// This provider registers the drag handle element.
+// If clrDragHandle is nested inside clrDraggable, the drag handle will be clrDragHandle element.
+// If not, the default or fallback drag handle will the clrDraggable element.
+// When it registers the handle element, it attaches that element to the listeners from ClrDragEventListener.
+// Also, it adds the "drag-handle" css class to the registered element through Renderer.
+
+@Injectable()
+export class ClrDragHandleRegistrar<T> {
+    private _customHandleEl: Node;
+    private _draggableEl: Node;
+
+    set draggableEl(value: Node) {
+        // First, we set clrDraggable element as the default drag handle.
+        this._draggableEl = value;
+        this.makeElementHandle(this._draggableEl);
+    }
+
+    constructor(private dragEventListener: ClrDragEventListener<T>, private renderer: Renderer2) {}
+
+    private makeElementHandle(el: Node) {
+        if (this._draggableEl && this._draggableEl !== el) {
+            // Before making an element the custom handle element,
+            // we should remove the existing drag-handle class from the draggable element.
+            this.renderer.removeClass(this._draggableEl, "drag-handle");
+        }
+        this.dragEventListener.attachDragListeners(el);
+        this.renderer.addClass(el, "drag-handle");
+    }
+
+    get customHandle() {
+        return this._customHandleEl;
+    }
+
+    public registerCustomHandle(handleElement: Node) {
+        this._customHandleEl = handleElement;
+        this.makeElementHandle(this._customHandleEl);
+    }
+
+    public unregisterCustomHandle() {
+        delete this._customHandleEl;
+        this.makeElementHandle(this._draggableEl);
+    }
+}


### PR DESCRIPTION
API for users will look like:
```html
<div class="card" clrDraggable>
     ...
    <button clrDragHandle><clr-icon shape="folder"></clr-icon></button>
    ...
</div>
```

Beside `ClrDragEventListener` now, `ClrDragHandleRegistrar` is also provided into `ClrDraggable`. So `ClrDragHandleRegistrar` has access to `ClrDragEventListener`. Now `ClrDraggable` itself doesn't directictly call the `.attachListeners()` method of `ClrDragEventListener` on its element. It provides for its element to `ClrDragHandleRegistrar`, which configures which element to be attached to the listeners.

Signed-off-by: Shijir Tsogoo <stsogoo@vmware.com>