### PR TITLE
Schematic fix for webcomponents script ordering and monorepo support

### DIFF
--- a/src/schematics/src/add/index.ts
+++ b/src/schematics/src/add/index.ts
@@ -150,7 +150,8 @@ export default function(options: ComponentOptions): Rule {
           scripts.push(pathPrefix + 'node_modules/@clr/icons/clr-icons.min.js');
         }
         if (scriptsSearch.search('node_modules/@webcomponents/custom-elements/custom-elements.min.js') < 0) {
-          scripts.push(pathPrefix + 'node_modules/@webcomponents/custom-elements/custom-elements.min.js');
+          // Want this first
+          scripts.unshift(pathPrefix + 'node_modules/@webcomponents/custom-elements/custom-elements.min.js');
         }
       });
     } else {

--- a/src/schematics/src/add/schema.d.ts
+++ b/src/schematics/src/add/schema.d.ts
@@ -1,6 +1,4 @@
 export interface Schema {
-  sourceDir?: string;
-  appRoot?: string;
-  module?: string;
-  directory?: string;
+  project: string;
+  module: string;
 }

--- a/src/schematics/src/add/schema.json
+++ b/src/schematics/src/add/schema.json
@@ -4,31 +4,15 @@
   "title": "Clarity Add Options Schema",
   "type": "object",
   "properties": {
-    "sourceDir": {
+    "project": {
       "type": "string",
-      "format": "path",
-      "description": "The path of the source directory.",
-      "default": "src",
-      "alias": "sd",
-      "visible": false
-    },
-    "appRoot": {
-      "type": "string",
-      "format": "path",
-      "default": "app",
-      "description": "The root of the application.",
-      "visible": false
-    },
-    "directory": {
-      "type": "string",
-      "format": "path",
-      "description": "The directory the app resides in"
+      "description": "The project to add Clarity to."
     },
     "module": {
       "type": "string",
-      "description": "Allows specification of the declaring module.",
+      "description": "The module file to add Clarity to, should be relative to project source directory.",
       "alias": "m",
-      "default": "app.module"
+      "default": "app/app.module.ts"
     }
   }
 }


### PR DESCRIPTION
This brings support for a mono-repo with schematics by declaring the `--project` flag. Originally it only would install into the main app module, now it can _optionally_ target a different project.

This fixes a bug where webcomponents polyfill was after the icons script.

Closes #2406 #2410 