### PR TITLE
[NG] Replace old forms module

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -622,10 +622,10 @@ export declare class ClrEmphasisModule {
 export declare class ClrForm {
 }
 
-export declare class ClrFormsModule {
+export declare class ClrFormsDeprecatedModule {
 }
 
-export declare class ClrFormsNextModule {
+export declare class ClrFormsModule {
 }
 
 export declare class ClrHeader implements OnDestroy {

--- a/src/clr-angular/clr-angular.module.ts
+++ b/src/clr-angular/clr-angular.module.ts
@@ -9,7 +9,7 @@ import { ClrButtonModule } from './button/button.module';
 import { ClrDataModule } from './data/data.module';
 import { ClrDragAndDropModule } from './utils/drag-and-drop/drag-and-drop.module';
 import { ClrEmphasisModule } from './emphasis/emphasis.module';
-import { ClrFormsModule } from './forms-deprecated/forms.module';
+import { ClrFormsModule } from './forms/forms.module';
 import { ClrIconModule } from './icon/icon.module';
 import { ClrLayoutModule } from './layout/layout.module';
 import { ClrModalModule } from './modal/modal.module';

--- a/src/clr-angular/data/datagrid/datagrid.module.ts
+++ b/src/clr-angular/data/datagrid/datagrid.module.ts
@@ -8,7 +8,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule, Type } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
-import { ClrFormsNextModule } from '../../forms/forms.module';
+import { ClrFormsModule } from '../../forms/forms.module';
 import { ClrIconModule } from '../../icon/icon.module';
 import { ClrCommonPopoverModule } from '../../popover/common/popover.module';
 import { ClrIfExpandModule } from '../../utils/expand/if-expand.module';
@@ -94,7 +94,7 @@ export const CLR_DATAGRID_DIRECTIVES: Type<any>[] = [
   imports: [
     CommonModule,
     ClrIconModule,
-    ClrFormsNextModule,
+    ClrFormsModule,
     FormsModule,
     ClrCommonPopoverModule,
     ClrLoadingModule,

--- a/src/clr-angular/data/tree-view/tree-view.module.ts
+++ b/src/clr-angular/data/tree-view/tree-view.module.ts
@@ -8,7 +8,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule, Type } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
-import { ClrFormsModule } from '../../forms-deprecated/forms.module';
+import { ClrFormsDeprecatedModule } from '../../forms-deprecated/forms.module';
 import { ClrIconModule } from '../../icon/icon.module';
 import { ClrIfExpandModule } from '../../utils/expand/if-expand.module';
 import { ClrTreeNode } from './tree-node';
@@ -16,7 +16,7 @@ import { ClrTreeNode } from './tree-node';
 export const CLR_TREE_VIEW_DIRECTIVES: Type<any>[] = [ClrTreeNode];
 
 @NgModule({
-  imports: [CommonModule, ClrIconModule, FormsModule, ClrFormsModule],
+  imports: [CommonModule, ClrIconModule, FormsModule, ClrFormsDeprecatedModule],
   declarations: [CLR_TREE_VIEW_DIRECTIVES],
   exports: [CLR_TREE_VIEW_DIRECTIVES, ClrIfExpandModule],
 })

--- a/src/clr-angular/forms-deprecated/checkbox/checkbox.spec.ts
+++ b/src/clr-angular/forms-deprecated/checkbox/checkbox.spec.ts
@@ -7,7 +7,7 @@ import { Component, Type, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
-import { ClrFormsModule } from '../forms.module';
+import { ClrFormsDeprecatedModule } from '../forms.module';
 
 import { ClrCheckboxDeprecated } from './checkbox';
 
@@ -100,7 +100,7 @@ describe('Checkbox', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ClrFormsModule, FormsModule],
+      imports: [ClrFormsDeprecatedModule, FormsModule],
       declarations: [
         BasicCheckbox,
         CheckboxWithNgModel,

--- a/src/clr-angular/forms-deprecated/forms.module.ts
+++ b/src/clr-angular/forms-deprecated/forms.module.ts
@@ -14,4 +14,4 @@ import { ClrCheckboxModule } from './checkbox/checkbox.module';
   imports: [CommonModule],
   exports: [ClrCheckboxModule, ClrDatepickerModule],
 })
-export class ClrFormsModule {}
+export class ClrFormsDeprecatedModule {}

--- a/src/clr-angular/forms/datepicker/date-input.spec.ts
+++ b/src/clr-angular/forms/datepicker/date-input.spec.ts
@@ -11,7 +11,7 @@ import { By } from '@angular/platform-browser';
 
 import { itIgnore } from '../../../../tests/tests.helpers';
 import { TestContext } from '../../data/datagrid/helpers.spec';
-import { ClrFormsModule } from '../../forms-deprecated/forms.module';
+import { ClrFormsDeprecatedModule } from '../../forms-deprecated/forms.module';
 import { IfOpenService } from '../../utils/conditional/if-open.service';
 import { IfErrorService } from '../common/if-error/if-error.service';
 import { ControlClassService } from '../common/providers/control-class.service';
@@ -237,7 +237,7 @@ export default function() {
 
       beforeEach(function() {
         TestBed.configureTestingModule({
-          imports: [FormsModule, ClrFormsModule],
+          imports: [FormsModule, ClrFormsDeprecatedModule],
           declarations: [TestComponentWithNgModel],
         });
 
@@ -304,7 +304,7 @@ export default function() {
 
       beforeEach(function() {
         TestBed.configureTestingModule({
-          imports: [ReactiveFormsModule, ClrFormsModule],
+          imports: [ReactiveFormsModule, ClrFormsDeprecatedModule],
           declarations: [TestComponentWithReactiveForms],
         });
 
@@ -383,7 +383,7 @@ export default function() {
 
       beforeEach(function() {
         TestBed.configureTestingModule({
-          imports: [FormsModule, ClrFormsModule],
+          imports: [FormsModule, ClrFormsDeprecatedModule],
           declarations: [TestComponentWithTemplateDrivenForms],
         });
         fixture = TestBed.createComponent(TestComponentWithTemplateDrivenForms);
@@ -451,7 +451,7 @@ export default function() {
 
       beforeEach(function() {
         TestBed.configureTestingModule({
-          imports: [FormsModule, ClrFormsModule],
+          imports: [FormsModule, ClrFormsDeprecatedModule],
           declarations: [TestComponentWithClrDate],
         });
 

--- a/src/clr-angular/forms/forms.module.ts
+++ b/src/clr-angular/forms/forms.module.ts
@@ -29,4 +29,4 @@ import { ClrTextareaModule } from './textarea/textarea.module';
     ClrTextareaModule,
   ],
 })
-export class ClrFormsNextModule {}
+export class ClrFormsModule {}

--- a/src/dev/src/app/button-group/button-group.demo.module.ts
+++ b/src/dev/src/app/button-group/button-group.demo.module.ts
@@ -6,7 +6,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
-import { ClarityModule } from '@clr/angular';
+import { ClarityModule, ClrFormsDeprecatedModule } from '@clr/angular';
 
 import { BasicButtonGroupDemo } from './angular/basic-structure/basic-button-group';
 import { ButtonGroupAngularDemo } from './angular/button-group-angular';
@@ -38,7 +38,7 @@ import { ButtonGroupRadiosDemo } from './static/radio/button-group-radios';
 import { ButtonGroupTypes } from './static/types/button-group-types';
 
 @NgModule({
-  imports: [CommonModule, ClarityModule, ROUTING],
+  imports: [CommonModule, ClarityModule, ClrFormsDeprecatedModule, ROUTING],
   declarations: [
     BasicButtonGroupDemo,
     IconButtonGroupDemo,

--- a/src/dev/src/app/checkboxes/checkboxes.demo.module.ts
+++ b/src/dev/src/app/checkboxes/checkboxes.demo.module.ts
@@ -7,14 +7,14 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
-import { ClarityModule, ClrCheckboxNextModule } from '@clr/angular';
+import { ClarityModule, ClrFormsDeprecatedModule } from '@clr/angular';
 
 import { CheckboxesDemo } from './checkboxes.demo';
 import { ROUTING } from './checkboxes.demo.routing';
 import { Status } from './data/status';
 
 @NgModule({
-  imports: [CommonModule, FormsModule, ClrCheckboxNextModule, ClarityModule, ROUTING],
+  imports: [CommonModule, FormsModule, ClarityModule, ClrFormsDeprecatedModule, ROUTING],
   declarations: [CheckboxesDemo],
   providers: [Status],
   exports: [CheckboxesDemo],

--- a/src/dev/src/app/datagrid/datagrid.demo.module.ts
+++ b/src/dev/src/app/datagrid/datagrid.demo.module.ts
@@ -7,7 +7,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
-import { ClarityModule } from '@clr/angular';
+import { ClarityModule, ClrFormsDeprecatedModule } from '@clr/angular';
 import { UtilsDemoModule } from '../_utils/utils.module';
 
 import { DatagridBasicStructureDemo } from './basic-structure/basic-structure';
@@ -41,7 +41,7 @@ import { DatagridTestCasesDemo } from './test-cases/test-cases';
 import { ColorFilter } from './utils/color-filter';
 
 @NgModule({
-  imports: [CommonModule, FormsModule, ClarityModule, ROUTING, UtilsDemoModule],
+  imports: [CommonModule, FormsModule, ClarityModule, ClrFormsDeprecatedModule, ROUTING, UtilsDemoModule],
   declarations: [
     DatagridDemo,
     DatagridBasicStructureDemo,

--- a/src/dev/src/app/datepicker/datepicker.demo.module.ts
+++ b/src/dev/src/app/datepicker/datepicker.demo.module.ts
@@ -7,7 +7,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
-import { ClarityModule, ClrFormsNextModule } from '@clr/angular';
+import { ClarityModule } from '@clr/angular';
 
 import { DatepickerCSSRegressionDemo } from './css-regression';
 import { DatepickerAKDemo } from './datepicker-AK';
@@ -28,7 +28,7 @@ import { NgModelExplicitWrapperDemo } from './ngmodel-wrapper-explicit-wrapper';
 import { DisabledDemo } from './disabled';
 
 @NgModule({
-  imports: [CommonModule, ClarityModule, ClrFormsNextModule, ROUTING, FormsModule, ReactiveFormsModule],
+  imports: [CommonModule, ClarityModule, ROUTING, FormsModule, ReactiveFormsModule],
   declarations: [
     DatepickerDemo,
     DatepickerInTemplateDrivenFormsDemo,

--- a/src/dev/src/app/forms/forms.demo.module.ts
+++ b/src/dev/src/app/forms/forms.demo.module.ts
@@ -8,7 +8,7 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ReactiveFormsModule } from '@angular/forms';
 
-import { ClarityModule, ClrFormsNextModule } from '@clr/angular';
+import { ClarityModule } from '@clr/angular';
 
 import { FormsCheckboxDemo } from './controls/checkbox';
 import { FormsFileDemo } from './controls/file';
@@ -30,7 +30,7 @@ import { FormsTemplateDrivenDemo } from './template-driven/template-driven';
 import { FormsReactiveDemo } from './reactive/reactive';
 
 @NgModule({
-  imports: [CommonModule, FormsModule, ReactiveFormsModule, ClarityModule, ClrFormsNextModule, ROUTING],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, ClarityModule, ROUTING],
   declarations: [
     FormsDemo,
     FormsInputGroupDemo,

--- a/src/dev/src/app/input/input.demo.module.ts
+++ b/src/dev/src/app/input/input.demo.module.ts
@@ -6,13 +6,13 @@
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
-import { ClarityModule, ClrFormsNextModule } from '@clr/angular';
+import { ClarityModule } from '@clr/angular';
 
 import { InputDemo } from './input.demo';
 import { ROUTING } from './input.demo.routing';
 
 @NgModule({
-  imports: [ClarityModule, ClrFormsNextModule, FormsModule, ROUTING],
+  imports: [ClarityModule, FormsModule, ROUTING],
   declarations: [InputDemo],
 })
 export class InputDemoModule {}

--- a/src/dev/src/app/password/password.demo.module.ts
+++ b/src/dev/src/app/password/password.demo.module.ts
@@ -6,13 +6,13 @@
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
-import { ClarityModule, ClrFormsNextModule } from '@clr/angular';
+import { ClarityModule } from '@clr/angular';
 
 import { PasswordDemo } from './password.demo';
 import { ROUTING } from './password.demo.routing';
 
 @NgModule({
-  imports: [ClarityModule, ClrFormsNextModule, FormsModule, ROUTING],
+  imports: [ClarityModule, FormsModule, ROUTING],
   declarations: [PasswordDemo],
 })
 export class PasswordDemoModule {}

--- a/src/dev/src/app/radios/radios.demo.module.ts
+++ b/src/dev/src/app/radios/radios.demo.module.ts
@@ -6,13 +6,13 @@
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
-import { ClarityModule, ClrFormsNextModule } from '@clr/angular';
+import { ClarityModule } from '@clr/angular';
 
 import { RadiosDemo } from './radios.demo';
 import { ROUTING } from './radios.demo.routing';
 
 @NgModule({
-  imports: [ClarityModule, ClrFormsNextModule, FormsModule, ROUTING],
+  imports: [ClarityModule, FormsModule, ROUTING],
   declarations: [RadiosDemo],
   exports: [RadiosDemo],
 })

--- a/src/dev/src/app/selects/selects.demo.module.ts
+++ b/src/dev/src/app/selects/selects.demo.module.ts
@@ -7,13 +7,13 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
-import { ClarityModule, ClrFormsNextModule } from '@clr/angular';
+import { ClarityModule } from '@clr/angular';
 
 import { SelectsDemo } from './selects.demo';
 import { ROUTING } from './selects.demo.routing';
 
 @NgModule({
-  imports: [CommonModule, ClarityModule, ClrFormsNextModule, FormsModule, ROUTING],
+  imports: [CommonModule, ClarityModule, FormsModule, ROUTING],
   declarations: [SelectsDemo],
   exports: [SelectsDemo],
 })

--- a/src/dev/src/app/textarea/textarea.demo.module.ts
+++ b/src/dev/src/app/textarea/textarea.demo.module.ts
@@ -6,13 +6,13 @@
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
-import { ClarityModule, ClrFormsNextModule } from '@clr/angular';
+import { ClarityModule } from '@clr/angular';
 
 import { TextareaDemo } from './textarea.demo';
 import { ROUTING } from './textarea.demo.routing';
 
 @NgModule({
-  imports: [ClarityModule, ClrFormsNextModule, FormsModule, ROUTING],
+  imports: [ClarityModule, FormsModule, ROUTING],
   declarations: [TextareaDemo],
 })
 export class TextareaDemoModule {}

--- a/src/ks-app/src/app/app.module.ts
+++ b/src/ks-app/src/app/app.module.ts
@@ -8,7 +8,7 @@ import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { ClarityModule, ClrFormsNextModule } from '@clr/angular';
+import { ClarityModule, ClrFormsDeprecatedModule } from '@clr/angular';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -109,7 +109,7 @@ import { KSToggle } from './containers/forms/toggle.component';
     FormsModule,
     ReactiveFormsModule,
     ClarityModule,
-    ClrFormsNextModule,
+    ClrFormsDeprecatedModule,
     AppRoutingModule,
   ],
   providers: [],


### PR DESCRIPTION
This change removes and renames the old forms module.

- The `ClrFormsModule` becomes `ClrFormsDeprecatedModule`
- The `ClrFormsNextModule`becomes `ClrFormsModule`
- `ClrFormsDeprecatedModule` is no longer published in `ClarityModule` and will need to be explicetly imported if an app still has old forms. (TODO: Document this on the website)

Signed-off-by: Matt Hippely <mhippely@vmware.com>