### PR TITLE
[NG] Schematics update for deprecated icons

### DIFF
--- a/src/schematics/src/update/update-0.13.0.ts
+++ b/src/schematics/src/update/update-0.13.0.ts
@@ -76,6 +76,16 @@ Start changes for Clarity 0.13.0
             );
           }
 
+          // Alert to using deprecated icons
+          if (updated.search(/shape=['"](angle-double|bar-chart|collapse|line-chart|wand)['"]/g) > -1) {
+            logMessage(
+              'info',
+              'UPDATED: The following icons have been deprecated in its respective set and have been moved to another set: \n`angle-double`, `bar-chart`, `collapse`, `line-chart`, `wand`\nPlease check that they are being imported from the correct set.',
+              filePath,
+              '0.13.0-beta.2'
+            );
+          }
+
           // Alert to using bootstrap's push / pull in Clarity grid
           if (updated.search(/(push|pull)-(xs|sm|md|lg|xl)-([0-9])/g) > -1) {
             logMessage(


### PR DESCRIPTION
Screenshot of a sample run:
![screen shot 2018-08-22 at 3 17 44 pm](https://user-images.githubusercontent.com/1827742/44494014-11f0f080-a61f-11e8-86ae-abb77f17cd30.png)

Signed-off-by: Jeeyun Lim <jeeyun.lim@gmail.com>