### PR TITLE
[NG] Fix tooltip visibility issue on trigger focus

### DIFF
--- a/src/clr-angular/forms/common/layout.ts
+++ b/src/clr-angular/forms/common/layout.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { AfterContentInit, Directive, ElementRef, Input, OnInit, Renderer2 } from '@angular/core';
+import { Directive, Input, OnInit } from '@angular/core';
 import { Layouts, LayoutService } from './providers/layout.service';
 
 @Directive({

--- a/src/clr-angular/popover/tooltip/_tooltips.clarity.scss
+++ b/src/clr-angular/popover/tooltip/_tooltips.clarity.scss
@@ -204,4 +204,12 @@
       pointer-events: none;
     }
   }
+
+  //Angular component with current structure focuses on the tooltip trigger
+  //whereas the static component host is focused on as its normally a link with an icon in it.
+  //Tooltip is due for a refactor but as of now this fix solves the immediate accessibility bug that
+  //the tooltip component faces.
+  .tooltip-trigger:focus + .tooltip-content {
+    visibility: visible;
+  }
 }

--- a/src/clr-angular/popover/tooltip/tooltip-trigger.ts
+++ b/src/clr-angular/popover/tooltip/tooltip-trigger.ts
@@ -6,7 +6,7 @@
 import { Directive, HostListener } from '@angular/core';
 import { IfOpenService } from '../../utils/conditional/if-open.service';
 
-@Directive({ selector: '[clrTooltipTrigger]', host: { '[attr.tabindex]': '0' } })
+@Directive({ selector: '[clrTooltipTrigger]', host: { '[attr.tabindex]': '0', '[class.tooltip-trigger]': 'true' } })
 export class ClrTooltipTrigger {
   constructor(private ifOpenService: IfOpenService) {}
 


### PR DESCRIPTION
Fixes: #1927

This is not the perfect solution for this issue but we need to refactor the Angular component. Before refactoring the Angular component, we also need to solidify the tooltip design guidelines. As of now, we recommend tooltips to be used only on actionable icons but UX is looking in other valid use cases too. Until we can finalize that, this PR fixes but it solves the high priority accessibility bug.

Before:
![image](https://user-images.githubusercontent.com/1426805/42182557-909e9a26-7e0c-11e8-80cf-6d75412ec988.png)

![image](https://user-images.githubusercontent.com/1426805/42182569-9de1e0e4-7e0c-11e8-938d-62acca7e7f55.png)


After:
![image](https://user-images.githubusercontent.com/1426805/42182526-76461ec4-7e0c-11e8-98dd-7f948e57a12b.png)


Signed-off-by: Aditya Bhandari <adityab@vmware.com>