### PR TITLE
[NG] support reset and forced validation

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -152,10 +152,8 @@ export declare class ClrCalendar implements OnDestroy {
     onKeyDown(event: KeyboardEvent): void;
 }
 
-export declare class ClrCheckbox extends WrappedFormControl<ClrCheckboxWrapper> implements OnInit {
-    constructor(vcr: ViewContainerRef, ngControlService: NgControlService, ifErrorService: IfErrorService, control: NgControl, controlClassService: ControlClassService, el: ElementRef, renderer: Renderer2);
-    ngOnInit(): void;
-    onBlur(): void;
+export declare class ClrCheckbox extends WrappedFormControl<ClrCheckboxWrapper> {
+    constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef);
 }
 
 export declare class ClrCheckboxContainer implements OnDestroy {
@@ -514,18 +512,21 @@ export declare class ClrDateContainer implements DynamicWrapper, OnDestroy {
 export declare class ClrDateInput extends WrappedFormControl<ClrDateContainer> implements OnInit, AfterViewInit, OnDestroy {
     _dateUpdated: EventEmitter<Date>;
     clrNewLayout: boolean;
+    protected control: NgControl;
     date: Date;
+    protected el: ElementRef;
+    protected index: number;
     readonly inputType: string;
     newFormsLayout: boolean;
     placeholder: string;
     readonly placeholderText: string;
-    constructor(container: ClrDateContainer, vcr: ViewContainerRef, elRef: ElementRef, renderer: Renderer2, _ngControl: NgControl, _dateIOService: DateIOService, _dateNavigationService: DateNavigationService, _datepickerEnabledService: DatepickerEnabledService, dateFormControlService: DateFormControlService, platformId: Object, ngControlService: NgControlService, controlClassService: ControlClassService, focusService: FocusService, ifErrorService: IfErrorService, control: NgControl, newFormsLayout: boolean);
+    protected renderer: Renderer2;
+    constructor(vcr: ViewContainerRef, injector: Injector, el: ElementRef, renderer: Renderer2, control: NgControl, container: ClrDateContainer, _dateIOService: DateIOService, _dateNavigationService: DateNavigationService, _datepickerEnabledService: DatepickerEnabledService, dateFormControlService: DateFormControlService, platformId: Object, focusService: FocusService, newFormsLayout: boolean);
     ngAfterViewInit(): void;
-    ngOnDestroy(): void;
     ngOnInit(): void;
     onValueChange(target: HTMLInputElement): void;
-    setBlurStates(): void;
     setFocusStates(): void;
+    triggerValidation(): void;
 }
 
 export declare class ClrDatepickerModule {
@@ -659,6 +660,8 @@ export declare class ClrEmphasisModule {
 }
 
 export declare class ClrForm {
+    constructor(markControlService: MarkControlService);
+    markAsDirty(): void;
 }
 
 export declare class ClrFormsDeprecatedModule {
@@ -700,9 +703,8 @@ export declare class ClrIfDragged<T> implements OnDestroy {
 
 export declare class ClrIfError {
     error: string;
-    constructor(service: IfErrorService, template: TemplateRef<any>, container: ViewContainerRef);
+    constructor(ifErrorService: IfErrorService, ngControlService: NgControlService, template: TemplateRef<any>, container: ViewContainerRef);
     ngOnDestroy(): void;
-    ngOnInit(): void;
 }
 
 export declare class ClrIfExpanded implements OnInit, OnDestroy {
@@ -721,10 +723,9 @@ export declare class ClrIfOpen implements OnDestroy {
     updateView(value: boolean): void;
 }
 
-export declare class ClrInput extends WrappedFormControl<ClrInputContainer> implements OnInit {
-    constructor(vcr: ViewContainerRef, ngControlService: NgControlService, ifErrorService: IfErrorService, control: NgControl, controlClassService: ControlClassService, renderer: Renderer2, el: ElementRef);
-    ngOnInit(): void;
-    onBlur(): void;
+export declare class ClrInput extends WrappedFormControl<ClrInputContainer> {
+    protected index: number;
+    constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef);
 }
 
 export declare class ClrInputContainer implements DynamicWrapper, OnDestroy {
@@ -852,12 +853,10 @@ export declare class ClrNavLevel implements OnInit {
 }
 
 export declare class ClrPassword extends WrappedFormControl<ClrPasswordContainer> implements OnInit, OnDestroy {
-    subscription: Subscription;
-    constructor(vcr: ViewContainerRef, ngControlService: NgControlService, ifErrorService: IfErrorService, control: NgControl, focusService: FocusService, controlClassService: ControlClassService, renderer: Renderer2, el: ElementRef, toggleService: BehaviorSubject<boolean>);
-    ngOnDestroy(): void;
-    ngOnInit(): void;
-    onBlur(): void;
-    onFocus(): void;
+    protected index: number;
+    constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef, focusService: FocusService, toggleService: BehaviorSubject<boolean>);
+    triggerFocus(): void;
+    triggerValidation(): void;
 }
 
 export declare class ClrPasswordContainer implements DynamicWrapper, OnDestroy {
@@ -883,10 +882,8 @@ export declare class ClrPasswordModule {
 export declare class ClrPopoverModule {
 }
 
-export declare class ClrRadio extends WrappedFormControl<ClrRadioWrapper> implements OnInit {
-    constructor(vcr: ViewContainerRef, ngControlService: NgControlService, ifErrorService: IfErrorService, control: NgControl, controlClassService: ControlClassService, el: ElementRef, renderer: Renderer2);
-    ngOnInit(): void;
-    onBlur(): void;
+export declare class ClrRadio extends WrappedFormControl<ClrRadioWrapper> {
+    constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef);
 }
 
 export declare class ClrRadioContainer implements OnDestroy {
@@ -908,10 +905,9 @@ export declare class ClrRadioWrapper implements DynamicWrapper {
     label: ClrLabel;
 }
 
-export declare class ClrSelect extends WrappedFormControl<ClrSelectContainer> implements OnInit {
-    constructor(vcr: ViewContainerRef, ngControlService: NgControlService, ifErrorService: IfErrorService, control: NgControl, controlClassService: ControlClassService, el: ElementRef, renderer: Renderer2);
-    ngOnInit(): void;
-    onBlur(): void;
+export declare class ClrSelect extends WrappedFormControl<ClrSelectContainer> {
+    protected index: number;
+    constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef);
 }
 
 export declare class ClrSelectContainer implements DynamicWrapper, OnDestroy {
@@ -1055,10 +1051,9 @@ export declare class ClrTabs implements AfterContentInit {
 export declare class ClrTabsModule {
 }
 
-export declare class ClrTextarea extends WrappedFormControl<ClrTextareaContainer> implements OnInit {
-    constructor(vcr: ViewContainerRef, ngControlService: NgControlService, ifErrorService: IfErrorService, control: NgControl, controlClassService: ControlClassService, renderer: Renderer2, el: ElementRef);
-    ngOnInit(): void;
-    onBlur(): void;
+export declare class ClrTextarea extends WrappedFormControl<ClrTextareaContainer> {
+    protected index: number;
+    constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef);
 }
 
 export declare class ClrTextareaContainer implements DynamicWrapper, OnDestroy {

--- a/src/clr-angular/forms/checkbox/checkbox-container.ts
+++ b/src/clr-angular/forms/checkbox/checkbox-container.ts
@@ -90,8 +90,8 @@ export class ClrCheckboxContainer implements OnDestroy {
     // @TODO put a solution in for form group validation
     // if (!this.formGroup) {
     this.subscriptions.push(
-      this.ifErrorService.statusChanges.subscribe(control => {
-        this.invalid = control.invalid;
+      this.ifErrorService.statusChanges.subscribe(invalid => {
+        this.invalid = invalid;
       })
     );
     // } else {

--- a/src/clr-angular/forms/checkbox/checkbox.spec.ts
+++ b/src/clr-angular/forms/checkbox/checkbox.spec.ts
@@ -6,7 +6,7 @@
 import { Component } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 
-import { ControlInvalidSpec, ReactiveSpec, TemplateDrivenSpec } from '../tests/control.spec';
+import { ControlStandaloneSpec, ReactiveSpec, TemplateDrivenSpec } from '../tests/control.spec';
 import { ClrCheckbox } from './checkbox';
 import { ClrCheckboxWrapper } from './checkbox-wrapper';
 
@@ -15,7 +15,7 @@ import { ClrCheckboxWrapper } from './checkbox-wrapper';
     <input type="checkbox" clrCheckbox />
     `,
 })
-class InvalidUseTest {}
+class StandaloneUseTest {}
 
 @Component({
   template: `
@@ -39,7 +39,7 @@ class ReactiveTest {
 
 export default function(): void {
   describe('ClrCheckbox directive', () => {
-    ControlInvalidSpec(ClrCheckbox, InvalidUseTest);
+    ControlStandaloneSpec(StandaloneUseTest);
     TemplateDrivenSpec(ClrCheckboxWrapper, ClrCheckbox, TemplateDrivenTest, 'clr-checkbox');
     ReactiveSpec(ClrCheckboxWrapper, ClrCheckbox, ReactiveTest, 'clr-checkbox');
   });

--- a/src/clr-angular/forms/checkbox/checkbox.ts
+++ b/src/clr-angular/forms/checkbox/checkbox.ts
@@ -4,43 +4,23 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Directive, Renderer2, ElementRef, HostListener, OnInit, Optional, ViewContainerRef } from '@angular/core';
+import { Directive, Renderer2, ElementRef, Injector, Self, Optional, ViewContainerRef } from '@angular/core';
 import { NgControl } from '@angular/forms';
 import { ClrCheckboxWrapper } from './checkbox-wrapper';
 
-import { IfErrorService } from '../common/if-error/if-error.service';
-import { ControlClassService } from '../common/providers/control-class.service';
-import { NgControlService } from '../common/providers/ng-control.service';
 import { WrappedFormControl } from '../common/wrapped-control';
 
 @Directive({ selector: '[clrCheckbox]' })
-export class ClrCheckbox extends WrappedFormControl<ClrCheckboxWrapper> implements OnInit {
+export class ClrCheckbox extends WrappedFormControl<ClrCheckboxWrapper> {
   constructor(
     vcr: ViewContainerRef,
-    @Optional() private ngControlService: NgControlService,
-    @Optional() private ifErrorService: IfErrorService,
-    @Optional() private control: NgControl,
-    @Optional() controlClassService: ControlClassService,
-    el: ElementRef,
-    renderer: Renderer2
+    injector: Injector,
+    @Self()
+    @Optional()
+    control: NgControl,
+    renderer: Renderer2,
+    el: ElementRef
   ) {
-    super(ClrCheckboxWrapper, vcr, 0);
-    if (controlClassService) {
-      controlClassService.initControlClass(renderer, el.nativeElement);
-    }
-  }
-
-  ngOnInit() {
-    super.ngOnInit();
-    if (this.ngControlService) {
-      this.ngControlService.setControl(this.control);
-    }
-  }
-
-  @HostListener('blur')
-  onBlur() {
-    if (this.ifErrorService) {
-      this.ifErrorService.triggerStatusChange();
-    }
+    super(vcr, ClrCheckboxWrapper, injector, control, renderer, el);
   }
 }

--- a/src/clr-angular/forms/common/common.spec.ts
+++ b/src/clr-angular/forms/common/common.spec.ts
@@ -33,7 +33,7 @@ class GenericWrapper implements DynamicWrapper {
 @Directive({ selector: '[genericControl]' })
 class GenericControl extends WrappedFormControl<GenericWrapper> {
   constructor(vcr: ViewContainerRef) {
-    super(GenericWrapper, vcr);
+    super(vcr, GenericWrapper, null, null, null, null);
   }
 }
 

--- a/src/clr-angular/forms/common/form.spec.ts
+++ b/src/clr-angular/forms/common/form.spec.ts
@@ -3,15 +3,18 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { ClrForm } from './form';
 import { LayoutService } from './providers/layout.service';
+import { MarkControlService } from './providers/mark-control.service';
 
 @Component({ template: `<form clrForm></form>` })
-class SimpleTest {}
+class SimpleTest {
+  @ViewChild(ClrForm) form: ClrForm;
+}
 
 export default function(): void {
   describe('ClrForm', () => {
@@ -30,6 +33,17 @@ export default function(): void {
 
     it('provides the LayoutService', function() {
       expect(directive.injector.get(LayoutService)).toBeTruthy();
+    });
+
+    it('provides the MarkControlService', function() {
+      expect(directive.injector.get(MarkControlService)).toBeTruthy();
+    });
+
+    it('calls markAsDirty', function() {
+      const service = directive.injector.get(MarkControlService);
+      spyOn(service, 'markAsDirty');
+      directive.componentInstance.form.markAsDirty();
+      expect(service.markAsDirty).toHaveBeenCalled();
     });
   });
 }

--- a/src/clr-angular/forms/common/form.ts
+++ b/src/clr-angular/forms/common/form.ts
@@ -7,10 +7,17 @@
 import { Directive } from '@angular/core';
 import { LayoutService } from './providers/layout.service';
 import { IS_NEW_FORMS_LAYOUT_TRUE_PROVIDER } from './providers/new-forms.service';
+import { MarkControlService } from './providers/mark-control.service';
 
 @Directive({
   selector: '[clrForm]',
-  providers: [LayoutService, IS_NEW_FORMS_LAYOUT_TRUE_PROVIDER],
+  providers: [LayoutService, MarkControlService, IS_NEW_FORMS_LAYOUT_TRUE_PROVIDER],
   host: { '[class.clr-form]': 'true' },
 })
-export class ClrForm {}
+export class ClrForm {
+  constructor(private markControlService: MarkControlService) {}
+
+  markAsDirty() {
+    this.markControlService.markAsDirty();
+  }
+}

--- a/src/clr-angular/forms/common/if-error/if-error.service.spec.ts
+++ b/src/clr-angular/forms/common/if-error/if-error.service.spec.ts
@@ -25,7 +25,7 @@ export default function(): void {
       expect(testControl.statusChanges.subscribe).toHaveBeenCalled();
     });
 
-    it('provides observable for statusChanges, passing the control', () => {
+    it('provides observable for statusChanges, passing the invalid state', () => {
       const cb = jasmine.createSpy('cb');
       const sub = service.statusChanges.subscribe(control => cb(control));
       ngControlService.setControl(testControl);
@@ -33,7 +33,7 @@ export default function(): void {
       testControl.markAsTouched();
       testControl.updateValueAndValidity();
       expect(cb).toHaveBeenCalled();
-      expect(cb).toHaveBeenCalledWith(testControl);
+      expect(cb).toHaveBeenCalledWith(false);
       sub.unsubscribe();
     });
 
@@ -44,18 +44,25 @@ export default function(): void {
       // Manually trigger status check
       service.triggerStatusChange();
       expect(cb).toHaveBeenCalled();
-      expect(cb).toHaveBeenCalledWith(testControl);
+      expect(cb).toHaveBeenCalledWith(false);
       sub.unsubscribe();
     });
 
-    it('should not fire status changes if control is untouched', () => {
+    it('should return invalid state', () => {
       const cb = jasmine.createSpy('cb');
       const sub = service.statusChanges.subscribe(control => cb(control));
-      ngControlService.setControl(testControl);
-      // Change state of the input, should only fire when touched
-      testControl.markAsDirty();
-      testControl.updateValueAndValidity();
-      expect(cb).not.toHaveBeenCalled();
+      const fakeControl = {
+        statusChanges: {
+          subscribe: () => {
+            return function unsubscribe() {};
+          },
+        },
+        dirty: true,
+        invalid: true,
+      };
+      ngControlService.setControl(fakeControl);
+      service.triggerStatusChange();
+      expect(cb).toHaveBeenCalledWith(true);
       sub.unsubscribe();
     });
   });

--- a/src/clr-angular/forms/common/providers/mark-control.service.ts
+++ b/src/clr-angular/forms/common/providers/mark-control.service.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Injectable } from '@angular/core';
+import { Subject, Observable } from 'rxjs';
+
+@Injectable()
+export class MarkControlService {
+  private _dirty: Subject<void> = new Subject();
+
+  get dirtyChange(): Observable<void> {
+    return this._dirty.asObservable();
+  }
+
+  markAsDirty() {
+    this._dirty.next();
+  }
+}

--- a/src/clr-angular/forms/common/wrapped-control.spec.ts
+++ b/src/clr-angular/forms/common/wrapped-control.spec.ts
@@ -3,15 +3,20 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { Component, Directive, NgModule, Type, ViewContainerRef } from '@angular/core';
+import { Component, Directive, NgModule, Type, ViewContainerRef, ElementRef, Renderer2, Injector } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { NgControl, FormsModule } from '@angular/forms';
 
 import { DynamicWrapper } from '../../utils/host-wrapping/dynamic-wrapper';
 import { HostWrapper } from '../../utils/host-wrapping/host-wrapper';
 import { ClrHostWrappingModule } from '../../utils/host-wrapping/host-wrapping.module';
 
 import { ControlIdService } from './providers/control-id.service';
+import { NgControlService } from './providers/ng-control.service';
+import { IfErrorService } from './if-error/if-error.service';
+import { ControlClassService } from './providers/control-class.service';
+import { MarkControlService } from './providers/mark-control.service';
 import { WrappedFormControl } from './wrapped-control';
 
 /*
@@ -25,7 +30,7 @@ class TestWrapper implements DynamicWrapper {
 @Directive({ selector: '[testControl]' })
 class TestControl extends WrappedFormControl<TestWrapper> {
   constructor(vcr: ViewContainerRef) {
-    super(TestWrapper, vcr);
+    super(vcr, TestWrapper, null, null, null, null);
   }
 }
 
@@ -41,15 +46,31 @@ class TestWrapper2 implements DynamicWrapper {
 @Directive({ selector: '[testControl2]' })
 class TestControl2 extends WrappedFormControl<TestWrapper2> {
   constructor(vcr: ViewContainerRef) {
-    super(TestWrapper2, vcr, 1);
+    super(vcr, TestWrapper2, null, null, null, null);
+  }
+}
+
+@Component({
+  selector: 'test-wrapper3',
+  template: `<div id="wrapper"><ng-content></ng-content></div>`,
+  providers: [ControlIdService, MarkControlService, NgControlService, IfErrorService, ControlClassService],
+})
+class TestWrapper3 implements DynamicWrapper {
+  _dynamic = false;
+}
+
+@Directive({ selector: '[testControl3]' })
+class TestControl3 extends WrappedFormControl<TestWrapper3> {
+  constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef) {
+    super(vcr, TestWrapper3, injector, control, renderer, el);
   }
 }
 
 @NgModule({
-  imports: [ClrHostWrappingModule],
-  declarations: [TestWrapper, TestControl, TestWrapper2, TestControl2],
-  exports: [TestWrapper, TestControl, TestWrapper2, TestControl2],
-  entryComponents: [TestWrapper, TestWrapper2],
+  imports: [ClrHostWrappingModule, FormsModule],
+  declarations: [TestWrapper, TestControl, TestWrapper2, TestControl2, TestControl3, TestWrapper3],
+  exports: [TestWrapper, TestControl, TestWrapper2, TestControl2, TestControl3, TestWrapper3],
+  entryComponents: [TestWrapper, TestWrapper2, TestWrapper3],
 })
 class WrappedFormControlTestModule {}
 
@@ -71,42 +92,61 @@ class WithWrapperWithId {}
 @Component({ template: `<test-wrapper2><input testControl id="hello" /></test-wrapper2>` })
 class WithMultipleNgContent {}
 
+@Component({ template: `<test-wrapper3><input testControl3 [(ngModel)]="model" /><test-wrapper>` })
+class WithControl {
+  model = '';
+}
+
 interface TestContext {
   fixture: ComponentFixture<any>;
   wrapper: TestWrapper;
-  control: TestControl;
+  control: any;
   controlIdService: ControlIdService;
   input: any;
+  controlClassService?: ControlClassService;
+  markControlService?: MarkControlService;
+  ngControlService?: NgControlService;
+  ifErrorService?: IfErrorService;
 }
 
 export default function(): void {
   describe('WrappedFormControl', () => {
-    function setupTest<T>(testContext: TestContext, testComponent: Type<T>) {
-      TestBed.configureTestingModule({ imports: [WrappedFormControlTestModule], declarations: [testComponent] });
+    function setupTest<T>(testContext: TestContext, testComponent: Type<T>, testControl: any) {
+      TestBed.configureTestingModule({
+        imports: [WrappedFormControlTestModule, FormsModule],
+        declarations: [testComponent],
+      });
       testContext.fixture = TestBed.createComponent(testComponent);
       testContext.fixture.detectChanges();
       const wrapperDebugElement = testContext.fixture.debugElement.query(By.directive(TestWrapper));
       testContext.wrapper = wrapperDebugElement.componentInstance;
-      testContext.control = testContext.fixture.debugElement.query(By.directive(TestControl)).injector.get(TestControl);
+      testContext.control = testContext.fixture.debugElement.query(By.directive(testControl)).injector.get(testControl);
       testContext.controlIdService = wrapperDebugElement.injector.get(ControlIdService);
       testContext.input = testContext.fixture.nativeElement.querySelector('input');
+      // Capture them only when present, they are optional
+      try {
+        testContext.markControlService = wrapperDebugElement.injector.get(MarkControlService);
+        testContext.controlClassService = wrapperDebugElement.injector.get(ControlClassService);
+        testContext.ngControlService = wrapperDebugElement.injector.get(NgControlService);
+        testContext.ifErrorService = testContext.control.injector.get(IfErrorService);
+      } catch (error) {}
     }
 
     describe('with an explicit wrapper', function() {
       it('uses HostWrapper to inject the ControlIdService', function(this: TestContext) {
         spyOn(HostWrapper.prototype, 'get').and.callThrough();
-        setupTest(this, WithWrapperNoId);
+        setupTest(this, WithWrapperNoId, TestControl);
         expect(HostWrapper.prototype.get).toHaveBeenCalledWith(ControlIdService);
         expect(this.wrapper._dynamic).toBe(false);
       });
 
       it('sets the id of the host to the id given by the service', function(this: TestContext) {
-        setupTest(this, WithWrapperNoId);
+        setupTest(this, WithWrapperNoId, TestControl);
         expect(this.input.getAttribute('id')).toBe(this.controlIdService.id);
       });
 
       it('updates the service to the correct id if it exists', function(this: TestContext) {
-        setupTest(this, WithWrapperWithId);
+        setupTest(this, WithWrapperWithId, TestControl);
         expect(this.input.getAttribute('id')).toBe('hello');
         expect(this.controlIdService.id).toBe('hello');
       });
@@ -115,18 +155,18 @@ export default function(): void {
     describe('without an explicit wrapper', function() {
       it('uses HostWrapper to inject the ControlIdService', function(this: TestContext) {
         spyOn(HostWrapper.prototype, 'get').and.callThrough();
-        setupTest(this, NoWrapperNoId);
+        setupTest(this, NoWrapperNoId, TestControl);
         expect(HostWrapper.prototype.get).toHaveBeenCalledWith(ControlIdService);
         expect(this.wrapper._dynamic).toBe(true);
       });
 
       it('sets the id of the host to the id given by the service', function(this: TestContext) {
-        setupTest(this, NoWrapperNoId);
+        setupTest(this, NoWrapperNoId, TestControl);
         expect(this.input.getAttribute('id')).toBe(this.controlIdService.id);
       });
 
       it('updates the service to the correct id if it exists', function(this: TestContext) {
-        setupTest(this, NoWrapperWithId);
+        setupTest(this, NoWrapperWithId, TestControl);
         expect(this.input.getAttribute('id')).toBe('hello');
         expect(this.controlIdService.id).toBe('hello');
       });
@@ -134,9 +174,45 @@ export default function(): void {
 
     describe('with multiple projection slots', function() {
       it('projects into the second slot when configured', function(this: TestContext) {
-        setupTest(this, WithMultipleNgContent);
+        setupTest(this, WithMultipleNgContent, TestControl);
         expect(this.fixture.nativeElement.querySelector('#first').innerHTML).toBe('');
         expect(this.fixture.nativeElement.querySelector('#second').querySelector('input')).toBeTruthy();
+      });
+    });
+
+    describe('with a real NgControl', function() {
+      it('sets the control class', function(this: TestContext) {
+        spyOn(ControlClassService.prototype, 'initControlClass').and.callThrough();
+        setupTest(this, WithControl, TestControl3);
+        expect(ControlClassService.prototype.initControlClass).toHaveBeenCalled();
+      });
+
+      it('subscribes to requests to mark as dirty', function(this: TestContext) {
+        setupTest(this, WithControl, TestControl3);
+        expect(this.input.className).not.toContain('ng-dirty');
+        this.markControlService.markAsDirty();
+        this.fixture.detectChanges();
+        expect(this.input.className).toContain('ng-dirty');
+      });
+
+      it('sets the control on ngControlService', function(this: TestContext) {
+        spyOn(NgControlService.prototype, 'setControl').and.callThrough();
+        setupTest(this, WithControl, TestControl3);
+        expect(NgControlService.prototype.setControl).toHaveBeenCalled();
+      });
+
+      it('triggers status changes on blur', function(this: TestContext) {
+        spyOn(IfErrorService.prototype, 'triggerStatusChange').and.callThrough();
+        setupTest(this, WithControl, TestControl3);
+        this.input.focus();
+        this.input.blur();
+        this.fixture.detectChanges();
+        expect(IfErrorService.prototype.triggerStatusChange).toHaveBeenCalled();
+      });
+
+      it('implements ngOnDestroy', function(this: TestContext) {
+        setupTest(this, WithControl, TestControl3);
+        expect(this.control.ngOnDestroy).toBeDefined();
       });
     });
   });

--- a/src/clr-angular/forms/common/wrapped-control.ts
+++ b/src/clr-angular/forms/common/wrapped-control.ts
@@ -3,21 +3,72 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { HostBinding, InjectionToken, Injector, Input, OnInit, Type, ViewContainerRef } from '@angular/core';
+import {
+  HostBinding,
+  InjectionToken,
+  HostListener,
+  Injector,
+  Input,
+  OnInit,
+  Type,
+  ViewContainerRef,
+  Renderer2,
+  ElementRef,
+  OnDestroy,
+} from '@angular/core';
 
 import { HostWrapper } from '../../utils/host-wrapping/host-wrapper';
 import { DynamicWrapper } from '../../utils/host-wrapping/dynamic-wrapper';
 
 import { ControlIdService } from './providers/control-id.service';
+import { NgControlService } from './providers/ng-control.service';
+import { IfErrorService } from './if-error/if-error.service';
+import { NgControl } from '@angular/forms';
+import { ControlClassService } from './providers/control-class.service';
+import { MarkControlService } from './providers/mark-control.service';
+import { Subscription } from 'rxjs';
 
-export class WrappedFormControl<W extends DynamicWrapper> implements OnInit {
-  // I lost way too much time trying to make this work without injecting the ViewContainerRef and the Injector,
-  // I'm giving up. So we have to inject these two manually for now.
-  constructor(protected wrapperType: Type<W>, protected vcr: ViewContainerRef, protected index: number = 0) {}
+export class WrappedFormControl<W extends DynamicWrapper> implements OnInit, OnDestroy {
+  private ngControlService: NgControlService;
+  private ifErrorService: IfErrorService;
+  private controlClassService: ControlClassService;
+  private markControlService: MarkControlService;
 
+  protected subscriptions: Subscription[] = [];
+  protected index = 0;
   protected controlIdService: ControlIdService;
 
   _id: string;
+
+  // I lost way too much time trying to make this work without injecting the ViewContainerRef and the Injector,
+  // I'm giving up. So we have to inject these two manually for now.
+  constructor(
+    protected vcr: ViewContainerRef,
+    protected wrapperType: Type<W>,
+    injector: Injector,
+    private ngControl: NgControl,
+    renderer: Renderer2,
+    el: ElementRef
+  ) {
+    try {
+      this.ngControlService = injector.get(NgControlService);
+      this.ifErrorService = injector.get(IfErrorService);
+      this.controlClassService = injector.get(ControlClassService);
+      this.markControlService = injector.get(MarkControlService);
+    } catch (e) {}
+
+    if (this.controlClassService) {
+      this.controlClassService.initControlClass(renderer, el.nativeElement);
+    }
+    if (this.markControlService) {
+      this.subscriptions.push(
+        this.markControlService.dirtyChange.subscribe(() => {
+          this.ngControl.control.markAsDirty();
+          this.ngControl.control.updateValueAndValidity();
+        })
+      );
+    }
+  }
 
   @HostBinding()
   @Input()
@@ -28,6 +79,13 @@ export class WrappedFormControl<W extends DynamicWrapper> implements OnInit {
     this._id = value;
     if (this.controlIdService) {
       this.controlIdService.id = value;
+    }
+  }
+
+  @HostListener('blur')
+  triggerValidation() {
+    if (this.ifErrorService) {
+      this.ifErrorService.triggerStatusChange();
     }
   }
 
@@ -45,6 +103,13 @@ export class WrappedFormControl<W extends DynamicWrapper> implements OnInit {
     } else {
       this._id = this.controlIdService.id;
     }
-    // No need to subscribe to controlIdService.idChange because the input is the only one that can update the id.
+
+    if (this.ngControlService) {
+      this.ngControlService.setControl(this.ngControl);
+    }
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.forEach(sub => sub.unsubscribe());
   }
 }

--- a/src/clr-angular/forms/datepicker/date-container.ts
+++ b/src/clr-angular/forms/datepicker/date-container.ts
@@ -134,8 +134,8 @@ export class ClrDateContainer implements DynamicWrapper, OnDestroy {
 
   ngOnInit() {
     this.subscriptions.push(
-      this.ifErrorService.statusChanges.subscribe(control => {
-        this.invalid = control.invalid;
+      this.ifErrorService.statusChanges.subscribe(invalid => {
+        this.invalid = invalid;
       })
     );
   }

--- a/src/clr-angular/forms/input/input-container.ts
+++ b/src/clr-angular/forms/input/input-container.ts
@@ -51,8 +51,8 @@ export class ClrInputContainer implements DynamicWrapper, OnDestroy {
     private ngControlService: NgControlService
   ) {
     this.subscriptions.push(
-      this.ifErrorService.statusChanges.subscribe(control => {
-        this.invalid = control.invalid;
+      this.ifErrorService.statusChanges.subscribe(invalid => {
+        this.invalid = invalid;
       })
     );
     this.subscriptions.push(

--- a/src/clr-angular/forms/input/input.spec.ts
+++ b/src/clr-angular/forms/input/input.spec.ts
@@ -6,7 +6,7 @@
 import { Component } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 
-import { TemplateDrivenSpec, ControlInvalidSpec, ReactiveSpec } from '../tests/control.spec';
+import { TemplateDrivenSpec, ControlStandaloneSpec, ReactiveSpec } from '../tests/control.spec';
 import { ClrInputContainer } from './input-container';
 import { ClrInput } from './input';
 
@@ -15,7 +15,7 @@ import { ClrInput } from './input';
        <input type="text" clrInput />
     `,
 })
-class InvalidUseTest {}
+class StandaloneUseTest {}
 
 @Component({
   template: `
@@ -39,7 +39,7 @@ class ReactiveTest {
 
 export default function(): void {
   describe('Input directive', () => {
-    ControlInvalidSpec(ClrInput, InvalidUseTest);
+    ControlStandaloneSpec(StandaloneUseTest);
     TemplateDrivenSpec(ClrInputContainer, ClrInput, TemplateDrivenTest, 'clr-input');
     ReactiveSpec(ClrInputContainer, ClrInput, ReactiveTest, 'clr-input');
   });

--- a/src/clr-angular/forms/input/input.ts
+++ b/src/clr-angular/forms/input/input.ts
@@ -4,48 +4,25 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Directive, HostListener, Optional, ViewContainerRef, OnInit, Renderer2, ElementRef } from '@angular/core';
+import { Directive, Optional, ViewContainerRef, Renderer2, ElementRef, Injector, Self } from '@angular/core';
 import { NgControl } from '@angular/forms';
 
-import { IfErrorService } from '../common/if-error/if-error.service';
-import { NgControlService } from '../common/providers/ng-control.service';
 import { ClrInputContainer } from './input-container';
 import { WrappedFormControl } from '../common/wrapped-control';
-import { ControlClassService } from '../common/providers/control-class.service';
 
 @Directive({ selector: '[clrInput]', host: { '[class.clr-input]': 'true' } })
-export class ClrInput extends WrappedFormControl<ClrInputContainer> implements OnInit {
+export class ClrInput extends WrappedFormControl<ClrInputContainer> {
+  protected index = 1;
+
   constructor(
     vcr: ViewContainerRef,
-    @Optional() private ngControlService: NgControlService,
-    @Optional() private ifErrorService: IfErrorService,
-    @Optional() private control: NgControl,
-    @Optional() controlClassService: ControlClassService,
+    injector: Injector,
+    @Self()
+    @Optional()
+    control: NgControl,
     renderer: Renderer2,
     el: ElementRef
   ) {
-    super(ClrInputContainer, vcr, 1);
-    if (!control) {
-      throw new Error(
-        'clrInput can only be used within an Angular form control, add ngModel or formControl to the input'
-      );
-    }
-    if (controlClassService) {
-      controlClassService.initControlClass(renderer, el.nativeElement);
-    }
-  }
-
-  ngOnInit() {
-    super.ngOnInit();
-    if (this.ngControlService) {
-      this.ngControlService.setControl(this.control);
-    }
-  }
-
-  @HostListener('blur')
-  onBlur() {
-    if (this.ifErrorService) {
-      this.ifErrorService.triggerStatusChange();
-    }
+    super(vcr, ClrInputContainer, injector, control, renderer, el);
   }
 }

--- a/src/clr-angular/forms/password/password-container.ts
+++ b/src/clr-angular/forms/password/password-container.ts
@@ -96,8 +96,8 @@ export class ClrPasswordContainer implements DynamicWrapper, OnDestroy {
     public commonStrings: ClrCommonStrings
   ) {
     this.subscriptions.push(
-      this.ifErrorService.statusChanges.subscribe(control => {
-        this.invalid = control.invalid;
+      this.ifErrorService.statusChanges.subscribe(invalid => {
+        this.invalid = invalid;
       })
     );
     this.subscriptions.push(

--- a/src/clr-angular/forms/password/password.spec.ts
+++ b/src/clr-angular/forms/password/password.spec.ts
@@ -9,7 +9,7 @@ import { By } from '@angular/platform-browser';
 
 import { ClrPassword } from './password';
 import { ClrPasswordContainer } from './password-container';
-import { ControlInvalidSpec, ReactiveSpec, TemplateDrivenSpec } from '../tests/control.spec';
+import { ReactiveSpec, TemplateDrivenSpec } from '../tests/control.spec';
 import { TestBed } from '@angular/core/testing';
 import { LayoutService } from '../common/providers/layout.service';
 import { ClrIconModule } from '../../icon/icon.module';
@@ -19,7 +19,7 @@ import { NgControlService } from '../common/providers/ng-control.service';
 
 @Component({
   template: `
-    <input clrPassword />
+    <input type="password" clrPassword />
   `,
 })
 class InvalidUseTest {}
@@ -50,7 +50,18 @@ class ReactiveTest {
 
 export default function(): void {
   describe('ClrPassword', () => {
-    ControlInvalidSpec(ClrPassword, InvalidUseTest);
+    describe('invalid use', () => {
+      it('should throw an error when used without a password container', () => {
+        TestBed.configureTestingModule({
+          imports: [ClrPassword],
+          declarations: [InvalidUseTest],
+        });
+        expect(() => {
+          const fixture = TestBed.createComponent(InvalidUseTest);
+          fixture.detectChanges();
+        }).toThrow();
+      });
+    });
     TemplateDrivenSpec(ClrPasswordContainer, ClrPassword, TemplateDrivenTest, 'clr-input');
     ReactiveSpec(ClrPasswordContainer, ClrPassword, ReactiveTest, 'clr-input');
 

--- a/src/clr-angular/forms/radio/radio-container.spec.ts
+++ b/src/clr-angular/forms/radio/radio-container.spec.ts
@@ -77,14 +77,14 @@ class ReactiveTest {
 
 export default function(): void {
   describe('ClrRadioContainer', () => {
-    ContainerNoLabelSpec(ClrRadioContainer, [ClrRadioWrapper, ClrRadio], NoLabelTest);
+    ContainerNoLabelSpec(ClrRadioContainer, [ClrRadio, ClrRadioWrapper], NoLabelTest);
     TemplateDrivenSpec(
       ClrRadioContainer,
-      [ClrRadioWrapper, ClrRadio],
+      [ClrRadio, ClrRadioWrapper],
       TemplateDrivenTest,
       '.clr-radio-wrapper [clrRadio]'
     );
-    ReactiveSpec(ClrRadioContainer, [ClrRadioWrapper, ClrRadio], ReactiveTest, '.clr-radio-wrapper [clrRadio]');
+    ReactiveSpec(ClrRadioContainer, [ClrRadio, ClrRadioWrapper], ReactiveTest, '.clr-radio-wrapper [clrRadio]');
 
     describe('inline buttons', () => {
       let fixture, containerDE, containerEl;

--- a/src/clr-angular/forms/radio/radio-container.ts
+++ b/src/clr-angular/forms/radio/radio-container.ts
@@ -67,8 +67,8 @@ export class ClrRadioContainer implements OnDestroy {
     private ngControlService: NgControlService
   ) {
     this.subscriptions.push(
-      this.ifErrorService.statusChanges.subscribe(control => {
-        this.invalid = control.invalid;
+      this.ifErrorService.statusChanges.subscribe(invalid => {
+        this.invalid = invalid;
       })
     );
     this.subscriptions.push(

--- a/src/clr-angular/forms/radio/radio.spec.ts
+++ b/src/clr-angular/forms/radio/radio.spec.ts
@@ -6,7 +6,7 @@
 import { Component } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 
-import { ControlInvalidSpec, ReactiveSpec, TemplateDrivenSpec } from '../tests/control.spec';
+import { ControlStandaloneSpec, ReactiveSpec, TemplateDrivenSpec } from '../tests/control.spec';
 import { ClrRadio } from './radio';
 import { ClrRadioWrapper } from './radio-wrapper';
 
@@ -15,7 +15,7 @@ import { ClrRadioWrapper } from './radio-wrapper';
     <input type="radio" clrRadio />
     `,
 })
-class InvalidUseTest {}
+class StandaloneUseTest {}
 
 @Component({
   template: `
@@ -39,7 +39,7 @@ class ReactiveTest {
 
 export default function(): void {
   describe('ClrRadio directive', () => {
-    ControlInvalidSpec(ClrRadio, InvalidUseTest);
+    ControlStandaloneSpec(StandaloneUseTest);
     TemplateDrivenSpec(ClrRadioWrapper, ClrRadio, TemplateDrivenTest, 'clr-radio');
     ReactiveSpec(ClrRadioWrapper, ClrRadio, ReactiveTest, 'clr-radio');
   });

--- a/src/clr-angular/forms/radio/radio.ts
+++ b/src/clr-angular/forms/radio/radio.ts
@@ -4,43 +4,23 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Directive, Renderer2, ElementRef, HostListener, OnInit, Optional, ViewContainerRef } from '@angular/core';
+import { Directive, ElementRef, Injector, Optional, Renderer2, Self, ViewContainerRef } from '@angular/core';
 import { NgControl } from '@angular/forms';
 
-import { IfErrorService } from '../common/if-error/if-error.service';
-import { ControlClassService } from '../common/providers/control-class.service';
-import { NgControlService } from '../common/providers/ng-control.service';
 import { WrappedFormControl } from '../common/wrapped-control';
 import { ClrRadioWrapper } from '../radio/radio-wrapper';
 
 @Directive({ selector: '[clrRadio]' })
-export class ClrRadio extends WrappedFormControl<ClrRadioWrapper> implements OnInit {
+export class ClrRadio extends WrappedFormControl<ClrRadioWrapper> {
   constructor(
     vcr: ViewContainerRef,
-    @Optional() private ngControlService: NgControlService,
-    @Optional() private ifErrorService: IfErrorService,
-    @Optional() private control: NgControl,
-    @Optional() controlClassService: ControlClassService,
-    el: ElementRef,
-    renderer: Renderer2
+    injector: Injector,
+    @Self()
+    @Optional()
+    control: NgControl,
+    renderer: Renderer2,
+    el: ElementRef
   ) {
-    super(ClrRadioWrapper, vcr, 0);
-    if (controlClassService) {
-      controlClassService.initControlClass(renderer, el.nativeElement);
-    }
-  }
-
-  ngOnInit() {
-    super.ngOnInit();
-    if (this.ngControlService) {
-      this.ngControlService.setControl(this.control);
-    }
-  }
-
-  @HostListener('blur')
-  onBlur() {
-    if (this.ifErrorService) {
-      this.ifErrorService.triggerStatusChange();
-    }
+    super(vcr, ClrRadioWrapper, injector, control, renderer, el);
   }
 }

--- a/src/clr-angular/forms/select/select-container.ts
+++ b/src/clr-angular/forms/select/select-container.ts
@@ -54,8 +54,8 @@ export class ClrSelectContainer implements DynamicWrapper, OnDestroy {
     private ngControlService: NgControlService
   ) {
     this.subscriptions.push(
-      this.ifErrorService.statusChanges.subscribe(control => {
-        this.invalid = control.invalid;
+      this.ifErrorService.statusChanges.subscribe(invalid => {
+        this.invalid = invalid;
       })
     );
     this.subscriptions.push(

--- a/src/clr-angular/forms/select/select.spec.ts
+++ b/src/clr-angular/forms/select/select.spec.ts
@@ -9,14 +9,14 @@ import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { ClrSelect } from './select';
 import { ClrSelectContainer } from './select-container';
 
-import { TemplateDrivenSpec, ControlInvalidSpec, ReactiveSpec } from '../tests/control.spec';
+import { TemplateDrivenSpec, ControlStandaloneSpec, ReactiveSpec } from '../tests/control.spec';
 
 @Component({
   template: `
     <select clrSelect></select>
     `,
 })
-class InvalidUseTest {}
+class StandaloneUseTest {}
 
 @Component({
   template: `
@@ -39,7 +39,7 @@ class ReactiveTest {
 
 export default function(): void {
   describe('Select directive', () => {
-    ControlInvalidSpec(ClrSelect, InvalidUseTest);
+    ControlStandaloneSpec(StandaloneUseTest);
     TemplateDrivenSpec(ClrSelectContainer, ClrSelect, TemplateDrivenTest, 'clr-select');
     ReactiveSpec(ClrSelectContainer, ClrSelect, ReactiveTest, 'clr-select');
   });

--- a/src/clr-angular/forms/select/select.ts
+++ b/src/clr-angular/forms/select/select.ts
@@ -4,48 +4,25 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Directive, Renderer2, ElementRef, HostListener, OnInit, Optional, ViewContainerRef } from '@angular/core';
-import { NgControl } from '@angular/forms';
+import { Directive, ViewContainerRef, Renderer2, ElementRef, Injector, Optional, Self } from '@angular/core';
 
-import { IfErrorService } from '../common/if-error/if-error.service';
-import { ControlClassService } from '../common/providers/control-class.service';
-import { NgControlService } from '../common/providers/ng-control.service';
 import { WrappedFormControl } from '../common/wrapped-control';
 import { ClrSelectContainer } from './select-container';
+import { NgControl } from '@angular/forms';
 
 @Directive({ selector: '[clrSelect]', host: { '[class.clr-select]': 'true' } })
-export class ClrSelect extends WrappedFormControl<ClrSelectContainer> implements OnInit {
+export class ClrSelect extends WrappedFormControl<ClrSelectContainer> {
+  protected index = 1;
+
   constructor(
     vcr: ViewContainerRef,
-    @Optional() private ngControlService: NgControlService,
-    @Optional() private ifErrorService: IfErrorService,
-    @Optional() private control: NgControl,
-    @Optional() controlClassService: ControlClassService,
-    el: ElementRef,
-    renderer: Renderer2
+    injector: Injector,
+    @Self()
+    @Optional()
+    control: NgControl,
+    renderer: Renderer2,
+    el: ElementRef
   ) {
-    super(ClrSelectContainer, vcr, 1);
-    if (!control) {
-      throw new Error(
-        'clrSelect can only be used within an Angular form control, add ngModel or formControl to the select'
-      );
-    }
-    if (controlClassService) {
-      controlClassService.initControlClass(renderer, el.nativeElement);
-    }
-  }
-
-  ngOnInit() {
-    super.ngOnInit();
-    if (this.ngControlService) {
-      this.ngControlService.setControl(this.control);
-    }
-  }
-
-  @HostListener('blur')
-  onBlur() {
-    if (this.ifErrorService) {
-      this.ifErrorService.triggerStatusChange();
-    }
+    super(vcr, ClrSelectContainer, injector, control, renderer, el);
   }
 }

--- a/src/clr-angular/forms/tests/container.spec.ts
+++ b/src/clr-angular/forms/tests/container.spec.ts
@@ -13,6 +13,7 @@ import { IfErrorService } from '../common/if-error/if-error.service';
 
 import { NgControlService } from '../common/providers/ng-control.service';
 import { Layouts, LayoutService } from '../common/providers/layout.service';
+import { MarkControlService } from '../common/providers/mark-control.service';
 
 export function ContainerNoLabelSpec(testContainer, testControl, testComponent): void {
   describe('no label', () => {
@@ -21,7 +22,7 @@ export function ContainerNoLabelSpec(testContainer, testControl, testComponent):
       TestBed.configureTestingModule({
         imports: [ClrIconModule, ClrCommonFormsModule, FormsModule],
         declarations: [testContainer, testControl, testComponent],
-        providers: [NgControl, NgControlService, IfErrorService, LayoutService],
+        providers: [NgControl, NgControlService, IfErrorService, LayoutService, MarkControlService],
       });
       fixture = TestBed.createComponent(testComponent);
 
@@ -55,7 +56,7 @@ export function ReactiveSpec(testContainer, testControl, testComponent, wrapperC
 
 function fullSpec(description, testContainer, directives: any | any[], testComponent, wrapperClass) {
   describe(description, () => {
-    let fixture, containerDE, container, containerEl, ifErrorService, layoutService;
+    let fixture, containerDE, container, containerEl, ifErrorService, layoutService, markControlService;
     if (!Array.isArray(directives)) {
       directives = [directives];
     }
@@ -63,7 +64,7 @@ function fullSpec(description, testContainer, directives: any | any[], testCompo
       TestBed.configureTestingModule({
         imports: [ClrIconModule, ClrCommonFormsModule, FormsModule, ReactiveFormsModule],
         declarations: [testContainer, ...directives, testComponent],
-        providers: [NgControl, NgControlService, IfErrorService, LayoutService],
+        providers: [NgControl, NgControlService, IfErrorService, LayoutService, MarkControlService],
       });
       fixture = TestBed.createComponent(testComponent);
 
@@ -71,6 +72,7 @@ function fullSpec(description, testContainer, directives: any | any[], testCompo
       container = containerDE.componentInstance;
       containerEl = containerDE.nativeElement;
       ifErrorService = containerDE.injector.get(IfErrorService);
+      markControlService = containerDE.injector.get(MarkControlService);
       layoutService = containerDE.injector.get(LayoutService);
       fixture.detectChanges();
     });
@@ -150,7 +152,7 @@ function fullSpec(description, testContainer, directives: any | any[], testCompo
 
     it('tracks the validity of the form control', () => {
       expect(container.invalid).toBeFalse();
-      ifErrorService.triggerStatusChange();
+      markControlService.markAsDirty();
       fixture.detectChanges();
       expect(container.invalid).toBeTrue();
     });

--- a/src/clr-angular/forms/tests/control.spec.ts
+++ b/src/clr-angular/forms/tests/control.spec.ts
@@ -15,15 +15,19 @@ import { ClrCommonFormsModule } from '../common/common.module';
 import { WrappedFormControl } from '../common/wrapped-control';
 import { ControlIdService } from '../common/providers/control-id.service';
 import { ControlClassService } from '../common/providers/control-class.service';
+import { MarkControlService } from '../common/providers/mark-control.service';
 
-export function ControlInvalidSpec(testControl, testComponent): void {
-  describe('invalid use', () => {
-    it('throws error when used without a form control', () => {
-      TestBed.configureTestingModule({ declarations: [testControl, testComponent] });
+export function ControlStandaloneSpec(testComponent): void {
+  describe('standalone use', () => {
+    it('should not throw an error when used without a form control', () => {
+      TestBed.configureTestingModule({
+        imports: [ClrIconModule, ClrCommonFormsModule],
+        declarations: [testComponent],
+      });
       expect(() => {
         const fixture = TestBed.createComponent(testComponent);
         fixture.detectChanges();
-      }).toThrow();
+      }).not.toThrow();
     });
   });
 }
@@ -38,7 +42,7 @@ export function ReactiveSpec(testContainer, testControl, testComponent, controlC
 
 function fullTest(description, testContainer, testControl, testComponent, controlClass) {
   describe(description, () => {
-    let control, fixture, ifErrorService, ngControlService, controlClassService;
+    let control, fixture, ifErrorService, controlClassService, markControlService;
 
     beforeEach(() => {
       spyOn(WrappedFormControl.prototype, 'ngOnInit');
@@ -46,15 +50,14 @@ function fullTest(description, testContainer, testControl, testComponent, contro
       TestBed.configureTestingModule({
         imports: [FormsModule, ClrIconModule, ClrCommonFormsModule, ReactiveFormsModule],
         declarations: [testContainer, testControl, testComponent],
-        providers: [IfErrorService, NgControlService, ControlIdService, ControlClassService],
+        providers: [IfErrorService, NgControlService, ControlIdService, ControlClassService, MarkControlService],
       });
       fixture = TestBed.createComponent(testComponent);
       control = fixture.debugElement.query(By.directive(testControl));
       controlClassService = control.injector.get(ControlClassService);
       ifErrorService = control.injector.get(IfErrorService);
-      ngControlService = control.injector.get(NgControlService);
+      markControlService = control.injector.get(MarkControlService);
       spyOn(ifErrorService, 'triggerStatusChange');
-      spyOn(ngControlService, 'setControl');
       fixture.detectChanges();
     });
 
@@ -66,9 +69,8 @@ function fullTest(description, testContainer, testControl, testComponent, contro
       expect(ifErrorService).toBeTruthy();
     });
 
-    it('should have the NgControlService and set the control', () => {
-      expect(ngControlService).toBeTruthy();
-      expect(ngControlService.setControl).toHaveBeenCalled();
+    it('should have the MarkControlService', () => {
+      expect(markControlService.markAsDirty).toBeTruthy();
     });
 
     it('correctly extends WrappedFormControl', () => {

--- a/src/clr-angular/forms/textarea/textarea-container.ts
+++ b/src/clr-angular/forms/textarea/textarea-container.ts
@@ -51,8 +51,8 @@ export class ClrTextareaContainer implements DynamicWrapper, OnDestroy {
     private ngControlService: NgControlService
   ) {
     this.subscriptions.push(
-      this.ifErrorService.statusChanges.subscribe(control => {
-        this.invalid = control.invalid;
+      this.ifErrorService.statusChanges.subscribe(invalid => {
+        this.invalid = invalid;
       })
     );
     this.subscriptions.push(

--- a/src/clr-angular/forms/textarea/textarea.spec.ts
+++ b/src/clr-angular/forms/textarea/textarea.spec.ts
@@ -9,14 +9,14 @@ import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { ClrTextarea } from './textarea';
 import { ClrTextareaContainer } from './textarea-container';
 
-import { TemplateDrivenSpec, ControlInvalidSpec, ReactiveSpec } from '../tests/control.spec';
+import { TemplateDrivenSpec, ControlStandaloneSpec, ReactiveSpec } from '../tests/control.spec';
 
 @Component({
   template: `
     <textarea clrTextarea></textarea>
     `,
 })
-class InvalidUseTest {}
+class StandaloneUseTest {}
 
 @Component({
   template: `
@@ -39,7 +39,7 @@ class ReactiveTest {
 
 export default function(): void {
   describe('Textarea directive', () => {
-    ControlInvalidSpec(ClrTextarea, InvalidUseTest);
+    ControlStandaloneSpec(StandaloneUseTest);
     TemplateDrivenSpec(ClrTextareaContainer, ClrTextarea, TemplateDrivenTest, 'clr-textarea');
     ReactiveSpec(ClrTextareaContainer, ClrTextarea, ReactiveTest, 'clr-textarea');
   });

--- a/src/clr-angular/forms/textarea/textarea.ts
+++ b/src/clr-angular/forms/textarea/textarea.ts
@@ -4,48 +4,25 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Directive, HostListener, Optional, ViewContainerRef, Renderer2, ElementRef, OnInit } from '@angular/core';
+import { Directive, ViewContainerRef, Renderer2, ElementRef, Injector, Optional, Self } from '@angular/core';
 import { NgControl } from '@angular/forms';
 
-import { IfErrorService } from '../common/if-error/if-error.service';
-import { NgControlService } from '../common/providers/ng-control.service';
-import { ClrTextareaContainer } from './textarea-container';
 import { WrappedFormControl } from '../common/wrapped-control';
-import { ControlClassService } from '../common/providers/control-class.service';
+import { ClrTextareaContainer } from './textarea-container';
 
 @Directive({ selector: '[clrTextarea]', host: { '[class.clr-textarea]': 'true' } })
-export class ClrTextarea extends WrappedFormControl<ClrTextareaContainer> implements OnInit {
+export class ClrTextarea extends WrappedFormControl<ClrTextareaContainer> {
+  protected index = 1;
+
   constructor(
     vcr: ViewContainerRef,
-    @Optional() private ngControlService: NgControlService,
-    @Optional() private ifErrorService: IfErrorService,
-    @Optional() private control: NgControl,
-    @Optional() controlClassService: ControlClassService,
+    injector: Injector,
+    @Self()
+    @Optional()
+    control: NgControl,
     renderer: Renderer2,
     el: ElementRef
   ) {
-    super(ClrTextareaContainer, vcr, 1);
-    if (!control) {
-      throw new Error(
-        'clrTextarea can only be used within an Angular form control, add ngModel or formControl to the textarea'
-      );
-    }
-    if (controlClassService) {
-      controlClassService.initControlClass(renderer, el.nativeElement);
-    }
-  }
-
-  ngOnInit() {
-    super.ngOnInit();
-    if (this.ngControlService) {
-      this.ngControlService.setControl(this.control);
-    }
-  }
-
-  @HostListener('blur')
-  onBlur() {
-    if (this.ifErrorService) {
-      this.ifErrorService.triggerStatusChange();
-    }
+    super(vcr, ClrTextareaContainer, injector, control, renderer, el);
   }
 }

--- a/src/dev/src/app/forms/forms.demo.module.ts
+++ b/src/dev/src/app/forms/forms.demo.module.ts
@@ -28,6 +28,7 @@ import { FormsLayoutVerticalDemo } from './layout/layout-vertical';
 import { FormsLayoutVerticalGridDemo } from './layout/layout-vertical-grid';
 import { FormsTemplateDrivenDemo } from './template-driven/template-driven';
 import { FormsReactiveDemo } from './reactive/reactive';
+import { FormsResetDemo } from './reset/reset';
 
 @NgModule({
   imports: [CommonModule, FormsModule, ReactiveFormsModule, ClarityModule, ROUTING],
@@ -49,6 +50,7 @@ import { FormsReactiveDemo } from './reactive/reactive';
     FormsTextareaDemo,
     FormsTemplateDrivenDemo,
     FormsReactiveDemo,
+    FormsResetDemo,
   ],
   exports: [
     FormsDemo,
@@ -68,6 +70,7 @@ import { FormsReactiveDemo } from './reactive/reactive';
     FormsTextareaDemo,
     FormsTemplateDrivenDemo,
     FormsReactiveDemo,
+    FormsResetDemo,
   ],
 })
 export class FormsDemoModule {}

--- a/src/dev/src/app/forms/forms.demo.routing.ts
+++ b/src/dev/src/app/forms/forms.demo.routing.ts
@@ -23,6 +23,7 @@ import { FormsLayoutVerticalDemo } from './layout/layout-vertical';
 import { FormsLayoutVerticalGridDemo } from './layout/layout-vertical-grid';
 import { FormsTemplateDrivenDemo } from './template-driven/template-driven';
 import { FormsReactiveDemo } from './reactive/reactive';
+import { FormsResetDemo } from './reset/reset';
 
 const ROUTES: Routes = [
   {
@@ -46,6 +47,7 @@ const ROUTES: Routes = [
       { path: 'textarea', component: FormsTextareaDemo },
       { path: 'template-driven', component: FormsTemplateDrivenDemo },
       { path: 'reactive', component: FormsReactiveDemo },
+      { path: 'reset', component: FormsResetDemo },
     ],
   },
 ];

--- a/src/dev/src/app/forms/forms.demo.ts
+++ b/src/dev/src/app/forms/forms.demo.ts
@@ -27,6 +27,7 @@ import { Component } from '@angular/core';
             <li><a [routerLink]="['./select']">Select</a></li>
             <li><a [routerLink]="['./template-driven']">Template Driven</a></li>
             <li><a [routerLink]="['./reactive']">Reactive</a></li>
+            <li><a [routerLink]="['./reset']">Reset</a></li>
         </ul>
         <router-outlet></router-outlet>
     `,

--- a/src/dev/src/app/forms/reset/reset.html
+++ b/src/dev/src/app/forms/reset/reset.html
@@ -1,0 +1,22 @@
+<!--
+  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<h2>Reset and Validation</h2>
+
+<form clrForm [formGroup]="model">
+  <clr-input-container>
+    <label>Required</label>
+    <input clrInput placeholder="Input control" name="required" formControlName="required" />
+    <clr-control-helper>Helper text</clr-control-helper>
+    <clr-control-error *clrIfError="'required'">This is a required field</clr-control-error>
+    <clr-control-error *clrIfError="'minlength'">Must be at least 5 characters</clr-control-error>
+    <clr-control-error *clrIfError="'pattern'">It must match 'asdfasdf'</clr-control-error>
+  </clr-input-container>
+
+  <button class="btn btn-primary" type="button" (click)="validate()">Validate</button>
+  <button class="btn btn-primary" type="button" (click)="model.reset()">Reset</button>
+  <button class="btn btn-primary" type="button" (click)="model.get('required').setValue('asdfasdf')">Fill in</button>
+</form>

--- a/src/dev/src/app/forms/reset/reset.ts
+++ b/src/dev/src/app/forms/reset/reset.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import '@clr/icons/shapes/social-shapes';
+import '@clr/icons/shapes/essential-shapes';
+import { Component, ViewChild } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { ClrForm } from '@clr/angular';
+
+@Component({ templateUrl: './reset.html' })
+export class FormsResetDemo {
+  @ViewChild(ClrForm) form: ClrForm;
+
+  model = new FormGroup({
+    required: new FormControl('', [Validators.required, Validators.minLength(6), Validators.pattern(/asdfasdf/)]),
+  });
+
+  validate() {
+    this.form.markAsDirty();
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,6 @@
       "@clr/icons/shapes/*": ["src/clr-icons/shapes", "src/clr-icons/shapes/*"]
     },
     "lib": ["es2017", "dom"]
-  }
+  },
+  "exclude": ["node_modules/**", "dist/**"]
 }


### PR DESCRIPTION
The forms now handle form resets (which will clear validation errors) by calling `reset()` on a form group or control.

The new API for forcing validation is to get ahold of a `ClrForm` instance and call `markAsDirty()` which will mark every control as dirty in the form. I chose this naming to be very explicit about what happens (instead of saying 'validate' which is a side effect).

This also introduces some internal refactorings for the controls to remove the duplicate logic from individual controls and put it into the WrappedFormControl. Most of the changes are from carrying this change through all the controls. It also refactors the private ifErrorService to return a boolean instead of the control itself so that logic is contained in one place.

closes #2678 