### PR TITLE
[NG] Add Stack View aria-expanded attribute

### DIFF
--- a/src/clr-angular/data/stack-view/stack-block.spec.ts
+++ b/src/clr-angular/data/stack-view/stack-block.spec.ts
@@ -200,6 +200,30 @@ export default function(): void {
       expect(fixture.nativeElement.querySelector('.stack-block-label').getAttribute('tabindex')).toBeNull();
     });
 
+    it('adds the aria-expanded attribute when the stack block is expandable', () => {
+      fixture = TestBed.createComponent(DynamicBlock);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('.stack-block-label').getAttribute('aria-expanded')).not.toBeNull();
+
+      getBlockInstance(fixture).expandable = false;
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('.stack-block-label').getAttribute('aria-expanded')).toBeNull();
+    });
+
+    it('sets the aria-expanded attribute to true when the stack block is expanded', () => {
+      fixture = TestBed.createComponent(DynamicBlock);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('.stack-block-label').getAttribute('aria-expanded')).toBe('false');
+
+      getBlockInstance(fixture).expanded = true;
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('.stack-block-label').getAttribute('aria-expanded')).toBe('true');
+    });
+
     it('starts collapsed', () => {
       fixture = TestBed.createComponent(DynamicBlock);
       fixture.detectChanges();

--- a/src/clr-angular/data/stack-view/stack-block.ts
+++ b/src/clr-angular/data/stack-view/stack-block.ts
@@ -13,10 +13,11 @@ import { Component, EventEmitter, HostBinding, Input, OnInit, Optional, Output, 
         (click)="toggleExpand()"
         (keyup.enter)="toggleExpand()"
         (keyup.space)="toggleExpand()"
-        (focus)="onStackBlockFocus(true)"
-        (blur)="onStackBlockFocus(false)"
+        (focus)="focused = true"
+        (blur)="focused = false"
         [attr.role]="role"
-        [attr.tabindex]="tabIndex">
+        [attr.tabindex]="tabIndex"
+        [attr.aria-expanded]="ariaExpanded">
       <clr-icon shape="caret"
                 class="stack-block-caret"
                 *ngIf="expandable"
@@ -27,7 +28,7 @@ import { Component, EventEmitter, HostBinding, Input, OnInit, Optional, Output, 
       <ng-content></ng-content>
     </dd>
     <!-- FIXME: remove this string concatenation when boolean states are supported -->
-    <div [@collapse]="''+!expanded" class="stack-children">
+    <div [@collapse]="''+!expanded" class="stack-children" >
       <ng-content select="clr-stack-block"></ng-content>
     </div>
   `,
@@ -111,10 +112,6 @@ export class ClrStackBlock implements OnInit {
     }
   }
 
-  onStackBlockFocus(focusState: boolean): void {
-    this.focused = focusState;
-  }
-
   get caretDirection(): string {
     return this.expanded ? 'down' : 'right';
   }
@@ -130,5 +127,13 @@ export class ClrStackBlock implements OnInit {
   @HostBinding('class.on-focus')
   get onStackLabelFocus(): boolean {
     return this.expandable && !this.expanded && this.focused;
+  }
+
+  get ariaExpanded(): string {
+    if (!this.expandable) {
+      return null;
+    } else {
+      return this.expanded ? 'true' : 'false';
+    }
   }
 }


### PR DESCRIPTION
Fixes: #2429

@youdz mentioned that only the `aria-expanded` attributes are needed because StackView is already semantic as we already use `dd` and `dt`

More info here: https://www.w3.org/TR/wai-aria-practices/examples/accordion/accordion.html

Signed-off-by: Aditya Bhandari <adityab@vmware.com>