### PR TITLE
[NG] remove deprecated wizard features

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -1196,7 +1196,6 @@ export declare class ClrWizard implements OnInit, OnDestroy, AfterContentInit, D
     ngOnDestroy(): void;
     ngOnInit(): void;
     open(): void;
-    prev(): void;
     previous(): void;
     reset(): void;
     toggle(value: boolean): void;

--- a/src/clr-angular/wizard/providers/wizard-navigation.service.spec.ts
+++ b/src/clr-angular/wizard/providers/wizard-navigation.service.spec.ts
@@ -534,7 +534,7 @@ export default function(): void {
         const testPage = pageCollectionService.lastPage;
         spyOn(testPage.onCommit, 'emit');
 
-        wiz.navService.setCurrentPage(testPage);
+        wiz.navService.currentPage = testPage;
         expect(wiz.currentPage).toBe(testPage, 'last page was made current');
         context.detectChanges();
 

--- a/src/clr-angular/wizard/providers/wizard-navigation.service.ts
+++ b/src/clr-angular/wizard/providers/wizard-navigation.service.ts
@@ -270,17 +270,6 @@ export class WizardNavigationService implements OnDestroy {
   }
 
   /**
-   * (DEPRECATED) A legacy means of setting the current page in the wizard.
-   * Deprecated in 0.9.4. Accepts a ClrWizardPage object as a parameter and then
-   * tries to set that page to be the current page in the wizard.
-   *
-   * @memberof WizardNavigationService
-   */
-  public setCurrentPage(page: ClrWizardPage): void {
-    this.currentPage = page;
-  }
-
-  /**
    * @memberof WizardNavigationService
    */
   private _movedToNextPage = new Subject<boolean>();

--- a/src/clr-angular/wizard/wizard.spec.ts
+++ b/src/clr-angular/wizard/wizard.spec.ts
@@ -148,14 +148,6 @@ export default function(): void {
           });
         });
 
-        describe('prev', () => {
-          it('should call the navService', () => {
-            spyOn(wizardNavigationService, 'previous');
-            wizard.prev();
-            expect(wizardNavigationService.previous).toHaveBeenCalledTimes(1);
-          });
-        });
-
         describe('previous', () => {
           it('should call the navService', () => {
             spyOn(wizardNavigationService, 'previous');

--- a/src/clr-angular/wizard/wizard.ts
+++ b/src/clr-angular/wizard/wizard.ts
@@ -536,18 +536,6 @@ export class ClrWizard implements OnInit, OnDestroy, AfterContentInit, DoCheck {
   }
 
   /**
-   * DEPRECATED. Moves the wizard to the previous page. Carried over from legacy.
-   *
-   * It is recommended that you use previous() instead.
-   *
-   * @name prev
-   * @memberof ClrWizard
-   */
-  public prev(): void {
-    this.previous();
-  }
-
-  /**
    * Moves the wizard to the previous page.
    *
    * @name previous


### PR DESCRIPTION
This removes the deprecated wizard `prev()` method, and nav service `setCurrentPage()` method.