### PR TITLE
[NG] Fix bug with clr-dropdown with OnPush detection strategy

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -509,7 +509,7 @@ export declare class ClrDropdown implements OnDestroy {
     ifOpenService: IfOpenService;
     isMenuClosable: boolean;
     parent: ClrDropdown;
-    constructor(parent: ClrDropdown, ifOpenService: IfOpenService, dropdownService: RootDropdownService);
+    constructor(parent: ClrDropdown, ifOpenService: IfOpenService, cdr: ChangeDetectorRef, dropdownService: RootDropdownService);
     ngOnDestroy(): void;
 }
 


### PR DESCRIPTION
When the client app is using OnPush detection strategy, clicking outside of a clr-dropdown doesn't hide the dropdown menu. This PR fixes the bug by using `ChangeDetectorRef` to mark the component for checking since our `AbstractPopover` class sets the `ifOpenService`'s `open` to false when a click event happens outside.

All unit tests passing. Tested across browsers.

Signed-off-by: Jeeyun Lim <jeeyun.lim@gmail.com>