### PR TITLE
[NG] fix index for radios and rows to be consistent

### DIFF
--- a/src/clr-angular/data/datagrid/datagrid-row.ts
+++ b/src/clr-angular/data/datagrid/datagrid-row.ts
@@ -114,8 +114,9 @@ export class ClrDatagridRow<T = any> implements AfterContentInit {
     public hideableColumnService: HideableColumnService,
     public commonStrings: ClrCommonStrings
   ) {
-    this.id = 'clr-dg-row' + nbRow++;
-    this.radioId = 'clr-dg-row-rd' + nbRow++;
+    nbRow++;
+    this.id = 'clr-dg-row' + nbRow;
+    this.radioId = 'clr-dg-row-rd' + nbRow;
   }
 
   private _selected = false;


### PR DESCRIPTION
fixes #2644

We are double bumping the index for each row, so this does it only once.