### PR TITLE
[NG] remove deprecated datagrid features

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -233,7 +233,6 @@ export declare class ClrDatagrid<T = any> implements AfterContentInit, AfterView
     refresh: EventEmitter<ClrDatagridStateInterface<T>>;
     rowActionService: RowActionService;
     rowSelectionMode: boolean;
-    /** @deprecated */ rowSelectionModeDeprecated: boolean;
     rows: QueryList<ClrDatagridRow<T>>;
     scrollableColumns: ViewContainerRef;
     selected: T[];

--- a/src/clr-angular/data/datagrid/datagrid-column-toggle-button.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-toggle-button.spec.ts
@@ -10,29 +10,6 @@ import { ColumnToggleButtonsService } from './providers/column-toggle-buttons.se
 
 export default function(): void {
   describe('Datagrid Column Toggle Button component', function() {
-    describe('Typescript API', function() {
-      let columnToggleButtons: ColumnToggleButtonsService;
-      let component: ClrDatagridColumnToggleButton;
-
-      beforeEach(function() {
-        columnToggleButtons = new ColumnToggleButtonsService();
-        component = new ClrDatagridColumnToggleButton(columnToggleButtons);
-      });
-
-      it('calls the click method', function() {
-        spyOn(columnToggleButtons, 'buttonClicked');
-        component.click();
-        expect(columnToggleButtons.buttonClicked).toHaveBeenCalledWith(component.clrType);
-      });
-
-      it('calls the click method when clrType is `ok`', function() {
-        component.clrType = 'ok';
-        spyOn(columnToggleButtons, 'buttonClicked');
-        component.click();
-        expect(columnToggleButtons.buttonClicked).toHaveBeenCalledWith(component.clrType);
-      });
-    });
-
     describe('View', function() {
       // Until we can properly type "this"
       let context: TestContext<ClrDatagridColumnToggleButton, ButtonTest>;
@@ -55,20 +32,22 @@ export default function(): void {
       });
 
       it('should disable the button when all are active', function() {
-        context.testComponent.type = 'selectAll';
         columnToggleButtons.selectAllDisabled = true;
         context.detectChanges();
         expect(button.disabled).toBe(true);
+      });
+
+      it('calls the click method', function() {
+        spyOn(columnToggleButtons, 'buttonClicked');
+        button.click();
+        context.detectChanges();
+        expect(columnToggleButtons.buttonClicked).toHaveBeenCalled();
       });
     });
   });
 }
 
 @Component({
-  template: `
-        <clr-dg-column-toggle-button [clrType]="type">Testing 1 2 3</clr-dg-column-toggle-button>
-    `,
+  template: `<clr-dg-column-toggle-button>Testing 1 2 3</clr-dg-column-toggle-button>`,
 })
-class ButtonTest {
-  type = 'selectAll';
-}
+class ButtonTest {}

--- a/src/clr-angular/data/datagrid/datagrid-column-toggle-button.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-toggle-button.ts
@@ -3,15 +3,15 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { Component, Input } from '@angular/core';
+import { Component } from '@angular/core';
 
-import { ColumnToggleButtons, ColumnToggleButtonsService } from './providers/column-toggle-buttons.service';
+import { ColumnToggleButtonsService } from './providers/column-toggle-buttons.service';
 
 @Component({
   selector: 'clr-dg-column-toggle-button',
   template: `
         <button class="btn btn-sm btn-link"
-            (click)="click()"
+            (click)="toggleButtons.buttonClicked()"
             [disabled]="toggleButtons.selectAllDisabled"
             type="button">
             <ng-content></ng-content>
@@ -19,12 +19,5 @@ import { ColumnToggleButtons, ColumnToggleButtonsService } from './providers/col
     `,
 })
 export class ClrDatagridColumnToggleButton {
-  /** @deprecated since 0.13 */
-  @Input() clrType: ColumnToggleButtons = 'selectAll';
-
   constructor(public toggleButtons: ColumnToggleButtonsService) {}
-
-  click() {
-    this.toggleButtons.buttonClicked(this.clrType);
-  }
 }

--- a/src/clr-angular/data/datagrid/datagrid.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid.spec.ts
@@ -680,13 +680,6 @@ export default function(): void {
           context.detectChanges();
           expect(context.testComponent.selected).toEqual(2);
         });
-
-        it("sets deprecated attribute 'clDgRowSelection' as expected `rowSelectionMode` is enabled", function() {
-          expect(selection.rowSelectionMode).toBe(false);
-          context.clarityDirective.rowSelectionModeDeprecated = true;
-          context.detectChanges();
-          expect(selection.rowSelectionMode).toBe(true);
-        });
       });
 
       describe('View', function() {

--- a/src/clr-angular/data/datagrid/datagrid.ts
+++ b/src/clr-angular/data/datagrid/datagrid.ts
@@ -153,15 +153,6 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
   }
 
   /**
-   * stay backwards compatible , will be renamed to clrDgRowSelection
-   * @deprecated since 0.12
-   */
-  @Input('clDgRowSelection')
-  set rowSelectionModeDeprecated(value: boolean) {
-    this.rowSelectionMode = value;
-  }
-
-  /**
    * Indicates if all currently displayed items are selected
    */
   public get allSelected() {

--- a/src/clr-angular/data/datagrid/providers/column-toggle-buttons.service.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/column-toggle-buttons.service.spec.ts
@@ -20,14 +20,13 @@ export default function(): void {
       expect(service.selectAllButtonClicked.subscribe).toBeDefined();
     });
 
-    it('should emit clicks only if clrType is `selectAll`', function() {
+    it('should emit clicks', function() {
       let calls = 0;
       service.selectAllButtonClicked.subscribe(() => {
         calls++;
       });
 
-      service.buttonClicked('ok');
-      service.buttonClicked('selectAll');
+      service.buttonClicked();
       expect(calls).toEqual(1);
     });
   });

--- a/src/clr-angular/data/datagrid/providers/column-toggle-buttons.service.ts
+++ b/src/clr-angular/data/datagrid/providers/column-toggle-buttons.service.ts
@@ -7,8 +7,6 @@ import { Injectable, TemplateRef } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Subject } from 'rxjs';
 
-export type ColumnToggleButtons = 'ok' | 'selectAll';
-
 @Injectable()
 export class ColumnToggleButtonsService {
   buttons: TemplateRef<any> = null;
@@ -19,9 +17,7 @@ export class ColumnToggleButtonsService {
     return this._selectAllButtonClicked.asObservable();
   }
 
-  public buttonClicked(type: ColumnToggleButtons): void {
-    if (type.toLowerCase() === 'selectall') {
-      this._selectAllButtonClicked.next();
-    }
+  public buttonClicked(): void {
+    this._selectAllButtonClicked.next();
   }
 }


### PR DESCRIPTION
This removes the `clrType` input on the toggle button, and the typo input `clDgRowSelection`