### PR TITLE
[NG] Set isRootLevelToggle to public

### DIFF
--- a/src/clr-angular/popover/dropdown/dropdown-trigger.ts
+++ b/src/clr-angular/popover/dropdown/dropdown-trigger.ts
@@ -20,8 +20,7 @@ import {ClrDropdown} from "./dropdown";
     }
 })
 export class ClrDropdownTrigger {
-    /* tslint:disable-next-line:no-unused-variable */
-    private isRootLevelToggle: boolean = true;
+    public isRootLevelToggle: boolean = true;
 
     constructor(dropdown: ClrDropdown, private ifOpenService: IfOpenService) {
         // if the containing dropdown has a parent, then this is not the root level one


### PR DESCRIPTION
When running a strict configuration of ngc (e.g. ng-packagr) against a library
which imports the ClrDropdownModule (e.g. ng-packagr), ngc errors out because
the dropdown's private property is used in the "host" component. Note that
even though the compiler appears to access clarity, the component isn't actually
bundled in the resulting output.

Signed-off-by: Michael Krotscheck <krotscheck@gmail.com>