### PR TITLE
[NG] fix layout to not use Object.values since its not ie11 supported

### DIFF
--- a/src/clr-angular/forms/common/layout.ts
+++ b/src/clr-angular/forms/common/layout.ts
@@ -19,8 +19,8 @@ export class ClrLayout implements OnInit {
   constructor(public layoutService: LayoutService) {}
 
   ngOnInit() {
-    // Only set the layout if it is a valid option from our enum
-    if (this.layout && Object.values(Layouts).includes(this.layout)) {
+    // Only set the layout if it is a valid option
+    if (this.layout && this.layoutService.isValid(this.layout)) {
       this.layoutService.layout = this.layout;
     }
   }

--- a/src/clr-angular/forms/common/providers/layout.service.spec.ts
+++ b/src/clr-angular/forms/common/providers/layout.service.spec.ts
@@ -29,5 +29,12 @@ export default function(): void {
       service.layout = Layouts.HORIZONTAL;
       expect(service.layoutClass).toEqual('clr-form-horizontal');
     });
+
+    it('can validate layouts by string value', () => {
+      expect(service.isValid('vertical')).toBeTrue();
+      expect(service.isValid('horizontal')).toBeTrue();
+      expect(service.isValid('compact')).toBeTrue();
+      expect(service.isValid('asdf')).toBeFalse();
+    });
   });
 }

--- a/src/clr-angular/forms/common/providers/layout.service.ts
+++ b/src/clr-angular/forms/common/providers/layout.service.ts
@@ -15,12 +15,20 @@ export enum Layouts {
 @Injectable()
 export class LayoutService {
   layout: Layouts = Layouts.VERTICAL;
+  // This is basically a replacement for Object.values(), which IE11 and Node <9 don't support :(
+  // String enums cannot be reverse-mapped, meaning Layouts['COMPACT'] does not return 'compact' so
+  // this exists to deal with this little caveat to get the list of the values as an array.
+  private layoutValues: string[] = Object.keys(Layouts).map(key => Layouts[key]);
 
-  isVertical() {
+  isVertical(): boolean {
     return this.layout === Layouts.VERTICAL;
   }
 
   get layoutClass(): string {
     return `clr-form-${this.layout}`;
+  }
+
+  isValid(layout: string): boolean {
+    return this.layoutValues.indexOf(layout) > -1;
   }
 }


### PR DESCRIPTION
This is basically a polyfill for Object.values(), which IE11 and Node <9 don't support :(

String enums cannot be reverse-mapped, meaning Layouts['COMPACT'] does not return 'compact' so this exists to deal with this little caveat to get the list of the values of a string enum.

Source: https://github.com/tc39/proposal-object-values-entries/blob/master/polyfill.js