### PR TITLE
[UI] Alerts overflow bug fix

### DIFF
--- a/src/clr-angular/emphasis/alert/_alert.clarity.scss
+++ b/src/clr-angular/emphasis/alert/_alert.clarity.scss
@@ -32,6 +32,7 @@
 
   .alert-icon-wrapper {
     flex: 0 0 $alertIconWidth;
+    align-self: start;
     padding-top: $clr-rem-1px;
     height: 0.75rem;
   }
@@ -193,7 +194,6 @@
     margin: 0;
     border: none;
     border-radius: 0;
-    max-height: 4rem;
     overflow-y: auto;
 
     @include generateAlertType(app-info);
@@ -236,7 +236,11 @@
 
     .alert-item > span,
     .alert-text {
-      flex: 0 0 auto;
+      flex: 0 1 auto;
+    }
+
+    .alert-icon-wrapper {
+      margin-top: 0.125rem;
     }
 
     .close {


### PR DESCRIPTION
Fixes: #2338

Before:
![image](https://user-images.githubusercontent.com/1426805/42110257-6d52d13c-7bae-11e8-890f-b69af06be153.png)

After:
![image](https://user-images.githubusercontent.com/1426805/42110238-60416d50-7bae-11e8-84b3-bb3c97797db9.png)

Note: This PR removes the `max-height` restriction from alerts. The reasoning behind this being that the user can add a max-height if required but we by default shouldn't clip/scroll important content that the app level alert is supposed to display.

cc: @reddolan 

Tested on Chrome

Signed-off-by: Aditya Bhandari <adityab@vmware.com>