### PR TITLE
[ICONS] export all shapes modules from index.ts

### DIFF
--- a/src/clr-icons/index.ts
+++ b/src/clr-icons/index.ts
@@ -28,3 +28,13 @@ if (typeof window !== 'undefined') {
 }
 
 export { clarityIcons as ClarityIcons };
+
+export * from './shapes/chart-shapes';
+export * from './shapes/commerce-shapes';
+export * from './shapes/core-shapes';
+export * from './shapes/essential-shapes';
+export * from './shapes/media-shapes';
+export * from './shapes/social-shapes';
+export * from './shapes/technology-shapes';
+export * from './shapes/text-edit-shapes';
+export * from './shapes/travel-shapes';

--- a/src/ks-app/src/app/app.component.ts
+++ b/src/ks-app/src/app/app.component.ts
@@ -5,13 +5,17 @@
  */
 import { Component } from '@angular/core';
 import { ClrIconCustomTag, ClrLoading, ClrMainContainer, IconCustomTag, Loading, MainContainer } from '@clr/angular';
-import { ClarityIcons } from '@clr/icons';
-import { ClrShapeStore } from '@clr/icons/shapes/commerce-shapes';
-import { ClrShapePin } from '@clr/icons/shapes/essential-shapes';
-import { ClrShapeHeadphones } from '@clr/icons/shapes/media-shapes';
-import { ClrShapeStar } from '@clr/icons/shapes/social-shapes';
-import { ClrShapeHelix } from '@clr/icons/shapes/technology-shapes';
-import { ClrShapeCar } from '@clr/icons/shapes/travel-shapes';
+import {
+  ClarityIcons,
+  ClrShapeBarChart,
+  ClrShapeBold,
+  ClrShapeCar,
+  ClrShapeHeadphones,
+  ClrShapeHelix,
+  ClrShapePin,
+  ClrShapeStar,
+  ClrShapeStore,
+} from '@clr/icons';
 
 @Component({ selector: 'KS-root', templateUrl: './app.component.html', styleUrls: ['./app.component.scss'] })
 export class AppComponent {
@@ -69,6 +73,8 @@ export class AppComponent {
       star: ClrShapeStar,
       car: ClrShapeCar,
       helix: ClrShapeHelix,
+      bold: ClrShapeBold,
+      'bar-chart': ClrShapeBarChart,
     });
   }
 }

--- a/src/ks-app/src/app/containers/buttons/buttons.component.html
+++ b/src/ks-app/src/app/containers/buttons/buttons.component.html
@@ -161,24 +161,60 @@
       <span class="clr-icon-title">Store</span>
     </button>
     <button class="btn">
+      <clr-icon shape="calculator"></clr-icon>
+      <span class="clr-icon-title">Calculator</span>
+    </button>
+    <button class="btn">
       <clr-icon shape="pin"></clr-icon>
       <span class="clr-icon-title">Pin</span>
+    </button>
+    <button class="btn">
+      <clr-icon shape="refresh"></clr-icon>
+      <span class="clr-icon-title">Refresh</span>
     </button>
     <button class="btn">
       <clr-icon shape="headphones"></clr-icon>
       <span class="clr-icon-title">Headphones</span>
     </button>
     <button class="btn">
+        <clr-icon shape="flag"></clr-icon>
+        <span class="clr-icon-title">Flag</span>
+      </button>
+    <button class="btn">
       <clr-icon shape="star"></clr-icon>
       <span class="clr-icon-title">Star</span>
     </button>
+    <button class="btn">
+        <clr-icon shape="map"></clr-icon>
+        <span class="clr-icon-title">Map</span>
+      </button>
     <button class="btn">
       <clr-icon shape="car"></clr-icon>
       <span class="clr-icon-title">Car</span>
     </button>
     <button class="btn">
+        <clr-icon shape="cloud-network"></clr-icon>
+        <span class="clr-icon-title">Cloud Network</span>
+      </button>
+    <button class="btn">
       <clr-icon shape="helix"></clr-icon>
       <span class="clr-icon-title">Helix</span>
+    </button>
+    <button class="btn">
+        <clr-icon shape="font-size"></clr-icon>
+        <span class="clr-icon-title">Font Size</span>
+      </button>
+    <button class="btn">
+        <clr-icon shape="bold"></clr-icon>
+        <span class="clr-icon-title">Bold</span>
+    </button>
+    <button class="btn">
+        <clr-icon shape="axis-chart"></clr-icon>
+        <span class="clr-icon-title">Axis Chart</span>
+      </button>
+    <button class="btn">
+        <clr-icon shape="bar-chart"></clr-icon>
+        <span class="clr-icon-title">Bar Chart</span>
     </button>
   </div>
 

--- a/src/ks-app/src/main.ts
+++ b/src/ks-app/src/main.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import '@clr/icons';
+
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 


### PR DESCRIPTION
This PR will allow users to import all shapes from the same source path. And this should be the recommended way to import shape modules. 

Example: 

```
import {ClrShapeCar, ClrShapeApplication, EssentialShapes } from "@clr/icons"
```

Signed-off-by: Shijir Tsogoo <stsogoo@vmware.com>