### PR TITLE
[BUG] Odd wizard vertical height issue when resizing browser

### DIFF
--- a/src/clr-angular/wizard/_wizard.clarity.scss
+++ b/src/clr-angular/wizard/_wizard.clarity.scss
@@ -11,11 +11,8 @@
 @include exports('wizard.clarity') {
   .clr-wizard {
     .modal-dialog {
-      // removed for IE10... maybe remove altogether? or only remove for IE10?
-      // position: static;
       display: flex;
       flex-direction: column;
-      justify-content: space-between;
       align-items: center;
       box-shadow: $clr-wizard-box-shadow;
       height: 50%;
@@ -28,10 +25,9 @@
       padding: 0;
       flex: 2 2 auto;
       width: 66%;
-      height: 100%;
+      height: initial;
       overflow: hidden;
       display: flex;
-      justify-content: space-between;
       align-items: flex-start;
       flex-direction: column;
     }
@@ -121,14 +117,13 @@
       flex: 1 1 auto;
       width: 34%;
       max-width: 34%;
-      display: block;
+      display: flex;
+      flex-direction: column;
       order: -1;
-      // TODO: test with many, many stepnav items!
       overflow: hidden;
       overflow-y: auto;
       padding-bottom: $clr-wizard-default-space;
       line-height: $clr-wizard-default-space;
-      // TODO: NEED COLORVAR HERE
       border-right: $clr-default-borderwidth solid $clr-wizard-step-nav-border-color;
       height: 100%;
       background-color: $clr-wizard-sidenav-bgcolor;
@@ -141,6 +136,7 @@
       font-size: 0.583333rem;
       color: $clr-wizard-sidenav-text;
       width: 100%;
+      flex: 1 1 auto;
     }
 
     .clr-wizard-stepnav-list {
@@ -212,6 +208,7 @@
       padding-left: $clr-wizard-default-space;
       padding-right: $clr-wizard-default-space * 0.5;
       padding-bottom: $clr-wizard-default-space;
+      flex: 0 0 auto;
     }
 
     // normal modal ignores this. wizard needs it so the nav and content
@@ -312,11 +309,7 @@
     &.wizard-xl {
       .modal-dialog {
         height: $clr-wizard-xl-dialog-max-height;
-      }
-
-      .modal-content,
-      .clr-wizard-stepnav-wrapper {
-        max-height: $clr-wizard-xl-dialog-max-height;
+        max-height: none;
       }
 
       .nav-panel,


### PR DESCRIPTION
• This was caused by a combination of justify-content flexbox settings that Microsoft browsers didn't care for complicated by Microsoft browsers being confused over the max-height vs. height settings when the content in either the stepnav or content panel exceeded the available height

• I did some whack-a-mole through the SASS to find the guilty parties and removed/amended them

• I'm marking this as Low priority and only back porting it to 0.12 because it only happens on XL wizards when the vertical height of the screen goes below a certain range determined by the height of EITHER the stepnav or the content area

Tested in:
✔︎ Chrome
✔︎ Firefox
✔︎ Safari
✔︎ IE11
✔︎ Edge

Closes: #2493

Signed-off-by: Scott Mathis <smathis@vmware.com>