### PR TITLE
[NG] Page size change was not triggering a state change (#1752)

### DIFF
--- a/src/clr-angular/data/datagrid/datagrid.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid.spec.ts
@@ -434,6 +434,19 @@ export default function(): void {
           expect(context.testComponent.nbRefreshed).toBe(1);
         });
 
+        it('emits once when the page size changes', function() {
+          context.testComponent.nbRefreshed = 0;
+          const page: Page = context.getClarityProvider(Page);
+          page.size = 2;
+          context.detectChanges();
+          expect(context.testComponent.nbRefreshed).toBe(1);
+          page.size = 5;
+          context.detectChanges();
+          expect(context.testComponent.nbRefreshed).toBe(2);
+          page.resetPageSize();
+          expect(context.testComponent.nbRefreshed).toBe(3);
+        });
+
         it('emits the complete state of the datagrid', function() {
           context.testComponent.items = [1, 2, 3, 4, 5, 6];
           context.detectChanges();

--- a/src/clr-angular/data/datagrid/providers/page.ts
+++ b/src/clr-angular/data/datagrid/providers/page.ts
@@ -22,6 +22,7 @@ export class Page {
   public set size(size: number) {
     const oldSize = this._size;
     if (size !== oldSize) {
+      this.stateDebouncer.changeStart();
       this._size = size;
       if (size === 0) {
         this._current = 1;
@@ -34,6 +35,7 @@ export class Page {
       // the size changing means the items inside the page are different
       this._change.next(this._current);
       this._sizeChange.next(this._size);
+      this.stateDebouncer.changeDone();
     }
   }
 


### PR DESCRIPTION
During 0.9 -> 0.10 refactoring, the refresh has no longer been managed locally in the datagrid component, but delegated to the state provider service. Thus, we're no longer listening to page.change events directly.
StateDebouncer calls added to the _size_ setter, similar to the _current_ setter.
Tests are checking initial size change (from not set), then transition from one size to another, finally a size reset.