### PR TITLE
[UI] Deprecate non-documented bootstrap files (#2163)

### DIFF
--- a/src/clr-angular/layout/_card.clarity.scss
+++ b/src/clr-angular/layout/_card.clarity.scss
@@ -77,6 +77,7 @@
     }
 
     //Bootstrap 4 List Groups
+    // @deprecated Bootstrap dependencies are deprecated since 1.0. Review and edit if necessary before 2.0.
     .list-group-item {
       font-size: $card-text-fontsize;
       border-left-width: 0;

--- a/src/clr-angular/typography/_code.clarity.scss
+++ b/src/clr-angular/typography/_code.clarity.scss
@@ -17,6 +17,7 @@
     white-space: pre;
   }
   //Overriding bootstrap code styles
+  // @deprecated Bootstrap dependencies are deprecated since 1.0. Review and edit before 2.0 if needed.
   code {
     &.clr-code {
       color: $reds-dark-midtone;

--- a/src/clr-angular/utils/_components.clarity.scss
+++ b/src/clr-angular/utils/_components.clarity.scss
@@ -7,6 +7,7 @@
 
 // Bootstrap 4 Dependencies - Begin Part 2
 // NOTE: These are here b/c they need to be overwritable for the $grid-breakpoints map in a theme.
+// @deprecated Bootstrap dependencies are deprecated since 1.0. Remove before 2.0.
 @import 'bootstrap/scss/media';
 @import 'bootstrap/scss/utilities';
 @import 'bootstrap/scss/images';

--- a/src/clr-angular/utils/_dependencies.clarity.scss
+++ b/src/clr-angular/utils/_dependencies.clarity.scss
@@ -3,8 +3,10 @@
 // The full license information can be found in LICENSE in the root directory of this project.
 
 // Bootstrap 4 Grid Overrides
+// @deprecated Bootstrap dependencies are deprecated since 1.0. Remove before 2.0.
 @import '../utils/bs4-grid-breakpoint-overrides.clarity';
 
+// @deprecated Bootstrap dependencies are deprecated since 1.0. Remove before 2.0.
 // Bootstrap 4 Dependencies - Begin Part 1
 @import 'bootstrap/scss/variables';
 @import 'bootstrap/scss/mixins';

--- a/src/clr-angular/utils/_reboot.clarity.scss
+++ b/src/clr-angular/utils/_reboot.clarity.scss
@@ -2,6 +2,8 @@
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
+// @deprecated Bootstrap dependencies are deprecated since 1.0. Review for removal of this file before 2.0
+// (note that there is a section at the bottom that's not related to bootstap but may also be candidate for removal by 2.0)
 @include exports('reboot.clarity') {
   // Customizing BS4 reboot file below from Bootstrap 4.0.0-alpha.3
   // Styles taken directly from BS4 reboot file.
@@ -393,6 +395,7 @@
   // END BS4 REBOOT STYLES
 
   //Overrides carried over from earlier versions of Clarity
+  //TODO: Review below items for removal before 2.0.
 
   dl {
     margin-bottom: 0;

--- a/src/clr-angular/utils/_variables.global.scss
+++ b/src/clr-angular/utils/_variables.global.scss
@@ -62,6 +62,7 @@ $clr-baseline-int: $clr-baseline-px / 1px;
 $clr-rem-1px: 1 / $clr-baseline-int * 1rem;
 $clr-rem-1px: 1 / $clr-baseline-int * 1rem;
 
+// @deprecated Bootstrap dependencies are deprecated since 1.0. Review for removal before 2.0.
 //BS4 overrides
 $enable-flex: true;
 $grid-gutter-width-base: 1rem;


### PR DESCRIPTION
The goal is to completely move off of bootstrap by 2.0, so making note of both direct imports from bootstrap, as well as variables that are overwriting values from bootstrap. In the second case, we would probably need to do a sweep of our scss files to see if those variables need to be replaced if they are being used in our components. 

Signed-off-by: Jeeyun Lim <jeeyun.lim@gmail.com>