### PR TITLE
[ng] Bug fix on spinner button to work with [disabled] input (#2375)

### DIFF
--- a/src/clr-angular/button/button-loading/loading-button.spec.ts
+++ b/src/clr-angular/button/button-loading/loading-button.spec.ts
@@ -45,9 +45,79 @@ describe('Loading Buttons', () => {
       fixture.detectChanges();
       expect(fixture.componentInstance.buttonState).toEqual(ClrLoadingState.SUCCESS);
 
-      tick(2000);
+      tick(1000);
       fixture.detectChanges();
       expect(fixture.componentInstance.buttonState).toEqual(ClrLoadingState.DEFAULT);
+    })
+  );
+
+  it(
+    'sets the disabled state back to value defined in disabled input',
+    fakeAsync(() => {
+      fixture.componentInstance.disabled = true;
+      fixture.detectChanges();
+
+      fixture.componentInstance.buttonState = ClrLoadingState.LOADING;
+      fixture.detectChanges();
+      expect(fixture.componentInstance.buttonState).toEqual(ClrLoadingState.LOADING);
+      expect(fixture.componentInstance.loadingButtonInstance.el.nativeElement.attributes['disabled']).toBeTruthy();
+
+      fixture.componentInstance.buttonState = ClrLoadingState.SUCCESS;
+      fixture.detectChanges();
+      expect(fixture.componentInstance.buttonState).toEqual(ClrLoadingState.SUCCESS);
+      expect(fixture.componentInstance.loadingButtonInstance.el.nativeElement.attributes['disabled']).toBeTruthy();
+
+      tick(1000);
+      fixture.detectChanges();
+      expect(fixture.componentInstance.buttonState).toEqual(ClrLoadingState.DEFAULT);
+      expect(fixture.componentInstance.loadingButtonInstance.el.nativeElement.attributes['disabled']).toBeTruthy();
+
+      // now the input binding sets the disabled to false
+      // it should be disabled while loading, and success, but change back to not disabled when it goes back to DEFAULT
+      fixture.componentInstance.disabled = false;
+      fixture.detectChanges();
+
+      fixture.componentInstance.buttonState = ClrLoadingState.LOADING;
+      fixture.detectChanges();
+      expect(fixture.componentInstance.buttonState).toEqual(ClrLoadingState.LOADING);
+      expect(fixture.componentInstance.loadingButtonInstance.el.nativeElement.attributes['disabled']).toBeTruthy();
+
+      fixture.componentInstance.buttonState = ClrLoadingState.SUCCESS;
+      fixture.detectChanges();
+      expect(fixture.componentInstance.buttonState).toEqual(ClrLoadingState.SUCCESS);
+      expect(fixture.componentInstance.loadingButtonInstance.el.nativeElement.attributes['disabled']).toBeTruthy();
+
+      tick(1000);
+      fixture.detectChanges();
+      expect(fixture.componentInstance.buttonState).toEqual(ClrLoadingState.DEFAULT);
+      expect(fixture.componentInstance.loadingButtonInstance.el.nativeElement.attributes['disabled']).toBeFalsy();
+    })
+  );
+
+  it(
+    'sets an explicit width value of the button when [(clrButtonState)] value is set to LOADING or SUCCESS',
+    fakeAsync(() => {
+      let style = fixture.componentInstance.loadingButtonInstance.el.nativeElement.attributes.style;
+      expect(style).toBeFalsy();
+
+      fixture.componentInstance.buttonState = ClrLoadingState.LOADING;
+      fixture.detectChanges();
+      style = fixture.componentInstance.loadingButtonInstance.el.nativeElement.attributes.style;
+      expect(style).toBeTruthy();
+      expect(style.value).toMatch(/width:*/);
+
+      fixture.componentInstance.buttonState = ClrLoadingState.SUCCESS;
+      fixture.detectChanges();
+      style = fixture.componentInstance.loadingButtonInstance.el.nativeElement.attributes.style;
+      expect(style).toBeTruthy();
+      expect(style.value).toMatch(/width:*/);
+
+      tick(1000);
+      fixture.detectChanges();
+      expect(fixture.componentInstance.buttonState).toEqual(ClrLoadingState.DEFAULT);
+      style = fixture.componentInstance.loadingButtonInstance.el.nativeElement.attributes.style;
+      // here, we check to see if style.value is falsy instead of style, because even though the style is cleared the attribute remains
+      expect(style.value).toBeFalsy();
     })
   );
 
@@ -60,11 +130,12 @@ describe('Loading Buttons', () => {
 
 @Component({
   template: `
-        <button [(clrLoading)]="buttonState" id="testBtn">Test 1</button>
+        <button [(clrLoading)]="buttonState" id="testBtn" [disabled]="disabled">Test 1</button>
     `,
 })
 class TestLoadingButtonComponent {
   @ViewChild(ClrLoadingButton) loadingButtonInstance: ClrLoadingButton;
 
   buttonState: ClrLoadingState = ClrLoadingState.DEFAULT;
+  disabled: boolean = false;
 }

--- a/src/dev/src/app/buttons/button-loading.html
+++ b/src/dev/src/app/buttons/button-loading.html
@@ -9,6 +9,11 @@
 <button [clrLoading]="validateState" class="btn btn-primary" (click)="validateDemo()">Validate</button>
 <button [clrLoading]="submitState" type="submit" class="btn btn-success-outline" (click)="submitDemo()">Submit</button>
 
+<h4>Loading Buttons with Disabled Input</h4>
+<button [clrLoading]="disabledState" [disabled]="disabledStateDisabled" type="submit" class="btn btn-primary" (click)="disabledDemo()">Disable After Success</button>
+<button [clrLoading]="enabledState" [disabled]="enabledStateDisabled" type="submit" class="btn btn-primary" (click)="enabledDemo()">Enable After Success</button>
+
+
 <h4>Small Loading Buttons</h4>
 <button [clrLoading]="validateSmState" class="btn btn-sm btn-info-outline" (click)="validateSmDemo()">Validate</button>
 <button [clrLoading]="submitSmState" type="submit" class="btn btn-sm btn-success-outline" (click)="submitSmDemo()">Submit</button>

--- a/src/dev/src/app/buttons/button-loading.ts
+++ b/src/dev/src/app/buttons/button-loading.ts
@@ -14,9 +14,30 @@ import { ClrLoadingState } from '@clr/angular';
 export class ButtonLoadingDemo {
   public validateState: ClrLoadingState = ClrLoadingState.DEFAULT;
   public submitState: ClrLoadingState = ClrLoadingState.DEFAULT;
+  public disabledState: ClrLoadingState = ClrLoadingState.DEFAULT;
+  public enabledState: ClrLoadingState = ClrLoadingState.DEFAULT;
+  public disabledStateDisabled: boolean = false;
+  public enabledStateDisabled: boolean = false;
+
   public validateSmState: boolean = false;
   public submitSmState: ClrLoadingState = ClrLoadingState.DEFAULT;
   public validateFalsyState: any;
+
+  disabledDemo() {
+    this.disabledState = ClrLoadingState.LOADING;
+    setTimeout(() => {
+      this.disabledState = ClrLoadingState.SUCCESS;
+      this.disabledStateDisabled = true;
+    }, 1500);
+  }
+
+  enabledDemo() {
+    this.enabledState = ClrLoadingState.LOADING;
+    setTimeout(() => {
+      this.enabledState = ClrLoadingState.SUCCESS;
+      this.enabledStateDisabled = false;
+    }, 1500);
+  }
 
   validateDemo() {
     this.validateState = ClrLoadingState.LOADING;


### PR DESCRIPTION
- Now spinner button respects the [disabled] input after state change
- Using `getBoundingClientRect` instead of `getComputedStyle` to set the width of the button

Signed-off-by: Jeeyun Lim <jeeyun.lim@gmail.com>