### PR TITLE
[NG] Proper Datagrid typing

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -240,26 +240,26 @@ export declare class ClrControlError {
 export declare class ClrControlHelper {
 }
 
-export declare class ClrDatagrid implements AfterContentInit, AfterViewInit, OnDestroy {
+export declare class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, OnDestroy {
     SELECTION_TYPE: typeof SelectionType;
     allSelected: boolean;
-    columns: QueryList<ClrDatagridColumn>;
+    columns: QueryList<ClrDatagridColumn<T>>;
     expandableRows: ExpandableRowsCount;
-    items: Items;
-    iterator: ClrDatagridItems;
+    items: Items<T>;
+    iterator: ClrDatagridItems<T>;
     loading: boolean;
-    placeholder: ClrDatagridPlaceholder;
-    refresh: EventEmitter<ClrDatagridStateInterface>;
+    placeholder: ClrDatagridPlaceholder<T>;
+    refresh: EventEmitter<ClrDatagridStateInterface<T>>;
     rowActionService: RowActionService;
     rowSelectionMode: boolean;
     /** @deprecated */ rowSelectionModeDeprecated: boolean;
-    rows: QueryList<ClrDatagridRow>;
-    selected: any[];
-    selectedChanged: EventEmitter<any[]>;
-    selection: Selection;
-    singleSelected: any;
-    singleSelectedChanged: EventEmitter<any>;
-    constructor(columnService: HideableColumnService, organizer: DatagridRenderOrganizer, items: Items, expandableRows: ExpandableRowsCount, selection: Selection, rowActionService: RowActionService, stateProvider: StateProvider);
+    rows: QueryList<ClrDatagridRow<T>>;
+    selected: T[];
+    selectedChanged: EventEmitter<T[]>;
+    selection: Selection<T>;
+    singleSelected: T;
+    singleSelectedChanged: EventEmitter<T>;
+    constructor(columnService: HideableColumnService, organizer: DatagridRenderOrganizer, items: Items<T>, expandableRows: ExpandableRowsCount, selection: Selection<T>, rowActionService: RowActionService, stateProvider: StateProvider<T>);
     dataChanged(): void;
     ngAfterContentInit(): void;
     ngAfterViewInit(): void;
@@ -289,7 +289,7 @@ export declare class ClrDatagridCell {
     ngOnDestroy(): void;
 }
 
-export declare class ClrDatagridColumn extends DatagridFilterRegistrar<DatagridStringFilterImpl> {
+export declare class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<T, DatagridStringFilterImpl<T>> {
     readonly ariaSort: string;
     readonly asc: boolean;
     columnId: string;
@@ -303,14 +303,14 @@ export declare class ClrDatagridColumn extends DatagridFilterRegistrar<DatagridS
     readonly hidden: boolean;
     hideable: DatagridHideableColumnModel;
     projectedFilter: any;
-    sortBy: ClrDatagridComparatorInterface<any> | string;
+    sortBy: ClrDatagridComparatorInterface<T> | string;
     sortOrder: ClrDatagridSortOrder;
     sortOrderChange: EventEmitter<ClrDatagridSortOrder>;
     readonly sortable: boolean;
     /** @deprecated */ sorted: boolean;
     /** @deprecated */ sortedChange: EventEmitter<boolean>;
     updateFilterValue: string;
-    constructor(_sort: Sort, filters: FiltersProvider, _dragDispatcher: DragDispatcher);
+    constructor(_sort: Sort<T>, filters: FiltersProvider<T>, _dragDispatcher: DragDispatcher);
     ngOnDestroy(): void;
     sort(reverse?: boolean): void;
 }
@@ -336,15 +336,15 @@ export interface ClrDatagridComparatorInterface<T> {
     compare(a: T, b: T): number;
 }
 
-export declare class ClrDatagridFilter extends DatagridFilterRegistrar<ClrDatagridFilterInterface<any>> implements CustomFilter {
+export declare class ClrDatagridFilter<T = any> extends DatagridFilterRegistrar<T, ClrDatagridFilterInterface<T>> implements CustomFilter {
     readonly active: boolean;
     anchorPoint: Point;
-    customFilter: ClrDatagridFilterInterface<any> | RegisteredFilter<ClrDatagridFilterInterface<any>>;
+    customFilter: ClrDatagridFilterInterface<T> | RegisteredFilter<T, ClrDatagridFilterInterface<T>>;
     open: boolean;
     openChanged: EventEmitter<boolean>;
     popoverOptions: PopoverOptions;
     popoverPoint: Point;
-    constructor(_filters: FiltersProvider);
+    constructor(_filters: FiltersProvider<T>);
     toggle(): void;
 }
 
@@ -354,30 +354,32 @@ export interface ClrDatagridFilterInterface<T> {
     isActive(): boolean;
 }
 
-export declare class ClrDatagridFooter implements OnInit {
+export declare class ClrDatagridFooter<T = any> implements OnInit {
     SELECTION_TYPE: typeof SelectionType;
     activeToggler: boolean;
     cdr: ChangeDetectorRef;
     hideableColumnService: HideableColumnService;
-    selection: Selection;
+    selection: Selection<T>;
     toggle: ClrDatagridColumnToggle;
-    constructor(selection: Selection, hideableColumnService: HideableColumnService, cdr: ChangeDetectorRef);
+    constructor(selection: Selection<T>, hideableColumnService: HideableColumnService, cdr: ChangeDetectorRef);
     ngOnDestroy(): void;
     ngOnInit(): void;
 }
 
 export declare class ClrDatagridHideableColumn {
-    clrDgHideableColumn: any;
+    clrDgHideableColumn: {
+        hidden: boolean;
+    };
     column: DatagridHideableColumnModel;
     columnId: string;
-    constructor(templateRef: TemplateRef<any>, viewContainerRef: ViewContainerRef, dgColumn: ClrDatagridColumn);
+    constructor(templateRef: TemplateRef<any>, viewContainerRef: ViewContainerRef, dgColumn: ClrDatagridColumn<any>);
 }
 
-export declare class ClrDatagridItems implements OnChanges, DoCheck {
-    rawItems: any[];
-    template: TemplateRef<any>;
-    trackBy: TrackByFunction<any>;
-    constructor(template: TemplateRef<any>, _differs: IterableDiffers, _items: Items);
+export declare class ClrDatagridItems<T = any> implements OnChanges, DoCheck {
+    rawItems: T[];
+    template: TemplateRef<NgForOfContext<T>>;
+    trackBy: TrackByFunction<T>;
+    constructor(template: TemplateRef<NgForOfContext<T>>, _differs: IterableDiffers, _items: Items<T>);
     ngDoCheck(): void;
     ngOnChanges(changes: SimpleChanges): void;
 }
@@ -402,12 +404,12 @@ export declare class ClrDatagridPagination implements OnDestroy, OnInit {
     previous(): void;
 }
 
-export declare class ClrDatagridPlaceholder {
+export declare class ClrDatagridPlaceholder<T = any> {
     readonly emptyDatagrid: boolean;
-    constructor(items: Items);
+    constructor(items: Items<T>);
 }
 
-export declare class ClrDatagridRow implements AfterContentInit {
+export declare class ClrDatagridRow<T = any> implements AfterContentInit {
     SELECTION_TYPE: typeof SelectionType;
     dgCells: QueryList<ClrDatagridCell>;
     expand: Expand;
@@ -416,13 +418,13 @@ export declare class ClrDatagridRow implements AfterContentInit {
     globalExpandable: ExpandableRowsCount;
     hideableColumnService: HideableColumnService;
     id: string;
-    item: any;
+    item: T;
     radioId: string;
     rowActionService: RowActionService;
     selected: boolean;
     selectedChanged: EventEmitter<boolean>;
-    selection: Selection;
-    constructor(selection: Selection, rowActionService: RowActionService, globalExpandable: ExpandableRowsCount, expand: Expand, hideableColumnService: HideableColumnService);
+    selection: Selection<T>;
+    constructor(selection: Selection<T>, rowActionService: RowActionService, globalExpandable: ExpandableRowsCount, expand: Expand, hideableColumnService: HideableColumnService);
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
     toggle(selected?: boolean): void;
@@ -430,15 +432,15 @@ export declare class ClrDatagridRow implements AfterContentInit {
     updateCellsForColumns(columnList: DatagridHideableColumnModel[]): void;
 }
 
-export declare class ClrDatagridRowDetail implements AfterContentInit, OnDestroy {
+export declare class ClrDatagridRowDetail<T = any> implements AfterContentInit, OnDestroy {
     SELECTION_TYPE: typeof SelectionType;
     cells: QueryList<ClrDatagridCell>;
     expand: Expand;
     hideableColumnService: HideableColumnService;
     replace: boolean;
     rowActionService: RowActionService;
-    selection: Selection;
-    constructor(selection: Selection, rowActionService: RowActionService, expand: Expand, hideableColumnService: HideableColumnService);
+    selection: Selection<T>;
+    constructor(selection: Selection<T>, rowActionService: RowActionService, expand: Expand, hideableColumnService: HideableColumnService);
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
     updateCellsForColumns(columnList: DatagridHideableColumnModel[]): void;
@@ -450,18 +452,18 @@ export declare enum ClrDatagridSortOrder {
     DESC = -1,
 }
 
-export interface ClrDatagridStateInterface {
+export interface ClrDatagridStateInterface<T = any> {
     filters?: ({
         property: string;
         value: string;
-    } | ClrDatagridFilterInterface<any>)[];
+    } | ClrDatagridFilterInterface<T>)[];
     page?: {
         from?: number;
         to?: number;
         size?: number;
     };
     sort?: {
-        by: string | ClrDatagridComparatorInterface<any>;
+        by: string | ClrDatagridComparatorInterface<T>;
         reverse: boolean;
     };
 }
@@ -1261,17 +1263,17 @@ export declare const DatagridPagination: typeof ClrDatagridPagination;
 /** @deprecated */
 export declare const DatagridPlaceholder: typeof ClrDatagridPlaceholder;
 
-export declare class DatagridPropertyComparator implements ClrDatagridComparatorInterface<any> {
+export declare class DatagridPropertyComparator<T = any> implements ClrDatagridComparatorInterface<T> {
     prop: string;
     constructor(prop: string);
-    compare(a: any, b: any): number;
+    compare(a: T, b: T): number;
 }
 
-export declare class DatagridPropertyStringFilter implements ClrDatagridStringFilterInterface<any> {
+export declare class DatagridPropertyStringFilter<T = any> implements ClrDatagridStringFilterInterface<T> {
     exact: boolean;
     prop: string;
     constructor(prop: string, exact?: boolean);
-    accepts(item: any, search: string): boolean;
+    accepts(item: T, search: string): boolean;
 }
 
 /** @deprecated */
@@ -1280,14 +1282,14 @@ export declare const DatagridRow: typeof ClrDatagridRow;
 /** @deprecated */
 export declare const DatagridRowDetail: typeof ClrDatagridRowDetail;
 
-export declare class DatagridStringFilter extends DatagridFilterRegistrar<DatagridStringFilterImpl> implements CustomFilter, AfterViewInit {
-    customStringFilter: ClrDatagridStringFilterInterface<any> | RegisteredFilter<DatagridStringFilterImpl>;
-    filterContainer: ClrDatagridFilter;
+export declare class DatagridStringFilter<T = any> extends DatagridFilterRegistrar<T, DatagridStringFilterImpl<T>> implements CustomFilter, AfterViewInit {
+    customStringFilter: ClrDatagridStringFilterInterface<T> | RegisteredFilter<T, DatagridStringFilterImpl<T>>;
+    filterContainer: ClrDatagridFilter<T>;
     filterValueChange: EventEmitter<{}>;
     input: ElementRef;
     open: boolean;
     value: string;
-    constructor(filters: FiltersProvider, domAdapter: DomAdapter);
+    constructor(filters: FiltersProvider<T>, domAdapter: DomAdapter);
     close(): void;
     ngAfterViewInit(): void;
 }
@@ -1416,7 +1418,7 @@ export declare const StackView: typeof ClrStackView;
 export declare const StackViewCustomTags: typeof ClrStackViewCustomTags;
 
 /** @deprecated */
-export interface State extends ClrDatagridStateInterface {
+export interface State extends ClrDatagridStateInterface<any> {
 }
 
 /** @deprecated */

--- a/src/clr-angular/data/datagrid/all.spec.ts
+++ b/src/clr-angular/data/datagrid/all.spec.ts
@@ -14,6 +14,7 @@ import DatagridRowExpandAnimationSpecs from './animation-hack/row-expand-animati
 import DatagridPropertyComparatorSpecs from './built-in/comparators/datagrid-property-comparator.spec';
 import DatagridPropertyStringFilterSpecs from './built-in/filters/datagrid-property-string-filter.spec';
 import DatagridStringFilterSpecs from './built-in/filters/datagrid-string-filter.spec';
+import DatagridStringFilterImplSpecs from './built-in/filters/datagrid-string-filter-impl.spec';
 import NestedPropertySpecs from './built-in/nested-property.spec';
 import DatagridActionBarSpecs from './datagrid-action-bar.spec';
 import DatagridActionOverflowSpecs from './datagrid-action-overflow.spec';
@@ -102,5 +103,6 @@ describe('Datagrid', function() {
     DatagridPropertyComparatorSpecs();
     DatagridPropertyStringFilterSpecs();
     DatagridStringFilterSpecs();
+    DatagridStringFilterImplSpecs();
   });
 });

--- a/src/clr-angular/data/datagrid/built-in/comparators/datagrid-property-comparator.ts
+++ b/src/clr-angular/data/datagrid/built-in/comparators/datagrid-property-comparator.ts
@@ -6,14 +6,14 @@
 import { ClrDatagridComparatorInterface } from '../../interfaces/comparator.interface';
 import { NestedProperty } from '../nested-property';
 
-export class DatagridPropertyComparator implements ClrDatagridComparatorInterface<any> {
-  private nestedProp: NestedProperty;
+export class DatagridPropertyComparator<T = any> implements ClrDatagridComparatorInterface<T> {
+  private nestedProp: NestedProperty<T>;
 
   constructor(public prop: string) {
     this.nestedProp = new NestedProperty(prop);
   }
 
-  public compare(a: any, b: any): number {
+  public compare(a: T, b: T): number {
     let propA = this.nestedProp.getPropValue(a);
     let propB = this.nestedProp.getPropValue(b);
 

--- a/src/clr-angular/data/datagrid/built-in/filters/datagrid-property-string-filter.ts
+++ b/src/clr-angular/data/datagrid/built-in/filters/datagrid-property-string-filter.ts
@@ -6,14 +6,14 @@
 import { ClrDatagridStringFilterInterface } from '../../interfaces/string-filter.interface';
 import { NestedProperty } from '../nested-property';
 
-export class DatagridPropertyStringFilter implements ClrDatagridStringFilterInterface<any> {
-  private nestedProp: NestedProperty;
+export class DatagridPropertyStringFilter<T = any> implements ClrDatagridStringFilterInterface<T> {
+  private nestedProp: NestedProperty<T>;
 
   constructor(public prop: string, public exact = false) {
     this.nestedProp = new NestedProperty(prop);
   }
 
-  accepts(item: any, search: string): boolean {
+  accepts(item: T, search: string): boolean {
     const propValue = this.nestedProp.getPropValue(item);
     if (typeof propValue === 'undefined') {
       return false;

--- a/src/clr-angular/data/datagrid/built-in/filters/datagrid-string-filter-impl.spec.ts
+++ b/src/clr-angular/data/datagrid/built-in/filters/datagrid-string-filter-impl.spec.ts
@@ -9,7 +9,7 @@ import { DatagridStringFilterImpl } from './datagrid-string-filter-impl';
 
 export default function(): void {
   describe('DatagridStringFilterImpl', function() {
-    let fullFilter: DatagridStringFilterImpl;
+    let fullFilter: DatagridStringFilterImpl<string>;
 
     beforeEach(function() {
       const stringFilter = new TestFilter();

--- a/src/clr-angular/data/datagrid/built-in/filters/datagrid-string-filter-impl.ts
+++ b/src/clr-angular/data/datagrid/built-in/filters/datagrid-string-filter-impl.ts
@@ -8,8 +8,8 @@ import { Subject } from 'rxjs';
 import { ClrDatagridFilterInterface } from '../../interfaces/filter.interface';
 import { ClrDatagridStringFilterInterface } from '../../interfaces/string-filter.interface';
 
-export class DatagridStringFilterImpl implements ClrDatagridFilterInterface<any> {
-  constructor(public filterFn: ClrDatagridStringFilterInterface<any>) {}
+export class DatagridStringFilterImpl<T = any> implements ClrDatagridFilterInterface<T> {
+  constructor(public filterFn: ClrDatagridStringFilterInterface<T>) {}
 
   /**
    * The Observable required as part of the Filter interface
@@ -58,7 +58,7 @@ export class DatagridStringFilterImpl implements ClrDatagridFilterInterface<any>
   /**
    * Tests if an item matches a search text
    */
-  public accepts(item: any): boolean {
+  public accepts(item: T): boolean {
     // We always test with the lowercase value of the input, to stay case insensitive
     return this.filterFn.accepts(item, this.lowerCaseValue);
   }

--- a/src/clr-angular/data/datagrid/built-in/filters/datagrid-string-filter.spec.ts
+++ b/src/clr-angular/data/datagrid/built-in/filters/datagrid-string-filter.spec.ts
@@ -23,9 +23,9 @@ const PROVIDERS = [FiltersProvider, DomAdapter, Page, StateDebouncer];
 export default function(): void {
   describe('DatagridStringFilter component', function() {
     // Until we can properly type "this"
-    let context: TestContext<DatagridStringFilter, FullTest>;
+    let context: TestContext<DatagridStringFilter<string>, FullTest>;
     let filter: TestFilter;
-    let filtersInstance: FiltersProvider;
+    let filtersInstance: FiltersProvider<string>;
 
     function openFilter() {
       context.clarityElement.querySelector('.datagrid-filter-toggle').click();
@@ -119,6 +119,6 @@ class TestFilter implements ClrDatagridStringFilterInterface<string> {
 class FullTest {
   @ViewChild(CustomFilter) customFilter: CustomFilter;
 
-  filter: ClrDatagridStringFilterInterface<any>;
+  filter: ClrDatagridStringFilterInterface<string>;
   filterValue: string;
 }

--- a/src/clr-angular/data/datagrid/built-in/filters/datagrid-string-filter.ts
+++ b/src/clr-angular/data/datagrid/built-in/filters/datagrid-string-filter.ts
@@ -30,9 +30,9 @@ import { DatagridStringFilterImpl } from './datagrid-string-filter-impl';
         </clr-dg-filter>
     `,
 })
-export class DatagridStringFilter extends DatagridFilterRegistrar<DatagridStringFilterImpl>
+export class DatagridStringFilter<T = any> extends DatagridFilterRegistrar<T, DatagridStringFilterImpl<T>>
   implements CustomFilter, AfterViewInit {
-  constructor(filters: FiltersProvider, private domAdapter: DomAdapter) {
+  constructor(filters: FiltersProvider<T>, private domAdapter: DomAdapter) {
     super(filters);
   }
 
@@ -40,11 +40,13 @@ export class DatagridStringFilter extends DatagridFilterRegistrar<DatagridString
    * Customizable filter logic based on a search text
    */
   @Input('clrDgStringFilter')
-  set customStringFilter(value: ClrDatagridStringFilterInterface<any> | RegisteredFilter<DatagridStringFilterImpl>) {
+  set customStringFilter(
+    value: ClrDatagridStringFilterInterface<T> | RegisteredFilter<T, DatagridStringFilterImpl<T>>
+  ) {
     if (value instanceof RegisteredFilter) {
       this.setFilter(value);
     } else {
-      this.setFilter(new DatagridStringFilterImpl(<ClrDatagridStringFilterInterface<any>>value));
+      this.setFilter(new DatagridStringFilterImpl(value));
     }
   }
 
@@ -61,7 +63,7 @@ export class DatagridStringFilter extends DatagridFilterRegistrar<DatagridString
   /**
    * We grab the ClrDatagridFilter we wrap to register this StringFilter to it.
    */
-  @ViewChild(ClrDatagridFilter) public filterContainer: ClrDatagridFilter;
+  @ViewChild(ClrDatagridFilter) public filterContainer: ClrDatagridFilter<T>;
   ngAfterViewInit() {
     this.filterContainer.openChanged.subscribe((open: boolean) => {
       if (open) {

--- a/src/clr-angular/data/datagrid/built-in/nested-property.ts
+++ b/src/clr-angular/data/datagrid/built-in/nested-property.ts
@@ -7,7 +7,7 @@
  * Generic accessor for deep object properties
  * that can be specified as simple dot-separated strings.
  */
-export class NestedProperty {
+export class NestedProperty<T = any> {
   private splitProp: string[];
 
   constructor(private prop: string) {
@@ -18,7 +18,7 @@ export class NestedProperty {
 
   // Safe getter for a deep object property, will not throw an error but return
   // undefined if one of the intermediate properties is null or undefined.
-  public getPropValue(item: any): any {
+  public getPropValue(item: T): any {
     if (this.splitProp) {
       let value = item;
       for (const nestedProp of this.splitProp) {

--- a/src/clr-angular/data/datagrid/datagrid-column.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column.spec.ts
@@ -39,11 +39,11 @@ const PROVIDERS_NEEDED = [
 export default function(): void {
   describe('DatagridColumn component', function() {
     describe('Typescript API', function() {
-      let sortService: Sort;
-      let filtersService: FiltersProvider;
+      let sortService: Sort<number>;
+      let filtersService: FiltersProvider<number>;
       let dragDispatcherService: DragDispatcher;
       let comparator: TestComparator;
-      let component: ClrDatagridColumn;
+      let component: ClrDatagridColumn<number>;
 
       beforeEach(function() {
         const stateDebouncer = new StateDebouncer();
@@ -297,7 +297,7 @@ export default function(): void {
     });
 
     describe('View basics', function() {
-      let context: TestContext<ClrDatagridColumn, SimpleTest>;
+      let context: TestContext<ClrDatagridColumn<number | string>, SimpleTest>;
 
       beforeEach(function() {
         context = this.create(ClrDatagridColumn, SimpleTest, PROVIDERS_NEEDED);
@@ -440,8 +440,8 @@ class TestFilter implements ClrDatagridFilterInterface<number> {
   changes = new Subject<boolean>();
 }
 
-class TestStringFilter implements ClrDatagridStringFilterInterface<string> {
-  accepts(s: string, search: string): boolean {
+class TestStringFilter implements ClrDatagridStringFilterInterface<number> {
+  accepts(n: number, search: string): boolean {
     return true;
   }
 }
@@ -457,7 +457,7 @@ class TestStringFilter implements ClrDatagridStringFilterInterface<string> {
     `,
 })
 class SimpleDeprecatedTest {
-  comparator: ClrDatagridComparatorInterface<any>;
+  comparator: ClrDatagridComparatorInterface<number>;
   field: string;
   sorted = false;
 }
@@ -473,7 +473,7 @@ class SimpleDeprecatedTest {
     `,
 })
 class SimpleTest {
-  comparator: ClrDatagridComparatorInterface<any> | string;
+  comparator: ClrDatagridComparatorInterface<number> | string;
   field: string;
   sortOrder = ClrDatagridSortOrder.UNSORTED;
 }
@@ -505,7 +505,7 @@ class StringFilterTest {
   filter = new TestStringFilter();
   field: string;
 
-  @ViewChild(DatagridStringFilter) stringFilter: DatagridStringFilter;
+  @ViewChild(DatagridStringFilter) stringFilter: DatagridStringFilter<number>;
 }
 
 @Component({

--- a/src/clr-angular/data/datagrid/datagrid-column.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column.ts
@@ -64,8 +64,8 @@ let nbCount: number = 0;
     role: 'columnheader',
   },
 })
-export class ClrDatagridColumn extends DatagridFilterRegistrar<DatagridStringFilterImpl> {
-  constructor(private _sort: Sort, filters: FiltersProvider, private _dragDispatcher: DragDispatcher) {
+export class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<T, DatagridStringFilterImpl<T>> {
+  constructor(private _sort: Sort<T>, filters: FiltersProvider<T>, private _dragDispatcher: DragDispatcher) {
     super(filters);
     this._sortSubscription = _sort.change.subscribe(sort => {
       // We're only listening to make sure we emit an event when the column goes from sorted to unsorted
@@ -156,14 +156,14 @@ export class ClrDatagridColumn extends DatagridFilterRegistrar<DatagridStringFil
    * ClrDatagridComparatorInterface to use when sorting the column
    */
 
-  private _sortBy: ClrDatagridComparatorInterface<any>;
+  private _sortBy: ClrDatagridComparatorInterface<T>;
 
   public get sortBy() {
     return this._sortBy;
   }
 
   @Input('clrDgSortBy')
-  public set sortBy(comparator: ClrDatagridComparatorInterface<any> | string) {
+  public set sortBy(comparator: ClrDatagridComparatorInterface<T> | string) {
     if (typeof comparator === 'string') {
       this._sortBy = new DatagridPropertyComparator(comparator);
     } else {

--- a/src/clr-angular/data/datagrid/datagrid-filter.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-filter.spec.ts
@@ -17,9 +17,9 @@ import { StateDebouncer } from './providers/state-debouncer.provider';
 export default function(): void {
   describe('ClrDatagridFilter component', function() {
     describe('Typescript API', function() {
-      let filterService: FiltersProvider;
+      let filterService: FiltersProvider<number>;
       let filter: TestFilter;
-      let component: ClrDatagridFilter;
+      let component: ClrDatagridFilter<number>;
 
       beforeEach(function() {
         const stateDebouncer = new StateDebouncer();
@@ -62,7 +62,7 @@ export default function(): void {
 
     describe('Template API', function() {
       // Until we can properly type "this"
-      let context: TestContext<ClrDatagridFilter, FullTest>;
+      let context: TestContext<ClrDatagridFilter<number>, FullTest>;
       let filter: TestFilter;
 
       beforeEach(function() {
@@ -92,7 +92,7 @@ export default function(): void {
     });
 
     describe('View', function() {
-      let context: TestContext<ClrDatagridFilter, FullTest>;
+      let context: TestContext<ClrDatagridFilter<number>, FullTest>;
 
       beforeEach(function() {
         context = this.create(ClrDatagridFilter, FullTest, [FiltersProvider, Page, StateDebouncer]);
@@ -137,6 +137,6 @@ class TestFilter implements ClrDatagridFilterInterface<number> {
 class FullTest {
   @ViewChild(CustomFilter) customFilter: CustomFilter;
 
-  filter: ClrDatagridFilterInterface<any>;
+  filter: ClrDatagridFilterInterface<number>;
   open: boolean;
 }

--- a/src/clr-angular/data/datagrid/datagrid-filter.ts
+++ b/src/clr-angular/data/datagrid/datagrid-filter.ts
@@ -44,9 +44,9 @@ import { DatagridFilterRegistrar } from './utils/datagrid-filter-registrar';
         </ng-template>
     `,
 })
-export class ClrDatagridFilter extends DatagridFilterRegistrar<ClrDatagridFilterInterface<any>>
+export class ClrDatagridFilter<T = any> extends DatagridFilterRegistrar<T, ClrDatagridFilterInterface<T>>
   implements CustomFilter {
-  constructor(_filters: FiltersProvider) {
+  constructor(_filters: FiltersProvider<T>) {
     super(_filters);
   }
 
@@ -73,7 +73,7 @@ export class ClrDatagridFilter extends DatagridFilterRegistrar<ClrDatagridFilter
   @Output('clrDgFilterOpenChange') public openChanged = new EventEmitter<boolean>(false);
 
   @Input('clrDgFilter')
-  public set customFilter(filter: ClrDatagridFilterInterface<any> | RegisteredFilter<ClrDatagridFilterInterface<any>>) {
+  public set customFilter(filter: ClrDatagridFilterInterface<T> | RegisteredFilter<T, ClrDatagridFilterInterface<T>>) {
     this.setFilter(filter);
   }
 

--- a/src/clr-angular/data/datagrid/datagrid-footer.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-footer.spec.ts
@@ -30,7 +30,7 @@ const PROVIDERS_NEEDED = [
 export default function(): void {
   describe('ClrDatagridFooter component', function() {
     describe('View', function() {
-      let context: TestContext<ClrDatagridFooter, SimpleTest>;
+      let context: TestContext<ClrDatagridFooter<number>, SimpleTest>;
 
       beforeEach(function() {
         context = this.create(ClrDatagridFooter, SimpleTest, PROVIDERS_NEEDED);
@@ -45,7 +45,7 @@ export default function(): void {
       });
 
       it('does not show the selection details when selection type is None', function() {
-        const clarityDirectiveSelection: Selection = context.clarityDirective.selection;
+        const clarityDirectiveSelection = context.clarityDirective.selection;
         clarityDirectiveSelection.selectionType = SelectionType.None;
 
         context.detectChanges();
@@ -54,7 +54,7 @@ export default function(): void {
       });
 
       it('does not show the selection details when selection type is single', function() {
-        const clarityDirectiveSelection: Selection = context.clarityDirective.selection;
+        const clarityDirectiveSelection = context.clarityDirective.selection;
         clarityDirectiveSelection.selectionType = SelectionType.Single;
         clarityDirectiveSelection.current.push(1);
 
@@ -64,7 +64,7 @@ export default function(): void {
       });
 
       it('shows the selection details when more than one item is selected', function() {
-        const clarityDirectiveSelection: Selection = context.clarityDirective.selection;
+        const clarityDirectiveSelection = context.clarityDirective.selection;
         clarityDirectiveSelection.selectionType = SelectionType.Multi;
         clarityDirectiveSelection.current.push(1);
 
@@ -91,7 +91,7 @@ export default function(): void {
     });
 
     describe('View with Custom Toggle Buttons', function() {
-      let context: TestContext<ClrDatagridFooter, ColumnTogglerTest>;
+      let context: TestContext<ClrDatagridFooter<void>, ColumnTogglerTest>;
 
       beforeEach(function() {
         context = this.create(ClrDatagridFooter, ColumnTogglerTest, PROVIDERS_NEEDED);

--- a/src/clr-angular/data/datagrid/datagrid-footer.ts
+++ b/src/clr-angular/data/datagrid/datagrid-footer.ts
@@ -30,9 +30,9 @@ import { Selection, SelectionType } from './providers/selection';
     '[class.datagrid-foot]': 'true',
   },
 })
-export class ClrDatagridFooter implements OnInit {
+export class ClrDatagridFooter<T = any> implements OnInit {
   constructor(
-    public selection: Selection,
+    public selection: Selection<T>,
     public hideableColumnService: HideableColumnService,
     public cdr: ChangeDetectorRef
   ) {}

--- a/src/clr-angular/data/datagrid/datagrid-hideable-column.model.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-hideable-column.model.spec.ts
@@ -28,7 +28,7 @@ const PROVIDERS_NEEDED = [
 
 export default function(): void {
   describe('DatagridHideableColumnModel', function() {
-    let context: TestContext<ClrDatagridColumn, SimpleTest>;
+    let context: TestContext<ClrDatagridColumn<void>, SimpleTest>;
     let testDgHideableColumn: DatagridHideableColumnModel;
 
     beforeEach(function() {

--- a/src/clr-angular/data/datagrid/datagrid-hideable-column.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-hideable-column.spec.ts
@@ -29,7 +29,7 @@ const PROVIDERS_NEEDED = [
 export default function(): void {
   describe('DatagridHideableColumn directive', function() {
     describe('TypeScript API', function() {
-      let context: TestContext<ClrDatagridColumn, HideableTest>;
+      let context: TestContext<ClrDatagridColumn<void>, HideableTest>;
 
       beforeEach(function() {
         context = this.create(ClrDatagridColumn, HideableTest, PROVIDERS_NEEDED);

--- a/src/clr-angular/data/datagrid/datagrid-hideable-column.ts
+++ b/src/clr-angular/data/datagrid/datagrid-hideable-column.ts
@@ -49,7 +49,7 @@ export class ClrDatagridHideableColumn {
    *
    */
   @Input('clrDgHideableColumn')
-  set clrDgHideableColumn(value: any) {
+  set clrDgHideableColumn(value: { hidden: boolean }) {
     this._hidden = value && value.hidden ? value.hidden : false;
     if (this.dgColumn.hideable) {
       this.dgColumn.hideable.hidden = value && value.hidden ? value.hidden : false;
@@ -82,7 +82,7 @@ export class ClrDatagridHideableColumn {
   constructor(
     private templateRef: TemplateRef<any>,
     private viewContainerRef: ViewContainerRef,
-    private dgColumn: ClrDatagridColumn
+    private dgColumn: ClrDatagridColumn<any>
   ) {
     this.columnId = dgColumn.columnId;
 

--- a/src/clr-angular/data/datagrid/datagrid-items-trackby.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-items-trackby.spec.ts
@@ -38,7 +38,7 @@ export default function(): void {
 
     it('receives an input for the trackBy option', function() {
       expect(this.itemsProvider.trackBy).toBeUndefined();
-      this.testComponent.trackBy = (index: number, item: any) => index;
+      this.testComponent.trackBy = (index: number, item: number) => index;
       this.fixture.detectChanges();
       expect(this.itemsProvider.trackBy).toBe(this.testComponent.trackBy);
     });
@@ -47,9 +47,9 @@ export default function(): void {
 
 @Component({ template: `<div *ngFor="let n of numbers; trackBy: trackBy">{{n}}</div>` })
 class FullTest {
-  @ViewChild(ClrDatagridItems) datagridItems: ClrDatagridItems;
+  @ViewChild(ClrDatagridItems) datagridItems: ClrDatagridItems<number>;
 
   numbers = [1, 2, 3, 4, 5];
 
-  trackBy: (index: number, item: any) => any;
+  trackBy: (index: number, item: number) => any;
 }

--- a/src/clr-angular/data/datagrid/datagrid-items-trackby.ts
+++ b/src/clr-angular/data/datagrid/datagrid-items-trackby.ts
@@ -10,11 +10,11 @@ import { Items } from './providers/items';
 @Directive({
   selector: '[ngForTrackBy]',
 })
-export class ClrDatagridItemsTrackBy {
-  constructor(@Optional() private _items: Items) {}
+export class ClrDatagridItemsTrackBy<T = any> {
+  constructor(@Optional() private _items: Items<T>) {}
 
   @Input('ngForTrackBy')
-  set trackBy(value: TrackByFunction<Function>) {
+  set trackBy(value: TrackByFunction<T>) {
     if (this._items) {
       this._items.trackBy = value;
     }

--- a/src/clr-angular/data/datagrid/datagrid-items.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-items.spec.ts
@@ -69,7 +69,7 @@ export default function(): void {
 
     it('receives an input for the trackBy option', function() {
       expect(this.itemsProvider.trackBy).toBeUndefined();
-      this.testComponent.trackBy = (index: number, item: any) => index;
+      this.testComponent.trackBy = (index: number, item: number) => index;
       this.fixture.detectChanges();
       expect(this.itemsProvider.trackBy).toBe(this.testComponent.trackBy);
     });
@@ -78,9 +78,9 @@ export default function(): void {
 
 @Component({ template: `<div *clrDgItems="let n of numbers; trackBy: trackBy">{{n}}</div>` })
 class FullTest {
-  @ViewChild(ClrDatagridItems) datagridItems: ClrDatagridItems;
+  @ViewChild(ClrDatagridItems) datagridItems: ClrDatagridItems<number>;
 
   numbers = [1, 2, 3, 4, 5];
 
-  trackBy: (index: number, item: any) => any;
+  trackBy: (index: number, item: number) => any;
 }

--- a/src/clr-angular/data/datagrid/datagrid-items.ts
+++ b/src/clr-angular/data/datagrid/datagrid-items.ts
@@ -14,21 +14,26 @@ import {
   TemplateRef,
   TrackByFunction,
 } from '@angular/core';
+import { NgForOfContext } from '@angular/common';
 
 import { Items } from './providers/items';
 
 @Directive({
   selector: '[clrDgItems][clrDgItemsOf]',
 })
-export class ClrDatagridItems implements OnChanges, DoCheck {
-  private _rawItems: any[];
+export class ClrDatagridItems<T = any> implements OnChanges, DoCheck {
+  private _rawItems: T[];
   @Input('clrDgItemsOf')
-  public set rawItems(items: any[]) {
+  public set rawItems(items: T[]) {
     this._rawItems = items ? items : [];
   }
-  private _differ: IterableDiffer<any>;
+  private _differ: IterableDiffer<T>;
 
-  constructor(public template: TemplateRef<any>, private _differs: IterableDiffers, private _items: Items) {
+  constructor(
+    public template: TemplateRef<NgForOfContext<T>>,
+    private _differs: IterableDiffers,
+    private _items: Items<T>
+  ) {
     _items.smartenUp();
   }
 
@@ -42,7 +47,7 @@ export class ClrDatagridItems implements OnChanges, DoCheck {
   }
 
   @Input('clrDgItemsTrackBy')
-  set trackBy(value: TrackByFunction<any>) {
+  set trackBy(value: TrackByFunction<T>) {
     this._items.trackBy = value;
   }
 

--- a/src/clr-angular/data/datagrid/datagrid-placeholder.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-placeholder.spec.ts
@@ -33,8 +33,8 @@ export default function(): void {
     });
 
     describe('View', function() {
-      let context: TestContext<ClrDatagridPlaceholder, SimpleTest>;
-      let itemsProvider: Items;
+      let context: TestContext<ClrDatagridPlaceholder<void>, SimpleTest>;
+      let itemsProvider: Items<void>;
 
       beforeEach(function() {
         context = this.create(ClrDatagridPlaceholder, SimpleTest, [Items, Page, Sort, FiltersProvider, StateDebouncer]);

--- a/src/clr-angular/data/datagrid/datagrid-placeholder.ts
+++ b/src/clr-angular/data/datagrid/datagrid-placeholder.ts
@@ -18,8 +18,8 @@ import { Items } from './providers/items';
     `,
   host: { '[class.datagrid-placeholder-container]': 'true' },
 })
-export class ClrDatagridPlaceholder {
-  constructor(private items: Items) {}
+export class ClrDatagridPlaceholder<T = any> {
+  constructor(private items: Items<T>) {}
 
   /**
    * Tests if the datagrid is empty, meaning it doesn't contain any items

--- a/src/clr-angular/data/datagrid/datagrid-row-detail.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-row-detail.spec.ts
@@ -22,7 +22,7 @@ import { DatagridRenderOrganizer } from './render/render-organizer';
 
 export default function(): void {
   describe('ClrDatagridRowDetail component', function() {
-    let context: TestContext<ClrDatagridRowDetail, FullTest>;
+    let context: TestContext<ClrDatagridRowDetail<void>, FullTest>;
 
     beforeEach(function() {
       context = this.create(ClrDatagridRowDetail, FullTest, [
@@ -74,7 +74,7 @@ export default function(): void {
     });
 
     it('displays an extra empty cell when the datagrid is selectable', function() {
-      const selection: Selection = context.getClarityProvider(Selection);
+      const selection = context.getClarityProvider(Selection);
       selection.selectionType = SelectionType.Multi;
       context.detectChanges();
       expect(context.clarityElement.querySelectorAll('.datagrid-fixed-column').length).toBe(2);
@@ -90,7 +90,7 @@ export default function(): void {
     });
 
     it('displays as many extra empty cells as needed', function() {
-      const selection: Selection = context.getClarityProvider(Selection);
+      const selection = context.getClarityProvider(Selection);
       selection.selectionType = SelectionType.Multi;
       context.getClarityProvider(RowActionService).register();
       context.detectChanges();
@@ -101,7 +101,7 @@ export default function(): void {
       context.testComponent.replace = true;
       context.detectChanges();
       expect(context.clarityElement.querySelectorAll('.datagrid-fixed-column').length).toBe(0);
-      const selection: Selection = context.getClarityProvider(Selection);
+      const selection = context.getClarityProvider(Selection);
       selection.selectionType = SelectionType.Multi;
       context.getClarityProvider(RowActionService).register();
       context.detectChanges();
@@ -110,7 +110,7 @@ export default function(): void {
   });
 
   describe('ClrDatagridRowDetail hide/show cell behavior', function() {
-    let context: TestContext<ClrDatagridRowDetail, HiddenTest>;
+    let context: TestContext<ClrDatagridRowDetail<void>, HiddenTest>;
     let hideableColumnService: HideableColumnService;
 
     beforeEach(function() {

--- a/src/clr-angular/data/datagrid/datagrid-row-detail.ts
+++ b/src/clr-angular/data/datagrid/datagrid-row-detail.ts
@@ -36,12 +36,12 @@ import { Selection, SelectionType } from './providers/selection';
     '[class.datagrid-container]': 'cells.length === 0',
   },
 })
-export class ClrDatagridRowDetail implements AfterContentInit, OnDestroy {
+export class ClrDatagridRowDetail<T = any> implements AfterContentInit, OnDestroy {
   /* reference to the enum so that template can access it */
   public SELECTION_TYPE = SelectionType;
 
   constructor(
-    public selection: Selection,
+    public selection: Selection<T>,
     public rowActionService: RowActionService,
     public expand: Expand,
     public hideableColumnService: HideableColumnService

--- a/src/clr-angular/data/datagrid/datagrid-row.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-row.spec.ts
@@ -41,11 +41,13 @@ const PROVIDERS = [
   StateDebouncer,
 ];
 
+type Item = { id: number };
+
 export default function(): void {
   describe('ClrDatagridRow component', function() {
     describe('View', function() {
       // Until we can properly type "this"
-      let context: TestContext<ClrDatagridRow, FullTest>;
+      let context: TestContext<ClrDatagridRow<Item>, FullTest>;
 
       beforeEach(function() {
         context = this.create(ClrDatagridRow, FullTest, PROVIDERS);
@@ -84,8 +86,8 @@ export default function(): void {
 
     describe('Selection', function() {
       // Until we can properly type "this"
-      let context: TestContext<ClrDatagridRow, FullTest>;
-      let selectionProvider: Selection;
+      let context: TestContext<ClrDatagridRow<Item>, FullTest>;
+      let selectionProvider: Selection<Item>;
 
       beforeEach(function() {
         context = this.create(ClrDatagridRow, FullTest, PROVIDERS);
@@ -235,7 +237,7 @@ export default function(): void {
 
     describe('Expand/Collapse', function() {
       // Until we can properly type "this"
-      let context: TestContext<ClrDatagridRow, ExpandTest>;
+      let context: TestContext<ClrDatagridRow<Item>, ExpandTest>;
       let expand: Expand;
 
       beforeEach(function() {
@@ -335,7 +337,7 @@ export default function(): void {
     });
 
     describe('Hide/Show', function() {
-      let context: TestContext<ClrDatagridRow, ExpandTest>;
+      let context: TestContext<ClrDatagridRow<Item>, ExpandTest>;
       let hideableColumnService: HideableColumnService;
 
       beforeEach(function() {
@@ -362,7 +364,7 @@ export default function(): void {
 
 @Component({ template: `<clr-dg-row [clrDgItem]="item" [(clrDgSelected)]="selected">Hello world</clr-dg-row>` })
 class FullTest {
-  item: any;
+  item: Item;
   selected = false;
 }
 

--- a/src/clr-angular/data/datagrid/datagrid-row.ts
+++ b/src/clr-angular/data/datagrid/datagrid-row.ts
@@ -84,7 +84,7 @@ let nbRow: number = 0;
   },
   providers: [Expand, { provide: LoadingListener, useExisting: Expand }],
 })
-export class ClrDatagridRow implements AfterContentInit {
+export class ClrDatagridRow<T = any> implements AfterContentInit {
   public id: string;
   public radioId: string;
 
@@ -94,10 +94,10 @@ export class ClrDatagridRow implements AfterContentInit {
   /**
    * Model of the row, to use for selection
    */
-  @Input('clrDgItem') item: any;
+  @Input('clrDgItem') item: T;
 
   constructor(
-    public selection: Selection,
+    public selection: Selection<T>,
     public rowActionService: RowActionService,
     public globalExpandable: ExpandableRowsCount,
     public expand: Expand,

--- a/src/clr-angular/data/datagrid/datagrid.module.ts
+++ b/src/clr-angular/data/datagrid/datagrid.module.ts
@@ -111,7 +111,7 @@ export class ClrDatagridModule {}
 
 /* tslint:disable variable-name */
 /** @deprecated since 0.11 */
-export interface Datagrid extends ClrDatagrid {}
+export interface Datagrid extends ClrDatagrid<any> {}
 /** @deprecated since 0.11 */
 export const Datagrid = ClrDatagrid;
 /** @deprecated since 0.11 */
@@ -123,7 +123,7 @@ export interface DatagridActionOverflow extends ClrDatagridActionOverflow {}
 /** @deprecated since 0.11 */
 export const DatagridActionOverflow = ClrDatagridActionOverflow;
 /** @deprecated since 0.11 */
-export interface DatagridColumn extends ClrDatagridColumn {}
+export interface DatagridColumn extends ClrDatagridColumn<any> {}
 /** @deprecated since 0.11 */
 export const DatagridColumn = ClrDatagridColumn;
 /** @deprecated since 0.11 */
@@ -135,19 +135,19 @@ export interface DatagridHideableColumnDirective extends ClrDatagridHideableColu
 /** @deprecated since 0.11 */
 export const DatagridHideableColumnDirective = ClrDatagridHideableColumn;
 /** @deprecated since 0.11 */
-export interface DatagridFilter extends ClrDatagridFilter {}
+export interface DatagridFilter extends ClrDatagridFilter<any> {}
 /** @deprecated since 0.11 */
 export const DatagridFilter = ClrDatagridFilter;
 /** @deprecated since 0.11 */
-export interface DatagridItems extends ClrDatagridItems {}
+export interface DatagridItems extends ClrDatagridItems<any> {}
 /** @deprecated since 0.11 */
 export const DatagridItems = ClrDatagridItems;
 /** @deprecated since 0.11 */
-export interface DatagridRow extends ClrDatagridRow {}
+export interface DatagridRow extends ClrDatagridRow<any> {}
 /** @deprecated since 0.11 */
 export const DatagridRow = ClrDatagridRow;
 /** @deprecated since 0.11 */
-export interface DatagridRowDetail extends ClrDatagridRowDetail {}
+export interface DatagridRowDetail extends ClrDatagridRowDetail<any> {}
 /** @deprecated since 0.11 */
 export const DatagridRowDetail = ClrDatagridRowDetail;
 /** @deprecated since 0.11 */
@@ -155,7 +155,7 @@ export interface DatagridCell extends ClrDatagridCell {}
 /** @deprecated since 0.11 */
 export const DatagridCell = ClrDatagridCell;
 /** @deprecated since 0.11 */
-export interface DatagridFooter extends ClrDatagridFooter {}
+export interface DatagridFooter extends ClrDatagridFooter<any> {}
 /** @deprecated since 0.11 */
 export const DatagridFooter = ClrDatagridFooter;
 /** @deprecated since 0.11 */
@@ -163,7 +163,7 @@ export interface DatagridPagination extends ClrDatagridPagination {}
 /** @deprecated since 0.11 */
 export const DatagridPagination = ClrDatagridPagination;
 /** @deprecated since 0.11 */
-export interface DatagridPlaceholder extends ClrDatagridPlaceholder {}
+export interface DatagridPlaceholder extends ClrDatagridPlaceholder<any> {}
 /** @deprecated since 0.11 */
 export const DatagridPlaceholder = ClrDatagridPlaceholder;
 /** @deprecated since 0.11 */
@@ -178,7 +178,7 @@ export interface Comparator<T> extends ClrDatagridComparatorInterface<T> {}
 /** @deprecated since 0.11 */
 export interface Filter<T> extends ClrDatagridFilterInterface<T> {}
 /** @deprecated since 0.11 */
-export interface State extends ClrDatagridStateInterface {}
+export interface State extends ClrDatagridStateInterface<any> {}
 /** @deprecated since 0.11 */
 export interface StringFilter<T> extends ClrDatagridStringFilterInterface<T> {}
 /* tslint:enable variable-name */

--- a/src/clr-angular/data/datagrid/datagrid.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid.spec.ts
@@ -27,14 +27,14 @@ import { DatagridRenderOrganizer } from './render/render-organizer';
 export default function(): void {
   describe('ClrDatagrid component', function() {
     describe('Typescript API', function() {
-      let context: TestContext<ClrDatagrid, FullTest>;
+      let context: TestContext<ClrDatagrid<number>, FullTest>;
 
       beforeEach(function() {
         context = this.create(ClrDatagrid, FullTest, [HideableColumnService]);
       });
 
       it('allows to manually force a refresh of displayed items when data mutates', function() {
-        const items: Items = context.getClarityProvider(Items);
+        const items = context.getClarityProvider(Items);
         let refreshed = false;
         items.change.subscribe(() => (refreshed = true));
         expect(refreshed).toBe(false);
@@ -55,7 +55,7 @@ export default function(): void {
     });
 
     describe('Template API', function() {
-      let context: TestContext<ClrDatagrid, FullTest>;
+      let context: TestContext<ClrDatagrid<number>, FullTest>;
 
       beforeEach(function() {
         context = this.create(ClrDatagrid, FullTest, [HideableColumnService]);
@@ -69,7 +69,7 @@ export default function(): void {
       });
 
       it('offers two-way binding on the currently selected items', function() {
-        const selection: Selection = context.getClarityProvider(Selection);
+        const selection = context.getClarityProvider(Selection);
         context.testComponent.selected = [2];
         context.detectChanges();
         expect(selection.current).toEqual([2]);
@@ -79,7 +79,7 @@ export default function(): void {
       });
 
       it('allows to set pre-selected items when initializing the full list of items', function() {
-        const selection: Selection = context.getClarityProvider(Selection);
+        const selection = context.getClarityProvider(Selection);
         context.testComponent.items = [4, 5, 6];
         context.testComponent.selected = [5];
         context.detectChanges();
@@ -93,7 +93,7 @@ export default function(): void {
 
         it('emits once when the sort order changes', function() {
           context.testComponent.nbRefreshed = 0;
-          const sort: Sort = context.getClarityProvider(Sort);
+          const sort = context.getClarityProvider(Sort);
           sort.toggle(new TestComparator());
           context.detectChanges();
           expect(context.testComponent.nbRefreshed).toBe(1);
@@ -101,7 +101,7 @@ export default function(): void {
 
         it('emits once when the filters change', function() {
           context.testComponent.nbRefreshed = 0;
-          const filters: FiltersProvider = context.getClarityProvider(FiltersProvider);
+          const filters = context.getClarityProvider(FiltersProvider);
           const filter = new TestFilter();
           filters.add(filter);
           context.detectChanges();
@@ -117,7 +117,7 @@ export default function(): void {
           page.size = 2;
           page.current = 2;
           context.testComponent.nbRefreshed = 0;
-          const filters: FiltersProvider = context.getClarityProvider(FiltersProvider);
+          const filters = context.getClarityProvider(FiltersProvider);
           const filter = new TestFilter();
           filters.add(filter);
           context.detectChanges();
@@ -136,9 +136,9 @@ export default function(): void {
           context.testComponent.items = [1, 2, 3, 4, 5, 6];
           context.detectChanges();
           const comparator = new TestComparator();
-          const sort: Sort = context.getClarityProvider(Sort);
+          const sort = context.getClarityProvider(Sort);
           sort.toggle(comparator);
-          const filters: FiltersProvider = context.getClarityProvider(FiltersProvider);
+          const filters = context.getClarityProvider(FiltersProvider);
           const filter = new TestFilter();
           filters.add(filter);
           const page: Page = context.getClarityProvider(Page);
@@ -160,7 +160,7 @@ export default function(): void {
         });
 
         it('emits the correct data for all filter types', function() {
-          const filters: FiltersProvider = context.getClarityProvider(FiltersProvider);
+          const filters = context.getClarityProvider(FiltersProvider);
           const customFilter = new TestFilter();
           const testStringFilter = new DatagridStringFilterImpl(new TestStringFilter());
           testStringFilter.value = 'whatever';
@@ -197,7 +197,7 @@ export default function(): void {
     });
 
     describe('View basics', function() {
-      let context: TestContext<ClrDatagrid, FullTest>;
+      let context: TestContext<ClrDatagrid<number>, FullTest>;
 
       beforeEach(function() {
         context = this.create(ClrDatagrid, FullTest, [HideableColumnService]);
@@ -251,7 +251,7 @@ export default function(): void {
     });
 
     describe('Actionable rows', function() {
-      let context: TestContext<ClrDatagrid, ActionableRowTest>;
+      let context: TestContext<ClrDatagrid<number>, ActionableRowTest>;
       let rowActionService: RowActionService;
       let headActionOverflowCell: HTMLElement;
       let actionOverflowCell: HTMLElement[];
@@ -300,12 +300,12 @@ export default function(): void {
     });
 
     describe('Single selection', function() {
-      let context: TestContext<ClrDatagrid, SingleSelectionTest>;
-      let selection: Selection;
+      let context: TestContext<ClrDatagrid<number>, SingleSelectionTest>;
+      let selection: Selection<number>;
 
       beforeEach(function() {
         context = this.create(ClrDatagrid, SingleSelectionTest, [Selection]);
-        selection = context.getClarityProvider(Selection);
+        selection = <Selection<number>>context.getClarityProvider(Selection);
       });
 
       describe('TypeScript API', function() {
@@ -408,12 +408,12 @@ export default function(): void {
     });
 
     describe('Multi selection', function() {
-      let context: TestContext<ClrDatagrid, OnPushTest>;
-      let selection: Selection;
+      let context: TestContext<ClrDatagrid<number>, OnPushTest>;
+      let selection: Selection<number>;
 
       beforeEach(function() {
         context = this.create(ClrDatagrid, OnPushTest, [Selection], [MultiSelectionTest]);
-        selection = context.getClarityProvider(Selection);
+        selection = <Selection<number>>context.getClarityProvider(Selection);
       });
 
       describe('Template API', function() {
@@ -495,7 +495,7 @@ class FullTest {
   selected: number[];
 
   nbRefreshed = 0;
-  latestState: ClrDatagridStateInterface;
+  latestState: ClrDatagridStateInterface<number>;
 
   fakeLoad = false;
 
@@ -505,7 +505,7 @@ class FullTest {
 
   destroy = false;
 
-  refresh(state: ClrDatagridStateInterface) {
+  refresh(state: ClrDatagridStateInterface<number>) {
     this.nbRefreshed++;
     this.latestState = state;
     this.loading = this.fakeLoad;
@@ -549,7 +549,7 @@ class NgForTest {
 class TrackByTest {
   items = [1, 2, 3];
 
-  trackByIndex(index: number, item: any) {
+  trackByIndex(index: number, item: number) {
     return index;
   }
 }
@@ -563,7 +563,7 @@ class TrackByTest {
 })
 class OnPushTest {
   items = [1, 2, 3];
-  selected: any[] = [];
+  selected: number[] = [];
 }
 
 @Component({
@@ -581,8 +581,8 @@ class OnPushTest {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 class MultiSelectionTest {
-  @Input() items: any[] = [];
-  @Input() selected: any[] = [];
+  @Input() items: number[] = [];
+  @Input() selected: number[] = [];
 }
 
 @Component({
@@ -602,7 +602,7 @@ class MultiSelectionTest {
 })
 class SingleSelectionTest {
   items = [1, 2, 3];
-  selected: any;
+  selected: number;
 }
 
 @Component({

--- a/src/clr-angular/data/datagrid/datagrid.ts
+++ b/src/clr-angular/data/datagrid/datagrid.ts
@@ -54,15 +54,15 @@ import { DatagridRenderOrganizer } from './render/render-organizer';
   ],
   host: { '[class.datagrid-host]': 'true' },
 })
-export class ClrDatagrid implements AfterContentInit, AfterViewInit, OnDestroy {
+export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, OnDestroy {
   constructor(
     private columnService: HideableColumnService,
     private organizer: DatagridRenderOrganizer,
-    public items: Items,
+    public items: Items<T>,
     public expandableRows: ExpandableRowsCount,
-    public selection: Selection,
+    public selection: Selection<T>,
     public rowActionService: RowActionService,
-    private stateProvider: StateProvider
+    private stateProvider: StateProvider<T>
   ) {}
 
   /* reference to the enum so that template can access */
@@ -83,7 +83,7 @@ export class ClrDatagrid implements AfterContentInit, AfterViewInit, OnDestroy {
   /**
    * Output emitted whenever the data needs to be refreshed, based on user action or external ones
    */
-  @Output('clrDgRefresh') public refresh = new EventEmitter<ClrDatagridStateInterface>(false);
+  @Output('clrDgRefresh') public refresh = new EventEmitter<ClrDatagridStateInterface<T>>(false);
 
   /**
    * Public method to re-trigger the computation of displayed items manually
@@ -95,13 +95,13 @@ export class ClrDatagrid implements AfterContentInit, AfterViewInit, OnDestroy {
   /**
    * We grab the smart iterator from projected content
    */
-  @ContentChild(ClrDatagridItems) public iterator: ClrDatagridItems;
+  @ContentChild(ClrDatagridItems) public iterator: ClrDatagridItems<T>;
 
   /**
    * Array of all selected items
    */
   @Input('clrDgSelected')
-  set selected(value: any[]) {
+  set selected(value: T[]) {
     if (value) {
       this.selection.selectionType = SelectionType.Multi;
     } else {
@@ -110,13 +110,13 @@ export class ClrDatagrid implements AfterContentInit, AfterViewInit, OnDestroy {
     this.selection.current = value;
   }
 
-  @Output('clrDgSelectedChange') selectedChanged = new EventEmitter<any[]>(false);
+  @Output('clrDgSelectedChange') selectedChanged = new EventEmitter<T[]>(false);
 
   /**
    * Selected item in single-select mode
    */
   @Input('clrDgSingleSelected')
-  set singleSelected(value: any) {
+  set singleSelected(value: T) {
     this.selection.selectionType = SelectionType.Single;
     // the clrDgSingleSelected is updated in one of two cases:
     // 1. an explicit value is passed
@@ -128,7 +128,7 @@ export class ClrDatagrid implements AfterContentInit, AfterViewInit, OnDestroy {
     }
   }
 
-  @Output('clrDgSingleSelectedChange') singleSelectedChanged = new EventEmitter<any>(false);
+  @Output('clrDgSingleSelectedChange') singleSelectedChanged = new EventEmitter<T>(false);
 
   /**
    * Selection/Deselection on row click mode
@@ -170,12 +170,12 @@ export class ClrDatagrid implements AfterContentInit, AfterViewInit, OnDestroy {
   /**
    * Custom placeholder detection
    */
-  @ContentChild(ClrDatagridPlaceholder) public placeholder: ClrDatagridPlaceholder;
+  @ContentChild(ClrDatagridPlaceholder) public placeholder: ClrDatagridPlaceholder<T>;
 
   /**
    * Hideable Column data source / detection.
    */
-  @ContentChildren(ClrDatagridColumn) public columns: QueryList<ClrDatagridColumn>;
+  @ContentChildren(ClrDatagridColumn) public columns: QueryList<ClrDatagridColumn<T>>;
 
   /**
    * When the datagrid is user-managed without the smart iterator, we get the items displayed
@@ -183,22 +183,22 @@ export class ClrDatagrid implements AfterContentInit, AfterViewInit, OnDestroy {
    * displayed, typically for selection.
    */
 
-  @ContentChildren(ClrDatagridRow) rows: QueryList<ClrDatagridRow>;
+  @ContentChildren(ClrDatagridRow) rows: QueryList<ClrDatagridRow<T>>;
 
   ngAfterContentInit() {
     this._subscriptions.push(
       this.rows.changes.subscribe(() => {
         if (!this.items.smart) {
-          this.items.all = this.rows.map((row: ClrDatagridRow) => row.item);
+          this.items.all = this.rows.map((row: ClrDatagridRow<T>) => row.item);
         }
       })
     );
     if (!this.items.smart) {
-      this.items.all = this.rows.map((row: ClrDatagridRow) => row.item);
+      this.items.all = this.rows.map((row: ClrDatagridRow<T>) => row.item);
     }
 
     this._subscriptions.push(
-      this.columns.changes.subscribe((columns: ClrDatagridColumn[]) => {
+      this.columns.changes.subscribe((columns: ClrDatagridColumn<T>[]) => {
         this.columnService.updateColumnList(this.columns.map(col => col.hideable));
       })
     );
@@ -217,9 +217,9 @@ export class ClrDatagrid implements AfterContentInit, AfterViewInit, OnDestroy {
     this._subscriptions.push(
       this.selection.change.subscribe(s => {
         if (this.selection.selectionType === SelectionType.Single) {
-          this.singleSelectedChanged.emit(s);
+          this.singleSelectedChanged.emit(<T>s);
         } else if (this.selection.selectionType === SelectionType.Multi) {
-          this.selectedChanged.emit(s);
+          this.selectedChanged.emit(<T[]>s);
         }
       })
     );

--- a/src/clr-angular/data/datagrid/interfaces/state.interface.ts
+++ b/src/clr-angular/data/datagrid/interfaces/state.interface.ts
@@ -6,8 +6,8 @@
 import { ClrDatagridComparatorInterface } from './comparator.interface';
 import { ClrDatagridFilterInterface } from './filter.interface';
 
-export interface ClrDatagridStateInterface {
+export interface ClrDatagridStateInterface<T = any> {
   page?: { from?: number; to?: number; size?: number };
-  sort?: { by: string | ClrDatagridComparatorInterface<any>; reverse: boolean };
-  filters?: ({ property: string; value: string } | ClrDatagridFilterInterface<any>)[];
+  sort?: { by: string | ClrDatagridComparatorInterface<T>; reverse: boolean };
+  filters?: ({ property: string; value: string } | ClrDatagridFilterInterface<T>)[];
 }

--- a/src/clr-angular/data/datagrid/providers/column-toggle-buttons.service.ts
+++ b/src/clr-angular/data/datagrid/providers/column-toggle-buttons.service.ts
@@ -14,13 +14,13 @@ export class ColumnToggleButtonsService {
   buttons: TemplateRef<any> = null;
   selectAllDisabled: boolean = false;
 
-  private _okButtonClicked = new Subject<any>();
-  public get okButtonClicked(): Observable<any> {
+  private _okButtonClicked = new Subject<void>();
+  public get okButtonClicked(): Observable<void> {
     return this._okButtonClicked.asObservable();
   }
 
-  private _selectAllButtonClicked = new Subject<any>();
-  public get selectAllButtonClicked(): Observable<any> {
+  private _selectAllButtonClicked = new Subject<void>();
+  public get selectAllButtonClicked(): Observable<void> {
     return this._selectAllButtonClicked.asObservable();
   }
 

--- a/src/clr-angular/data/datagrid/providers/drag-dispatcher.ts
+++ b/src/clr-angular/data/datagrid/providers/drag-dispatcher.ts
@@ -18,9 +18,9 @@ export class DragDispatcher {
   // Extra element to be used for tracking drag movements.
   handleTrackerRef: ElementRef;
 
-  private _onDragStart: Subject<void> = new Subject<void>();
-  private _onDragMove: Subject<void> = new Subject<void>();
-  private _onDragEnd: Subject<void> = new Subject<void>();
+  private _onDragStart: Subject<any> = new Subject<any>();
+  private _onDragMove: Subject<any> = new Subject<any>();
+  private _onDragEnd: Subject<any> = new Subject<any>();
 
   get onDragStart(): Observable<any> {
     return this._onDragStart;
@@ -45,8 +45,8 @@ export class DragDispatcher {
   }
 
   customDragEvent(element: HTMLElement, startOnEvent: string, moveOnEvent: string, endOnEvent: string): Function {
-    let dragMoveListener: any;
-    let dragEndListener: any;
+    let dragMoveListener: () => void;
+    let dragEndListener: () => void;
 
     return this._renderer.listen(element, startOnEvent, (startEvent: any) => {
       this.notifyDragStart(startEvent);

--- a/src/clr-angular/data/datagrid/providers/filters.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/filters.spec.ts
@@ -62,8 +62,8 @@ export default function(): void {
 
     it('exposes an Observable that proxies all filters changes', function() {
       let nbChanges = 0;
-      let latestChanges: ClrDatagridFilterInterface<any>[];
-      this.filtersInstance.change.subscribe((changes: ClrDatagridFilterInterface<any>[]) => {
+      let latestChanges: ClrDatagridFilterInterface<number>[];
+      this.filtersInstance.change.subscribe((changes: ClrDatagridFilterInterface<number>[]) => {
         nbChanges++;
         latestChanges = changes;
       });

--- a/src/clr-angular/data/datagrid/providers/items.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/items.spec.ts
@@ -16,9 +16,11 @@ import { StateDebouncer } from './state-debouncer.provider';
 
 const ALL_ITEMS = [9, 3, 5, 8, 2, 6, 10, 7, 4, 1];
 
+type User = { name: string };
+
 export default function(): void {
   describe('Items provider', function() {
-    function setSmartItems(itemsInstance: Items) {
+    function setSmartItems(itemsInstance: Items<number> | Items<User>) {
       itemsInstance.smartenUp();
       itemsInstance.all = ALL_ITEMS;
     }
@@ -119,8 +121,8 @@ export default function(): void {
 
     it('exposes an Observable to follow items changes', function() {
       let nbChanges = 0;
-      let latestDisplayed: any[];
-      this.itemsInstance.change.subscribe((items: any[]) => {
+      let latestDisplayed: number[];
+      this.itemsInstance.change.subscribe((items: number[]) => {
         nbChanges++;
         latestDisplayed = items;
       });
@@ -200,7 +202,7 @@ class TestComparator implements ClrDatagridComparatorInterface<number> {
   }
 }
 
-class NameFilter implements ClrDatagridFilterInterface<any> {
+class NameFilter implements ClrDatagridFilterInterface<User> {
   private _search = '';
   public search(value: string) {
     this._search = value;
@@ -213,13 +215,13 @@ class NameFilter implements ClrDatagridFilterInterface<any> {
 
   changes = new Subject<string>();
 
-  accepts(user: any): boolean {
+  accepts(user: User): boolean {
     return user.name.includes(this._search);
   }
 }
 
-class NameComparator implements ClrDatagridComparatorInterface<any> {
-  compare(a: any, b: any): number {
+class NameComparator implements ClrDatagridComparatorInterface<User> {
+  compare(a: User, b: User): number {
     return a.name < b.name ? -1 : 1;
   }
 }

--- a/src/clr-angular/data/datagrid/providers/items.ts
+++ b/src/clr-angular/data/datagrid/providers/items.ts
@@ -13,8 +13,8 @@ import { Page } from './page';
 import { Sort } from './sort';
 
 @Injectable()
-export class Items {
-  constructor(private _filters: FiltersProvider, private _sort: Sort, private _page: Page) {}
+export class Items<T = any> {
+  constructor(private _filters: FiltersProvider<T>, private _sort: Sort<T>, private _page: Page) {}
 
   /**
    * Indicates if the data is currently loading
@@ -25,7 +25,7 @@ export class Items {
   /**
    * Tracking function to identify objects. Default is reference equality.
    */
-  public trackBy: TrackByFunction<any> = (index: number, item: any) => item;
+  public trackBy: TrackByFunction<T> = (index: number, item: T) => item;
 
   /**
    * Subscriptions to the other providers changes.
@@ -78,11 +78,11 @@ export class Items {
   /**
    * List of all items in the datagrid
    */
-  private _all: any[];
+  private _all: T[];
   public get all() {
     return this._all;
   }
-  public set all(items: any[]) {
+  public set all(items: T[]) {
     this._all = items;
     this.emitAllChanges(items);
     if (this.smart) {
@@ -105,13 +105,13 @@ export class Items {
   /**
    * Internal temporary step, which we preserve to avoid re-filtering or re-sorting if not necessary
    */
-  private _filtered: any[];
+  private _filtered: T[];
 
   /**
    * List of items currently displayed
    */
-  private _displayed: any[] = [];
-  public get displayed(): any[] {
+  private _displayed: T[] = [];
+  public get displayed(): T[] {
     // Ideally we could return an immutable array, but we don't have it in Clarity yet.
     return this._displayed;
   }
@@ -119,21 +119,21 @@ export class Items {
   /**
    * The Observable that lets other classes subscribe to items changes
    */
-  private _change = new Subject<any[]>();
+  private _change = new Subject<T[]>();
   private emitChange() {
     this._change.next(this.displayed);
   }
   // We do not want to expose the Subject itself, but the Observable which is read-only
-  public get change(): Observable<any[]> {
+  public get change(): Observable<T[]> {
     return this._change.asObservable();
   }
 
-  private _allChanges = new Subject<any[]>();
-  private emitAllChanges(items: any[]): void {
+  private _allChanges = new Subject<T[]>();
+  private emitAllChanges(items: T[]): void {
     this._allChanges.next(items);
   }
 
-  public get allChanges(): Observable<any[]> {
+  public get allChanges(): Observable<T[]> {
     return this._allChanges.asObservable();
   }
 

--- a/src/clr-angular/data/datagrid/providers/selection.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/selection.spec.ts
@@ -19,31 +19,29 @@ import { StateDebouncer } from './state-debouncer.provider';
 const numberSort = (a: number, b: number) => a - b;
 
 export default function(): void {
-  let selectionInstance: Selection;
-  let sortInstance: Sort;
-  let pageInstance: Page;
-  let filtersInstance: FiltersProvider;
-  let itemsInstance: Items;
   describe('Selection provider', function() {
-    beforeEach(function() {
-      const stateDebouncer = new StateDebouncer();
-      pageInstance = new Page(stateDebouncer);
-      filtersInstance = new FiltersProvider(pageInstance, stateDebouncer);
-      sortInstance = new Sort(stateDebouncer);
-      itemsInstance = new Items(filtersInstance, sortInstance, pageInstance);
-
-      selectionInstance = new Selection(itemsInstance, filtersInstance);
-    });
-
-    afterEach(function() {
-      selectionInstance.destroy();
-      itemsInstance.destroy();
-    });
-
     describe('with smart items', function() {
+      let selectionInstance: Selection<number>;
+      let sortInstance: Sort<number>;
+      let pageInstance: Page;
+      let filtersInstance: FiltersProvider<number>;
+      let itemsInstance: Items<number>;
+
       beforeEach(function() {
+        const stateDebouncer = new StateDebouncer();
+        pageInstance = new Page(stateDebouncer);
+        filtersInstance = new FiltersProvider(pageInstance, stateDebouncer);
+        sortInstance = new Sort(stateDebouncer);
+        itemsInstance = new Items(filtersInstance, sortInstance, pageInstance);
         itemsInstance.smartenUp();
         itemsInstance.all = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+        selectionInstance = new Selection(itemsInstance, filtersInstance);
+      });
+
+      afterEach(function() {
+        selectionInstance.destroy();
+        itemsInstance.destroy();
       });
 
       it('starts inactive', function() {
@@ -152,8 +150,8 @@ export default function(): void {
 
       it('exposes an Observable to follow selection changes in multi selection type', function() {
         let nbChanges = 0;
-        let currentSelection: any[];
-        selectionInstance.change.subscribe((items: any[]) => {
+        let currentSelection: number[];
+        selectionInstance.change.subscribe((items: number[]) => {
           nbChanges++;
           currentSelection = items;
         });
@@ -171,8 +169,8 @@ export default function(): void {
 
       it('exposes an Observable to follow selection changes in single selection type', function() {
         let nbChanges = 0;
-        let currentSelection: any;
-        selectionInstance.change.subscribe((items: any) => {
+        let currentSelection: number;
+        selectionInstance.change.subscribe((items: number) => {
           nbChanges++;
           currentSelection = items;
         });
@@ -213,7 +211,7 @@ export default function(): void {
 
         const evenFilter: EvenFilter = new EvenFilter();
 
-        filtersInstance.add(<ClrDatagridFilterInterface<any>>evenFilter);
+        filtersInstance.add(<ClrDatagridFilterInterface<number>>evenFilter);
 
         evenFilter.toggle();
 
@@ -278,6 +276,14 @@ export default function(): void {
     });
 
     describe('client-side selection and pagination', function() {
+      type Item = { id: number; modified?: boolean };
+
+      let selectionInstance: Selection<Item>;
+      let sortInstance: Sort<Item>;
+      let pageInstance: Page;
+      let filtersInstance: FiltersProvider<Item>;
+      let itemsInstance: Items<Item>;
+
       const items = [
         { id: 1 },
         { id: 2 },
@@ -297,7 +303,7 @@ export default function(): void {
         });
       }
 
-      function testSelectedItems(latestItems, selectedIndexes: any[]) {
+      function testSelectedItems(latestItems, selectedIndexes: number[]) {
         latestItems.forEach((item, index) => {
           const state = selectedIndexes.indexOf(index) > -1;
           expect(selectionInstance.isSelected(item)).toEqual(state);
@@ -305,9 +311,21 @@ export default function(): void {
       }
 
       beforeEach(function() {
+        const stateDebouncer = new StateDebouncer();
+        pageInstance = new Page(stateDebouncer);
+        filtersInstance = new FiltersProvider(pageInstance, stateDebouncer);
+        sortInstance = new Sort(stateDebouncer);
+        itemsInstance = new Items(filtersInstance, sortInstance, pageInstance);
         itemsInstance.smartenUp();
         itemsInstance.all = items;
         pageInstance.size = 3;
+
+        selectionInstance = new Selection(itemsInstance, filtersInstance);
+      });
+
+      afterEach(function() {
+        selectionInstance.destroy();
+        itemsInstance.destroy();
       });
 
       describe('multi-selection', function() {
@@ -367,7 +385,7 @@ export default function(): void {
 
         it('does not apply trackBy to single selection with no items', () => {
           const emptyItems = new Items(filtersInstance, sortInstance, pageInstance);
-          const selection: Selection = new Selection(emptyItems, filtersInstance);
+          const selection = new Selection(emptyItems, filtersInstance);
 
           spyOn(emptyItems, 'trackBy');
 
@@ -394,6 +412,14 @@ export default function(): void {
     });
 
     describe('server-driven selection and pagination', function() {
+      type Item = { id: number; modified?: boolean };
+
+      let selectionInstance: Selection<Item>;
+      let sortInstance: Sort<Item>;
+      let pageInstance: Page;
+      let filtersInstance: FiltersProvider<Item>;
+      let itemsInstance: Items<Item>;
+
       const itemsA = [{ id: 1 }, { id: 2 }, { id: 3 }];
       const itemsB = [{ id: 4 }, { id: 5 }, { id: 6 }];
       const itemsC = itemsA.map(item => Object.assign({ modified: true }, item));
@@ -415,6 +441,21 @@ export default function(): void {
           expect(selectionInstance.isSelected(element)).toEqual(stateC);
         });
       }
+
+      beforeEach(function() {
+        const stateDebouncer = new StateDebouncer();
+        pageInstance = new Page(stateDebouncer);
+        filtersInstance = new FiltersProvider(pageInstance, stateDebouncer);
+        sortInstance = new Sort(stateDebouncer);
+        itemsInstance = new Items(filtersInstance, sortInstance, pageInstance);
+
+        selectionInstance = new Selection(itemsInstance, filtersInstance);
+      });
+
+      afterEach(function() {
+        selectionInstance.destroy();
+        itemsInstance.destroy();
+      });
 
       describe('multi-selection', function() {
         beforeEach(function() {

--- a/src/clr-angular/data/datagrid/providers/selection.ts
+++ b/src/clr-angular/data/datagrid/providers/selection.ts
@@ -20,12 +20,12 @@ export enum SelectionType {
 }
 
 @Injectable()
-export class Selection {
+export class Selection<T = any> {
   public id: string;
-  private prevSelectionRefs: any[] = []; // Refs of selected items
-  private prevSingleSelectionRef: any; // Ref of single selected item
+  private prevSelectionRefs: T[] = []; // Refs of selected items
+  private prevSingleSelectionRef: T; // Ref of single selected item
 
-  constructor(private _items: Items, private _filters: FiltersProvider) {
+  constructor(private _items: Items<T>, private _filters: FiltersProvider<T>) {
     this.id = 'clr-dg-selection' + nbSelection++;
 
     this.subscriptions.push(
@@ -46,7 +46,7 @@ export class Selection {
 
           case SelectionType.Single: {
             let newSingle: any;
-            const trackBy: TrackByFunction<any> = this._items.trackBy;
+            const trackBy: TrackByFunction<T> = this._items.trackBy;
             let selectionUpdated: boolean = false;
 
             updatedItems.forEach((item, index) => {
@@ -174,11 +174,11 @@ export class Selection {
   /**
    * The current selection in single selection type
    */
-  private _currentSingle: any;
-  public get currentSingle(): any {
+  private _currentSingle: T;
+  public get currentSingle(): T {
     return this._currentSingle;
   }
-  public set currentSingle(value: any) {
+  public set currentSingle(value: T) {
     if (value === this._currentSingle) {
       return;
     }
@@ -197,11 +197,11 @@ export class Selection {
   /**
    * The current selection
    */
-  private _current: any[];
-  public get current(): any[] {
+  private _current: T[];
+  public get current(): T[] {
     return this._current;
   }
-  public set current(value: any[]) {
+  public set current(value: T[]) {
     this._current = value;
     this.emitChange();
     // Ignore items changes in the same change detection cycle.
@@ -213,7 +213,7 @@ export class Selection {
   /**
    * The Observable that lets other classes subscribe to selection changes
    */
-  private _change = new Subject<any[] | any>();
+  private _change = new Subject<T[] | T>();
   private emitChange() {
     if (this._selectionType === SelectionType.Single) {
       this._change.next(this.currentSingle);
@@ -222,14 +222,14 @@ export class Selection {
     }
   }
   // We do not want to expose the Subject itself, but the Observable which is read-only
-  public get change(): Observable<any[] | any> {
+  public get change(): Observable<T[] | T> {
     return this._change.asObservable();
   }
 
   /**
    * Checks if an item is currently selected
    */
-  public isSelected(item: any): boolean {
+  public isSelected(item: T): boolean {
     if (this._selectionType === SelectionType.Single) {
       return this.currentSingle === item;
     } else if (this._selectionType === SelectionType.Multi) {
@@ -241,7 +241,7 @@ export class Selection {
   /**
    * Selects an item
    */
-  private selectItem(item: any): void {
+  private selectItem(item: T): void {
     this.current.push(item);
     if (this._items.trackBy) {
       // Push selected ref onto array
@@ -264,7 +264,7 @@ export class Selection {
   /**
    * Selects or deselects an item
    */
-  public setSelected(item: any, selected: boolean) {
+  public setSelected(item: T, selected: boolean) {
     switch (this._selectionType) {
       case SelectionType.None:
         break;
@@ -293,12 +293,12 @@ export class Selection {
     if (this._selectionType !== SelectionType.Multi || !this._items.displayed) {
       return false;
     }
-    const displayedItems: any[] = this._items.displayed;
+    const displayedItems: T[] = this._items.displayed;
     const nbDisplayed = this._items.displayed.length;
     if (nbDisplayed < 1) {
       return false;
     }
-    const temp: any[] = displayedItems.filter(item => this.current.indexOf(item) > -1);
+    const temp: T[] = displayedItems.filter(item => this.current.indexOf(item) > -1);
     return temp.length === displayedItems.length;
   }
 

--- a/src/clr-angular/data/datagrid/providers/sort.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/sort.spec.ts
@@ -92,7 +92,7 @@ export default function(): void {
       let nbChanges = 0;
       let latestComparator: ClrDatagridComparatorInterface<number>;
       let latestReverse: boolean;
-      this.sortInstance.change.subscribe((sort: Sort) => {
+      this.sortInstance.change.subscribe((sort: Sort<number>) => {
         nbChanges++;
         latestComparator = sort.comparator;
         latestReverse = sort.reverse;

--- a/src/clr-angular/data/datagrid/providers/sort.ts
+++ b/src/clr-angular/data/datagrid/providers/sort.ts
@@ -11,17 +11,17 @@ import { ClrDatagridComparatorInterface } from '../interfaces/comparator.interfa
 import { StateDebouncer } from './state-debouncer.provider';
 
 @Injectable()
-export class Sort {
+export class Sort<T = any> {
   constructor(private stateDebouncer: StateDebouncer) {}
 
   /**
    * Currently active comparator
    */
-  private _comparator: ClrDatagridComparatorInterface<any>;
-  public get comparator(): ClrDatagridComparatorInterface<any> {
+  private _comparator: ClrDatagridComparatorInterface<T>;
+  public get comparator(): ClrDatagridComparatorInterface<T> {
     return this._comparator;
   }
-  public set comparator(value: ClrDatagridComparatorInterface<any>) {
+  public set comparator(value: ClrDatagridComparatorInterface<T>) {
     this.stateDebouncer.changeStart();
     this._comparator = value;
     this.emitChange();
@@ -45,12 +45,12 @@ export class Sort {
   /**
    * The Observable that lets other classes subscribe to sort changes
    */
-  private _change = new Subject<Sort>();
+  private _change = new Subject<Sort<T>>();
   private emitChange() {
     this._change.next(this);
   }
   // We do not want to expose the Subject itself, but the Observable which is read-only
-  public get change(): Observable<Sort> {
+  public get change(): Observable<Sort<T>> {
     return this._change.asObservable();
   }
 
@@ -61,7 +61,7 @@ export class Sort {
    *
    * @memberof Sort
    */
-  public toggle(sortBy: ClrDatagridComparatorInterface<any>, forceReverse?: boolean) {
+  public toggle(sortBy: ClrDatagridComparatorInterface<T>, forceReverse?: boolean) {
     this.stateDebouncer.changeStart();
     // We modify private properties directly, to batch the change event
     if (this.comparator === sortBy) {
@@ -84,7 +84,7 @@ export class Sort {
   /**
    * Compares two objects according to the current comparator
    */
-  public compare(a: any, b: any): number {
+  public compare(a: T, b: T): number {
     return (this.reverse ? -1 : 1) * this.comparator.compare(a, b);
   }
 }

--- a/src/clr-angular/data/datagrid/render/column-resizer.spec.ts
+++ b/src/clr-angular/data/datagrid/render/column-resizer.spec.ts
@@ -15,7 +15,7 @@ import { DomAdapter } from './dom-adapter';
 
 export default function(): void {
   describe('DatagridColumnResizer directive', function() {
-    let context: TestContext<ClrDatagrid, ColumnResizerTest>;
+    let context: TestContext<ClrDatagrid<number>, ColumnResizerTest>;
 
     let column1: DebugElement;
     let column2: DebugElement;

--- a/src/clr-angular/data/datagrid/render/main-renderer.spec.ts
+++ b/src/clr-angular/data/datagrid/render/main-renderer.spec.ts
@@ -18,7 +18,7 @@ import { DatagridRenderOrganizer } from './render-organizer';
 export default function(): void {
   describe('DatagridMainRenderer directive', function() {
     describe('static loading', function() {
-      let context: TestContext<DatagridMainRenderer, StaticTest>;
+      let context: TestContext<DatagridMainRenderer<number>, StaticTest>;
       let organizer: DatagridRenderOrganizer;
       let resizeSpy: jasmine.Spy;
       let computeWidthSpy: jasmine.Spy;
@@ -72,7 +72,7 @@ export default function(): void {
     });
 
     describe('dynamic loading', function() {
-      let context: TestContext<DatagridMainRenderer, DynamicTest>;
+      let context: TestContext<DatagridMainRenderer<number>, DynamicTest>;
       let resizeSpy: jasmine.Spy;
 
       beforeEach(function() {
@@ -139,7 +139,7 @@ export default function(): void {
     });
 
     describe('smart columns width', function() {
-      let context: TestContext<DatagridMainRenderer, ColumnsWidthTest>;
+      let context: TestContext<DatagridMainRenderer<number>, ColumnsWidthTest>;
       let organizer: DatagridRenderOrganizer;
 
       beforeEach(function() {
@@ -184,7 +184,7 @@ export default function(): void {
     });
 
     describe('scrollbar spy on page change', () => {
-      let context: TestContext<DatagridMainRenderer, DatagridHeightTest>;
+      let context: TestContext<DatagridMainRenderer<number>, DatagridHeightTest>;
       let page: Page;
       let organizer: DatagridRenderOrganizer;
 
@@ -219,7 +219,7 @@ export default function(): void {
     });
 
     describe('scrollbar spy on expandable rows', () => {
-      let context: TestContext<DatagridMainRenderer, DatagridScrollbarTest>;
+      let context: TestContext<DatagridMainRenderer<number>, DatagridScrollbarTest>;
       let organizer: DatagridRenderOrganizer;
 
       beforeEach(function() {

--- a/src/clr-angular/data/datagrid/render/main-renderer.ts
+++ b/src/clr-angular/data/datagrid/render/main-renderer.ts
@@ -41,10 +41,10 @@ export const domAdapterFactory = (platformId: Object) => {
   selector: 'clr-datagrid',
   providers: [{ provide: DomAdapter, useFactory: domAdapterFactory, deps: [PLATFORM_ID] }],
 })
-export class DatagridMainRenderer implements AfterContentInit, AfterViewChecked, OnDestroy {
+export class DatagridMainRenderer<T = any> implements AfterContentInit, AfterViewChecked, OnDestroy {
   constructor(
     private organizer: DatagridRenderOrganizer,
-    private items: Items,
+    private items: Items<T>,
     private page: Page,
     private domAdapter: DomAdapter,
     private el: ElementRef,

--- a/src/clr-angular/data/datagrid/utils/datagrid-filter-registrar.ts
+++ b/src/clr-angular/data/datagrid/utils/datagrid-filter-registrar.ts
@@ -7,22 +7,22 @@ import { OnDestroy } from '@angular/core';
 import { ClrDatagridFilterInterface } from '../interfaces/filter.interface';
 import { FiltersProvider, RegisteredFilter } from '../providers/filters';
 
-export abstract class DatagridFilterRegistrar<F extends ClrDatagridFilterInterface<any>> implements OnDestroy {
-  constructor(private filters: FiltersProvider) {}
+export abstract class DatagridFilterRegistrar<T, F extends ClrDatagridFilterInterface<T>> implements OnDestroy {
+  constructor(private filters: FiltersProvider<T>) {}
 
-  public registered: RegisteredFilter<F>;
+  public registered: RegisteredFilter<T, F>;
 
   public get filter(): F {
     return this.registered && this.registered.filter;
   }
 
-  public setFilter(filter: F | RegisteredFilter<F>) {
+  public setFilter(filter: F | RegisteredFilter<T, F>) {
     // If we previously had another filter, we unregister it
     this.deleteFilter();
     if (filter instanceof RegisteredFilter) {
-      this.registered = <RegisteredFilter<F>>filter;
+      this.registered = filter;
     } else if (filter) {
-      this.registered = this.filters.add(<F>filter);
+      this.registered = this.filters.add(filter);
     }
   }
 

--- a/src/dev/src/app/datagrid/server-driven/server-driven.ts
+++ b/src/dev/src/app/datagrid/server-driven/server-driven.ts
@@ -25,7 +25,7 @@ export class DatagridServerDrivenDemo {
     inventory.reset();
   }
 
-  refresh(state: ClrDatagridStateInterface) {
+  refresh(state: ClrDatagridStateInterface<User>) {
     this.loading = true;
     const filters: { [prop: string]: any[] } = {};
     if (state.filters) {

--- a/src/ks-app/src/app/containers/data/datagrid.component.ts
+++ b/src/ks-app/src/app/containers/data/datagrid.component.ts
@@ -76,39 +76,39 @@ export class KSDatagrid {
    * These exist so that the exported API from Clarity is tested when ks-app is compiled with --prod.
    */
   private aDatagrid: Datagrid;
-  private aClrDatagrid: ClrDatagrid;
+  private aClrDatagrid: ClrDatagrid<User>;
   private aDatagridActionBar: DatagridActionBar;
   private aClrDatagridActionBar: ClrDatagridActionBar;
   private aDatagridActionOverflow: DatagridActionOverflow;
   private aClrDatagridActionOverflow: ClrDatagridActionOverflow;
   private aDatagridColumn: DatagridColumn;
-  private aClrDatagridColumn: ClrDatagridColumn;
+  private aClrDatagridColumn: ClrDatagridColumn<User>;
   private aDatagridColumnToggle: DatagridColumnToggle;
   private aClrDatagridColumnToggle: ClrDatagridColumnToggle;
   private aDatagridHideableColumnDirective: DatagridHideableColumnDirective;
   private aClrDatagridHideableColumnDirective: ClrDatagridHideableColumn;
   private aDatagridFilter: DatagridFilter;
-  private aClrDatagridFilter: ClrDatagridFilter;
+  private aClrDatagridFilter: ClrDatagridFilter<User>;
   private aDatagridItems: DatagridItems;
-  private aClrDatagridItems: ClrDatagridItems;
+  private aClrDatagridItems: ClrDatagridItems<User>;
   private aDatagridRow: DatagridRow;
-  private aClrDatagridRow: ClrDatagridRow;
+  private aClrDatagridRow: ClrDatagridRow<User>;
   private aDatagridRowDetail: DatagridRowDetail;
-  private aClrDatagridRowDetail: ClrDatagridRowDetail;
+  private aClrDatagridRowDetail: ClrDatagridRowDetail<User>;
   private aDatagridCell: DatagridCell;
   private aClrDatagridCell: ClrDatagridCell;
   private aDatagridFooter: DatagridFooter;
-  private aClrDatagridFooter: ClrDatagridFooter;
+  private aClrDatagridFooter: ClrDatagridFooter<User>;
   private aDatagridPagination: DatagridPagination;
   private aClrDatagridPagination: ClrDatagridPagination;
   private aDatagridPlaceholder: DatagridPlaceholder;
-  private aClrDatagridPlaceholder: ClrDatagridPlaceholder;
+  private aClrDatagridPlaceholder: ClrDatagridPlaceholder<User>;
   private aComparator: Comparator<string>;
   private aClrDatagridComparatorInterface: ClrDatagridComparatorInterface<string>;
   private aFilter: Filter<string>;
   private aClrDatagridFilterInterface: ClrDatagridFilterInterface<string>;
   private aState: State;
-  private aClrDatagridStateInterface: ClrDatagridStateInterface;
+  private aClrDatagridStateInterface: ClrDatagridStateInterface<User>;
   private aStringFilter: StringFilter<string>;
   private aClrDatagridStringFilterInterface: ClrDatagridStringFilterInterface<string>;
   // END Clarity Data Entities


### PR DESCRIPTION
This is a pass over our datagrid code to parametrize everything that needs to by the types of items we receive. It drastically reduces the number of `any` and improves the stability of our code.

I also removed old casts that are not needed anymore since both Angular and Typescript evolved and can now guess types better.

Deprecated exports are not type parametrized, so we simply use `<any>` for them.

### I just realized this is a breaking change for people who import our Datagrid classes in Typescript to interact dynamically with them.
I will mark this as "do not merge" until I either find a solution, we decide to squeeze it into 0.12 at the last minute, or we sit on it for long enough that it can go in the next major.