### PR TITLE
Reactive form fix, and tests

### DIFF
--- a/src/clr-angular/forms/input/input-container.spec.ts
+++ b/src/clr-angular/forms/input/input-container.spec.ts
@@ -4,16 +4,17 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { Component } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 
 import { ClrInput } from './input';
 import { ClrInputContainer } from './input-container';
 
-import { ContainerFullSpec, ContainerNoLabelSpec } from '../tests/container.spec';
+import { TemplateDrivenSpec, ReactiveSpec, ContainerNoLabelSpec } from '../tests/container.spec';
 
 @Component({
   template: `
     <clr-input-container>
-        <input type="text" name="test" clrInput required [(ngModel)]="model" />
+        <input name="model" clrInput required [(ngModel)]="model" />
         <label>Hello World</label>
         <clr-control-helper>Helper text</clr-control-helper>
         <clr-control-error>Must be at least 5 characters</clr-control-error>
@@ -27,14 +28,32 @@ class SimpleTest {
 @Component({
   template: `
   <clr-input-container>
-    <input clrInput [(ngModel)]="model" />
+    <input clrInput name="model" [(ngModel)]="model" />
   </clr-input-container>`,
 })
 class NoLabelTest {}
 
+@Component({
+  template: `
+  <form [formGroup]="form">
+    <clr-input-container>
+      <input clrInput formControlName="model" />
+      <label>Hello World</label>
+      <clr-control-helper>Helper text</clr-control-helper>
+      <clr-control-error>Must be at least 5 characters</clr-control-error>
+    </clr-input-container>
+  </form>`,
+})
+class ReactiveTest {
+  form = new FormGroup({
+    model: new FormControl('', Validators.required),
+  });
+}
+
 export default function(): void {
   describe('ClrInputContainer', () => {
     ContainerNoLabelSpec(ClrInputContainer, ClrInput, NoLabelTest);
-    ContainerFullSpec(ClrInputContainer, ClrInput, SimpleTest, '.clr-input-wrapper [clrInput]');
+    TemplateDrivenSpec(ClrInputContainer, ClrInput, SimpleTest, '.clr-input-wrapper [clrInput]');
+    ReactiveSpec(ClrInputContainer, ClrInput, ReactiveTest, '.clr-input-wrapper [clrInput]');
   });
 }

--- a/src/clr-angular/forms/input/input.spec.ts
+++ b/src/clr-angular/forms/input/input.spec.ts
@@ -4,8 +4,9 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { Component } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 
-import { ControlBasicTest, ControlInvalidTest } from '../tests/control.spec';
+import { TemplateDrivenSpec, ControlInvalidSpec, ReactiveSpec } from '../tests/control.spec';
 import { ClrInputContainer } from './input-container';
 import { ClrInput } from './input';
 
@@ -18,14 +19,28 @@ class InvalidUseTest {}
 
 @Component({
   template: `
-       <input type="text" clrInput name="model" class="test-class" [(ngModel)]="model" />
+       <input clrInput name="model" class="test-class" [(ngModel)]="model" />
     `,
 })
-class SimpleTest {}
+class TemplateDrivenTest {}
+
+@Component({
+  template: `
+    <div [formGroup]="example">
+       <input clrInput name="model" class="test-class" formControlName="model" />
+    </div>
+    `,
+})
+class ReactiveTest {
+  example = new FormGroup({
+    model: new FormControl('', Validators.required),
+  });
+}
 
 export default function(): void {
   describe('Input directive', () => {
-    ControlInvalidTest(ClrInput, InvalidUseTest);
-    ControlBasicTest(ClrInputContainer, ClrInput, SimpleTest, 'clr-input');
+    ControlInvalidSpec(ClrInput, InvalidUseTest);
+    TemplateDrivenSpec(ClrInputContainer, ClrInput, TemplateDrivenTest, 'clr-input');
+    ReactiveSpec(ClrInputContainer, ClrInput, ReactiveTest, 'clr-input');
   });
 }

--- a/src/clr-angular/forms/input/input.ts
+++ b/src/clr-angular/forms/input/input.ts
@@ -4,7 +4,16 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Directive, HostListener, Optional, ViewContainerRef, Attribute, Renderer2, ElementRef } from '@angular/core';
+import {
+  Directive,
+  HostListener,
+  Optional,
+  ViewContainerRef,
+  OnInit,
+  Attribute,
+  Renderer2,
+  ElementRef,
+} from '@angular/core';
 import { NgControl } from '@angular/forms';
 
 import { IfErrorService } from '../common/if-error/if-error.service';
@@ -14,12 +23,12 @@ import { WrappedFormControl } from '../common/wrapped-control';
 import { ControlClassService } from '../common/providers/control-class.service';
 
 @Directive({ selector: '[clrInput]', host: { '[class.clr-input]': 'true' } })
-export class ClrInput extends WrappedFormControl<ClrInputContainer> {
+export class ClrInput extends WrappedFormControl<ClrInputContainer> implements OnInit {
   constructor(
     vcr: ViewContainerRef,
-    @Optional() ngControlService: NgControlService,
+    @Optional() private ngControlService: NgControlService,
     @Optional() private ifErrorService: IfErrorService,
-    @Optional() control: NgControl,
+    @Optional() private control: NgControl,
     @Optional() controlClassService: ControlClassService,
     @Attribute('type') public type: string,
     renderer: Renderer2,
@@ -38,8 +47,12 @@ export class ClrInput extends WrappedFormControl<ClrInputContainer> {
     if (controlClassService) {
       controlClassService.className = el.nativeElement.className;
     }
-    if (ngControlService) {
-      ngControlService.setControl(control);
+  }
+
+  ngOnInit() {
+    super.ngOnInit();
+    if (this.ngControlService) {
+      this.ngControlService.setControl(this.control);
     }
   }
 

--- a/src/clr-angular/forms/tests/container.spec.ts
+++ b/src/clr-angular/forms/tests/container.spec.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { TestBed } from '@angular/core/testing';
-import { FormsModule, NgControl } from '@angular/forms';
+import { FormsModule, NgControl, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
 import { ClrIconModule } from '../../icon/icon.module';
@@ -45,12 +45,20 @@ export function ContainerNoLabelSpec(testContainer, testControl, testComponent):
   });
 }
 
-export function ContainerFullSpec(testContainer, testControl, testComponent, wrapperClass): void {
-  describe('full example', () => {
+export function TemplateDrivenSpec(testContainer, testControl, testComponent, wrapperClass): void {
+  fullSpec('template-driven', testContainer, testControl, testComponent, wrapperClass);
+}
+
+export function ReactiveSpec(testContainer, testControl, testComponent, wrapperClass): void {
+  fullSpec('reactive', testContainer, testControl, testComponent, wrapperClass);
+}
+
+function fullSpec(description, testContainer, testControl, testComponent, wrapperClass) {
+  describe(description, () => {
     let fixture, containerDE, container, containerEl, ifErrorService, layoutService;
     beforeEach(() => {
       TestBed.configureTestingModule({
-        imports: [ClrIconModule, ClrCommonFormsModule, FormsModule],
+        imports: [ClrIconModule, ClrCommonFormsModule, FormsModule, ReactiveFormsModule],
         declarations: [testContainer, testControl, testComponent],
         providers: [NgControl, NgControlService, IfErrorService, LayoutService],
       });

--- a/src/clr-angular/forms/tests/control.spec.ts
+++ b/src/clr-angular/forms/tests/control.spec.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { TestBed } from '@angular/core/testing';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
 import { ClrIconModule } from '../../icon/icon.module';
@@ -16,7 +16,7 @@ import { WrappedFormControl } from '../common/wrapped-control';
 import { ControlIdService } from '../common/providers/control-id.service';
 import { ControlClassService } from '../common/providers/control-class.service';
 
-export function ControlInvalidTest(testControl, testComponent): void {
+export function ControlInvalidSpec(testControl, testComponent): void {
   describe('invalid use', () => {
     it('throws error when used without a form control', () => {
       TestBed.configureTestingModule({ declarations: [testControl, testComponent] });
@@ -28,14 +28,22 @@ export function ControlInvalidTest(testControl, testComponent): void {
   });
 }
 
-export function ControlBasicTest(testContainer, testControl, testComponent, controlClass): void {
-  describe('basic use', () => {
+export function TemplateDrivenSpec(testContainer, testControl, testComponent, controlClass): void {
+  fullTest('template-driven', testContainer, testControl, testComponent, controlClass);
+}
+
+export function ReactiveSpec(testContainer, testControl, testComponent, controlClass): void {
+  fullTest('reactive', testContainer, testControl, testComponent, controlClass);
+}
+
+function fullTest(description, testContainer, testControl, testComponent, controlClass) {
+  describe(description, () => {
     let control, fixture, ifErrorService, ngControlService, controlClassService;
 
     beforeEach(() => {
       spyOn(WrappedFormControl.prototype, 'ngOnInit');
       TestBed.configureTestingModule({
-        imports: [FormsModule, ClrIconModule, ClrCommonFormsModule],
+        imports: [FormsModule, ClrIconModule, ClrCommonFormsModule, ReactiveFormsModule],
         declarations: [testContainer, testControl, testComponent],
         providers: [IfErrorService, NgControlService, ControlIdService, ControlClassService],
       });

--- a/src/clr-angular/forms/textarea/textarea-container.spec.ts
+++ b/src/clr-angular/forms/textarea/textarea-container.spec.ts
@@ -4,20 +4,21 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { Component } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 
 import { ClrTextarea } from './textarea';
 import { ClrTextareaContainer } from './textarea-container';
 
-import { ContainerNoLabelSpec, ContainerFullSpec } from '../tests/container.spec';
+import { ContainerNoLabelSpec, TemplateDrivenSpec, ReactiveSpec } from '../tests/container.spec';
 
 @Component({
   template: `
-    <clr-textarea-container>
-      <textarea name="test" clrTextarea required [(ngModel)]="model"></textarea>
-      <label>Hello World</label>
-      <clr-control-helper>Helper text</clr-control-helper>
-      <clr-control-error>Must be at least 5 characters</clr-control-error>
-    </clr-textarea-container>
+  <clr-textarea-container>
+    <textarea name="test" clrTextarea required [(ngModel)]="model"></textarea>
+    <label>Hello World</label>
+    <clr-control-helper>Helper text</clr-control-helper>
+    <clr-control-error>Must be at least 5 characters</clr-control-error>
+  </clr-textarea-container>
     `,
 })
 class SimpleTest {
@@ -32,9 +33,27 @@ class SimpleTest {
 })
 class NoLabelTest {}
 
+@Component({
+  template: `
+  <form [formGroup]="form">
+    <clr-textarea-container>
+      <textarea name="test" clrTextarea formControlName="model"></textarea>
+      <label>Hello World</label>
+      <clr-control-helper>Helper text</clr-control-helper>
+      <clr-control-error>Must be at least 5 characters</clr-control-error>
+    </clr-textarea-container>
+  </form>`,
+})
+class ReactiveTest {
+  form = new FormGroup({
+    model: new FormControl('', Validators.required),
+  });
+}
+
 export default function(): void {
   describe('ClrTextareaContainer', () => {
     ContainerNoLabelSpec(ClrTextareaContainer, ClrTextarea, NoLabelTest);
-    ContainerFullSpec(ClrTextareaContainer, ClrTextarea, SimpleTest, '.clr-textarea-wrapper [clrTextarea]');
+    TemplateDrivenSpec(ClrTextareaContainer, ClrTextarea, SimpleTest, '.clr-textarea-wrapper [clrTextarea]');
+    ReactiveSpec(ClrTextareaContainer, ClrTextarea, ReactiveTest, '.clr-textarea-wrapper [clrTextarea]');
   });
 }

--- a/src/clr-angular/forms/textarea/textarea.spec.ts
+++ b/src/clr-angular/forms/textarea/textarea.spec.ts
@@ -4,11 +4,12 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { Component } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 
 import { ClrTextarea } from './textarea';
 import { ClrTextareaContainer } from './textarea-container';
 
-import { ControlBasicTest, ControlInvalidTest } from '../tests/control.spec';
+import { TemplateDrivenSpec, ControlInvalidSpec, ReactiveSpec } from '../tests/control.spec';
 
 @Component({
   template: `
@@ -22,11 +23,24 @@ class InvalidUseTest {}
     <textarea clrTextarea name="model" class="test-class" [(ngModel)]="model"></textarea>
     `,
 })
-class SimpleTest {}
+class TemplateDrivenTest {}
+
+@Component({
+  template: `
+  <div [formGroup]="example">
+    <textarea clrTextarea name="model" class="test-class" formControlName="model"></textarea>
+  </div>`,
+})
+class ReactiveTest {
+  example = new FormGroup({
+    model: new FormControl('', Validators.required),
+  });
+}
 
 export default function(): void {
   describe('Textarea directive', () => {
-    ControlInvalidTest(ClrTextarea, InvalidUseTest);
-    ControlBasicTest(ClrTextareaContainer, ClrTextarea, SimpleTest, 'clr-textarea');
+    ControlInvalidSpec(ClrTextarea, InvalidUseTest);
+    TemplateDrivenSpec(ClrTextareaContainer, ClrTextarea, TemplateDrivenTest, 'clr-textarea');
+    ReactiveSpec(ClrTextareaContainer, ClrTextarea, ReactiveTest, 'clr-textarea');
   });
 }

--- a/src/clr-angular/forms/textarea/textarea.ts
+++ b/src/clr-angular/forms/textarea/textarea.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Directive, HostListener, Optional, ViewContainerRef, Renderer2, ElementRef } from '@angular/core';
+import { Directive, HostListener, Optional, ViewContainerRef, Renderer2, ElementRef, OnInit } from '@angular/core';
 import { NgControl } from '@angular/forms';
 
 import { IfErrorService } from '../common/if-error/if-error.service';
@@ -14,12 +14,12 @@ import { WrappedFormControl } from '../common/wrapped-control';
 import { ControlClassService } from '../common/providers/control-class.service';
 
 @Directive({ selector: '[clrTextarea]', host: { '[class.clr-textarea]': 'true' } })
-export class ClrTextarea extends WrappedFormControl<ClrTextareaContainer> {
+export class ClrTextarea extends WrappedFormControl<ClrTextareaContainer> implements OnInit {
   constructor(
     vcr: ViewContainerRef,
-    @Optional() ngControlService: NgControlService,
+    @Optional() private ngControlService: NgControlService,
     @Optional() private ifErrorService: IfErrorService,
-    @Optional() control: NgControl,
+    @Optional() private control: NgControl,
     @Optional() controlClassService: ControlClassService,
     renderer: Renderer2,
     el: ElementRef
@@ -33,8 +33,12 @@ export class ClrTextarea extends WrappedFormControl<ClrTextareaContainer> {
     if (controlClassService) {
       controlClassService.className = el.nativeElement.className;
     }
-    if (ngControlService) {
-      ngControlService.setControl(control);
+  }
+
+  ngOnInit() {
+    super.ngOnInit();
+    if (this.ngControlService) {
+      this.ngControlService.setControl(this.control);
     }
   }
 


### PR DESCRIPTION
fixes #2438

We need to use ngOnInit to give the form control more time to initialize for reactive forms, and reformatted some tests to run the same test suite on template driven and reactive forms for inputs and textareas.