### PR TITLE
[a11y] Adding aria role to alerts

### DIFF
--- a/src/clr-angular/emphasis/alert/alert.html
+++ b/src/clr-angular/emphasis/alert/alert.html
@@ -10,7 +10,8 @@
     [ngClass]="alertClass"
     [class.alert-hidden]="isHidden"
     [class.alert-sm]="isSmall"
-    [class.alert-app-level]="isAppLevel">
+    [class.alert-app-level]="isAppLevel"
+    role="alert">
     <div class="alert-items">
         <ng-content></ng-content>
     </div>

--- a/src/clr-angular/emphasis/alert/alert.spec.ts
+++ b/src/clr-angular/emphasis/alert/alert.spec.ts
@@ -118,9 +118,6 @@ export default function(): void {
 
     it('Has an ARIA role of alert', () => {
       const myAlert: HTMLElement = compiled.querySelector('.alert');
-      console.log('#########################');
-      console.log(myAlert.getAttribute('role'));
-      console.log('#########################');
       expect(myAlert.getAttribute('role')).toBe('alert');
     });
 

--- a/src/clr-angular/emphasis/alert/alert.spec.ts
+++ b/src/clr-angular/emphasis/alert/alert.spec.ts
@@ -116,6 +116,14 @@ export default function(): void {
       expect(compiled.querySelector('.alert')).toBeNull();
     });
 
+    it('Has an ARIA role of alert', () => {
+      const myAlert: HTMLElement = compiled.querySelector('.alert');
+      console.log('#########################');
+      console.log(myAlert.getAttribute('role'));
+      console.log('#########################');
+      expect(myAlert.getAttribute('role')).toBe('alert');
+    });
+
     it('shows and hides the alert based on the clrAlertClosed input', () => {
       expect(compiled.querySelector('.alert')).not.toBeNull();
       fixture.componentInstance.closed = true;


### PR DESCRIPTION
• Adding an aria role of "alert" to the clr-alert component
• Also added unit test to make sure they are there

Tested in:
✔︎ Chrome

Closes: #2582

Signed-off-by: Scott Mathis <smathis@vmware.com>