### PR TITLE
[NG] remove support for deprecated `alert-X` variations of alert types

### DIFF
--- a/src/clr-angular/emphasis/alert/alert-item.ts
+++ b/src/clr-angular/emphasis/alert/alert-item.ts
@@ -8,9 +8,7 @@ import { Component } from '@angular/core';
 import { AlertIconAndTypesService } from './providers/icon-and-types.service';
 
 @Component({
-  // the .alert-item selector is deprecated; the :not clause is to allow us to use static
-  // examples in demos on the demo-app and website
-  selector: '.alert-item:not(.static), clr-alert-item',
+  selector: 'clr-alert-item',
   template: `
         <div class="alert-icon-wrapper">
             <clr-icon class="alert-icon" 

--- a/src/clr-angular/emphasis/alert/alert.spec.ts
+++ b/src/clr-angular/emphasis/alert/alert.spec.ts
@@ -79,25 +79,25 @@ export default function(): void {
     });
 
     it('extends the alert type classes when clrAlertType is set', () => {
-      // default alert-info class
+      // default info class
       expect(compiled.querySelector('.alert-info')).not.toBeNull();
 
-      // set alert-danger
-      fixture.componentInstance.type = 'alert-danger';
+      // set danger
+      fixture.componentInstance.type = 'danger';
       fixture.detectChanges();
 
       expect(compiled.querySelector('.alert-info')).toBeNull();
       expect(compiled.querySelector('.alert-danger')).not.toBeNull();
 
-      // set alert-warning
-      fixture.componentInstance.type = 'alert-warning';
+      // set warning
+      fixture.componentInstance.type = 'warning';
       fixture.detectChanges();
 
       expect(compiled.querySelector('.alert-danger')).toBeNull();
       expect(compiled.querySelector('.alert-warning')).not.toBeNull();
 
-      // set alert-success
-      fixture.componentInstance.type = 'alert-success';
+      // set success
+      fixture.componentInstance.type = 'success';
       fixture.detectChanges();
 
       expect(compiled.querySelector('.alert-warning')).toBeNull();

--- a/src/clr-angular/emphasis/alert/alerts-pager.spec.ts
+++ b/src/clr-angular/emphasis/alert/alerts-pager.spec.ts
@@ -12,88 +12,90 @@ import { ClrAlert } from './alert';
 import { ClrAlertsPager } from './alerts-pager';
 import { MultiAlertService } from './providers/multi-alert.service';
 
-describe('ClrAlerts pager component', function() {
-  describe('Typescript API', function() {
-    let component: ClrAlertsPager;
-    let service: MultiAlertService;
+export default function() {
+  describe('ClrAlerts pager component', function() {
+    describe('Typescript API', function() {
+      let component: ClrAlertsPager;
+      let service: MultiAlertService;
 
-    beforeEach(() => {
-      service = new MultiAlertService();
-      component = new ClrAlertsPager(service, {});
+      beforeEach(() => {
+        service = new MultiAlertService();
+        component = new ClrAlertsPager(service, {});
+      });
+
+      afterEach(() => {
+        service = null;
+        component = null;
+      });
+
+      it('page up calls the multi alert service', function() {
+        spyOn(service, 'next').and.callFake(() => {});
+        component.pageUp();
+        expect(service.next).toHaveBeenCalled();
+      });
+
+      it('page down calls the multi alert service', function() {
+        spyOn(service, 'previous').and.callFake(() => {});
+        component.pageDown();
+        expect(service.previous).toHaveBeenCalled();
+      });
     });
 
-    afterEach(() => {
-      service = null;
-      component = null;
-    });
+    describe('Template API', function() {
+      beforeEach(function() {
+        const service = new MultiAlertService();
+        const queryList = new QueryList<ClrAlert>();
 
-    it('page up calls the multi alert service', function() {
-      spyOn(service, 'next').and.callFake(() => {});
-      component.pageUp();
-      expect(service.next).toHaveBeenCalled();
-    });
+        this.create = <T>(componentType: Type<T>) => {
+          TestBed.configureTestingModule({
+            imports: [ClrEmphasisModule],
+            declarations: [componentType],
+            providers: [{ provide: MultiAlertService, useValue: service }],
+          });
+          this.fixture = TestBed.createComponent(componentType);
 
-    it('page down calls the multi alert service', function() {
-      spyOn(service, 'previous').and.callFake(() => {});
-      component.pageDown();
-      expect(service.previous).toHaveBeenCalled();
-    });
-  });
+          this.alertFixture = TestBed.createComponent(ClrAlert);
+          this.alert = this.alertFixture.componentInstance;
+          this.secondAlertFixture = TestBed.createComponent(ClrAlert);
+          this.secondAlert = this.secondAlertFixture.componentInstance;
 
-  describe('Template API', function() {
-    beforeEach(function() {
-      const service = new MultiAlertService();
-      const queryList = new QueryList<ClrAlert>();
+          queryList.reset([this.alert, this.secondAlert]);
+          service.manage(queryList);
 
-      this.create = <T>(componentType: Type<T>) => {
-        TestBed.configureTestingModule({
-          imports: [ClrEmphasisModule],
-          declarations: [componentType],
-          providers: [{ provide: MultiAlertService, useValue: service }],
-        });
-        this.fixture = TestBed.createComponent(componentType);
+          this.fixture.detectChanges();
+        };
+      });
 
-        this.alertFixture = TestBed.createComponent(ClrAlert);
-        this.alert = this.alertFixture.componentInstance;
-        this.secondAlertFixture = TestBed.createComponent(ClrAlert);
-        this.secondAlert = this.secondAlertFixture.componentInstance;
+      afterEach(function() {
+        this.fixture.destroy();
+        this.alertFixture.destroy();
+        this.secondAlertFixture.destroy();
+      });
 
-        queryList.reset([this.alert, this.secondAlert]);
-        service.manage(queryList);
-
+      it('offers two way binding on the alert index', function() {
+        this.create(TestIndex);
+        this.fixture.componentInstance.index = 1;
         this.fixture.detectChanges();
-      };
-    });
+        expect(this.fixture.componentInstance.pagerInstance.currentAlertIndex).toEqual(1);
 
-    afterEach(function() {
-      this.fixture.destroy();
-      this.alertFixture.destroy();
-      this.secondAlertFixture.destroy();
-    });
+        this.fixture.componentInstance.pagerInstance.currentAlertIndex = 0;
+        this.fixture.detectChanges();
+        expect(this.fixture.componentInstance.index).toEqual(0);
+      });
 
-    it('offers two way binding on the alert index', function() {
-      this.create(TestIndex);
-      this.fixture.componentInstance.index = 1;
-      this.fixture.detectChanges();
-      expect(this.fixture.componentInstance.pagerInstance.currentAlertIndex).toEqual(1);
+      it('offers two way binding on the alert instance', function() {
+        this.create(TestInstance);
+        this.fixture.componentInstance.currentAlert = this.secondAlert;
+        this.fixture.detectChanges();
+        expect(this.fixture.componentInstance.pagerInstance.currentAlert).toEqual(this.secondAlert);
 
-      this.fixture.componentInstance.pagerInstance.currentAlertIndex = 0;
-      this.fixture.detectChanges();
-      expect(this.fixture.componentInstance.index).toEqual(0);
-    });
-
-    it('offers two way binding on the alert instance', function() {
-      this.create(TestInstance);
-      this.fixture.componentInstance.currentAlert = this.secondAlert;
-      this.fixture.detectChanges();
-      expect(this.fixture.componentInstance.pagerInstance.currentAlert).toEqual(this.secondAlert);
-
-      this.fixture.componentInstance.pagerInstance.currentAlert = this.alert;
-      this.fixture.detectChanges();
-      expect(this.fixture.componentInstance.currentAlert).toEqual(this.alert);
+        this.fixture.componentInstance.pagerInstance.currentAlert = this.alert;
+        this.fixture.detectChanges();
+        expect(this.fixture.componentInstance.currentAlert).toEqual(this.alert);
+      });
     });
   });
-});
+}
 
 @Component({ template: `<clr-alerts-pager [(clrCurrentAlertIndex)]="index"></clr-alerts-pager>` })
 export class TestIndex {

--- a/src/clr-angular/emphasis/alert/alerts.spec.ts
+++ b/src/clr-angular/emphasis/alert/alerts.spec.ts
@@ -12,253 +12,220 @@ import { ClrAlert } from './alert';
 import { ClrAlerts } from './alerts';
 import { MultiAlertService } from './providers/multi-alert.service';
 
-describe('ClrAlerts component', function() {
-  describe('Typescript API', function() {
-    let component: ClrAlerts;
-    let service: MultiAlertService;
-    let queryList: QueryList<ClrAlert>;
+export default function() {
+  describe('ClrAlerts component', function() {
+    describe('Typescript API', function() {
+      let component: ClrAlerts;
+      let service: MultiAlertService;
+      let queryList: QueryList<ClrAlert>;
 
-    beforeEach(function() {
-      service = new MultiAlertService();
+      beforeEach(function() {
+        service = new MultiAlertService();
 
-      TestBed.configureTestingModule({ imports: [ClrEmphasisModule] });
+        TestBed.configureTestingModule({ imports: [ClrEmphasisModule] });
 
-      const alertFixture = TestBed.createComponent(ClrAlert);
-      this.alert = alertFixture.componentInstance;
+        const alertFixture = TestBed.createComponent(ClrAlert);
+        this.alert = alertFixture.componentInstance;
 
-      const anotherAlertFixture = TestBed.createComponent(ClrAlert);
-      this.anotherAlert = anotherAlertFixture.componentInstance;
+        const anotherAlertFixture = TestBed.createComponent(ClrAlert);
+        this.anotherAlert = anotherAlertFixture.componentInstance;
 
-      queryList = new QueryList<ClrAlert>();
-      queryList.reset([this.alert, this.anotherAlert]);
-      service.manage(queryList);
-      component = new ClrAlerts(service);
-    });
-
-    it('knows the current alert', function() {
-      expect(component.currentAlert).toEqual(this.alert);
-    });
-  });
-
-  describe('Template API', function() {
-    let fixture: ComponentFixture<any>;
-
-    beforeEach(function() {
-      this.create = <T>(componentType: Type<T>) => {
-        TestBed.configureTestingModule({ imports: [ClrEmphasisModule], declarations: [componentType] });
-
-        fixture = TestBed.createComponent(componentType);
-        // fixture.detectChanges();
-      };
-    });
-
-    afterEach(() => {
-      fixture.destroy();
-    });
-
-    it('offers two way binding on the alert index', function() {
-      this.create(TestComponent);
-      const testComponent = fixture.componentInstance;
-      fixture.detectChanges();
-      testComponent.currentAlertIndex = 0;
-      fixture.detectChanges();
-      expect(testComponent.alertsInstance.currentAlertIndex).toEqual(0);
-      testComponent.alertsInstance.currentAlertIndex = 1;
-      fixture.detectChanges();
-      expect(testComponent.currentAlertIndex).toEqual(1);
-    });
-
-    it('allows changing alert index from 1 to 0', function() {
-      this.create(TestComponent);
-      const testComponent = fixture.componentInstance;
-      fixture.detectChanges();
-      testComponent.currentAlertIndex = 1;
-      fixture.detectChanges();
-      expect(testComponent.alertsInstance.currentAlertIndex).toEqual(1);
-      testComponent.currentAlertIndex = 0;
-      fixture.detectChanges();
-      expect(testComponent.alertsInstance.currentAlertIndex).toEqual(0);
-    });
-
-    it('does not allow invalid indexes (undefined, null, -1, 1.5, string)', function() {
-      this.create(TestComponent);
-      const testComponent = fixture.componentInstance;
-      fixture.detectChanges();
-      testComponent.currentAlertIndex = undefined;
-      fixture.detectChanges();
-      expect(testComponent.alertsInstance.currentAlertIndex).toEqual(0);
-      testComponent.currentAlertIndex = null;
-      fixture.detectChanges();
-      expect(testComponent.alertsInstance.currentAlertIndex).toEqual(0);
-      testComponent.currentAlertIndex = -1;
-      fixture.detectChanges();
-      expect(testComponent.alertsInstance.currentAlertIndex).toEqual(0);
-      testComponent.currentAlertIndex = 1.5;
-      fixture.detectChanges();
-      expect(testComponent.alertsInstance.currentAlertIndex).toEqual(0);
-      testComponent.currentAlertIndex = 'string';
-      fixture.detectChanges();
-      expect(testComponent.alertsInstance.currentAlertIndex).toEqual(0);
-    });
-
-    it('offers two way binding on the alert instance', function() {
-      this.create(TestAlertInstance);
-      fixture.detectChanges();
-
-      const clarityComponent = fixture.componentInstance.alertsInstance;
-      const testComponent = fixture.componentInstance;
-
-      expect(testComponent.alertInstances.length).toBe(2);
-      expect(testComponent.alertInstances.first).toBeTruthy();
-      expect(testComponent.alertInstances.last).toBeTruthy();
-
-      testComponent.currentAlert = testComponent.alertInstances.first;
-      fixture.detectChanges();
-      expect(clarityComponent.currentAlert).toEqual(testComponent.currentAlert);
-
-      clarityComponent.currentAlert = testComponent.alertInstances.last;
-      fixture.detectChanges();
-      expect(testComponent.currentAlert).toEqual(clarityComponent.currentAlert);
-    });
-  });
-
-  describe('View basics', function() {
-    let fixture: ComponentFixture<TestComponent>;
-    let compiled: any;
-    let alertElements: Array<Element>;
-
-    beforeEach(() => {
-      TestBed.configureTestingModule({ imports: [ClrEmphasisModule], declarations: [TestComponent] });
-
-      fixture = TestBed.createComponent(TestComponent);
-      fixture.detectChanges();
-      compiled = fixture.nativeElement;
-      alertElements = compiled.querySelectorAll('.alert');
-      expect(alertElements.length).toEqual(2);
-    });
-
-    afterEach(() => {
-      fixture.destroy();
-    });
-
-    it('projects content based on clrCurrentAlertIndex', function() {
-      expect(alertElements[0].textContent).toMatch(/This is the first alert/);
-      expect(alertElements[0].classList).not.toContain('alert-hidden');
-      expect(alertElements[1].classList).toContain('alert-hidden');
-
-      fixture.componentInstance.currentAlertIndex = 1;
-      fixture.detectChanges();
-
-      expect(alertElements[1].textContent).toMatch(/This is the second alert/);
-      expect(alertElements[1].classList).not.toContain('alert-hidden');
-      expect(alertElements[0].classList).toContain('alert-hidden');
-    });
-
-    it('makes the previous alert active when the current alert is closed', function() {
-      fixture.componentInstance.currentAlertIndex = 1;
-      fixture.detectChanges();
-      expect(alertElements[0].classList).toContain('alert-hidden');
-
-      fixture.componentInstance.alertInstances.toArray()[1].close();
-      fixture.detectChanges();
-      expect(alertElements[0].classList).not.toContain('alert-hidden');
-    });
-
-    it('shows the pager only when there is more than one alert', function() {
-      expect(compiled.querySelectorAll('clr-alerts-pager').length).toBe(1);
-      fixture.componentInstance.alertInstances.toArray()[0].close();
-      fixture.detectChanges();
-      expect(compiled.querySelectorAll('clr-alerts-pager').length).toBe(0);
-    });
-
-    describe('sets classname as expected', function() {
-      it('sets danger classname as expected', function() {
-        const alertsContainer: Element = fixture.nativeElement.querySelector('.alerts');
-        const myAlert: ClrAlert = fixture.componentInstance.alertsInstance.currentAlert;
-        myAlert.alertType = 'danger';
-        fixture.detectChanges();
-
-        expect(alertsContainer.classList.contains('alert-danger')).toBe(true);
+        queryList = new QueryList<ClrAlert>();
+        queryList.reset([this.alert, this.anotherAlert]);
+        service.manage(queryList);
+        component = new ClrAlerts(service);
       });
-      it('sets info classname as expected', function() {
-        const alertsContainer: Element = fixture.nativeElement.querySelector('.alerts');
-        const myAlert: ClrAlert = fixture.componentInstance.alertsInstance.currentAlert;
-        myAlert.alertType = 'info';
-        fixture.detectChanges();
 
-        expect(alertsContainer.classList.contains('alert-info')).toBe(true);
+      it('knows the current alert', function() {
+        expect(component.currentAlert).toEqual(this.alert);
       });
-      it('sets success classname as expected', function() {
-        const alertsContainer: Element = fixture.nativeElement.querySelector('.alerts');
-        const myAlert: ClrAlert = fixture.componentInstance.alertsInstance.currentAlert;
-        myAlert.alertType = 'success';
-        fixture.detectChanges();
-
-        expect(alertsContainer.classList.contains('alert-success')).toBe(true);
-      });
-      it('sets warning classname as expected', function() {
-        const alertsContainer: Element = fixture.nativeElement.querySelector('.alerts');
-        const myAlert: ClrAlert = fixture.componentInstance.alertsInstance.currentAlert;
-        myAlert.alertType = 'warning';
-        fixture.detectChanges();
-
-        expect(alertsContainer.classList.contains('alert-warning')).toBe(true);
-      });
-      // no tests for unexpected/unrecognized values because the alert types service ignores them
-      // and only changes an alert type when given a known value.
     });
 
-    describe('sets classname as expected with deprecated alert type', function() {
-      it('sets danger classname as expected', function() {
-        const alertsContainer: Element = fixture.nativeElement.querySelector('.alerts');
-        const myAlert: ClrAlert = fixture.componentInstance.alertsInstance.currentAlert;
-        myAlert.alertType = 'alert-danger';
-        fixture.detectChanges();
+    describe('Template API', function() {
+      let fixture: ComponentFixture<any>;
 
-        expect(alertsContainer.classList.contains('alert-danger')).toBe(true);
+      beforeEach(function() {
+        this.create = <T>(componentType: Type<T>) => {
+          TestBed.configureTestingModule({ imports: [ClrEmphasisModule], declarations: [componentType] });
+
+          fixture = TestBed.createComponent(componentType);
+          // fixture.detectChanges();
+        };
       });
-      it('sets info classname as expected', function() {
-        const alertsContainer: Element = fixture.nativeElement.querySelector('.alerts');
-        const myAlert: ClrAlert = fixture.componentInstance.alertsInstance.currentAlert;
-        myAlert.alertType = 'alert-info';
-        fixture.detectChanges();
 
-        expect(alertsContainer.classList.contains('alert-info')).toBe(true);
+      afterEach(() => {
+        fixture.destroy();
       });
-      it('sets success classname as expected', function() {
-        const alertsContainer: Element = fixture.nativeElement.querySelector('.alerts');
-        const myAlert: ClrAlert = fixture.componentInstance.alertsInstance.currentAlert;
-        myAlert.alertType = 'alert-success';
-        fixture.detectChanges();
 
-        expect(alertsContainer.classList.contains('alert-success')).toBe(true);
+      it('offers two way binding on the alert index', function() {
+        this.create(TestComponent);
+        const testComponent = fixture.componentInstance;
+        fixture.detectChanges();
+        testComponent.currentAlertIndex = 0;
+        fixture.detectChanges();
+        expect(testComponent.alertsInstance.currentAlertIndex).toEqual(0);
+        testComponent.alertsInstance.currentAlertIndex = 1;
+        fixture.detectChanges();
+        expect(testComponent.currentAlertIndex).toEqual(1);
       });
-      it('sets warning classname as expected', function() {
-        const alertsContainer: Element = fixture.nativeElement.querySelector('.alerts');
-        const myAlert: ClrAlert = fixture.componentInstance.alertsInstance.currentAlert;
-        myAlert.alertType = 'alert-warning';
+
+      it('allows changing alert index from 1 to 0', function() {
+        this.create(TestComponent);
+        const testComponent = fixture.componentInstance;
+        fixture.detectChanges();
+        testComponent.currentAlertIndex = 1;
+        fixture.detectChanges();
+        expect(testComponent.alertsInstance.currentAlertIndex).toEqual(1);
+        testComponent.currentAlertIndex = 0;
+        fixture.detectChanges();
+        expect(testComponent.alertsInstance.currentAlertIndex).toEqual(0);
+      });
+
+      it('does not allow invalid indexes (undefined, null, -1, 1.5, string)', function() {
+        this.create(TestComponent);
+        const testComponent = fixture.componentInstance;
+        fixture.detectChanges();
+        testComponent.currentAlertIndex = undefined;
+        fixture.detectChanges();
+        expect(testComponent.alertsInstance.currentAlertIndex).toEqual(0);
+        testComponent.currentAlertIndex = null;
+        fixture.detectChanges();
+        expect(testComponent.alertsInstance.currentAlertIndex).toEqual(0);
+        testComponent.currentAlertIndex = -1;
+        fixture.detectChanges();
+        expect(testComponent.alertsInstance.currentAlertIndex).toEqual(0);
+        testComponent.currentAlertIndex = 1.5;
+        fixture.detectChanges();
+        expect(testComponent.alertsInstance.currentAlertIndex).toEqual(0);
+        testComponent.currentAlertIndex = 'string';
+        fixture.detectChanges();
+        expect(testComponent.alertsInstance.currentAlertIndex).toEqual(0);
+      });
+
+      it('offers two way binding on the alert instance', function() {
+        this.create(TestAlertInstance);
         fixture.detectChanges();
 
-        expect(alertsContainer.classList.contains('alert-warning')).toBe(true);
+        const clarityComponent = fixture.componentInstance.alertsInstance;
+        const testComponent = fixture.componentInstance;
+
+        expect(testComponent.alertInstances.length).toBe(2);
+        expect(testComponent.alertInstances.first).toBeTruthy();
+        expect(testComponent.alertInstances.last).toBeTruthy();
+
+        testComponent.currentAlert = testComponent.alertInstances.first;
+        fixture.detectChanges();
+        expect(clarityComponent.currentAlert).toEqual(testComponent.currentAlert);
+
+        clarityComponent.currentAlert = testComponent.alertInstances.last;
+        fixture.detectChanges();
+        expect(testComponent.currentAlert).toEqual(clarityComponent.currentAlert);
+      });
+    });
+
+    describe('View basics', function() {
+      let fixture: ComponentFixture<TestComponent>;
+      let compiled: any;
+      let alertElements: Array<Element>;
+
+      beforeEach(() => {
+        TestBed.configureTestingModule({ imports: [ClrEmphasisModule], declarations: [TestComponent] });
+
+        fixture = TestBed.createComponent(TestComponent);
+        fixture.detectChanges();
+        compiled = fixture.nativeElement;
+        alertElements = compiled.querySelectorAll('.alert');
+        expect(alertElements.length).toEqual(2);
+      });
+
+      afterEach(() => {
+        fixture.destroy();
+      });
+
+      it('projects content based on clrCurrentAlertIndex', function() {
+        expect(alertElements[0].textContent).toMatch(/This is the first alert/);
+        expect(alertElements[0].classList).not.toContain('alert-hidden');
+        expect(alertElements[1].classList).toContain('alert-hidden');
+
+        fixture.componentInstance.currentAlertIndex = 1;
+        fixture.detectChanges();
+
+        expect(alertElements[1].textContent).toMatch(/This is the second alert/);
+        expect(alertElements[1].classList).not.toContain('alert-hidden');
+        expect(alertElements[0].classList).toContain('alert-hidden');
+      });
+
+      it('makes the previous alert active when the current alert is closed', function() {
+        fixture.componentInstance.currentAlertIndex = 1;
+        fixture.detectChanges();
+        expect(alertElements[0].classList).toContain('alert-hidden');
+
+        fixture.componentInstance.alertInstances.toArray()[1].close();
+        fixture.detectChanges();
+        expect(alertElements[0].classList).not.toContain('alert-hidden');
+      });
+
+      it('shows the pager only when there is more than one alert', function() {
+        expect(compiled.querySelectorAll('clr-alerts-pager').length).toBe(1);
+        fixture.componentInstance.alertInstances.toArray()[0].close();
+        fixture.detectChanges();
+        expect(compiled.querySelectorAll('clr-alerts-pager').length).toBe(0);
+      });
+
+      describe('sets classname as expected', function() {
+        it('sets danger classname as expected', function() {
+          const alertsContainer: Element = fixture.nativeElement.querySelector('.alerts');
+          const myAlert: ClrAlert = fixture.componentInstance.alertsInstance.currentAlert;
+          myAlert.alertType = 'danger';
+          fixture.detectChanges();
+
+          expect(alertsContainer.classList.contains('alert-danger')).toBe(true);
+        });
+        it('sets info classname as expected', function() {
+          const alertsContainer: Element = fixture.nativeElement.querySelector('.alerts');
+          const myAlert: ClrAlert = fixture.componentInstance.alertsInstance.currentAlert;
+          myAlert.alertType = 'info';
+          fixture.detectChanges();
+
+          expect(alertsContainer.classList.contains('alert-info')).toBe(true);
+        });
+        it('sets success classname as expected', function() {
+          const alertsContainer: Element = fixture.nativeElement.querySelector('.alerts');
+          const myAlert: ClrAlert = fixture.componentInstance.alertsInstance.currentAlert;
+          myAlert.alertType = 'success';
+          fixture.detectChanges();
+
+          expect(alertsContainer.classList.contains('alert-success')).toBe(true);
+        });
+        it('sets warning classname as expected', function() {
+          const alertsContainer: Element = fixture.nativeElement.querySelector('.alerts');
+          const myAlert: ClrAlert = fixture.componentInstance.alertsInstance.currentAlert;
+          myAlert.alertType = 'warning';
+          fixture.detectChanges();
+
+          expect(alertsContainer.classList.contains('alert-warning')).toBe(true);
+        });
+        // no tests for unexpected/unrecognized values because the alert types service ignores them
+        // and only changes an alert type when given a known value.
+      });
+    });
+
+    describe('Supports dynamic alerts', function() {
+      beforeEach(function() {
+        TestBed.configureTestingModule({ imports: [ClrEmphasisModule], declarations: [DynamicAlerts] });
+
+        this.fixture = TestBed.createComponent(DynamicAlerts);
+        this.compiled = this.fixture.nativeElement;
+        this.fixture.detectChanges();
+      });
+
+      it('contains dynamic alerts and set an initial index', function() {
+        expect(this.fixture.componentInstance.alertsInstance.currentAlertIndex).toEqual(0);
+        expect(this.fixture.componentInstance.alertInstances.length).toEqual(2);
       });
     });
   });
-
-  describe('Supports dynamic alerts', function() {
-    beforeEach(function() {
-      TestBed.configureTestingModule({ imports: [ClrEmphasisModule], declarations: [DynamicAlerts] });
-
-      this.fixture = TestBed.createComponent(DynamicAlerts);
-      this.compiled = this.fixture.nativeElement;
-      this.fixture.detectChanges();
-    });
-
-    it('contains dynamic alerts and set an initial index', function() {
-      expect(this.fixture.componentInstance.alertsInstance.currentAlertIndex).toEqual(0);
-      expect(this.fixture.componentInstance.alertInstances.length).toEqual(2);
-    });
-  });
-});
+}
 
 @Component({
   template: `

--- a/src/clr-angular/emphasis/alert/alerts.ts
+++ b/src/clr-angular/emphasis/alert/alerts.ts
@@ -7,17 +7,16 @@ import { AfterContentInit, Component, ContentChildren, EventEmitter, Input, Outp
 import { ClrAlert } from './alert';
 import { MultiAlertService } from './providers/multi-alert.service';
 
-// the 'alert-*' alert types are deprecated and should be removed in 0.12 or later
 @Component({
   selector: 'clr-alerts',
   templateUrl: './alerts.html',
   providers: [MultiAlertService],
   host: {
     '[class.alerts]': 'true',
-    '[class.alert-danger]': "this.currentAlertType == 'danger' || this.currentAlertType == 'alert-danger'",
-    '[class.alert-info]': "this.currentAlertType == 'info' || this.currentAlertType == 'alert-info'",
-    '[class.alert-success]': "this.currentAlertType == 'success' || this.currentAlertType == 'alert-success'",
-    '[class.alert-warning]': "this.currentAlertType == 'warning' || this.currentAlertType == 'alert-warning'",
+    '[class.alert-danger]': "this.currentAlertType == 'danger'",
+    '[class.alert-info]': "this.currentAlertType == 'info'",
+    '[class.alert-success]': "this.currentAlertType == 'success'",
+    '[class.alert-warning]': "this.currentAlertType == 'warning'",
   },
   styles: [':host { display: block }'],
 })

--- a/src/clr-angular/emphasis/alert/all.spec.ts
+++ b/src/clr-angular/emphasis/alert/all.spec.ts
@@ -4,9 +4,15 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import AlertSpecs from './alert.spec';
+import AlertsSpecs from './alerts.spec';
+import AlertsPagerSpecs from './alerts-pager.spec';
 import AlertIconAndTypesServiceSpecs from './providers/icon-and-types.service.spec';
+import MultiAlertServiceSpecs from './providers/multi-alert.service.spec';
 
 describe('Alert Tests', () => {
   AlertSpecs();
+  AlertsSpecs();
+  AlertsPagerSpecs();
   AlertIconAndTypesServiceSpecs();
+  MultiAlertServiceSpecs();
 });

--- a/src/clr-angular/emphasis/alert/providers/icon-and-types.service.spec.ts
+++ b/src/clr-angular/emphasis/alert/providers/icon-and-types.service.spec.ts
@@ -144,39 +144,5 @@ export default function(): void {
         expect(testTitle('info')).toBe(commonStrings.info);
       });
     });
-
-    describe('iconInfoFromType() -- deprecated types', function() {
-      it('returns warning icon', function() {
-        expect(testShape('alert-warning')).toBe('exclamation-triangle');
-      });
-
-      it('returns danger icon', function() {
-        expect(testShape('alert-danger')).toBe('exclamation-circle');
-      });
-
-      it('returns success icon', function() {
-        expect(testShape('alert-success')).toBe('check-circle');
-      });
-
-      it('returns info icon', function() {
-        expect(testShape('alert-info')).toBe('info-circle');
-      });
-
-      it('returns .alert-warning', function() {
-        expect(testCssClass('alert-warning')).toBe('alert-warning');
-      });
-
-      it('returns .alert-danger', function() {
-        expect(testCssClass('alert-danger')).toBe('alert-danger');
-      });
-
-      it('returns .alert-success', function() {
-        expect(testCssClass('alert-success')).toBe('alert-success');
-      });
-
-      it('returns .alert-info', function() {
-        expect(testCssClass('alert-info')).toBe('alert-info');
-      });
-    });
   });
 }

--- a/src/clr-angular/emphasis/alert/providers/icon-and-types.service.ts
+++ b/src/clr-angular/emphasis/alert/providers/icon-and-types.service.ts
@@ -45,24 +45,21 @@ export class AlertIconAndTypesService {
     return this.iconInfoFromType(this._alertType).title;
   }
 
-  public iconInfoFromType(type: string, classOrShape: string = 'shape'): AlertInfoObject {
+  public iconInfoFromType(type: string): AlertInfoObject {
     const returnObj = { shape: '', cssClass: '', title: '' };
 
     switch (type) {
       case 'warning':
-      case 'alert-warning':
         returnObj.shape = 'exclamation-triangle';
         returnObj.cssClass = 'alert-warning';
         returnObj.title = this.commonStrings.warning;
         break;
       case 'danger':
-      case 'alert-danger':
         returnObj.shape = 'exclamation-circle';
         returnObj.cssClass = 'alert-danger';
         returnObj.title = this.commonStrings.danger;
         break;
       case 'success':
-      case 'alert-success':
         returnObj.shape = 'check-circle';
         returnObj.cssClass = 'alert-success';
         returnObj.title = this.commonStrings.success;

--- a/src/clr-angular/emphasis/alert/providers/multi-alert.service.spec.ts
+++ b/src/clr-angular/emphasis/alert/providers/multi-alert.service.spec.ts
@@ -10,56 +10,58 @@ import { ClrEmphasisModule } from './../../emphasis.module';
 import { ClrAlert } from './../alert';
 import { MultiAlertService } from './multi-alert.service';
 
-describe('Multi Alert provider', function() {
-  let queryList: QueryList<ClrAlert>;
-  let alert: ComponentFixture<ClrAlert>;
-  let anotherAlert: ComponentFixture<ClrAlert>;
-  let multiAlertService: MultiAlertService;
+export default function() {
+  describe('Multi Alert provider', function() {
+    let queryList: QueryList<ClrAlert>;
+    let alert: ComponentFixture<ClrAlert>;
+    let anotherAlert: ComponentFixture<ClrAlert>;
+    let multiAlertService: MultiAlertService;
 
-  beforeEach(function() {
-    multiAlertService = new MultiAlertService();
+    beforeEach(function() {
+      multiAlertService = new MultiAlertService();
 
-    TestBed.configureTestingModule({
-      imports: [ClrEmphasisModule],
-      providers: [{ provide: MultiAlertService, useValue: multiAlertService }],
+      TestBed.configureTestingModule({
+        imports: [ClrEmphasisModule],
+        providers: [{ provide: MultiAlertService, useValue: multiAlertService }],
+      });
+
+      alert = TestBed.createComponent(ClrAlert);
+      anotherAlert = TestBed.createComponent(ClrAlert);
+
+      queryList = new QueryList<ClrAlert>();
+      queryList.reset([alert.componentInstance, anotherAlert.componentInstance]);
+
+      multiAlertService.manage(queryList);
     });
 
-    alert = TestBed.createComponent(ClrAlert);
-    anotherAlert = TestBed.createComponent(ClrAlert);
+    it('next updates the current alert index and cycles when the last index is found', function() {
+      expect(multiAlertService.current).toBe(0);
+      multiAlertService.next();
+      expect(multiAlertService.current).toBe(1);
+      multiAlertService.next();
+      expect(multiAlertService.current).toBe(0);
+    });
 
-    queryList = new QueryList<ClrAlert>();
-    queryList.reset([alert.componentInstance, anotherAlert.componentInstance]);
+    it('previous method updates the current alert index and cycles when the first index is found', function() {
+      multiAlertService.next();
+      expect(multiAlertService.current).toBe(1);
+      multiAlertService.previous();
+      expect(multiAlertService.current).toBe(0);
+      multiAlertService.previous();
+      expect(multiAlertService.current).toBe(1);
+    });
 
-    multiAlertService.manage(queryList);
+    it('close reduces the number of active alerts and updates the index', function() {
+      multiAlertService.next();
+      expect(multiAlertService.count).toBe(2);
+      expect(multiAlertService.current).toBe(1);
+      anotherAlert.componentInstance.close();
+      expect(multiAlertService.count).toBe(1);
+      expect(multiAlertService.current).toBe(0);
+      // Ensure current alert does not drop below 0
+      alert.componentInstance.close();
+      expect(multiAlertService.count).toBe(0);
+      expect(multiAlertService.current).toBe(0);
+    });
   });
-
-  it('next updates the current alert index and cycles when the last index is found', function() {
-    expect(multiAlertService.current).toBe(0);
-    multiAlertService.next();
-    expect(multiAlertService.current).toBe(1);
-    multiAlertService.next();
-    expect(multiAlertService.current).toBe(0);
-  });
-
-  it('previous method updates the current alert index and cycles when the first index is found', function() {
-    multiAlertService.next();
-    expect(multiAlertService.current).toBe(1);
-    multiAlertService.previous();
-    expect(multiAlertService.current).toBe(0);
-    multiAlertService.previous();
-    expect(multiAlertService.current).toBe(1);
-  });
-
-  it('close reduces the number of active alerts and updates the index', function() {
-    multiAlertService.next();
-    expect(multiAlertService.count).toBe(2);
-    expect(multiAlertService.current).toBe(1);
-    anotherAlert.componentInstance.close();
-    expect(multiAlertService.count).toBe(1);
-    expect(multiAlertService.current).toBe(0);
-    // Ensure current alert does not drop below 0
-    alert.componentInstance.close();
-    expect(multiAlertService.count).toBe(0);
-    expect(multiAlertService.current).toBe(0);
-  });
-});
+}

--- a/src/clr-angular/emphasis/alert/utils/alert-types.ts
+++ b/src/clr-angular/emphasis/alert/utils/alert-types.ts
@@ -4,14 +4,5 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-// TODO: alert-* types are deprecated and should be removed before 1.0!
-export const ALERT_TYPES: string[] = [
-  'alert-info',
-  'alert-warning',
-  'alert-danger',
-  'alert-success',
-  'info',
-  'warning',
-  'danger',
-  'success',
-];
+// @TODO Make this an enum
+export const ALERT_TYPES: string[] = ['info', 'warning', 'danger', 'success'];

--- a/src/dev/src/app/alert/angular/alert-angular-app-level-alerts.demo.html
+++ b/src/dev/src/app/alert/angular/alert-angular-app-level-alerts.demo.html
@@ -7,35 +7,35 @@
 <div class="clr-example">
   <div class="main-container">
     <clr-alerts>
-      <clr-alert [clrAlertType]="'info'" [clrAlertAppLevel]="true">
-        <div class="alert-item">
+      <clr-alert clrAlertType="info" [clrAlertAppLevel]="true">
+        <clr-alert-item>
           <span class="alert-text">
             View additional alerts using the pager
           </span>
           <div class="alert-actions">
             <button class="btn alert-action">Fix</button>
           </div>
-        </div>
+        </clr-alert-item>
       </clr-alert>
-      <clr-alert [clrAlertType]="'warning'" [clrAlertAppLevel]="true">
-        <div class="alert-item">
+      <clr-alert clrAlertType="warning" [clrAlertAppLevel]="true">
+        <clr-alert-item>
           <span class="alert-text">
             Application level alerts should only be used for important messages.
           </span>
           <div class="alert-actions">
             <button class="btn alert-action">Fix</button>
           </div>
-        </div>
+        </clr-alert-item>
       </clr-alert>
-      <clr-alert [clrAlertType]="'danger'" [clrAlertAppLevel]="true">
-        <div class="alert-item">
+      <clr-alert clrAlertType="danger" [clrAlertAppLevel]="true">
+        <clr-alert-item>
           <span class="alert-text">
             Don't add too many of these alerts!
           </span>
           <div class="alert-actions">
             <button class="btn alert-action">Fix</button>
           </div>
-        </div>
+        </clr-alert-item>
       </clr-alert>
     </clr-alerts>
     <header class="header header-6">

--- a/src/dev/src/app/alert/angular/alert-angular-app-level.demo.html
+++ b/src/dev/src/app/alert/angular/alert-angular-app-level.demo.html
@@ -6,15 +6,15 @@
 
 <div class="clr-example">
   <div class="main-container">
-    <clr-alert [clrAlertType]="'alert-danger'" [clrAlertAppLevel]="true">
-      <div class="alert-item">
+    <clr-alert clrAlertType="danger" [clrAlertAppLevel]="true">
+      <clr-alert-item>
         <span class="alert-text">
           This is an app level alert.
         </span>
         <div class="alert-actions">
           <button class="btn alert-action">Fix</button>
         </div>
-      </div>
+      </clr-alert-item>
     </clr-alert>
     <header class="header header-6">
       <div class="branding">

--- a/src/dev/src/app/alert/angular/alert-angular-close-event.demo.html
+++ b/src/dev/src/app/alert/angular/alert-angular-close-event.demo.html
@@ -13,12 +13,12 @@
     </header>
     <div class="content-container">
       <div class="content-area">
-        <clr-alert [clrAlertType]="'alert-success'" (clrAlertClosedChange)="onClose()">
-          <div class="alert-item">
+        <clr-alert clrAlertType="success" (clrAlertClosedChange)="onClose()">
+          <clr-alert-item>
             <span class="alert-text">
               This alert indicates a success!
             </span>
-          </div>
+          </clr-alert-item>
         </clr-alert>
         <div>{{closeMessage}}</div>
       </div>

--- a/src/dev/src/app/alert/angular/alert-angular-not-closable.demo.html
+++ b/src/dev/src/app/alert/angular/alert-angular-not-closable.demo.html
@@ -14,7 +14,7 @@
     <div class="content-container">
       <div class="content-area">
         <clr-alert [clrAlertClosable]="false">
-          <div class="alert-item">
+          <clr-alert-item>
             <span class="alert-text">
               This alert cannot be dismissed.
             </span>
@@ -33,27 +33,27 @@
                 </clr-dropdown-menu>
               </clr-dropdown>
             </div>
-          </div>
+          </clr-alert-item>
         </clr-alert>
-        <clr-alert [clrAlertType]="'alert-warning'">
-          <div class="alert-item">
+        <clr-alert clrAlertType="warning">
+          <clr-alert-item>
             <span class="alert-text">
               Try closing this alert.
             </span>
-          </div>
-          <div class="alert-item">
+          </clr-alert-item>
+          <clr-alert-item>
             <span class="alert-text">
               Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
               Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
               Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
               sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
             </span>
-          </div>
-          <div class="alert-item">
+          </clr-alert-item>
+          <clr-alert-item>
             <span class="alert-text">
               Try closing this alert.
             </span>
-          </div>
+          </clr-alert-item>
         </clr-alert>
         <p>
           Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

--- a/src/dev/src/app/alert/angular/alert-angular-small.demo.html
+++ b/src/dev/src/app/alert/angular/alert-angular-small.demo.html
@@ -14,38 +14,38 @@
     <div class="content-container">
       <div class="content-area">
         <clr-alert [clrAlertSizeSmall]="true">
-          <div class="alert-item">
+          <clr-alert-item>
             <span class="alert-text">
               This is a small alert.
             </span>
-          </div>
+          </clr-alert-item>
         </clr-alert>
         <clr-alert>
-          <div class="alert-item">
+          <clr-alert-item>
             <span class="alert-text">
               This is a regular alert.
             </span>
-          </div>
+          </clr-alert-item>
         </clr-alert>
-        <clr-alert [clrAlertSizeSmall]="true" clrAlertType="alert-danger">
-          <div class="alert-item">
+        <clr-alert [clrAlertSizeSmall]="true" clrAlertType="danger">
+          <clr-alert-item>
             <span class="alert-text">
               This is a small alert.
             </span>
-          </div>
-          <div class="alert-item">
+          </clr-alert-item>
+          <clr-alert-item>
             <span class="alert-text">
               Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
               Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
               Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
               sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
             </span>
-          </div>
-          <div class="alert-item">
+          </clr-alert-item>
+          <clr-alert-item>
             <span class="alert-text">
               This is a small alert.
             </span>
-          </div>
+          </clr-alert-item>
         </clr-alert>
         <p>
           Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

--- a/src/dev/src/app/alert/angular/alert-angular-success.demo.html
+++ b/src/dev/src/app/alert/angular/alert-angular-success.demo.html
@@ -13,19 +13,19 @@
     </header>
     <div class="content-container">
       <div class="content-area">
-        <clr-alert [clrAlertType]="'alert-success'">
-          <div class="alert-item">
+        <clr-alert clrAlertType="success">
+          <clr-alert-item>
             <span class="alert-text">
               This alert indicates success.
             </span>
-          </div>
+          </clr-alert-item>
         </clr-alert>
         <clr-alert>
-          <div class="alert-item">
+          <clr-alert-item>
             <span class="alert-text">
               This is a default info alert.
             </span>
-          </div>
+          </clr-alert-item>
         </clr-alert>
         <p>
           Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

--- a/src/dev/src/app/wizard/wizard-async-validation.demo.html
+++ b/src/dev/src/app/wizard/wizard-async-validation.demo.html
@@ -21,16 +21,16 @@
     <div class="spinner" *ngIf="loadingFlag">
       Loading...
     </div>
-    <clr-alert [clrAlertType]="'alert-info'" [clrAlertClosable]="false">
-      <div class="alert-item">
+    <clr-alert clrAlertType="info" [clrAlertClosable]="false">
+      <clr-alert-item>
         This&nbsp;
         <a href="https://en.wikipedia.org/wiki/42_(number)#The_Hitchhiker.27s_Guide_to_the_Galaxy" target="_blank">wiki article</a>&nbsp;might help you answer the question.
-      </div>
+      </clr-alert-item>
     </clr-alert>
-    <clr-alert *ngIf="errorFlag" [clrAlertType]="'alert-danger'">
-      <div class="alert-item">
+    <clr-alert *ngIf="errorFlag" clrAlertType="danger">
+      <clr-alert-item>
         Your answer is incorrect.
-      </div>
+      </clr-alert-item>
     </clr-alert>
     <form #myForm="ngForm" [class.hide]="loadingFlag">
       <section class="form-block">


### PR DESCRIPTION
This removes support for `alert-info` types and updates to use `clr-alert-item` for proper icon support.