### PR TITLE
[BUILD] This adds a custom TSLint rule for us to guard against barrel imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /out-tsc
 /.ng_build
 src/clr-angular/.ng_build
+/tests/tslint/dist
 
 /reports
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "golden:fix": "npm run build:angular && ts-api-guardian --out golden/clr-angular.d.ts --stripExportPattern 'FocusTrapTracker' dist/clr-angular/index.d.ts",
     "test:aot": "ng build --prod ks-app",
     "test:format": "prettier --list-different './**/*.{js,json,md,ts,scss}'",
+    "pretest:lint": "tsc -p tests/tslint/tsconfig.json",
     "test:lint": "tslint -p . -c tslint.json \"src/**/*.ts\" -e \"src/ks-app/**\" -e \"src/schematics/**\"",
     "test:visual": "./scripts/docker-cdc.js -t",
     "test:golden2": "ts-api-guardian --verify golden/clr-angular.d.ts dist/golden/clr-angular.d.ts",

--- a/src/clr-angular/button/button-group/button.spec.ts
+++ b/src/clr-angular/button/button-group/button.spec.ts
@@ -7,7 +7,8 @@
 import { Component, DebugElement, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { ClrLoadingModule, ClrLoadingState } from '../../utils/loading';
+import { ClrLoadingModule } from '../../utils/loading/loading.module';
+import { ClrLoadingState } from '../../utils/loading/loading';
 import { ButtonInGroupService } from '../providers/button-in-group.service';
 
 import { ClrButton } from './button';

--- a/src/clr-angular/button/button-group/button.ts
+++ b/src/clr-angular/button/button-group/button.ts
@@ -6,7 +6,7 @@
 
 import { Component, EventEmitter, Input, Optional, Output, SkipSelf, TemplateRef, ViewChild } from '@angular/core';
 
-import { ClrLoadingState } from '../../utils/loading';
+import { ClrLoadingState } from '../../utils/loading/loading';
 import { LoadingListener } from '../../utils/loading/loading-listener';
 import { ButtonInGroupService } from '../providers/button-in-group.service';
 

--- a/src/clr-angular/button/button-loading/loading-button.spec.ts
+++ b/src/clr-angular/button/button-loading/loading-button.spec.ts
@@ -8,7 +8,7 @@ import { Component, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
-import { ClrLoadingState } from '../../utils/loading';
+import { ClrLoadingState } from '../../utils/loading/loading';
 import { ClrLoadingModule } from '../../utils/loading/loading.module';
 
 import { ClrLoadingButton } from './loading-button';

--- a/src/clr-angular/forms/common/wrapped-control.ts
+++ b/src/clr-angular/forms/common/wrapped-control.ts
@@ -5,7 +5,8 @@
  */
 import { HostBinding, InjectionToken, Injector, Input, OnInit, Type, ViewContainerRef } from '@angular/core';
 
-import { DynamicWrapper, HostWrapper } from '../../utils/host-wrapping';
+import { HostWrapper } from '../../utils/host-wrapping/host-wrapper';
+import { DynamicWrapper } from '../../utils/host-wrapping/dynamic-wrapper';
 
 import { ControlIdService } from './providers/control-id.service';
 

--- a/src/clr-angular/forms/datepicker/date-container.ts
+++ b/src/clr-angular/forms/datepicker/date-container.ts
@@ -7,7 +7,7 @@ import { Component, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
 
 import { IfOpenService } from '../../utils/conditional/if-open.service';
-import { DynamicWrapper } from '../../utils/host-wrapping';
+import { DynamicWrapper } from '../../utils/host-wrapping/dynamic-wrapper';
 import { ControlIdService } from '../common/providers/control-id.service';
 
 import { DateFormControlService } from './providers/date-form-control.service';

--- a/src/clr-angular/forms/datepicker/date-input.spec.ts
+++ b/src/clr-angular/forms/datepicker/date-input.spec.ts
@@ -11,7 +11,7 @@ import { By } from '@angular/platform-browser';
 
 import { itIgnore } from '../../../../tests/tests.helpers';
 import { TestContext } from '../../data/datagrid/helpers.spec';
-import { ClrFormsModule } from '../../forms-deprecated';
+import { ClrFormsModule } from '../../forms-deprecated/forms.module';
 import { IfOpenService } from '../../utils/conditional/if-open.service';
 import { ControlIdService } from '../common/providers/control-id.service';
 

--- a/src/clr-angular/popover/signpost/signpost-content.spec.ts
+++ b/src/clr-angular/popover/signpost/signpost-content.spec.ts
@@ -8,7 +8,7 @@ import { TestBed } from '@angular/core/testing';
 
 // I'm giving up, I'm using the datagrid ones for now.
 import { addHelpers, TestContext } from '../../data/datagrid/helpers.spec';
-import { ClrIconCustomTag } from '../../icon';
+import { ClrIconCustomTag } from '../../icon/icon';
 import { IfOpenService } from '../../utils/conditional/if-open.service';
 import { POPOVER_HOST_ANCHOR } from '../common/popover-host-anchor.token';
 

--- a/src/clr-angular/utils/expand/providers/expand.spec.ts
+++ b/src/clr-angular/utils/expand/providers/expand.spec.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { ClrLoadingState } from '../../loading';
+import { ClrLoadingState } from '../../loading/loading';
 
 import { Expand } from './expand';
 

--- a/src/clr-angular/utils/expand/providers/expand.ts
+++ b/src/clr-angular/utils/expand/providers/expand.ts
@@ -7,7 +7,7 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Subject } from 'rxjs';
 import { LoadingListener } from '../../../utils/loading/loading-listener';
-import { ClrLoadingState } from '../../loading';
+import { ClrLoadingState } from '../../loading/loading';
 
 @Injectable()
 export class Expand implements LoadingListener {

--- a/src/dev/src/app/grid/grid.demo.module.ts
+++ b/src/dev/src/app/grid/grid.demo.module.ts
@@ -6,7 +6,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
-import { ClarityModule } from '../../../../clr-angular';
+import { ClarityModule } from '@clr/angular';
 
 import { GridHorizontalAlignmentDemo } from './alignment/horizontal/horizontal-alignment';
 import { GridVerticalAlignmentDemo } from './alignment/vertical/vertical-alignment';

--- a/tests/tslint/README.md
+++ b/tests/tslint/README.md
@@ -1,0 +1,18 @@
+# no-barrel-imports
+
+This is a custom TSLint rule that checks that any relative imports are not imported from the barrel (or in other words
+not from an `index.ts` file). This forces all relative imports to target the full file path.
+
+Since our Angular build has issues when you import from a barrel, this is the solution to catch it with the linter.
+
+### Build
+
+The source is in `src` and it compiles in to the `dist` directory. From the root of this repo, you can run
+`npx tsc -p tests/tslint/tsconfig.json` to compile the rule. However, we don't need to commit the `dist` directory,
+because its recompiled before any run of tslint (assuming you use `npm run test:lint`).
+
+### References
+
+* https://palantir.github.io/tslint/develop/custom-rules/
+* https://github.com/Microsoft/tslint-microsoft-contrib
+* https://github.com/eranshabi/tslint-custom-rules-boilerplate

--- a/tests/tslint/src/noBarrelImportsRule.ts
+++ b/tests/tslint/src/noBarrelImportsRule.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { IRuleMetadata } from 'tslint';
+import * as ts from 'typescript';
+import * as Lint from 'tslint';
+import { resolve } from 'path';
+import { statSync } from 'fs';
+
+export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: IRuleMetadata = {
+    ruleName: 'no-barrel-imports',
+    type: 'maintainability',
+    description: 'Prevents imports from referencing an index file',
+    hasFix: false,
+    options: null,
+    optionsDescription: '',
+    typescriptOnly: false,
+  };
+
+  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    return this.applyWithWalker(new NoBarrelImportsWalker(sourceFile, this.getOptions()));
+  }
+}
+
+// The walker takes care of all the work.
+class NoBarrelImportsWalker extends Lint.RuleWalker {
+  // This will run anytime TSLint runs into an import declaration, so we want to
+  // use it to detect if relative imports are pointing to a file or directory
+  public visitImportDeclaration(node: ts.ImportDeclaration) {
+    // This is the file that is currently being checked
+    const importFile = node.parent.getSourceFile().fileName;
+    // Here we chop off the filename to get just the host directory
+    const importDir = importFile.substring(0, importFile.lastIndexOf('/'));
+    // Here we get the path of the file being imported, and add `.ts` for full path
+    const path = node.moduleSpecifier.getText().replace(/'|"/gi, '') + '.ts';
+
+    // We only care if this is a relative path, otherwise its fine
+    if (path.startsWith('.')) {
+      // Try to get file stats, or else its not a file and we throw fail
+      try {
+        // Using resolve we get the full path of what is being imported to check if
+        // it is a file or not
+        statSync(resolve(importDir, path)).isFile();
+      } catch (e) {
+        // IF this fails (because statSync will fail if the path is not known),
+        // we catch it and throw an error because its a barrel.
+        this.addFailureAtNode(node, `Not allowed to import from a barrel`);
+      }
+    }
+
+    // call the base version of this visitor to actually parse this node
+    super.visitImportDeclaration(node);
+  }
+}

--- a/tests/tslint/tsconfig.json
+++ b/tests/tslint/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es5",
+    "sourceMap": false,
+    "outDir": "dist",
+    "skipLibCheck": true,
+    "lib": ["es6"]
+  },
+  "exclude": ["node_modules"],
+  "include": ["src"]
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,5 @@
 {
-  "rulesDirectory": ["./node_modules/tslint-defocus/dist"],
+  "rulesDirectory": ["./node_modules/tslint-defocus/dist", "./tests/tslint/dist"],
   "rules": {
     "class-name": true,
     "curly": true,
@@ -10,6 +10,7 @@
     "label-position": true,
     "member-access": false,
     "no-arg": true,
+    "no-barrel-imports": true,
     "no-bitwise": true,
     "no-conditional-assignment": true,
     "no-console": [true, "debug", "info", "time", "timeEnd", "trace"],


### PR DESCRIPTION
This has been a challenge to always catch correctly in reviews, so this will automatically throw linting errors (even in your IDE) if you are importing from a barrel instead of the file directly. This also fixes several instances of this issue that don't seem to cause build issues, because they are just interfaces and dropped from the final build anyways or are in spec files.