### PR TITLE
[NG] Datagrid: reduce the number of outputs for selection changes

### DIFF
--- a/src/clr-angular/data/datagrid/datagrid.ts
+++ b/src/clr-angular/data/datagrid/datagrid.ts
@@ -109,7 +109,7 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
     } else {
       this.selection.selectionType = SelectionType.None;
     }
-    this.selection.current = value;
+    this.selection.updateCurrent(value, false);
   }
 
   @Output('clrDgSelectedChange') selectedChanged = new EventEmitter<T[]>(false);

--- a/src/clr-angular/data/datagrid/providers/selection.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/selection.spec.ts
@@ -183,50 +183,46 @@ export default function(): void {
       );
 
       it('exposes an Observable to follow selection changes in multi selection type', function() {
+        selectionInstance.selectionType = SelectionType.Multi;
         let nbChanges = 0;
         let currentSelection: number[];
         selectionInstance.change.subscribe((items: number[]) => {
           nbChanges++;
           currentSelection = items;
         });
-        expect(currentSelection).toBeUndefined();
-        selectionInstance.selectionType = SelectionType.Multi;
-        expect(currentSelection).toEqual([]);
         selectionInstance.setSelected(4, true);
-        expect(selectionInstance.current).toEqual([4]);
+        expect(currentSelection).toEqual([4]);
         selectionInstance.toggleAll();
-        expect(selectionInstance.current.sort(numberSort)).toEqual(itemsInstance.displayed);
+        expect(currentSelection.sort(numberSort)).toEqual(itemsInstance.displayed);
         selectionInstance.toggleAll();
-        expect(selectionInstance.current).toEqual([]);
-        expect(nbChanges).toBe(4);
-      });
-
-      it('exposes an Observable to follow selection changes in single selection type', function() {
-        let nbChanges = 0;
-        let currentSelection: number;
-        selectionInstance.change.subscribe((items: number) => {
-          nbChanges++;
-          currentSelection = items;
-        });
-        expect(currentSelection).toBeUndefined();
-        selectionInstance.selectionType = SelectionType.Single;
-        expect(currentSelection).toBeUndefined();
-        selectionInstance.currentSingle = 4;
-        selectionInstance.currentSingle = 2;
+        expect(currentSelection).toEqual([]);
         expect(nbChanges).toBe(3);
       });
 
+      it('exposes an Observable to follow selection changes in single selection type', function() {
+        selectionInstance.selectionType = SelectionType.Single;
+        let nbChanges = 0;
+        let currentSelection: number;
+        selectionInstance.change.subscribe((item: number) => {
+          nbChanges++;
+          currentSelection = item;
+        });
+        selectionInstance.currentSingle = 4;
+        expect(currentSelection).toBe(4);
+        selectionInstance.currentSingle = 2;
+        expect(currentSelection).toBe(2);
+        expect(nbChanges).toBe(2);
+      });
+
       it('does not emit selection change twice after a filter is applied', function() {
+        selectionInstance.selectionType = SelectionType.Multi;
         let nbChanges = 0;
         selectionInstance.change.subscribe((items: any) => {
           nbChanges++;
         });
 
-        selectionInstance.selectionType = SelectionType.Multi;
-        expect(nbChanges).toBe(1); // current is initialized to [] at this point
-
         selectionInstance.current = [4, 2];
-        expect(nbChanges).toBe(2);
+        expect(nbChanges).toBe(1);
 
         const evenFilter: EvenFilter = new EvenFilter();
         filtersInstance.add(<ClrDatagridFilterInterface<any>>evenFilter);
@@ -236,7 +232,7 @@ export default function(): void {
         // there isn't an additional change that would have been fired to
         // update current selection given the new data set post filter.
         expect(selectionInstance.current.length).toBe(0);
-        expect(nbChanges).toBe(3);
+        expect(nbChanges).toBe(2);
       });
 
       it('clears selection when a filter is added', function() {

--- a/src/clr-angular/data/datagrid/providers/selection.ts
+++ b/src/clr-angular/data/datagrid/providers/selection.ts
@@ -164,7 +164,7 @@ export class Selection<T = any> {
     if (value === SelectionType.None) {
       delete this.current;
     } else {
-      this.current = [];
+      this.updateCurrent([], false);
     }
   }
 
@@ -221,12 +221,18 @@ export class Selection<T = any> {
     return this._current;
   }
   public set current(value: T[]) {
+    this.updateCurrent(value, true);
+  }
+
+  public updateCurrent(value: T[], emit: boolean) {
     this._current = value;
-    this.emitChange();
-    // Ignore items changes in the same change detection cycle.
-    // @TODO This can likely be removed!
-    this.debounce = true;
-    setTimeout(() => (this.debounce = false));
+    if (emit) {
+      this.emitChange();
+      // Ignore items changes in the same change detection cycle.
+      // @TODO This can likely be removed!
+      this.debounce = true;
+      setTimeout(() => (this.debounce = false));
+    }
   }
 
   /**


### PR DESCRIPTION
We were emitting multiple outputs for a single change, which made debugging on the app side pretty hard. In particular, we have [a guideline](https://github.com/vmware/clarity/blob/master/CODING_GUIDELINES.md#gotchas) stating:
> An `@Output` should not fire when we receive a new `@Input` value from the app.

Due to this change, a few unit tests needed to be cleaned up to reflect the correct behavior.