### PR TITLE
Fix modal boolean testing

### DIFF
--- a/src/clr-angular/modal/modal.ts
+++ b/src/clr-angular/modal/modal.ts
@@ -85,7 +85,7 @@ export class ClrModal implements OnChanges, OnDestroy {
   }
 
   open(): void {
-    if (this._open === true) {
+    if (this._open) {
       return;
     }
     this._open = true;
@@ -98,7 +98,7 @@ export class ClrModal implements OnChanges, OnDestroy {
       this.altClose.emit(false);
       return;
     }
-    if (!this.closable || this._open === false) {
+    if (!this.closable || !this._open) {
       return;
     }
     this._open = false;


### PR DESCRIPTION
Our boolean testing in modals was very weird. Being too strict could be a problem, so I'm changing it back to a more standard syntax.

Yes, this commit is only here for me to catch up to Scott.

Fixes #2760.