### PR TITLE
fix(core): removes the old npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
         "lite-server": "^2.3.0",
         "loader-utils": "^1.1.0",
         "ng-packagr": "^2.0.0",
-        "npm": "^4.6.1",
         "npm-run-all": "^4.1.1",
         "optimize-css-assets-webpack-plugin": "^3.2.0",
         "postcss-loader": "^1.3.3",

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -27,8 +27,7 @@ prompt.start();
  */
 prompt.get(['confirmation'], function (err, result) {
     if(/yes/i.test(result.confirmation) || /y/i.test(result.confirmation)) {
-        const npm = path.join(process.cwd(), 'node_modules', '.bin', 'npm');
-        shell.exec(`${npm} publish dist/clr-ui; ${npm} publish dist/clr-angular/clr-angular-${version}.tgz; ${npm} publish dist/clr-icons`);
+        shell.exec(`npm publish dist/clr-ui; npm publish dist/clr-angular/clr-angular-${version}.tgz; npm publish dist/clr-icons`);
         console.log(colors.green(`Clarity v${version} successfully published to npm!`));
     } else {
         console.log(colors.red('Nah, just kidding for now!'));


### PR DESCRIPTION
Switched to the user installed npm  for publishing

- removes npm as devDependency
- mods publish script to use the users npm install, not one in node_modules

Signed-off-by: Matt Hippely <mhippely@vmware.com>