### PR TITLE
[NG] fix memory leak in focus trap

### DIFF
--- a/src/clr-angular/utils/focus-trap/focus-trap.directive.ts
+++ b/src/clr-angular/utils/focus-trap/focus-trap.directive.ts
@@ -49,7 +49,8 @@ export class FocusTrapDirective implements AfterViewInit, OnDestroy {
   }
 
   private createFocusableOffScreenEl(): any {
-    const offScreenSpan = this.renderer.createElement('span');
+    // Not using Renderer2's createElement method because that leads to DOM leakage.
+    const offScreenSpan = this.document.createElement('span');
     this.renderer.setAttribute(offScreenSpan, 'tabindex', '0');
     this.renderer.addClass(offScreenSpan, 'offscreen-focus-rebounder');
 
@@ -81,6 +82,11 @@ export class FocusTrapDirective implements AfterViewInit, OnDestroy {
     ) {
       this.renderer.removeChild(this.document.body, this.topReboundEl);
       this.renderer.removeChild(this.document.body, this.bottomReboundEl);
+
+      // These are here to to make sure that
+      // we completely delete all traces of the removed DOM objects.
+      delete this.topReboundEl;
+      delete this.bottomReboundEl;
     }
   }
 

--- a/src/clr-angular/utils/focus-trap/focus-trap.directive.ts
+++ b/src/clr-angular/utils/focus-trap/focus-trap.directive.ts
@@ -50,6 +50,7 @@ export class FocusTrapDirective implements AfterViewInit, OnDestroy {
 
   private createFocusableOffScreenEl(): any {
     // Not using Renderer2's createElement method because that leads to DOM leakage.
+    // https://github.com/angular/angular/issues/26954
     const offScreenSpan = this.document.createElement('span');
     this.renderer.setAttribute(offScreenSpan, 'tabindex', '0');
     this.renderer.addClass(offScreenSpan, 'offscreen-focus-rebounder');


### PR DESCRIPTION
**Before**:

![screenshot 2018-11-05 10 38 10](https://user-images.githubusercontent.com/3958008/48018989-2c4b4e00-e0e7-11e8-88a4-fa53f16f5f9d.png)


Angular Render2's `createElement` keeps the traces of the detached doms. Each time I open a modal component, the JS heap size kept getting the retained size of 40 bytes.

**After**:


After resorting the native DOM's `createElement` method, I found no traces of left over objects and the retained size became 0 bytes.

![screenshot 2018-11-05 10 36 51](https://user-images.githubusercontent.com/3958008/48019349-19854900-e0e8-11e8-859d-0b110f18892c.png)

Also, I communicated with Mustafa and received his confirmation on the solution.

Signed-off-by: stsogoo <stsogoo@vmware.com>