### PR TITLE
[NG] remove unneeded block styling from datagrid column toggle button

### DIFF
--- a/src/clr-angular/data/datagrid/datagrid-column-toggle-button.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-toggle-button.ts
@@ -18,7 +18,7 @@ import { ColumnToggleButtons, ColumnToggleButtonsService } from './providers/col
             <ng-content></ng-content>
         </button>
     `,
-  host: { '[class.action-right]': 'isOk()', '[style.display]': 'block' },
+  host: { '[class.action-right]': 'isOk()' },
 })
 export class ClrDatagridColumnToggleButton {
   @Input() clrType: ColumnToggleButtons;


### PR DESCRIPTION
This addresses this comment https://github.com/vmware/clarity/pull/1861/files#r196707052, and upon testing it seems this is unnecessary to have.