### PR TITLE
[NG] fix support for TS 2.7+

### DIFF
--- a/src/clr-angular/utils/i18n/common-strings.service.ts
+++ b/src/clr-angular/utils/i18n/common-strings.service.ts
@@ -8,7 +8,10 @@ import { Injectable, SkipSelf, Optional } from '@angular/core';
 import { ClrCommonStrings } from './common-strings.interface';
 
 @Injectable()
-export class ClrCommonStringsService implements Required<ClrCommonStrings> {
+// @TODO Put the Required type back in when our minimumly supported version of Angular uses
+// TS 2.8 or greater (should be Angular 7)
+// export class ClrCommonStringsService implements Required<ClrCommonStrings> {
+export class ClrCommonStringsService implements ClrCommonStrings {
   open = 'Open';
   close = 'Close';
   show = 'Show';


### PR DESCRIPTION
Using `Required` type from TS 2.8 caused us to break support for Angular 6 projects using TS 2.7, this removes it for now with a note to put it back when we can.