### PR TITLE
[NG] StackView Accessibility Bug Fixes

### DIFF
--- a/src/clr-angular/data/datagrid/providers/selection.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/selection.spec.ts
@@ -186,10 +186,8 @@ export default function(): void {
 
       it('does not emit selection change twice after a filter is applied', function() {
         let nbChanges = 0;
-        let currentSelection: any;
         selectionInstance.change.subscribe((items: any) => {
           nbChanges++;
-          currentSelection = items;
         });
 
         selectionInstance.selectionType = SelectionType.Multi;

--- a/src/clr-angular/data/stack-view/_stack-view.clarity.scss
+++ b/src/clr-angular/data/stack-view/_stack-view.clarity.scss
@@ -90,6 +90,10 @@
       }
     }
 
+    .stack-block-label {
+      outline: none;
+    }
+
     .stack-block-label,
     .stack-block-content {
       padding: 0.25rem 0.5rem;
@@ -118,6 +122,14 @@
         margin: (0.25rem + $clr-rem-1px) 0.25rem 0 0;
         text-align: center;
       }
+    }
+
+    .stack-block-caret {
+      height: 0.5rem;
+      width: 0.5rem;
+      margin-right: 0.125rem;
+
+      fill: $clr-stack-view-stack-block-caret-color;
     }
 
     .stack-block-content {
@@ -171,6 +183,7 @@
         transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out;
       }
 
+      &.on-focus:not(.stack-block-expanded),
       &:hover:not(.stack-block-expanded) {
         > .stack-block-label,
         > .stack-block-content {
@@ -251,6 +264,22 @@
     .modal & {
       height: 55vh;
       margin-bottom: 0;
+    }
+  }
+
+  //Disable the generated icon without a breaking change for the stackview static markup
+  //Only targets the Angular component as of now. Static will require a breaking change.
+  .stack-view {
+    clr-stack-block.stack-block-expandable {
+      .stack-block-label::before {
+        content: none;
+      }
+    }
+
+    .stack-children clr-stack-block {
+      .stack-block-label {
+        padding-left: 1.5rem;
+      }
     }
   }
 }

--- a/src/clr-angular/data/stack-view/_variables.stack-view.scss
+++ b/src/clr-angular/data/stack-view/_variables.stack-view.scss
@@ -17,4 +17,5 @@ $clr-stack-view-stack-block-expanded-bg-color: $clr-global-selection-color;
 $clr-stack-view-stack-block-expandable-hover: $gray-light;
 $clr-stack-view-stack-block-content-text-color: inherit;
 $clr-stack-view-stack-block-expanded-text-color: $clr-black;
+$clr-stack-view-stack-block-caret-color: $gray-dark-midtone;
 $styledInputs: inputs('text', 'password', 'number', 'email', 'url', 'tel', 'date', 'time', 'datetime-local');

--- a/src/clr-angular/data/stack-view/stack-block.spec.ts
+++ b/src/clr-angular/data/stack-view/stack-block.spec.ts
@@ -110,6 +110,96 @@ export default function(): void {
       expect(getBlockInstance(fixture).expandable).toBeTruthy();
     });
 
+    it('displays a caret when the stack block is expandable', () => {
+      fixture = TestBed.createComponent(DynamicBlock);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('.stack-block-caret')).not.toBeNull();
+
+      getBlockInstance(fixture).expandable = false;
+
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('.stack-block-caret')).toBeNull();
+    });
+
+    it('toggles the caret direction based on the expandable property', () => {
+      fixture = TestBed.createComponent(DynamicBlock);
+      fixture.detectChanges();
+
+      const caret: HTMLElement = fixture.nativeElement.querySelector('.stack-block-caret');
+
+      expect(caret.getAttribute('dir')).toBe('right');
+
+      getBlockInstance(fixture).expanded = true;
+
+      fixture.detectChanges();
+
+      expect(caret.getAttribute('dir')).toBe('down');
+    });
+
+    it('adds the on-focus class when the stack label is focused in an expandable but collapsed stack block', () => {
+      fixture = TestBed.createComponent(DynamicBlock);
+      fixture.detectChanges();
+
+      const block: HTMLElement = fixture.nativeElement.querySelector('clr-stack-block');
+      const label: HTMLElement = fixture.nativeElement.querySelector('.stack-block-label');
+
+      expect(block.classList.contains('on-focus')).toBe(false);
+
+      label.focus();
+      fixture.detectChanges();
+
+      expect(block.classList.contains('on-focus')).toBe(true);
+
+      label.blur();
+      fixture.detectChanges();
+
+      expect(block.classList.contains('on-focus')).toBe(false);
+    });
+
+    it('does not add the on-focus class when the stack block is not expandable', () => {
+      fixture = TestBed.createComponent(DynamicBlock);
+      fixture.detectChanges();
+
+      getBlockInstance(fixture).expandable = false;
+      fixture.detectChanges();
+
+      const block: HTMLElement = fixture.nativeElement.querySelector('clr-stack-block');
+      const label: HTMLElement = fixture.nativeElement.querySelector('.stack-block-label');
+
+      expect(block.classList.contains('on-focus')).toBe(false);
+
+      label.focus();
+      fixture.detectChanges();
+
+      expect(block.classList.contains('on-focus')).toBe(false);
+    });
+
+    it('adds a button role on a stack label in an expandable stack block', () => {
+      fixture = TestBed.createComponent(DynamicBlock);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('.stack-block-label').getAttribute('role')).toBe('button');
+
+      getBlockInstance(fixture).expandable = false;
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('.stack-block-label').getAttribute('role')).toBeNull();
+    });
+
+    it('adds a tabindex on a stack label in an expandable stack block', () => {
+      fixture = TestBed.createComponent(DynamicBlock);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('.stack-block-label').getAttribute('tabindex')).toBe('0');
+
+      getBlockInstance(fixture).expandable = false;
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('.stack-block-label').getAttribute('tabindex')).toBeNull();
+    });
+
     it('starts collapsed', () => {
       fixture = TestBed.createComponent(DynamicBlock);
       fixture.detectChanges();

--- a/src/clr-angular/data/stack-view/stack-block.ts
+++ b/src/clr-angular/data/stack-view/stack-block.ts
@@ -9,17 +9,28 @@ import { Component, EventEmitter, HostBinding, Input, OnInit, Optional, Output, 
 @Component({
   selector: 'clr-stack-block',
   template: `
-        <dt class="stack-block-label" (click)="toggleExpand()">
-            <ng-content select="clr-stack-label"></ng-content>
-        </dt>
-        <dd class="stack-block-content">
-            <ng-content></ng-content>
-        </dd>
-        <!-- FIXME: remove this string concatenation when boolean states are supported -->
-        <div [@collapse]="''+!expanded" class="stack-children">
-            <ng-content select="clr-stack-block"></ng-content>
-        </div>
-    `,
+    <dt class="stack-block-label"
+        (click)="toggleExpand()"
+        (keyup.enter)="toggleExpand()"
+        (keyup.space)="toggleExpand()"
+        (focus)="onStackBlockFocus(true)"
+        (blur)="onStackBlockFocus(false)"
+        [attr.role]="role"
+        [attr.tabindex]="tabIndex">
+      <clr-icon shape="caret"
+                class="stack-block-caret"
+                *ngIf="expandable"
+                [attr.dir]="caretDirection"></clr-icon>
+      <ng-content select="clr-stack-label"></ng-content>
+    </dt>
+    <dd class="stack-block-content">
+      <ng-content></ng-content>
+    </dd>
+    <!-- FIXME: remove this string concatenation when boolean states are supported -->
+    <div [@collapse]="''+!expanded" class="stack-children">
+      <ng-content select="clr-stack-block"></ng-content>
+    </div>
+  `,
   // Custom elements are inline by default
   styles: [
     `
@@ -45,6 +56,7 @@ export class ClrStackBlock implements OnInit {
   @Input('clrSbExpandable')
   expandable: boolean = false;
 
+  private focused: boolean = false;
   private _changedChildren: number = 0;
   private _fullyInitialized: boolean = false;
   private _changed: boolean = false;
@@ -97,5 +109,26 @@ export class ClrStackBlock implements OnInit {
       this.expanded = !this.expanded;
       this.expandedChange.emit(this.expanded);
     }
+  }
+
+  onStackBlockFocus(focusState: boolean): void {
+    this.focused = focusState;
+  }
+
+  get caretDirection(): string {
+    return this.expanded ? 'down' : 'right';
+  }
+
+  get role(): string {
+    return this.expandable ? 'button' : null;
+  }
+
+  get tabIndex(): string {
+    return this.expandable ? '0' : null;
+  }
+
+  @HostBinding('class.on-focus')
+  get onStackLabelFocus(): boolean {
+    return this.expandable && !this.expanded && this.focused;
   }
 }

--- a/src/clr-angular/data/stack-view/stack-view.module.ts
+++ b/src/clr-angular/data/stack-view/stack-view.module.ts
@@ -14,6 +14,7 @@ import { ClrStackInput } from './stack-input';
 import { ClrStackSelect } from './stack-select';
 import { ClrStackView } from './stack-view';
 import { ClrStackViewCustomTags } from './stack-view-custom-tags';
+import { ClrIconModule } from '../../icon/icon.module';
 
 export const CLR_STACK_VIEW_DIRECTIVES: Type<any>[] = [
   ClrStackView,
@@ -31,7 +32,7 @@ export const CLR_STACK_VIEW_DIRECTIVES: Type<any>[] = [
 ];
 
 @NgModule({
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, ClrIconModule],
   declarations: [CLR_STACK_VIEW_DIRECTIVES],
   exports: [CLR_STACK_VIEW_DIRECTIVES],
 })

--- a/src/clr-angular/utils/_theme.dark.clarity.scss
+++ b/src/clr-angular/utils/_theme.dark.clarity.scss
@@ -624,6 +624,7 @@ $clr-stack-view-stack-block-expanded-bg-color: #324f61;
 $clr-stack-view-stack-block-expandable-hover: #324f61;
 $clr-stack-view-stack-block-content-text-color: #adbbc4;
 $clr-stack-view-stack-block-expanded-text-color: $clr-white;
+$clr-stack-view-stack-block-caret-color: $gray-dark-midtone;
 // END: Stack View overrides
 
 /**********


### PR DESCRIPTION
Fixes: #2357, #1946

**Demo:**
![stackview demo](https://user-images.githubusercontent.com/1426805/42391055-ff5be7d6-811b-11e8-80a2-d54fac4fb0fd.gif)


**NOTE:** 
1. The static markup cannot be fixed without a breaking change. This PR fixes the accessibility issues in the Angular component. We still have the generated icon in use for the static markup but the angular component uses `clr-icon`.
2. Tested on Chrome, Firefox and Safari. My VM isn't working properly so couldnt test on IE and Edge. 🤞 
3. @youdz: I am pretty sure you wont like the way the tests are structured, but I didn't want to fix that in this PR.

**Fixes:**
1. Adds a `button` `role` to the `.stack-block-label`
2. Adds a `tabindex` to the `.stack-block-label`
3. Opens the stack block on `enter` and `space`
4. Uses `clr-icon` instead of the generated icon.

Signed-off-by: Aditya Bhandari <adityab@vmware.com>