### PR TITLE
[ng] Datagrid bug fix for when selection is cleared by applying filter

### DIFF
--- a/src/clr-angular/data/datagrid/providers/selection.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/selection.spec.ts
@@ -184,6 +184,31 @@ export default function(): void {
         expect(nbChanges).toBe(3);
       });
 
+      it('does not emit selection change twice after a filter is applied', function() {
+        let nbChanges = 0;
+        let currentSelection: any;
+        selectionInstance.change.subscribe((items: any) => {
+          nbChanges++;
+          currentSelection = items;
+        });
+
+        selectionInstance.selectionType = SelectionType.Multi;
+        expect(nbChanges).toBe(1); // current is initialized to [] at this point
+
+        selectionInstance.current = [4, 2];
+        expect(nbChanges).toBe(2);
+
+        const evenFilter: EvenFilter = new EvenFilter();
+        filtersInstance.add(<ClrDatagridFilterInterface<any>>evenFilter);
+        evenFilter.toggle();
+
+        // current is set to [] because filter is applied, and nbChanges is 3.
+        // there isn't an additional change that would have been fired to
+        // update current selection given the new data set post filter.
+        expect(selectionInstance.current.length).toBe(0);
+        expect(nbChanges).toBe(3);
+      });
+
       it('clears selection when a filter is added', function() {
         selectionInstance.selectionType = SelectionType.Multi;
         selectionInstance.current = [4, 2];


### PR DESCRIPTION
The datagrid clears the current selection to empty array when filter is applied and we have a separate ticket (https://github.com/vmware/clarity/issues/2342) to preserve selection when filter is applied. 

My code was not accounting for this fact, and was trying to re-select the previous selections when data is refreshed in the case where filter is applied as well. This results in having inaccurate current selection data post-filter, since `prevSelectionRefs` still contained refs for selection even though current is cleared.

Signed-off-by: Jeeyun Lim <jeeyun.lim@gmail.com>