### PR TITLE
[NG] Check listener is defined before invoking it

### DIFF
--- a/src/clr-angular/utils/loading/loading.spec.ts
+++ b/src/clr-angular/utils/loading/loading.spec.ts
@@ -72,6 +72,32 @@ describe('Loading directive', function() {
   });
 });
 
+describe('Loading directive without listener', function() {
+  beforeEach(function() {
+    TestBed.configureTestingModule({
+      declarations: [ClrLoading, FullTest],
+    });
+    this.fixture = TestBed.createComponent(FullTest);
+    this.fixture.detectChanges();
+    this.testComponent = this.fixture.componentInstance;
+    this.clarityDirective = this.fixture.componentInstance.loadingDirective;
+  });
+
+  afterEach(function() {
+    this.fixture.destroy();
+  });
+
+  it('keeps loading state without exceptions', function() {
+    expect(this.clarityDirective.loadingState).toEqual(ClrLoadingState.DEFAULT);
+    this.testComponent.loading = true;
+    this.fixture.detectChanges();
+    expect(this.clarityDirective.loadingState).toEqual(ClrLoadingState.LOADING);
+    this.testComponent.loading = false;
+    this.fixture.detectChanges();
+    expect(this.clarityDirective.loadingState).toEqual(ClrLoadingState.DEFAULT);
+  });
+});
+
 @Component({ template: `<div *ngIf="displayed" [clrLoading]="loading"></div>` })
 class FullTest {
   @ViewChild(ClrLoading) loadingDirective: ClrLoading;

--- a/src/clr-angular/utils/loading/loading.ts
+++ b/src/clr-angular/utils/loading/loading.ts
@@ -38,7 +38,9 @@ export class ClrLoading implements OnDestroy {
     }
 
     this._loadingState = value;
-    this.listener.loadingStateChange(value);
+    if (this.listener) {
+      this.listener.loadingStateChange(value);
+    }
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
`listener` has `@Optional()` decorator, therefore we have to check it's not null before calling it.