### PR TITLE
[a11y] Updating alerts dox

### DIFF
--- a/latest/src/app/documentation/demos/alert/alerts.demo.html
+++ b/latest/src/app/documentation/demos/alert/alerts.demo.html
@@ -307,7 +307,7 @@
             </div>
 
             <p>
-                Alerts could appear within modals. It is recommended that no more than one alert appear within modal. Their function should not be to validate, validation should be done inline and closer to the error itself.
+                Alerts could appear within modals. It is recommended that no more than one alert appear within a modal. Their function should not be to validate, validation should be done inline and closer to the error itself.
             </p>
 
             <p>&nbsp;</p>
@@ -417,7 +417,7 @@
                 <clr-alert-item>
                     <div class="alert-text">
                         <div style="margin-bottom: 8px">The use of <code class="clr-code">.alert-item</code> in the <code class="clr-code">clr-alert</code> Angular component is deprecated. Try to use <code class="clr-code">clr-alert-item</code> instead.</div>
-                        <div style="margin-bottom: 8px">If your application uses a combination of <code class="clr-code">clr-alert</code> Angular components and hand-coded DOM alerts, you should put the <code class="clr-code">.static</code> class on your <code class="clr-code">.alert-item</code>  elements.</div>
+                        <div style="margin-bottom: 8px">If your application uses a combination of <code class="clr-code">clr-alert</code> Angular components and hand-coded DOM alerts, you should put the <code class="clr-code">.static</code> class on your non-Angular <code class="clr-code">.alert-item</code>  elements.</div>
                         <div>Once <code class="clr-code">clr-alert</code> no longer recognizes <code class="clr-code">.alert-item</code> classnames as a subcomponent, it will no longer be an issue.</div>
                     </div>
                 </clr-alert-item>

--- a/latest/src/app/documentation/demos/alert/angular/alert-angular-app-level-alerts.demo.html
+++ b/latest/src/app/documentation/demos/alert/angular/alert-angular-app-level-alerts.demo.html
@@ -1,84 +1,83 @@
 <!--
-  ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
-  ~ This software is released under MIT license.
-  ~ The full license information can be found in LICENSE in the root directory of this project.
-  -->
+    ~ Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+    ~ This software is released under MIT license.
+    ~ The full license information can be found in LICENSE in the root directory of this project.
+-->
 
-  <div class="clr-example">
-      <div class="main-container">
-          <clr-alerts>
-              <clr-alert [clrAlertType]="'info'" [clrAlertAppLevel]="true">
-                  <div class="alert-item">
-                      <span class="alert-text">
-                          View additional alerts using the pager
-                      </span>
-                      <div class="alert-actions">
-                          <button class="btn alert-action">Fix</button>
-                      </div>
-                  </div>
-              </clr-alert>
-              <clr-alert [clrAlertType]="'warning'" [clrAlertAppLevel]="true">
-                  <div class="alert-item">
-                      <span class="alert-text">
-                          Application level alerts should only be used for important messages.
-                      </span>
-                      <div class="alert-actions">
-                          <button class="btn alert-action">Fix</button>
-                      </div>
-                  </div>
-              </clr-alert>
-              <clr-alert [clrAlertType]="'danger'" [clrAlertAppLevel]="true">
-                  <div class="alert-item">
-                      <span class="alert-text">
-                          Don't add too many of these alerts!
-                      </span>
-                      <div class="alert-actions">
-                          <button class="btn alert-action">Fix</button>
-                      </div>
-                  </div>
-              </clr-alert>
-          </clr-alerts>
-          <header class="header header-6">
-              <div class="branding">
-                  <span class="title">Header</span>
-              </div>
-          </header>
-          <div class="content-container">
-              <div class="content-area">
-                  <p>
-                      Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-                      Delectus non beatae omnis esse quibusdam dolorum voluptatem
-                      reiciendis quaerat assumenda optio, porro expedita similique
-                      dolore quidem aliquam. Ullam, eaque enim nobis.
-                  </p>
-              </div>
-          </div>
-      </div>
-  </div>
+<div class="clr-example">
+    <div class="main-container">
+        <clr-alerts>
+            <clr-alert [clrAlertType]="'info'" [clrAlertAppLevel]="true">
+                <clr-alert-item>
+                    <span class="alert-text">
+                        View additional alerts using the pager
+                    </span>
+                    <div class="alert-actions">
+                        <button class="btn alert-action">Fix</button>
+                    </div>
+                </clr-alert-item>
+            </clr-alert>
+            <clr-alert [clrAlertType]="'warning'" [clrAlertAppLevel]="true">
+                <clr-alert-item>
+                    <span class="alert-text">
+                        Application level alerts should only be used for important messages.
+                    </span>
+                    <div class="alert-actions">
+                        <button class="btn alert-action">Fix</button>
+                    </div>
+                </clr-alert-item>
+            </clr-alert>
+            <clr-alert [clrAlertType]="'danger'" [clrAlertAppLevel]="true">
+                <div class="alert-item">
+                    <span class="alert-text">
+                        Don't add too many of these alerts!
+                    </span>
+                    <div class="alert-actions">
+                        <button class="btn alert-action">Fix</button>
+                    </div>
+                </div>
+            </clr-alert>
+        </clr-alerts>
+        <header class="header header-6">
+            <div class="branding">
+                <span class="title">Header</span>
+            </div>
+        </header>
+        <div class="content-container">
+            <div class="content-area">
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+                    Delectus non beatae omnis esse quibusdam dolorum voluptatem
+                    reiciendis quaerat assumenda optio, porro expedita similique
+                    dolore quidem aliquam. Ullam, eaque enim nobis.
+                </p>
+            </div>
+        </div>
+    </div>
+</div>
 <pre>
-<code clr-code-highlight="language-html">
-&lt;clr-alerts&gt;
-    &lt;clr-alert [clrAlertType]=&quot;'info'&quot; [clrAlertAppLevel]=&quot;true&quot;&gt;
-        &lt;div class=&quot;alert-item&quot;&gt;
-            &lt;span class=&quot;alert-text&quot;&gt;
-                This is the first app level alert.
-            &lt;/span&gt;
-            &lt;div class=&quot;alert-actions&quot;&gt;
-                &lt;button class=&quot;btn alert-action&quot;&gt;Fix&lt;/button&gt;
-            &lt;/div&gt;
+    <code clr-code-highlight="language-html">
+        &lt;clr-alerts&gt;
+        &lt;clr-alert [clrAlertType]=&quot;'info'&quot; [clrAlertAppLevel]=&quot;true&quot;&gt;
+        &lt;clr-alert-item&gt;
+        &lt;span class=&quot;alert-text&quot;&gt;
+        This is the first app level alert.
+        &lt;/span&gt;
+        &lt;div class=&quot;alert-actions&quot;&gt;
+        &lt;button class=&quot;btn alert-action&quot;&gt;Fix&lt;/button&gt;
         &lt;/div&gt;
-    &lt;/clr-alert&gt;
-    &lt;clr-alert [clrAlertType]=&quot;'danger'&quot; [clrAlertAppLevel]=&quot;true&quot;&gt;
-        &lt;div class=&quot;alert-item&quot;&gt;
-            &lt;span class=&quot;alert-text&quot;&gt;
-                This is a second app level alert.
-            &lt;/span&gt;
-            &lt;div class=&quot;alert-actions&quot;&gt;
-                &lt;button class=&quot;btn alert-action&quot;&gt;Fix&lt;/button&gt;
-            &lt;/div&gt;
+        &lt;/clr-alert-item&gt;
+        &lt;/clr-alert&gt;
+        &lt;clr-alert [clrAlertType]=&quot;'danger'&quot; [clrAlertAppLevel]=&quot;true&quot;&gt;
+        &lt;clr-alert-item&gt;
+        &lt;span class=&quot;alert-text&quot;&gt;
+        This is a second app level alert.
+        &lt;/span&gt;
+        &lt;div class=&quot;alert-actions&quot;&gt;
+        &lt;button class=&quot;btn alert-action&quot;&gt;Fix&lt;/button&gt;
         &lt;/div&gt;
-    &lt;/clr-alert&gt;
-&lt;/clr-alerts&gt;
-</code>
+        &lt;/clr-alert-item&gt;
+        &lt;/clr-alert&gt;
+        &lt;/clr-alerts&gt;
+    </code>
 </pre>
-  

--- a/latest/src/app/documentation/demos/alert/angular/alert-angular-close-event.demo.html
+++ b/latest/src/app/documentation/demos/alert/angular/alert-angular-close-event.demo.html
@@ -14,11 +14,11 @@
         <div class="content-container">
             <div class="content-area">
                 <clr-alert [clrAlertType]="'alert-success'" (clrAlertClosedChange)="onClose()">
-                    <div class="alert-item">
+                    <clr-alert-item>
                         <span class="alert-text">
                             This alert indicates a success!
                         </span>
-                    </div>
+                    </clr-alert-item>
                 </clr-alert>
                 <div>{{closeMessage}}</div>
             </div>

--- a/latest/src/app/documentation/demos/alert/angular/alert-angular-close-event.ts
+++ b/latest/src/app/documentation/demos/alert/angular/alert-angular-close-event.ts
@@ -7,11 +7,11 @@ import {Component} from "@angular/core";
 
 const HTML_EXAMPLE = `
 <clr-alert [clrAlertType]="'alert-success'" (clrAlertClosedChange)="onClose()">
-    <div class="alert-item">
+    <clr-alert-item>
         <span class="alert-text">
             This alert indicates a success!
         </span>
-    </div>
+    </clr-alert-item>
 </clr-alert>
 <div>{{closeMessage}}</div>
 `;

--- a/latest/src/app/documentation/demos/alert/angular/alert-angular-not-closable.demo.html
+++ b/latest/src/app/documentation/demos/alert/angular/alert-angular-not-closable.demo.html
@@ -14,7 +14,7 @@
         <div class="content-container">
             <div class="content-area">
                 <clr-alert [clrAlertClosable]="false">
-                    <div clr-alert-item class="alert-item">
+                    <clr-alert-item>
                         <span class="alert-text">
                             This alert cannot be dismissed.
                         </span>
@@ -31,14 +31,14 @@
                                 </clr-dropdown-menu>
                             </clr-dropdown>
                         </div>
-                    </div>
+                    </clr-alert-item>
                 </clr-alert>
                 <clr-alert [clrAlertType]="'alert-warning'">
-                    <div clr-alert-item class="alert-item">
+                    <clr-alert-item>
                         <span class="alert-text">
                             Try closing this alert.
                         </span>
-                    </div>
+                    </clr-alert-item>
                 </clr-alert>
                 <p>
                     Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor

--- a/latest/src/app/documentation/demos/alert/angular/alert-angular-not-closable.ts
+++ b/latest/src/app/documentation/demos/alert/angular/alert-angular-not-closable.ts
@@ -7,7 +7,7 @@ import {Component} from "@angular/core";
 
 const HTML_EXAMPLE = `
 <clr-alert [clrAlertClosable]="false">
-    <div clr-alert-item class="alert-item">
+    <clr-alert-item>
         <span class="alert-text">
             This alert cannot be dismissed.
         </span>
@@ -24,14 +24,14 @@ const HTML_EXAMPLE = `
                 </clr-dropdown-menu>
             </clr-dropdown>
         </div>
-    </div>
+    </clr-alert-item>
 </clr-alert>
 <clr-alert [clrAlertType]="'alert-warning'">
-    <div clr-alert-item class="alert-item">
+    <clr-alert-item>
         <span class="alert-text">
             Try closing this alert.
         </span>
-    </div>
+    </clr-alert-item>
 </clr-alert>
 `;
 

--- a/latest/src/app/documentation/demos/alert/angular/alert-angular-small.demo.html
+++ b/latest/src/app/documentation/demos/alert/angular/alert-angular-small.demo.html
@@ -14,18 +14,18 @@
         <div class="content-container">
             <div class="content-area">
                 <clr-alert [clrAlertSizeSmall]="true">
-                    <div class="alert-item">
+                    <clr-alert-item>
                         <span class="alert-text">
                             This is a small alert.
                         </span>
-                    </div>
+                    </clr-alert-item>
                 </clr-alert>
                 <clr-alert>
-                    <div class="alert-item">
+                    <clr-alert-item>
                         <span class="alert-text">
                             This is a regular alert.
                         </span>
-                    </div>
+                    </clr-alert-item>
                 </clr-alert>
                 <p>
                     Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor

--- a/latest/src/app/documentation/demos/alert/angular/alert-angular-small.ts
+++ b/latest/src/app/documentation/demos/alert/angular/alert-angular-small.ts
@@ -7,18 +7,18 @@ import {Component} from "@angular/core";
 
 const HTML_EXAMPLE = `
 <clr-alert [clrAlertSizeSmall]="true">
-    <div class="alert-item">
+    <clr-alert-item>
         <span class="alert-text">
             This is a small alert.
         </span>
-    </div>
+    </clr-alert-item>
 </clr-alert>
 <clr-alert>
-    <div class="alert-item">
+    <clr-alert-item>
         <span class="alert-text">
             This is a regular alert.
         </span>
-    </div>
+    </clr-alert-item>
 </clr-alert>
 `;
 

--- a/latest/src/app/documentation/demos/alert/angular/alert-angular-success.demo.html
+++ b/latest/src/app/documentation/demos/alert/angular/alert-angular-success.demo.html
@@ -14,18 +14,18 @@
         <div class="content-container">
             <div class="content-area">
                 <clr-alert [clrAlertType]="'alert-success'">
-                    <div class="alert-item">
+                    <clr-alert-item>
                         <span class="alert-text">
                             This alert indicates success.
                         </span>
-                    </div>
+                    </clr-alert-item>
                 </clr-alert>
                 <clr-alert>
-                    <div class="alert-item">
+                    <clr-alert-item>
                         <span class="alert-text">
                             This is a default info alert.
                         </span>
-                    </div>
+                    </clr-alert-item>
                 </clr-alert>
                 <p>
                     Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor

--- a/latest/src/app/documentation/demos/alert/angular/alert-angular-success.ts
+++ b/latest/src/app/documentation/demos/alert/angular/alert-angular-success.ts
@@ -7,18 +7,18 @@ import {Component} from "@angular/core";
 
 const HTML_EXAMPLE = `
 <clr-alert [clrAlertType]="'alert-success'">
-    <div class="alert-item">
+    <clr-alert-item>
         <span class="alert-text">
             This alert indicates success.
         </span>
-    </div>
+    </clr-alert-item>
 </clr-alert>
 <clr-alert>
-    <div class="alert-item">
+    <clr-alert-item>
         <span class="alert-text">
             This is a default info alert.
         </span>
-    </div>
+    </clr-alert-item>
 </clr-alert>
 `;
 

--- a/latest/src/app/documentation/demos/alert/static/alert-app-level.ts
+++ b/latest/src/app/documentation/demos/alert/static/alert-app-level.ts
@@ -6,7 +6,7 @@
 import {Component} from "@angular/core";
 
 const HTML_EXAMPLE_1 = `
-<div class="alert alert-app-level alert-danger" style="margin-bottom:24px">
+<div class="alert alert-app-level alert-danger" style="margin-bottom:24px" role="alert">
     <div class="alert-items">
         <div class="alert-item static">
             <div class="alert-icon-wrapper">
@@ -24,7 +24,7 @@ const HTML_EXAMPLE_1 = `
         <clr-icon aria-hidden="true" shape="close"></clr-icon>
     </button>
 </div>
-<div class="alert alert-app-level alert-warning" style="margin-bottom:24px">
+<div class="alert alert-app-level alert-warning" style="margin-bottom:24px" role="alert">
     <div class="alert-items">
         <div class="alert-item static">
             <div class="alert-icon-wrapper">
@@ -42,7 +42,7 @@ const HTML_EXAMPLE_1 = `
         <clr-icon aria-hidden="true" shape="close"></clr-icon>
     </button>
 </div>
-<div class="alert alert-app-level alert-info">
+<div class="alert alert-app-level alert-info" role="alert">
     <div class="alert-items">
         <div class="alert-item static">
             <div class="alert-icon-wrapper">
@@ -64,7 +64,7 @@ const HTML_EXAMPLE_1 = `
 
 const HTML_EXAMPLE_2 = `
 <div class="main-container">
-    <div class="alert alert-app-level alert-info">
+    <div class="alert alert-app-level alert-info" role="alert">
         <div class="alert-items">
             <div class="alert-item static">
                 <div class="alert-icon-wrapper">
@@ -97,7 +97,7 @@ const HTML_EXAMPLE_2 = `
 
 const HTML_EXAMPLE_3 = `
 <div class="main-container">
-    <div class="alert alert-app-level alert-warning">
+    <div class="alert alert-app-level alert-warning" role="alert">
         <div class="alert-items">
             <div class="alert-item static">
                 <div class="alert-icon-wrapper">

--- a/latest/src/app/documentation/demos/alert/static/alert-cards.ts
+++ b/latest/src/app/documentation/demos/alert/static/alert-cards.ts
@@ -8,7 +8,7 @@ import {Component} from "@angular/core";
 const HTML_EXAMPLE = `
 <div class="card">
     <div class="card-block">
-        <div class="alert alert-warning alert-sm">
+        <div class="alert alert-warning alert-sm" role="alert">
             <div class="alert-items">
                 <div class="alert-item static">
                     <div class="alert-icon-wrapper">

--- a/latest/src/app/documentation/demos/alert/static/alert-content-area.ts
+++ b/latest/src/app/documentation/demos/alert/static/alert-content-area.ts
@@ -7,7 +7,7 @@ import {Component} from "@angular/core";
 
 const HTML_EXAMPLE = `
 <div class="content-area">
-    <div class="alert alert-danger">
+    <div class="alert alert-danger" role="alert">
         <div class="alert-items">
             <div class="alert-item static">
                 <div class="alert-icon-wrapper">
@@ -20,7 +20,7 @@ const HTML_EXAMPLE = `
         </div>
     </div>
     <p>...</p>
-    <div class="alert alert-success">
+    <div class="alert alert-success" role="alert">
         <div class="alert-items">
             <div class="alert-item static">
                 <div class="alert-icon-wrapper">

--- a/latest/src/app/documentation/demos/alert/static/alert-modals.ts
+++ b/latest/src/app/documentation/demos/alert/static/alert-modals.ts
@@ -9,7 +9,7 @@ const HTML_EXAMPLE = `
 <div class="modal static bump-down">
     <div class="modal-dialog" role="dialog" aria-hidden="true">
         <div class="modal-content">
-            <div class="alert alert-danger">
+            <div class="alert alert-danger" role="alert">
                 <div class="alert-items">
                     <div class="alert-item static">
                         <div class="alert-icon-wrapper">

--- a/latest/src/app/documentation/demos/alert/static/alert-sizes.ts
+++ b/latest/src/app/documentation/demos/alert/static/alert-sizes.ts
@@ -8,7 +8,7 @@ import {Component} from "@angular/core";
 const HTML_EXAMPLE = `
 <div class="alert alert-danger">
     <div class="alert-items">
-        <div class="alert-item static">
+        <div class="alert-item static" role="alert">
             <div class="alert-icon-wrapper">
                 <clr-icon class="alert-icon" shape="exclamation-circle"></clr-icon>
             </div>
@@ -21,7 +21,7 @@ const HTML_EXAMPLE = `
         <clr-icon aria-hidden="true" shape="close"></clr-icon>
     </button>
 </div>
-<div class="alert alert-success alert-sm">
+<div class="alert alert-success alert-sm" role="alert">
     <div class="alert-items">
         <div class="alert-item static">
             <div class="alert-icon-wrapper">

--- a/latest/src/app/documentation/demos/alert/static/alert-styles.ts
+++ b/latest/src/app/documentation/demos/alert/static/alert-styles.ts
@@ -6,7 +6,7 @@
 import {Component} from "@angular/core";
 
 const HTML_EXAMPLE = `
-<div class="alert alert-danger">
+<div class="alert alert-danger" role="alert">
     <div class="alert-items">
         <div class="alert-item static">
             <div class="alert-icon-wrapper">
@@ -48,7 +48,7 @@ const HTML_EXAMPLE = `
         </div>
     </div>
 </div>
-<div class="alert alert-warning">
+<div class="alert alert-warning" role="alert">
     <div class="alert-items">
         <div class="alert-item static">
             <div class="alert-icon-wrapper">
@@ -74,7 +74,7 @@ const HTML_EXAMPLE = `
         <clr-icon aria-hidden="true" shape="close"></clr-icon>
     </button>
 </div>
-<div class="alert alert-info">
+<div class="alert alert-info" role="alert">
     <div class="alert-items">
         <div class="alert-item static">
             <div class="alert-icon-wrapper">
@@ -91,7 +91,7 @@ const HTML_EXAMPLE = `
         <clr-icon aria-hidden="true" shape="close"></clr-icon>
     </button>
 </div>
-<div class="alert alert-success">
+<div class="alert alert-success" role="alert">
     <div class="alert-items">
         <div class="alert-item static">
             <div class="alert-icon-wrapper">


### PR DESCRIPTION
• Added examples of using ARIA role "alert" to the static alert examples
• Removed instances of using div.alert-item in Angular examples to using the preferred cir-alert-item
• Did not add ARIA roles to examples on page in order to prevent screenreaders from freaking out on the number of example alerts

Tested in:
✔︎ Chrome

Signed-off-by: Scott Mathis <smathis@vmware.com>