### PR TITLE
Fix to SelectAll reamins Enabled issue

### DIFF
--- a/src/clr-angular/data/datagrid/datagrid-column-toggle.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-toggle.ts
@@ -42,7 +42,7 @@ import { ClrCommonStrings } from '../../utils/i18n/common-strings.interface';
                     <clr-checkbox-container>
                         <input clrCheckbox type="checkbox"
                           [disabled]="column.lastVisibleColumn"
-                          [ngModel]="!column.hidden" 
+                          [ngModel]="!column.hidden"
                           (ngModelChange)="toggleColumn($event, column)">
                         <label><ng-template [ngTemplateOutlet]="column.template"></ng-template></label>
                     </clr-checkbox-container>
@@ -130,6 +130,7 @@ export class ClrDatagridColumnToggle implements OnInit, OnDestroy {
   selectAll() {
     this.hideableColumnService.showHiddenColumns();
     this.allColumnsVisible = this.hideableColumnService.checkForAllColumnsVisible;
+    this.columnToggleButtons.selectAllDisabled = this.allColumnsVisible;
   }
 
   toggleColumn(event: boolean, column: DatagridHideableColumnModel) {


### PR DESCRIPTION
Signed-off-by: AMERICAS\Chandra_Bhumireddy <chandra_bhumireddy@dell.com>
Closing [PR](https://github.com/vmware/clarity/pull/2737) and reopening clear one

[Fix: 2734](https://github.com/vmware/clarity/issues/2734)
[Already clicked "Select All" button remains enabled](https://github.com/vmware/clarity/issues/2734)

Added missing statement to disable select all button which is needed input for  'clr-dg-column-toggle-button' when select all button is clicked. For toggle Column this is already in place.