### PR TITLE
[NG] fix import paths for dev app

### DIFF
--- a/src/dev/src/app/alert/alert.demo.routing.ts
+++ b/src/dev/src/app/alert/alert.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { AlertsDemo } from './alert.demo';

--- a/src/dev/src/app/badges/badges.demo.routing.ts
+++ b/src/dev/src/app/badges/badges.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { BadgeColorsDemo } from './badge-colors';

--- a/src/dev/src/app/button-group/button-group.demo.routing.ts
+++ b/src/dev/src/app/button-group/button-group.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { BasicButtonGroupDemo } from './angular/basic-structure/basic-button-group';

--- a/src/dev/src/app/buttons/buttons.demo.routing.ts
+++ b/src/dev/src/app/buttons/buttons.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { ButtonLoadingDemo } from './button-loading';

--- a/src/dev/src/app/card/card.demo.routing.ts
+++ b/src/dev/src/app/card/card.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { CardClickableDemo } from './card-clickable';

--- a/src/dev/src/app/checkboxes/checkboxes.demo.routing.ts
+++ b/src/dev/src/app/checkboxes/checkboxes.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { CheckboxesDemo } from './checkboxes.demo';

--- a/src/dev/src/app/color/color.demo.routing.ts
+++ b/src/dev/src/app/color/color.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { ColorContrastDemo } from './color-contrast';

--- a/src/dev/src/app/datagrid/datagrid.demo.routing.ts
+++ b/src/dev/src/app/datagrid/datagrid.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { DatagridBasicStructureDemo } from './basic-structure/basic-structure';

--- a/src/dev/src/app/dropdown/dropdown.demo.routing.ts
+++ b/src/dev/src/app/dropdown/dropdown.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { DropdownAngularCloseItemFalseDemo } from './dropdown-angular-close-item-false';

--- a/src/dev/src/app/forms-deprecated/forms.demo.routing.ts
+++ b/src/dev/src/app/forms-deprecated/forms.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { FormCompactDemo } from './compact-forms/form-compact';

--- a/src/dev/src/app/grid-deprecated/grid.demo.routing.ts
+++ b/src/dev/src/app/grid-deprecated/grid.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { GridAutoLayout1Demo } from './grid-auto-layout-1';

--- a/src/dev/src/app/iconography/iconography.demo.routing.ts
+++ b/src/dev/src/app/iconography/iconography.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { IconColorsDemo } from './icon-colors';

--- a/src/dev/src/app/images/images.demo.routing.ts
+++ b/src/dev/src/app/images/images.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { ImagesDemo } from './images.demo';

--- a/src/dev/src/app/input-fields/input-fields.demo.routing.ts
+++ b/src/dev/src/app/input-fields/input-fields.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { InputFieldsDemo } from './input-fields.demo';

--- a/src/dev/src/app/input/input.demo.routing.ts
+++ b/src/dev/src/app/input/input.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { InputDemo } from './input.demo';

--- a/src/dev/src/app/labels/labels.demo.routing.ts
+++ b/src/dev/src/app/labels/labels.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { LabelsClickableDemo } from './labels-clickable';

--- a/src/dev/src/app/layout/layout.demo.routing.ts
+++ b/src/dev/src/app/layout/layout.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { LayoutAdditionalSectionsDemo } from './layout-additional-sections';

--- a/src/dev/src/app/lists/lists.demo.routing.ts
+++ b/src/dev/src/app/lists/lists.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { ListsCompactDemo } from './lists-compact';

--- a/src/dev/src/app/login/login.demo.routing.ts
+++ b/src/dev/src/app/login/login.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { LoginDemo } from './login.demo';

--- a/src/dev/src/app/modal/modal.demo.routing.ts
+++ b/src/dev/src/app/modal/modal.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { ModalAngularNotClosableDemo } from './modal-angular-not-closable';

--- a/src/dev/src/app/nav/nav.demo.routing.ts
+++ b/src/dev/src/app/nav/nav.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { HeaderColorsDemo } from './header-colors';

--- a/src/dev/src/app/popovers/popovers.demo.routing.ts
+++ b/src/dev/src/app/popovers/popovers.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { PopoversDemo } from './popovers.demo';

--- a/src/dev/src/app/progress-bars/progress-bars.demo.routing.ts
+++ b/src/dev/src/app/progress-bars/progress-bars.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { OldProgressBarCardsDemo } from './old-progress-bar-cards';

--- a/src/dev/src/app/radios/radios.demo.routing.ts
+++ b/src/dev/src/app/radios/radios.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { RadiosDemo } from './radios.demo';

--- a/src/dev/src/app/selects/selects.demo.routing.ts
+++ b/src/dev/src/app/selects/selects.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { SelectsDemo } from './selects.demo';

--- a/src/dev/src/app/signpost/signpost.routing.ts
+++ b/src/dev/src/app/signpost/signpost.routing.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { SignpostDemo } from './signpost.demo';

--- a/src/dev/src/app/spinners/spinners.demo.routing.ts
+++ b/src/dev/src/app/spinners/spinners.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { SpinnerSizesDemo } from './spinner-sizes';

--- a/src/dev/src/app/stack-view/stack-view.demo.routing.ts
+++ b/src/dev/src/app/stack-view/stack-view.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { StackViewAngularBasicDemo } from './stack-view-angular-basic';

--- a/src/dev/src/app/tables/tables.demo.routing.ts
+++ b/src/dev/src/app/tables/tables.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { TablesBasicDemo } from './tables-basic';

--- a/src/dev/src/app/tabs/tabs.demo.routing.ts
+++ b/src/dev/src/app/tabs/tabs.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { TabsAngularDemo } from './tabs-angular';

--- a/src/dev/src/app/toggles/toggles.demo.routing.ts
+++ b/src/dev/src/app/toggles/toggles.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { TogglesDemo } from './toggles.demo';

--- a/src/dev/src/app/tooltips/tooltips.demo.routing.ts
+++ b/src/dev/src/app/tooltips/tooltips.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { TooltipsAngularDemo } from './tooltips-angular';

--- a/src/dev/src/app/tree-view/tree-view.demo.routing.ts
+++ b/src/dev/src/app/tree-view/tree-view.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { BasicSelectionTreeDemo } from './basic-selection-tree/basic-selection-tree';

--- a/src/dev/src/app/typography/typography.demo.routing.ts
+++ b/src/dev/src/app/typography/typography.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { TypographyFontCharTestDemo } from './typography-font-char-test';

--- a/src/dev/src/app/vertical-nav/vertical-nav.demo.routing.ts
+++ b/src/dev/src/app/vertical-nav/vertical-nav.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { VerticalNavAllCases } from './all-cases/vertical-all-cases.demo';

--- a/src/dev/src/app/virtual-scroll/virtual-scroll.demo.routing.ts
+++ b/src/dev/src/app/virtual-scroll/virtual-scroll.demo.routing.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
+import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { VirtualScrollArrayDemo } from './virtual-scroll-array';


### PR DESCRIPTION
The import paths for ModuleWithProviders was wrong for many of the dev app demos, this fixes that.