### PR TITLE
[WEB] Unset max-height on pre of code-snippet

### DIFF
--- a/latest/src/app/utils/code-snippet.ts
+++ b/latest/src/app/utils/code-snippet.ts
@@ -20,6 +20,7 @@ import {CodeHighlight} from "./code-highlight";
         pre {
             background: transparent;
             padding: 12px;
+            max-height: none;
         }
     `]
 })

--- a/v0.10/src/app/utils/code-snippet.ts
+++ b/v0.10/src/app/utils/code-snippet.ts
@@ -20,6 +20,7 @@ import {CodeHighlight} from "@clr/angular";
         pre {
             background: transparent;
             padding: 12px;
+            max-height: none;
         }
     `]
 })

--- a/v0.11/src/app/utils/code-snippet.ts
+++ b/v0.11/src/app/utils/code-snippet.ts
@@ -20,6 +20,7 @@ import {CodeHighlight} from "@clr/angular";
         pre {
             background: transparent;
             padding: 12px;
+            max-height: none;
         }
     `]
 })

--- a/v0.12/src/app/utils/code-snippet.ts
+++ b/v0.12/src/app/utils/code-snippet.ts
@@ -20,6 +20,7 @@ import {CodeHighlight} from "./code-highlight";
         pre {
             background: transparent;
             padding: 12px;
+            max-height: none;
         }
     `]
 })


### PR DESCRIPTION
It's too often that default `pre { max-height: 15rem }` gets in the way while reading sample code on the doc site, given that other sites (e.g. MDN / Bootstrap / Angular.io) would just show code snippet in full-size, suggest to take out the squeezing to make it more readable.