### PR TITLE
[WEB] Checkboxes in wrong format (#2822)

### DIFF
--- a/latest/src/app/documentation/demos/button-group/button-group.demo.html
+++ b/latest/src/app/documentation/demos/button-group/button-group.demo.html
@@ -501,12 +501,18 @@
                         <div class="clrweb-DoxMedia-block">
                             <div class="clrweb-DoxMedia-img">
                                 <div class="btn-group">
-                                    <input type="checkbox" id="cb-1" checked class="btn" />
-                                    <label for="cb-1">Apples</label>
-                                    <input type="checkbox" id="cb-2" checked class="btn" />
-                                    <label for="cb-2">Oranges</label>
-                                    <input type="checkbox" id="cb-3" class="btn" />
-                                    <label for="cb-3">Kiwis</label>
+                                    <div class="checkbox btn">
+                                        <input type="checkbox" id="cb-1" checked class="btn" />
+                                        <label for="cb-1">Apples</label>
+                                    </div>
+                                    <div class="checkbox btn">
+                                        <input type="checkbox" id="cb-2" checked class="btn" />
+                                        <label for="cb-2">Oranges</label>
+                                    </div>
+                                    <div class="checkbox btn">
+                                        <input type="checkbox" id="cb-3" class="btn" />
+                                        <label for="cb-3">Kiwis</label>
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -523,10 +529,14 @@
                         <div class="clrweb-DoxMedia-block">
                             <div class="clrweb-DoxMedia-img">
                                 <div class="btn-group">
-                                    <input type="checkbox" id="cb-4" checked class="btn" />
-                                    <label for="cb-4">Apples</label>
-                                    <input type="checkbox" id="cb-5" class="btn" />
-                                    <label for="cb-5">Fresh Local Gold Kiwis</label>
+                                    <div class="checkbox btn">
+                                        <input type="checkbox" id="cb-4" checked class="btn" />
+                                        <label for="cb-4">Apples</label>
+                                    </div>
+                                    <div class="checkbox btn">
+                                        <input type="checkbox" id="cb-5" class="btn" />
+                                        <label for="cb-5">Fresh Local Gold Kiwis</label>
+                                    </div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Between 0.13 and 1.0 the checkbox text was extracted to label. This requires
a parent div.btn.checkbox though, which was missing.

Signed-off-by: Ivan Donchev <idonchev@vmware.com>