### PR TITLE
[INTERNAL] Quick incremental improvement of our test helpers

### DIFF
--- a/src/clr-angular/popover/signpost/signpost.spec.ts
+++ b/src/clr-angular/popover/signpost/signpost.spec.ts
@@ -6,30 +6,30 @@
 import { Component, ViewChild } from '@angular/core';
 
 import { IfOpenService } from '../../utils/conditional/if-open.service';
-import { addHelpers, TestContext } from '../../utils/testing/helpers.spec';
+import { spec, TestContext } from '../../utils/testing/helpers.spec';
 
 import { ClrSignpost } from './signpost';
 import { ClrSignpostModule } from './signpost.module';
 
+interface Context extends TestContext<ClrSignpost, TestDefaultSignpost | TestCustomTriggerSignpost> {
+  ifOpenService: IfOpenService;
+}
+
 export default function(): void {
   describe('Signpost', function() {
-    addHelpers([ClrSignpostModule]);
-
     describe('default trigger', function() {
-      let context: TestContext<ClrSignpost, TestDefaultSignpost>;
-      let ifOpenService: IfOpenService;
+      spec(ClrSignpost, TestDefaultSignpost, ClrSignpostModule);
 
-      beforeEach(function() {
-        context = this.create(ClrSignpost, TestDefaultSignpost);
-        ifOpenService = context.getClarityProvider(IfOpenService);
+      beforeEach(function(this: Context) {
+        this.ifOpenService = this.getClarityProvider(IfOpenService);
       });
 
-      it('adds the .signpost class to clr-signpost', function() {
-        expect(context.clarityElement.classList).toContain('signpost');
+      it('adds the .signpost class to clr-signpost', function(this: Context) {
+        expect(this.clarityElement.classList).toContain('signpost');
       });
 
-      it('has a default trigger that can hide/show content', function() {
-        const signpostToggle: HTMLElement = context.testElement.querySelector('.signpost-action');
+      it('has a default trigger that can hide/show content', function(this: Context) {
+        const signpostToggle: HTMLElement = this.hostElement.querySelector('.signpost-action');
         let signpostContent: HTMLElement;
 
         // Test we have a trigger
@@ -37,34 +37,32 @@ export default function(): void {
 
         // // Test that content shows
         signpostToggle.click();
-        context.detectChanges();
-        signpostContent = context.testElement.querySelector('.signpost-content');
+        this.detectChanges();
+        signpostContent = this.hostElement.querySelector('.signpost-content');
         expect(signpostContent).not.toBeNull();
-        expect(ifOpenService.open).toBe(true);
+        expect(this.ifOpenService.open).toBe(true);
 
         // Test that content hides again
         signpostToggle.click();
-        context.detectChanges();
-        signpostContent = context.testElement.querySelector('.signpost-content');
+        this.detectChanges();
+        signpostContent = this.hostElement.querySelector('.signpost-content');
         expect(signpostContent).toBeNull();
-        expect(ifOpenService.open).toBe(false);
+        expect(this.ifOpenService.open).toBe(false);
       });
     });
 
     describe('custom trigger', function() {
-      let context: TestContext<ClrSignpost, TestCustomTriggerSignpost>;
-      let ifOpenService: IfOpenService;
+      spec(ClrSignpost, TestCustomTriggerSignpost, ClrSignpostModule);
 
-      beforeEach(function() {
-        context = this.create(ClrSignpost, TestCustomTriggerSignpost);
-        ifOpenService = context.getClarityProvider(IfOpenService);
+      beforeEach(function(this: Context) {
+        this.ifOpenService = this.getClarityProvider(IfOpenService);
       });
 
       /********
        * This test assumes that if
        */
-      it('does not display the default trigger', function() {
-        const triggerIcon: HTMLElement = context.testElement.querySelector('clr-icon');
+      it('does not display the default trigger', function(this: Context) {
+        const triggerIcon: HTMLElement = this.hostElement.querySelector('clr-icon');
 
         /**********
          * If there is a clr-icon we are testing that it is not the same shape
@@ -75,8 +73,8 @@ export default function(): void {
         }
       });
 
-      it('projects a custom trigger element to hide/show content', function() {
-        const signpostTrigger: HTMLElement = context.testElement.querySelector('.signpost-action');
+      it('projects a custom trigger element to hide/show content', function(this: Context) {
+        const signpostTrigger: HTMLElement = this.hostElement.querySelector('.signpost-action');
         let signpostContent: HTMLElement;
 
         expect(signpostTrigger.textContent.trim()).toBe('Custom trigger');
@@ -86,17 +84,17 @@ export default function(): void {
 
         // Test it shows after changes
         signpostTrigger.click();
-        context.detectChanges();
-        signpostContent = context.testElement.querySelector('.signpost-content');
+        this.detectChanges();
+        signpostContent = this.hostElement.querySelector('.signpost-content');
         expect(signpostContent).not.toBeNull();
-        expect(ifOpenService.open).toBe(true);
+        expect(this.ifOpenService.open).toBe(true);
 
         // Test it hide when clicked again
         signpostTrigger.click();
-        context.detectChanges();
-        signpostContent = context.testElement.querySelector('.signpost-content');
+        this.detectChanges();
+        signpostContent = this.hostElement.querySelector('.signpost-content');
         expect(signpostContent).toBeNull();
-        expect(ifOpenService.open).toBe(false);
+        expect(this.ifOpenService.open).toBe(false);
       });
     });
   });

--- a/src/clr-angular/utils/testing/helpers.spec.ts
+++ b/src/clr-angular/utils/testing/helpers.spec.ts
@@ -8,38 +8,49 @@
  * when we have the time. This will be very helpful in future refactors due to Angular upgrades, or simply
  * just to avoid leaks since destroying fixtures is automatic with this.
  */
-import { DebugElement, ModuleWithProviders, Type } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DebugElement, InjectionToken, ModuleWithProviders, Type } from '@angular/core';
+import { ComponentFixture, TestBed, TestBedStatic, TestModuleMetadata } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 // import { reportSlowSpecs } from "./slow-specs.spec";
 
-export class TestContext<D, C> {
-  fixture: ComponentFixture<C>;
-  testComponent: C;
-  testElement: any;
-  clarityDirective: D;
-  clarityElement: any;
+export class TestContext<C, H> {
+  /*
+   * Spec config
+   */
+  clarityDirectiveType: Type<C>;
+  hostType: Type<H>;
+  testingModule: TestBedStatic;
+
+  /*
+   * Objects instantiated for one test
+   */
+  fixture: ComponentFixture<H>;
+  hostComponent: H;
+  hostElement: HTMLElement;
+  clarityDirective: C;
+  clarityElement: HTMLElement;
 
   private clarityDebugElement: DebugElement;
 
-  constructor(clarityDirectiveType: Type<D>, componentType: Type<C>) {
-    this.fixture = TestBed.createComponent(componentType);
+  // Initialization logic can be manually called to allow for overrides before instantiation
+  init() {
+    this.fixture = TestBed.createComponent(this.hostType);
     this.fixture.detectChanges();
-    this.testComponent = this.fixture.componentInstance;
-    this.testElement = this.fixture.nativeElement;
-    this.clarityDebugElement = this.fixture.debugElement.query(By.directive(clarityDirectiveType));
+    this.hostComponent = this.fixture.componentInstance;
+    this.hostElement = this.fixture.nativeElement;
+    this.clarityDebugElement = this.fixture.debugElement.query(By.directive(this.clarityDirectiveType));
     if (!this.clarityDebugElement) {
-      const componentName = (<any>componentType).name;
-      const clarityDirectiveName = (<any>clarityDirectiveType).name;
+      const componentName = (<any>this.hostType).name;
+      const clarityDirectiveName = (<any>this.clarityDirectiveType).name;
       throw new Error(`Test component ${componentName} doesn't contain a ${clarityDirectiveName}`);
     }
-    this.clarityDirective = this.clarityDebugElement.injector.get(clarityDirectiveType);
+    this.clarityDirective = this.clarityDebugElement.injector.get(this.clarityDirectiveType);
     this.clarityElement = this.clarityDebugElement.nativeElement;
   }
 
-  getClarityProvider(token: any) {
-    return this.clarityDebugElement.injector.get(token);
+  getClarityProvider<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T): T {
+    return this.clarityDebugElement.injector.get(token, notFoundValue);
   }
 
   /**
@@ -50,8 +61,69 @@ export class TestContext<D, C> {
   }
 }
 
-// This is so unusable right now, we need to fix it ASAP.
-export function addHelpers(modulesToImport?: Array<Type<any> | ModuleWithProviders | any[]>): void {
+/**
+ * @param clarityDirectiveType - the Clarity directive/component class being tested
+ * @param hostType - the host test component used to run the specs
+ * @param claritySubmodule - If you need a whole Clarity component submodule to test the component, provide it here
+ * @param moduleMetadata - custom additional metadata for the testing module: extra imports, extra declarations, etc.
+ * @param autoInit - the host test component is instantiated by default when the test starts. If you need to override
+ *  some component's provider, templates or other override TestBed provides, set this autoInit option to false and
+ *  perform your overrides before manually calling this.init() on the TestContext.
+ */
+export function spec<C, H>(
+  clarityDirectiveType: Type<C>,
+  hostType: Type<H>,
+  claritySubmodule?: any,
+  moduleMetadata: TestModuleMetadata = {},
+  autoInit = true
+) {
+  beforeEach(function() {
+    /*
+     * I feel slightly dirty writing this, but Jasmine creates plain objects
+     * and modifying their prototype is definitely a bad idea
+     */
+    Object.assign(this, TestContext.prototype);
+  });
+
+  beforeEach(function(this: TestContext<C, H>) {
+    const imports = [];
+    if (claritySubmodule) {
+      imports.push(claritySubmodule);
+    }
+    if (moduleMetadata && moduleMetadata.imports) {
+      imports.push(...moduleMetadata.imports);
+    }
+    const declarations: Type<any>[] = [hostType];
+    if (!claritySubmodule) {
+      declarations.push(clarityDirectiveType);
+    }
+    if (moduleMetadata && moduleMetadata.declarations) {
+      declarations.push(...moduleMetadata.declarations);
+    }
+    this.testingModule = TestBed.configureTestingModule({ ...moduleMetadata, imports, declarations });
+    this.clarityDirectiveType = clarityDirectiveType;
+    this.hostType = hostType;
+    if (autoInit) {
+      this.init();
+    }
+  });
+
+  afterEach(function(this: TestContext<C, H>) {
+    if (this.fixture) {
+      this.fixture.destroy();
+      this.fixture.nativeElement.remove();
+    }
+  });
+}
+
+/**
+ * This was initially a copy-paste of the datagrid helpers, but when we modularized Clarity, it got updated to
+ * something that's way too rigid and doesn't help for complex specs anymore. Deprecating for now, I'm going
+ * to create a temporary new one until we can take some time to finally, one day, if ever, hopefully, maybe,
+ * unify our test helpers across all of our code base.
+ * @deprecated
+ */
+export function addHelpersDeprecated(modulesToImport?: Array<Type<any> | ModuleWithProviders | any[]>): void {
   beforeEach(function() {
     /*
          * Ideally we would just make "this" a TestContext, but typing "this" in typescript
@@ -59,7 +131,11 @@ export function addHelpers(modulesToImport?: Array<Type<any> | ModuleWithProvide
          */
     this.create = <D, C>(clarityDirective: Type<D>, testComponent: Type<C>, providers: any[] = []) => {
       TestBed.configureTestingModule({ imports: modulesToImport, declarations: [testComponent], providers: providers });
-      return (this._context = new TestContext<D, C>(clarityDirective, testComponent));
+      this._context = new TestContext<D, C>();
+      this._context.clarityDirectiveType = clarityDirective;
+      this._context.hostType = testComponent;
+      this._context.init();
+      return this._context;
     };
   });
   afterEach(function() {

--- a/src/clr-angular/wizard/all.spec.ts
+++ b/src/clr-angular/wizard/all.spec.ts
@@ -6,7 +6,7 @@
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { ClrIconModule } from '../icon/icon.module';
-import { addHelpers } from '../utils/testing/helpers.spec';
+import { addHelpersDeprecated } from '../utils/testing/helpers.spec';
 
 import ButtonHubSpecs from './providers/button-hub.service.spec';
 import HeaderActionsSpecs from './providers/header-actions.service.spec';
@@ -21,7 +21,7 @@ import { ClrWizardModule } from './wizard.module';
 import WizardSpecs from './wizard.spec';
 
 describe('New Wizard Tests', () => {
-  addHelpers([ClrWizardModule, ClrIconModule, NoopAnimationsModule]);
+  addHelpersDeprecated([ClrWizardModule, ClrIconModule, NoopAnimationsModule]);
 
   WizardSpecs();
   WizardStepnavSpecs();

--- a/src/clr-angular/wizard/wizard.spec.ts
+++ b/src/clr-angular/wizard/wizard.spec.ts
@@ -27,7 +27,7 @@ export default function(): void {
         beforeEach(function() {
           context = this.create(ClrWizard, UnopenedWizardTestComponent);
           wizard = context.clarityDirective;
-          component = context.testComponent;
+          component = context.hostComponent;
           context.detectChanges();
         });
 
@@ -237,85 +237,85 @@ export default function(): void {
       describe('Current page onchange', () => {
         it('should emit pageOnLoad when wizard is created', () => {
           context.detectChanges();
-          expect(context.testComponent._firstPageLoaded).toBe(1, 'only once when created');
+          expect(context.hostComponent._firstPageLoaded).toBe(1, 'only once when created');
         });
 
         it('should emit page on load when navigating', () => {
           wizard.next();
           wizard.next();
-          expect(context.testComponent._pagesLoaded).toBe(1);
+          expect(context.hostComponent._pagesLoaded).toBe(1);
         });
 
         it('should notify clrWizardCurrentPageChanged output', () => {
-          expect(context.testComponent._currentPageChanged).toBe(1, 'only initial load');
+          expect(context.hostComponent._currentPageChanged).toBe(1, 'only initial load');
           wizard.next();
-          expect(context.testComponent._currentPageChanged).toBe(2, 'increases with move forward');
+          expect(context.hostComponent._currentPageChanged).toBe(2, 'increases with move forward');
           wizard.next();
-          expect(context.testComponent._currentPageChanged).toBe(3, 'increases with move forward');
+          expect(context.hostComponent._currentPageChanged).toBe(3, 'increases with move forward');
           wizard.previous();
-          expect(context.testComponent._currentPageChanged).toBe(4, 'increases with move backward');
+          expect(context.hostComponent._currentPageChanged).toBe(4, 'increases with move backward');
         });
 
         it('should notify clrWizardOnNext output', () => {
-          expect(context.testComponent._movedForward).toBe(0, 'initial load');
+          expect(context.hostComponent._movedForward).toBe(0, 'initial load');
           // need to do event emissions here, so passing false
           wizard.next(false);
-          expect(context.testComponent._movedForward).toBe(1, 'increases with move forward');
+          expect(context.hostComponent._movedForward).toBe(1, 'increases with move forward');
           // need to do event emissions here, so passing false
           wizard.next(false);
-          expect(context.testComponent._movedForward).toBe(2, 'increases with move forward');
+          expect(context.hostComponent._movedForward).toBe(2, 'increases with move forward');
           wizard.previous();
-          expect(context.testComponent._movedForward).toBe(2, 'stays put with move backward');
+          expect(context.hostComponent._movedForward).toBe(2, 'stays put with move backward');
         });
 
         it('should notify clrWizardOnPrevious output', () => {
-          expect(context.testComponent._movedBackward).toBe(0, 'initial load');
+          expect(context.hostComponent._movedBackward).toBe(0, 'initial load');
           wizard.next();
-          expect(context.testComponent._movedBackward).toBe(0, 'stays put with move forward');
+          expect(context.hostComponent._movedBackward).toBe(0, 'stays put with move forward');
           wizard.next();
-          expect(context.testComponent._movedBackward).toBe(0, 'stays put with move forward');
+          expect(context.hostComponent._movedBackward).toBe(0, 'stays put with move forward');
           wizard.previous();
-          expect(context.testComponent._movedBackward).toBe(1, 'increases with move backward');
+          expect(context.hostComponent._movedBackward).toBe(1, 'increases with move backward');
           wizard.previous();
-          expect(context.testComponent._movedBackward).toBe(2, 'increases with move backward');
+          expect(context.hostComponent._movedBackward).toBe(2, 'increases with move backward');
         });
       });
 
       describe('Projection', () => {
         it('wizard title is projected', () => {
-          let val = context.testElement.querySelector('.clr-wizard-title').textContent.trim();
-          expect(val).toBe(context.testComponent.projectedTitle, 'projects as expected');
-          context.testComponent.projectedTitle = 'OHAI';
+          let val = context.hostElement.querySelector('.clr-wizard-title').textContent.trim();
+          expect(val).toBe(context.hostComponent.projectedTitle, 'projects as expected');
+          context.hostComponent.projectedTitle = 'OHAI';
           context.detectChanges();
-          val = context.testElement.querySelector('.clr-wizard-title').textContent.trim();
+          val = context.hostElement.querySelector('.clr-wizard-title').textContent.trim();
           expect(val).toBe('OHAI', 'updates as expected');
         });
 
         it('stepnav is present', () => {
-          const val = context.testElement.querySelector('.clr-wizard-stepnav');
+          const val = context.hostElement.querySelector('.clr-wizard-stepnav');
           expect(val).toBeTruthy();
         });
 
         it('content title should reflect current page and changes with it', () => {
-          let val = context.testElement.querySelector('.modal-title-text').textContent.trim();
+          let val = context.hostElement.querySelector('.modal-title-text').textContent.trim();
           expect(val).toBe('Longer Title for Page 1', 'inits as expected');
 
           wizard.next();
           context.detectChanges();
 
-          val = context.testElement.querySelector('.modal-title-text').textContent.trim();
-          expect(val).toBe(context.testComponent.projectedPageTitle, 'projects as expected');
+          val = context.hostElement.querySelector('.modal-title-text').textContent.trim();
+          expect(val).toBe(context.hostComponent.projectedPageTitle, 'projects as expected');
 
-          context.testComponent.projectedPageTitle = 'OHAI';
+          context.hostComponent.projectedPageTitle = 'OHAI';
           context.detectChanges();
 
-          val = context.testElement.querySelector('.modal-title-text').textContent.trim();
+          val = context.hostElement.querySelector('.modal-title-text').textContent.trim();
           expect(val).toBe('OHAI', 'updates as expected');
         });
 
         describe('Content', () => {
           it('content shows up', () => {
-            const val = context.testElement.querySelector('.clr-wizard-page.active').textContent.trim();
+            const val = context.hostElement.querySelector('.clr-wizard-page.active').textContent.trim();
             expect(val).toBe('Content for step 1');
           });
 
@@ -326,13 +326,13 @@ export default function(): void {
             context.detectChanges();
 
             // page 3 has projected content
-            val = context.testElement.querySelector('.clr-wizard-page.active').textContent.trim();
-            expect(val).toBe(context.testComponent.projectedContent, 'projects as expected');
+            val = context.hostElement.querySelector('.clr-wizard-page.active').textContent.trim();
+            expect(val).toBe(context.hostComponent.projectedContent, 'projects as expected');
 
-            context.testComponent.projectedContent = 'OHAI';
+            context.hostComponent.projectedContent = 'OHAI';
             context.detectChanges();
 
-            val = context.testElement.querySelector('.clr-wizard-page.active').textContent.trim();
+            val = context.hostElement.querySelector('.clr-wizard-page.active').textContent.trim();
             expect(val).toBe('OHAI', 'updates as expected');
           });
 
@@ -344,14 +344,14 @@ export default function(): void {
               wizard.next();
               context.detectChanges();
 
-              val = context.testElement.querySelector('.clr-wizard-page.active').textContent.trim();
-              expect(val).toBe(context.testComponent.lazyLoadContent, 'projects as expected');
+              val = context.hostElement.querySelector('.clr-wizard-page.active').textContent.trim();
+              expect(val).toBe(context.hostComponent.lazyLoadContent, 'projects as expected');
 
-              context.testComponent.doLazyLoad();
+              context.hostComponent.doLazyLoad();
               tick();
               context.detectChanges();
 
-              val = context.testElement.querySelector('.clr-wizard-page.active').textContent.trim();
+              val = context.hostElement.querySelector('.clr-wizard-page.active').textContent.trim();
               expect(val).toBe('Content loaded!', 'updates as expected');
             })
           );
@@ -359,10 +359,10 @@ export default function(): void {
 
         describe('Buttons', () => {
           it('buttons show up', () => {
-            const cancel = context.testElement.querySelector('.clr-wizard-btn--tertiary');
-            const previous = context.testElement.querySelector('.clr-wizard-btn--secondary');
-            const next = context.testElement.querySelector('.clr-wizard-btn--primary:not(.disabled)');
-            const finish = context.testElement.querySelector('.clr-wizard-btn--primary.disabled');
+            const cancel = context.hostElement.querySelector('.clr-wizard-btn--tertiary');
+            const previous = context.hostElement.querySelector('.clr-wizard-btn--secondary');
+            const next = context.hostElement.querySelector('.clr-wizard-btn--primary:not(.disabled)');
+            const finish = context.hostElement.querySelector('.clr-wizard-btn--primary.disabled');
 
             expect(cancel).toBeTruthy();
             expect(previous).toBeTruthy();
@@ -371,13 +371,13 @@ export default function(): void {
           });
 
           it('previous button is hidden on first page', () => {
-            const previous = context.testElement.querySelector('.clr-wizard-btn--secondary');
+            const previous = context.hostElement.querySelector('.clr-wizard-btn--secondary');
             const val = previous.parentElement.attributes['aria-hidden'].value;
             expect(val).toBe('true');
           });
 
           it('next button is visible on every page except the last page', () => {
-            const next = context.testElement.querySelector('.clr-wizard-btn--primary:not(.disabled)');
+            const next = context.hostElement.querySelector('.clr-wizard-btn--primary:not(.disabled)');
             let val = next.parentElement.attributes['aria-hidden'].value;
             expect(val).toBe('false');
 
@@ -389,7 +389,7 @@ export default function(): void {
           });
 
           it('finish button is hidden on every page except the last one', () => {
-            const finish = context.testElement.querySelector('.clr-wizard-btn--primary.disabled');
+            const finish = context.hostElement.querySelector('.clr-wizard-btn--primary.disabled');
             let val = finish.parentElement.attributes['aria-hidden'].value;
             expect(val).toBe('true');
 
@@ -401,11 +401,11 @@ export default function(): void {
           });
 
           it('button text is projected as expected', () => {
-            const previous = context.testElement.querySelector('.clr-wizard-btn--secondary');
+            const previous = context.hostElement.querySelector('.clr-wizard-btn--secondary');
             let val = previous.textContent.trim();
-            expect(val).toBe(context.testComponent.projectedButton, 'projects as expected');
+            expect(val).toBe(context.hostComponent.projectedButton, 'projects as expected');
 
-            context.testComponent.projectedButton = 'OHAI';
+            context.hostComponent.projectedButton = 'OHAI';
             context.detectChanges();
 
             val = previous.textContent.trim();
@@ -421,19 +421,19 @@ export default function(): void {
             wizard.pageCollection.lastPage.makeCurrent();
             context.detectChanges();
 
-            cancel = context.testElement.querySelector('.clr-wizard-btn--tertiary');
-            previous = context.testElement.querySelector('.clr-wizard-btn--secondary');
-            next = context.testElement.querySelector('.clr-wizard-btn--primary.disabled');
-            finish = context.testElement.querySelector('.clr-wizard-btn--primary:not(.disabled)');
+            cancel = context.hostElement.querySelector('.clr-wizard-btn--tertiary');
+            previous = context.hostElement.querySelector('.clr-wizard-btn--secondary');
+            next = context.hostElement.querySelector('.clr-wizard-btn--primary.disabled');
+            finish = context.hostElement.querySelector('.clr-wizard-btn--primary:not(.disabled)');
 
             // custom buttons can omit expected buttons if they want
             expect(cancel).toBeNull();
             expect(previous).toBeNull();
             expect(next).toBeNull();
             expect(finish).toBeTruthy();
-            expect(finish.textContent.trim()).toBe(context.testComponent.projectedCustomButton);
+            expect(finish.textContent.trim()).toBe(context.hostComponent.projectedCustomButton);
 
-            context.testComponent.projectedCustomButton = 'Ohai';
+            context.hostComponent.projectedCustomButton = 'Ohai';
             context.detectChanges();
             expect(finish.textContent.trim()).toBe('Ohai');
           });
@@ -467,50 +467,50 @@ export default function(): void {
 
       describe('Misc Observables', () => {
         it('clrWizardOnCancel output is fired when cancel button is clicked', () => {
-          const cancel = context.testElement.querySelector('.clr-wizard-btn--tertiary');
+          const cancel: HTMLElement = context.hostElement.querySelector('.clr-wizard-btn--tertiary');
 
-          expect(context.testComponent._cancelled).toBe(0, 'verify initial state');
+          expect(context.hostComponent._cancelled).toBe(0, 'verify initial state');
           cancel.click();
           context.detectChanges();
-          expect(context.testComponent._cancelled).toBe(1, 'cancel button worked');
+          expect(context.hostComponent._cancelled).toBe(1, 'cancel button worked');
         });
 
         it('clrWizardOnCancel output is fired when close X is clicked', () => {
-          const closeBtn = context.testElement.querySelector('button.close');
-          expect(context.testComponent._cancelled).toBe(0, 'verify initial state');
+          const closeBtn: HTMLElement = context.hostElement.querySelector('button.close');
+          expect(context.hostComponent._cancelled).toBe(0, 'verify initial state');
 
           closeBtn.click();
           context.detectChanges();
-          expect(context.testComponent._cancelled).toBe(1, 'close X worked');
+          expect(context.hostComponent._cancelled).toBe(1, 'close X worked');
         });
 
         it('clrWizardOnCancel output is not fired when wizard is closed by finish button', () => {
           let finish: any;
-          expect(context.testComponent._cancelled).toBe(0, 'verify initial state');
+          expect(context.hostComponent._cancelled).toBe(0, 'verify initial state');
 
           wizard.pageCollection.lastPage.makeCurrent();
           context.detectChanges();
-          finish = context.testElement.querySelector('.clr-wizard-btn--primary:not(.disabled)');
+          finish = context.hostElement.querySelector('.clr-wizard-btn--primary:not(.disabled)');
           finish.click();
           context.detectChanges();
 
           // also validates that custom button worked...
-          expect(context.testComponent._cancelled).toBe(0, 'finish button did not fire cancel');
+          expect(context.hostComponent._cancelled).toBe(0, 'finish button did not fire cancel');
           expect(wizard._open).toBe(false, 'custom finish closed the wizard');
         });
 
         it('clrWizardOnFinish output is fired', () => {
           let finish: any;
-          expect(context.testComponent._finished).toBe(0, 'verify initial state');
+          expect(context.hostComponent._finished).toBe(0, 'verify initial state');
 
           wizard.pageCollection.lastPage.makeCurrent();
           context.detectChanges();
-          finish = context.testElement.querySelector('.clr-wizard-btn--primary:not(.disabled)');
+          finish = context.hostElement.querySelector('.clr-wizard-btn--primary:not(.disabled)');
           finish.click();
           context.detectChanges();
 
           // also validates that custom button worked...
-          expect(context.testComponent._finished).toBe(1, 'finish button fired event');
+          expect(context.hostComponent._finished).toBe(1, 'finish button fired event');
         });
       });
 
@@ -529,7 +529,7 @@ export default function(): void {
           const origPageCount = wizard.pageCollection.pagesCount + 0;
 
           expect(expected).toBe(true, 'inits as the same');
-          context.testComponent.showExtraPage = true;
+          context.hostComponent.showExtraPage = true;
           context.detectChanges();
 
           expected = wizpages === pagecollection;
@@ -600,9 +600,9 @@ export default function(): void {
 
       describe('Sizing', () => {
         it('can be set and updates via the clrWizardSize input', () => {
-          const wizardModal = context.testElement.querySelector('.modal-dialog');
-          expect(context.testComponent.mySize).toBeUndefined();
-          context.testComponent.mySize = 'lg';
+          const wizardModal = context.hostElement.querySelector('.modal-dialog');
+          expect(context.hostComponent.mySize).toBeUndefined();
+          context.hostComponent.mySize = 'lg';
           context.detectChanges();
           expect(wizard.size).toBe('lg');
           expect(wizardModal.classList.contains('modal-lg')).toBeTrue();
@@ -615,28 +615,28 @@ export default function(): void {
         it('emits clrWizardOpenChange output', () => {
           wizard.close();
           context.detectChanges();
-          context.testComponent._openChange = 0;
-          expect(context.testComponent._openChange).toBe(0, 'make sure we have reset');
+          context.hostComponent._openChange = 0;
+          expect(context.hostComponent._openChange).toBe(0, 'make sure we have reset');
           wizard.open();
           context.detectChanges();
-          expect(context.testComponent._openChange).toBe(1, 'make sure we have reset');
+          expect(context.hostComponent._openChange).toBe(1, 'make sure we have reset');
         });
       });
 
       describe('Closing', () => {
         it('emits clrWizardOpenChange output', () => {
-          context.testComponent._openChange = 0;
-          expect(context.testComponent._openChange).toBe(0, 'make sure we have reset');
+          context.hostComponent._openChange = 0;
+          expect(context.hostComponent._openChange).toBe(0, 'make sure we have reset');
           wizard.close();
           context.detectChanges();
-          expect(context.testComponent._openChange).toBe(1, 'make sure we have reset');
+          expect(context.hostComponent._openChange).toBe(1, 'make sure we have reset');
         });
       });
 
       describe('Alt Cancel Override', () => {
         it('clrWizardPreventDefaultCancel input sets and updates stopCancel', () => {
-          expect(wizard.stopCancel).toBe(context.testComponent.stopCancel);
-          context.testComponent.stopCancel = true;
+          expect(wizard.stopCancel).toBe(context.hostComponent.stopCancel);
+          context.hostComponent.stopCancel = true;
           context.detectChanges();
           expect(wizard.stopCancel).toBe(true);
         });
@@ -658,23 +658,23 @@ export default function(): void {
 
         expect(wizard.pageCollection.pagesCount).toBe(3);
 
-        checkme = context.testElement.querySelector('#clr-wizard-page-1');
+        checkme = context.hostElement.querySelector('#clr-wizard-page-1');
         expect(checkme.textContent.trim()).toBe('Content for page 1', 'page 1 content ok');
 
-        checkme = context.testElement.querySelector('#clr-wizard-page-2');
+        checkme = context.hostElement.querySelector('#clr-wizard-page-2');
         expect(checkme.textContent.trim()).toBe('Content for page 2', 'page 2 content ok');
 
-        checkme = context.testElement.querySelector('#clr-wizard-page-4');
+        checkme = context.hostElement.querySelector('#clr-wizard-page-4');
         expect(checkme.textContent.trim()).toBe('Content for page 4', 'page 4 content ok');
 
         // NOW THE STEPNAV
-        checkme = context.testElement.querySelector('#clr-wizard-step-1');
+        checkme = context.hostElement.querySelector('#clr-wizard-step-1');
         expect(checkme.textContent.trim()).toBe('Page 1', 'step 1 ok');
 
-        checkme = context.testElement.querySelector('#clr-wizard-step-2');
+        checkme = context.hostElement.querySelector('#clr-wizard-step-2');
         expect(checkme.textContent.trim()).toBe('Page 2', 'step 2 ok');
 
-        checkme = context.testElement.querySelector('#clr-wizard-step-4');
+        checkme = context.hostElement.querySelector('#clr-wizard-step-4');
         expect(checkme.textContent.trim()).toBe('Page 4', 'step 4 ok');
       });
 
@@ -683,70 +683,70 @@ export default function(): void {
         expect(wizard.pageCollection.pagesCount).toBe(3);
 
         // adding an element to my array
-        context.testComponent.pages.splice(2, 0, 3);
+        context.hostComponent.pages.splice(2, 0, 3);
         context.detectChanges();
 
         expect(wizard.pageCollection.pagesCount).toBe(4);
-        checkme = context.testElement.querySelector('#clr-wizard-page-1');
+        checkme = context.hostElement.querySelector('#clr-wizard-page-1');
         expect(checkme.textContent.trim()).toBe('Content for page 1', 'page 1 content ok');
 
-        checkme = context.testElement.querySelector('#clr-wizard-page-2');
+        checkme = context.hostElement.querySelector('#clr-wizard-page-2');
         expect(checkme.textContent.trim()).toBe('Content for page 2', 'page 2 content ok');
 
-        checkme = context.testElement.querySelector('#clr-wizard-page-3');
+        checkme = context.hostElement.querySelector('#clr-wizard-page-3');
         expect(checkme.textContent.trim()).toBe('Content for page 3', 'page 3 content ok');
 
-        checkme = context.testElement.querySelector('#clr-wizard-page-4');
+        checkme = context.hostElement.querySelector('#clr-wizard-page-4');
         expect(checkme.textContent.trim()).toBe('Content for page 4', 'page 4 content ok');
 
         // NOW THE STEPNAV
-        checkme = context.testElement.querySelector('#clr-wizard-step-1');
+        checkme = context.hostElement.querySelector('#clr-wizard-step-1');
         expect(checkme.textContent.trim()).toBe('Page 1', 'step 1 ok');
 
-        checkme = context.testElement.querySelector('#clr-wizard-step-2');
+        checkme = context.hostElement.querySelector('#clr-wizard-step-2');
         expect(checkme.textContent.trim()).toBe('Page 2', 'step 2 ok');
 
-        checkme = context.testElement.querySelector('#clr-wizard-step-3');
+        checkme = context.hostElement.querySelector('#clr-wizard-step-3');
         expect(checkme.textContent.trim()).toBe('Page 3', 'step 3 ok');
 
-        checkme = context.testElement.querySelector('#clr-wizard-step-4');
+        checkme = context.hostElement.querySelector('#clr-wizard-step-4');
         expect(checkme.textContent.trim()).toBe('Page 4', 'step 4 ok');
 
         // dynamically hiding a page
-        context.testComponent.showSecondPage = false;
+        context.hostComponent.showSecondPage = false;
         context.detectChanges();
 
         expect(wizard.pageCollection.pagesCount).toBe(3);
-        checkme = context.testElement.querySelector('#clr-wizard-page-1');
+        checkme = context.hostElement.querySelector('#clr-wizard-page-1');
         expect(checkme.textContent.trim()).toBe('Content for page 1', 'page 1 content ok');
 
-        checkme = context.testElement.querySelector('#clr-wizard-page-2');
+        checkme = context.hostElement.querySelector('#clr-wizard-page-2');
         expect(checkme).toBeNull();
 
-        checkme = context.testElement.querySelector('#clr-wizard-page-3');
+        checkme = context.hostElement.querySelector('#clr-wizard-page-3');
         expect(checkme.textContent.trim()).toBe('Content for page 3', 'page 3 content ok');
 
-        checkme = context.testElement.querySelector('#clr-wizard-page-4');
+        checkme = context.hostElement.querySelector('#clr-wizard-page-4');
         expect(checkme.textContent.trim()).toBe('Content for page 4', 'page 4 content ok');
 
         // NOW THE STEPNAV
-        checkme = context.testElement.querySelector('#clr-wizard-step-1');
+        checkme = context.hostElement.querySelector('#clr-wizard-step-1');
         expect(checkme.textContent.trim()).toBe('Page 1', 'step 1 ok');
 
-        checkme = context.testElement.querySelector('#clr-wizard-step-2');
+        checkme = context.hostElement.querySelector('#clr-wizard-step-2');
         expect(checkme).toBeNull();
 
-        checkme = context.testElement.querySelector('#clr-wizard-step-3');
+        checkme = context.hostElement.querySelector('#clr-wizard-step-3');
         expect(checkme.textContent.trim()).toBe('Page 3', 'step 3 ok');
 
-        checkme = context.testElement.querySelector('#clr-wizard-step-4');
+        checkme = context.hostElement.querySelector('#clr-wizard-step-4');
         expect(checkme.textContent.trim()).toBe('Page 4', 'step 4 ok');
       });
 
       it('should survive if there are no pages', () => {
         expect(wizard.pageCollection.pagesCount).toBe(3);
         expect(function() {
-          context.testComponent.pages = [];
+          context.hostComponent.pages = [];
           context.detectChanges();
         }).not.toThrowError();
         expect(wizard.pageCollection.pagesCount).toBe(0);


### PR DESCRIPTION
As my comment in the code says, the generic helpers in `utils/` were initially a copy-paste of the datagrid helpers, but when we modularized Clarity they got updated to something that's way too rigid and doesn't help for complex specs anymore. As proof, only 2 specs were able to use it, and several others around the project have a comment along the lines of "Screw it, I'm using the datagrid ones".
To make it even worse, these early Datagrid test helpers were written at a time were the Typescript Language Service didn't exist and IDEs didn't provide the latest and greatest typing tools, so they were heavily compromising on the way to use them.

I renamed some pieces of the context to use clearer property names, which lead to a dumb but sizeable change in the wizard spec.
I also wrote a new version of the utility that finally fully embraces the typing of `this`, now that we can. To show a little bit how to use it, I updated the Signpost spec to the new version. It honestly doesn't change much for that spec, but the added flexibility it's one step towards being able to unify our unit tests.

PS: I'm using this in the Tree unit tests, yes.