### PR TITLE
fix(dark-theme): Selected datagrid row font color should be white

### DIFF
--- a/src/clr-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clr-angular/data/datagrid/_datagrid.clarity.scss
@@ -85,7 +85,7 @@
     }
 
     &.datagrid-selected {
-      color: $clr-black;
+      color: $clr-datagrid-row-selected;
 
       .datagrid-row-sticky,
       .datagrid-row-scrollable,


### PR DESCRIPTION

Signed-off-by: Matt Hippely <mhippely@vmware.com>