### PR TITLE
[NG] Fix Date Picker State

### DIFF
--- a/src/clr-angular/forms/datepicker/all.spec.ts
+++ b/src/clr-angular/forms/datepicker/all.spec.ts
@@ -17,6 +17,7 @@ import CalendarModelSpecs from "./model/calendar.model.spec";
 import DayModelSpecs from "./model/day.model.spec";
 import YearRangeModelSpecs from "./model/year-range.model.spec";
 import MonthpickerSpecs from "./monthpicker.spec";
+import DateFormControlServiceSpecs from "./providers/date-form-control.service.spec";
 import DateIOServiceSpecs from "./providers/date-io.service.spec";
 import DateNavigationServiceSpecs from "./providers/date-navigation.service.spec";
 import DatepickerEnabledServiceSpecs from "./providers/datepicker-enabled.service.spec";
@@ -42,6 +43,7 @@ describe("Datepicker", function() {
         DateIOServiceSpecs();
         DateNavigationServiceSpecs();
         DatepickerEnabledServiceSpecs();
+        DateFormControlServiceSpecs();
     });
 
     describe("Components", function() {

--- a/src/clr-angular/forms/datepicker/calendar.spec.ts
+++ b/src/clr-angular/forms/datepicker/calendar.spec.ts
@@ -13,6 +13,7 @@ import {DOWN_ARROW, LEFT_ARROW, RIGHT_ARROW, UP_ARROW} from "../../utils/key-cod
 
 import {ClrCalendar} from "./calendar";
 import {DayModel} from "./model/day.model";
+import {DateFormControlService} from "./providers/date-form-control.service";
 import {DateIOService} from "./providers/date-io.service";
 import {DateNavigationService} from "./providers/date-navigation.service";
 import {DatepickerFocusService} from "./providers/datepicker-focus.service";
@@ -33,7 +34,7 @@ export default function() {
 
             context = this.create(ClrCalendar, TestComponent, [
                 {provide: DateNavigationService, useValue: dateNavigationService}, DateIOService, IfOpenService,
-                ViewManagerService, LocaleHelperService, DatepickerFocusService
+                ViewManagerService, LocaleHelperService, DatepickerFocusService, DateFormControlService
             ]);
         });
 

--- a/src/clr-angular/forms/datepicker/date-container.spec.ts
+++ b/src/clr-angular/forms/datepicker/date-container.spec.ts
@@ -14,6 +14,7 @@ import {IfOpenService} from "../../utils/conditional/if-open.service";
 import {FormControlService} from "../common/form-control.service";
 
 import {ClrDateContainer} from "./date-container";
+import {DateFormControlService} from "./providers/date-form-control.service";
 import {DateIOService} from "./providers/date-io.service";
 import {DateNavigationService} from "./providers/date-navigation.service";
 import {DatepickerEnabledService} from "./providers/datepicker-enabled.service";
@@ -24,13 +25,15 @@ export default function() {
     describe("Date Container Component", () => {
         let context: TestContext<ClrDateContainer, TestComponent>;
         let enabledService: MockDatepickerEnabledService;
+        let dateFormControlService: DateFormControlService;
 
         beforeEach(function() {
             TestBed.overrideComponent(ClrDateContainer, {
                 set: {
                     providers: [
                         {provide: DatepickerEnabledService, useClass: MockDatepickerEnabledService}, IfOpenService,
-                        DateNavigationService, LocaleHelperService, DateIOService, FormControlService
+                        DateNavigationService, LocaleHelperService, DateIOService, FormControlService,
+                        DateFormControlService
                     ]
                 }
             });
@@ -38,6 +41,7 @@ export default function() {
             context = this.create(ClrDateContainer, TestComponent, []);
 
             enabledService = <MockDatepickerEnabledService>context.getClarityProvider(DatepickerEnabledService);
+            dateFormControlService = context.getClarityProvider(DateFormControlService);
         });
 
         describe("View Basics", () => {
@@ -93,6 +97,14 @@ export default function() {
                 expect(flag).toBe(true);
 
                 sub.unsubscribe();
+            });
+
+            it("marks the date control as touched when the datepicker popover is toggled", () => {
+                spyOn(dateFormControlService, "markAsTouched");
+
+                context.clarityDirective.toggleDatepicker(null);
+
+                expect(dateFormControlService.markAsTouched).toHaveBeenCalled();
             });
         });
     });

--- a/src/clr-angular/forms/datepicker/date-container.ts
+++ b/src/clr-angular/forms/datepicker/date-container.ts
@@ -10,6 +10,7 @@ import {IfOpenService} from "../../utils/conditional/if-open.service";
 import {DynamicWrapper} from "../../utils/host-wrapping";
 import {FormControlService} from "../common/form-control.service";
 
+import {DateFormControlService} from "./providers/date-form-control.service";
 import {DateIOService} from "./providers/date-io.service";
 import {DateNavigationService} from "./providers/date-navigation.service";
 import {DatepickerEnabledService} from "./providers/datepicker-enabled.service";
@@ -30,7 +31,7 @@ import {LocaleHelperService} from "./providers/locale-helper.service";
     `,
     providers: [
         FormControlService, IfOpenService, LocaleHelperService, DateIOService, DateNavigationService,
-        DatepickerEnabledService
+        DatepickerEnabledService, DateFormControlService
     ],
     host: {"[class.date-container]": "true"}
 })
@@ -41,7 +42,8 @@ export class ClrDateContainer implements DynamicWrapper, OnDestroy {
     private _sub: Subscription;
 
     constructor(private _ifOpenService: IfOpenService, private _dateNavigationService: DateNavigationService,
-                private _datepickerEnabledService: DatepickerEnabledService) {
+                private _datepickerEnabledService: DatepickerEnabledService,
+                private dateFormControlService: DateFormControlService) {
         this._sub = this._ifOpenService.openChange.subscribe((open) => {
             if (open) {
                 this.initializeCalendar();
@@ -68,6 +70,7 @@ export class ClrDateContainer implements DynamicWrapper, OnDestroy {
      */
     toggleDatepicker(event: MouseEvent) {
         this._ifOpenService.toggleWithEvent(event);
+        this.dateFormControlService.markAsTouched();
     }
 
     /**

--- a/src/clr-angular/forms/datepicker/date-input.ts
+++ b/src/clr-angular/forms/datepicker/date-input.ts
@@ -30,6 +30,7 @@ import {WrappedFormControl} from "../common/wrapped-form-control";
 
 import {ClrDateContainer} from "./date-container";
 import {DayModel} from "./model/day.model";
+import {DateFormControlService} from "./providers/date-form-control.service";
 import {DateIOService} from "./providers/date-io.service";
 import {DateNavigationService} from "./providers/date-navigation.service";
 import {DatepickerEnabledService} from "./providers/datepicker-enabled.service";
@@ -46,6 +47,7 @@ export class ClrDateInput extends WrappedFormControl<ClrDateContainer> implement
                 @Optional() private _dateIOService: DateIOService,
                 @Optional() private _dateNavigationService: DateNavigationService,
                 @Optional() private _datepickerEnabledService: DatepickerEnabledService,
+                @Optional() private dateFormControlService: DateFormControlService,
                 @Inject(PLATFORM_ID) private platformId: Object) {
         super(ClrDateContainer, vcr);
     }
@@ -117,6 +119,7 @@ export class ClrDateInput extends WrappedFormControl<ClrDateContainer> implement
         this._dateIOService = this.getProviderFromContainer(DateIOService);
         this._dateNavigationService = this.getProviderFromContainer(DateNavigationService);
         this._datepickerEnabledService = this.getProviderFromContainer(DatepickerEnabledService);
+        this.dateFormControlService = this.getProviderFromContainer(DateFormControlService);
     }
 
     /**
@@ -254,6 +257,20 @@ export class ClrDateInput extends WrappedFormControl<ClrDateContainer> implement
                     }
                 }));
             }
+        }
+
+        if (this.dateFormControlService) {
+            this._subscriptions.push(this.dateFormControlService.touchedChange.subscribe(() => {
+                if (this._ngControl) {
+                    this._ngControl.control.markAsTouched();
+                }
+            }));
+
+            this._subscriptions.push(this.dateFormControlService.dirtyChange.subscribe(() => {
+                if (this._ngControl) {
+                    this._ngControl.control.markAsDirty();
+                }
+            }));
         }
     }
 }

--- a/src/clr-angular/forms/datepicker/datepicker-view-manager.spec.ts
+++ b/src/clr-angular/forms/datepicker/datepicker-view-manager.spec.ts
@@ -11,6 +11,7 @@ import {TestContext} from "../../data/datagrid/helpers.spec";
 import {IfOpenService} from "../../utils/conditional/if-open.service";
 
 import {ClrDatepickerViewManager} from "./datepicker-view-manager";
+import {DateFormControlService} from "./providers/date-form-control.service";
 import {DateIOService} from "./providers/date-io.service";
 import {DateNavigationService} from "./providers/date-navigation.service";
 import {DatepickerFocusService} from "./providers/datepicker-focus.service";
@@ -25,7 +26,7 @@ export default function() {
         beforeEach(function() {
             context = this.create(ClrDatepickerViewManager, TestComponent, [
                 ViewManagerService, DatepickerFocusService, IfOpenService, DateNavigationService, LocaleHelperService,
-                DateIOService
+                DateIOService, DateFormControlService
             ]);
             viewManagerService = context.getClarityProvider(ViewManagerService);
         });

--- a/src/clr-angular/forms/datepicker/day.spec.ts
+++ b/src/clr-angular/forms/datepicker/day.spec.ts
@@ -13,6 +13,7 @@ import {IfOpenService} from "../../utils/conditional/if-open.service";
 import {ClrDay} from "./day";
 import {DayViewModel} from "./model/day-view.model";
 import {DayModel} from "./model/day.model";
+import {DateFormControlService} from "./providers/date-form-control.service";
 import {DateIOService} from "./providers/date-io.service";
 import {DateNavigationService} from "./providers/date-navigation.service";
 import {LocaleHelperService} from "./providers/locale-helper.service";
@@ -22,8 +23,9 @@ export default function() {
         let context: TestContext<ClrDay, TestComponent>;
 
         beforeEach(function() {
-            context = this.create(ClrDay, TestComponent,
-                                  [LocaleHelperService, DateNavigationService, DateIOService, IfOpenService]);
+            context = this.create(
+                ClrDay, TestComponent,
+                [LocaleHelperService, DateNavigationService, DateIOService, IfOpenService, DateFormControlService]);
         });
 
         describe("View Basics", function() {
@@ -193,6 +195,16 @@ export default function() {
                 expect(dateNavigationService.focusedDay.date).toBe(testDayView.dayModel.date);
                 expect(dateNavigationService.focusedDay.month).toBe(testDayView.dayModel.month);
                 expect(dateNavigationService.focusedDay.year).toBe(testDayView.dayModel.year);
+            });
+
+            it("marks the date control as dirty when a date is selected", () => {
+                const dateFormControlService: DateFormControlService =
+                    context.getClarityProvider(DateFormControlService);
+                spyOn(dateFormControlService, "markAsDirty");
+
+                context.clarityDirective.selectDay();
+
+                expect(dateFormControlService.markAsDirty).toHaveBeenCalled();
             });
         });
     });

--- a/src/clr-angular/forms/datepicker/day.ts
+++ b/src/clr-angular/forms/datepicker/day.ts
@@ -11,6 +11,7 @@ import {IfOpenService} from "../../utils/conditional/if-open.service";
 
 import {DayViewModel} from "./model/day-view.model";
 import {DayModel} from "./model/day.model";
+import {DateFormControlService} from "./providers/date-form-control.service";
 import {DateNavigationService} from "./providers/date-navigation.service";
 
 @Component({
@@ -31,7 +32,8 @@ import {DateNavigationService} from "./providers/date-navigation.service";
     host: {"[class.day]": "true"}
 })
 export class ClrDay {
-    constructor(private _dateNavigationService: DateNavigationService, private _ifOpenService: IfOpenService) {}
+    constructor(private _dateNavigationService: DateNavigationService, private _ifOpenService: IfOpenService,
+                private dateFormControlService: DateFormControlService) {}
 
     /**
      * DayViewModel input which is used to build the Day View.
@@ -51,6 +53,7 @@ export class ClrDay {
     selectDay(): void {
         const day: DayModel = this.dayView.dayModel;
         this._dateNavigationService.notifySelectedDayChanged(day);
+        this.dateFormControlService.markAsDirty();
         this._ifOpenService.open = false;
     }
 }

--- a/src/clr-angular/forms/datepicker/daypicker.spec.ts
+++ b/src/clr-angular/forms/datepicker/daypicker.spec.ts
@@ -12,6 +12,7 @@ import {IfOpenService} from "../../utils/conditional/if-open.service";
 
 import {ClrDaypicker} from "./daypicker";
 import {DayModel} from "./model/day.model";
+import {DateFormControlService} from "./providers/date-form-control.service";
 import {DateIOService} from "./providers/date-io.service";
 import {DateNavigationService} from "./providers/date-navigation.service";
 import {DatepickerFocusService} from "./providers/datepicker-focus.service";
@@ -33,7 +34,7 @@ export default function() {
 
             context = this.create(ClrDaypicker, TestComponent, [
                 {provide: DateNavigationService, useValue: dateNavigationService}, DateIOService, IfOpenService,
-                ViewManagerService, LocaleHelperService, DatepickerFocusService
+                ViewManagerService, LocaleHelperService, DatepickerFocusService, DateFormControlService
             ]);
             viewManagerService = context.getClarityProvider(ViewManagerService);
             localeHelperService = context.getClarityProvider(LocaleHelperService);

--- a/src/clr-angular/forms/datepicker/providers/date-form-control.service.spec.ts
+++ b/src/clr-angular/forms/datepicker/providers/date-form-control.service.spec.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import {Subscription} from "rxjs";
+
+import {DateFormControlService} from "./date-form-control.service";
+
+export default function() {
+    describe("Date Form Control Service", () => {
+        let dateFormControlService: DateFormControlService;
+
+        beforeEach(() => {
+            dateFormControlService = new DateFormControlService();
+        });
+
+        it("provides a way to listen to form state change to touched", () => {
+            expect(dateFormControlService.touchedChange).toBeDefined();
+        });
+
+        it("provides a way to listen to form state change to dirty", () => {
+            expect(dateFormControlService.dirtyChange).toBeDefined();
+        });
+
+        it("provides a method to notify that the form state should be changed to touched", () => {
+            let touchedStatus: boolean = false;
+
+            const sub: Subscription = dateFormControlService.touchedChange.subscribe(() => {
+                touchedStatus = true;
+            });
+
+            dateFormControlService.markAsTouched();
+
+            expect(touchedStatus).toBe(true);
+
+            sub.unsubscribe();
+        });
+
+        it("provides a method to notify that the form state should be changed to dirty", () => {
+            let dirtyStatus: boolean = false;
+
+            const sub: Subscription = dateFormControlService.dirtyChange.subscribe(() => {
+                dirtyStatus = true;
+            });
+
+            dateFormControlService.markAsDirty();
+
+            expect(dirtyStatus).toBe(true);
+
+            sub.unsubscribe();
+        });
+    });
+}

--- a/src/clr-angular/forms/datepicker/providers/date-form-control.service.ts
+++ b/src/clr-angular/forms/datepicker/providers/date-form-control.service.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import {Injectable} from "@angular/core";
+import {Observable, Subject} from "rxjs";
+
+@Injectable()
+export class DateFormControlService {
+    private _touchedChange: Subject<void> = new Subject<void>();
+
+    get touchedChange(): Observable<void> {
+        return this._touchedChange.asObservable();
+    }
+
+    private _dirtyChange: Subject<void> = new Subject<void>();
+
+    get dirtyChange(): Observable<void> {
+        return this._dirtyChange.asObservable();
+    }
+
+    markAsTouched(): void {
+        this._touchedChange.next();
+    }
+
+    markAsDirty(): void {
+        this._dirtyChange.next();
+    }
+}

--- a/src/dev/src/app/datepicker/datepicker-in-reactive-forms.html
+++ b/src/dev/src/app/datepicker/datepicker-in-reactive-forms.html
@@ -20,3 +20,11 @@
 </form>
 
 <p>Form Value: {{dateForm.value | json}}</p>
+
+<div>
+    Touched: {{dateForm.touched}}
+</div>
+
+<div>
+    Dirty: {{dateForm.dirty}}
+</div>

--- a/src/dev/src/app/datepicker/datepicker-in-template-driven-forms.html
+++ b/src/dev/src/app/datepicker/datepicker-in-template-driven-forms.html
@@ -7,6 +7,10 @@
 <h2>Template Driven Forms</h2>
 <form class="form" #simpleForm="ngForm">
     <div class="form-group">
+        <label for="name">Enter Name</label>
+        <input type="text" id="name" name="name" [(ngModel)]="name">
+    </div>
+    <div class="form-group">
         <label for="date1">Enter Date1</label>
         <input type="date" id="date1" name="date1" [(ngModel)]="date1" clrDate (clrDateChange)="date1Changed($event)">
     </div>
@@ -14,7 +18,14 @@
         <label for="date2">Enter Date2</label>
         <input type="date" id="date2" name="date2" [(ngModel)]="date2" clrDate (clrDateChange)="date2Changed($event)">
     </div>
-    <p>
-        {{simpleForm.value | json}}
-    </p>
 </form>
+
+<p>
+    {{simpleForm.value | json}}
+</p>
+<div>
+    Touched: {{simpleForm.touched}}
+</div>
+<div>
+    Dirty: {{simpleForm.dirty}}
+</div>

--- a/src/dev/src/app/datepicker/datepicker-in-template-driven-forms.ts
+++ b/src/dev/src/app/datepicker/datepicker-in-template-driven-forms.ts
@@ -12,6 +12,7 @@ import {Component} from "@angular/core";
     templateUrl: "./datepicker-in-template-driven-forms.html"
 })
 export class DatepickerInTemplateDrivenFormsDemo {
+    name: string = "Jane";
     date1: string = "01/02/2015";
     date2: string = "";
 


### PR DESCRIPTION
Fixes: #2263 

**Changes:**
1. Date Control marked as `touched` when the datepicker toggle is clicked.
2. Date Control marked as `dirty` when a date is selected from the popover.

**Tested on Chrome**

Signed-off-by: Aditya Bhandari <adityab@vmware.com>