### PR TITLE
[CORE] feature: Adds automatic publishing to build repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,20 @@ cache:
   directories:
     - node_modules
 
-before_install:
-
 before_script:
   - npm install -g gemini@5.2.0 html-reporter@2.0.1
 
 script:
   - node scripts/travis
+
+jobs:
+  include:
+    - stage: publish
+      if: (NOT type IN (pull_request)) AND branch = master
+      before_script:
+        - npm run build
+      script:
+        - bash ./scripts/publish-build.sh
+
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ group: edge
 notifications:
   email:
   - wilkenj@vmware.com
+  - mhippely@vmware.com
   slack:
-    secure: QpSneUjWu0vm/1o1Y/+Kqaoxz8GfF47lAbe9D8K9HvySvth+DSahGxOPCJQoc2I5Dfjq+v0kH0KbEPu/4KneUCyAM3dMsaKpA45txM2QJf8CmG6mvFR2I2yAVLmRdUt2lTugqG0WUifnWxIpNjrCQMb85t27NVO77ELS11et+KTtMSlbgK2QfxOj25BQX4cXwrOo/5zJ1kHjoomuOcn82XwAhcoUXpLZrGaXT7ye0TNYgKfm7KgMV9u1R9awoyUfnTx8nC43QFVsddayqFHz6ws83jSuxoLfTNQTvBvTKWsLd+9ACCVRpAKW1SE/faSYtGkJAlqSdjHWiiDbYAs33SYUTgwN32uzQzJjs3lbyjfE6k0XiyecdpAxFxqBDXWNjSivORpBVdJVnd/KVgEnvRTdqmRlCF7S+WkeDjUaW64HOVKIO4Et0oriF3v0miWro4t6HZ50qEeD4zyMXWY+IAuGoBoKEANkkKf06Pkgu8j+H1jmnMCYXfCthUZ0Fbq9gtKzjVPgwG0KWMRlhcqUrRQfZtU2+LX8H1NIRW1U2nKcFxJREADvfdbz+8vQBd6DzPXgmrx4AEDNGJ+ZYEIlQp/AdvteNwgj2wToPQTwFI/kD5eq/u5HyXKfMEQRzAFct2AoQZERm8ZFoQigICiruEuWT6viAhx0IcbQ/g7NmgA=
-
-
+    on_pull_requests: false
+    secure: IY0IuSAWJLpuMjlC576jPkurpUu/RZI2AJRP1Bt3TQ0a1TnfQvTFkhcTZ5NMx/wAClNRQXjCUCWtQUc4G05LQ8CSQziD7ayh57W8GJOgxYbUWh++OwsV1bFPWG0dgkrxcM2+Zut1CxUSH9m3iA/T3LTYC/DSKCpNgROXW7Rbb0EoPZ9Rtw507Q3PdXcGvA7FNUqRnK1tspShGtVu7FGpdSscCuhUEvf70W/Km58LGrsmM8s0On1StRWlR7Tcyfzr4Pgdnp43We8oOb5lY2t1BPhAhxpSqloniJY2QprJUs4jQe7PcPrNJufHL5NqwjOs3J1E7M78LQccDxS3aXe8R+H92WVYDXzQ0gxfbLOmLuUZpmp52nmj3JrR4SEx3sxq2h/OPMl9Fnl22Qa6rGuYRM3qrS4ZW6+Yzj18pKE6G2ayC4HiFLa2KMRI9fZHjrc9gF0KgrfZ+ynAspJRBU0bZFuW51IcWPtXb4Vh17XB6ZSp5N3h4KlqPDTmGXKt6wCpq9DFmUrpSWaLjx/OZ7T9luXyVDYOifBQ+TqTzEjVlo0nY3qISO+qPYlRcwhDZ3mlMj7HOR6OtNtQSVnYRM59RQc4d8dxN+ss5sbKAabPDDFmwNonbuvHYTrh7BJ/vYI8uVpZipdlkErzHrNVOpzdWoZpAuWrY81Kqf/FjSOWKoA=
 services:
   - docker
 
@@ -42,21 +42,16 @@ cache:
   apt: true
   directories:
     - node_modules
-
 before_script:
   - npm install -g gemini@5.2.0 html-reporter@2.0.1
 
 script:
   - node scripts/travis
-
 jobs:
   include:
     - stage: publish
-      if: (NOT type IN (pull_request)) AND branch = master
+      if: "(NOT type IN (api, cron, pull_request)) AND branch = master"
       before_script:
         - npm run build
       script:
         - bash ./scripts/publish-build.sh
-
-
-

--- a/scripts/publish-build.sh
+++ b/scripts/publish-build.sh
@@ -14,7 +14,7 @@ declare -a repos=("clr-angular" "clr-icons" "clr-ui")
 for repo in "${repos[@]}"
 do
     # Clone build repository, error out if command fails
-    if ! git clone http://${GITHUB_OAUTH_BUILD_TOKEN}@github.com/clr-team/${repo}.git --depth 1
+    if ! git clone https://${GITHUB_OAUTH_BUILD_TOKEN}@github.com/clr-team/${repo}.git --depth 1
     then
         # Echo an informative message and redirect it to stderr
         echo "Failed to clone ${repo}" >&2

--- a/scripts/publish-build.sh
+++ b/scripts/publish-build.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+echo "Travis runs in the $(pwd) directory"
+# Set up the user for commiting and pushing.
+git config --global user.email "<mhippely@vmware.com>"
+git config --global user.name "clr-team"
+
+SHA=$(git rev-parse HEAD)
+MESSAGE=$(git log -1 --pretty=format:%s)
+
+# Clone repositories
+git clone https://${GITHUB_OAUTH_BUILD_TOKEN}@github.com/clr-team/clr-angular.git
+git clone https://${GITHUB_OAUTH_BUILD_TOKEN}@github.com/clr-team/clr-icons.git
+git clone https://${GITHUB_OAUTH_BUILD_TOKEN}@github.com/clr-team/clr-ui.git
+
+declare -a repos=("clr-angular" "clr-icons" "clr-ui")
+for repo in "${repos[@]}"
+do
+    # change to the build repo directory
+    cd "./${repo}"
+    # Delete all the files from last build
+    # A filepath to the dist folder in clraity project
+    DIST="$TRAVIS_BUILD_DIR/dist/${repo}/*"
+    # Copy all files into the build repo
+    cp -rf $DIST .
+    # Add any changes to git
+    git add -A
+    # Commit changes with a link to the vmware/clarity commit on master and its message
+    git commit -m "Clarity Build: http://github.com/vmware/clarity/commit/${SHA}\nMessage: ${MESSAGE}"
+    # Push changes up the the build repo
+    git push
+    # Go back up to
+    cd ..
+done


### PR DESCRIPTION
- This will only run on master branch.
- It published to [clr-team](https://github.com/clr-team) build repositories for each of the Clarity packages
- Automatic commit messages will include a link to the commit on master that triggered the build and the commit message.
- clr-angular has an example of the automatic commit message but its left over from testing I did on my fork so it doesn't actually link to a published commit (yet).
- the publish should not run if any of the test jobs fail

Signed-off-by: Matt Hippely <mhippely@vmware.com>