### PR TITLE
[WEB] Fix wizard overflow on the website (#2828)

### DIFF
--- a/latest/src/app/documentation/demos/wizard/wizard-design.demo.ts
+++ b/latest/src/app/documentation/demos/wizard/wizard-design.demo.ts
@@ -85,6 +85,11 @@ import { DisableFocusTrap } from "../../utils/disable-focus-trap";
             .wizdemo-color-block.active {
                 border-color: #565656;
             }
+        `,
+        `
+            :host ::ng-deep .clr-wizard.wizard-xl .modal-dialog {
+                max-height: 100%;
+            }
         `
     ]
 })

--- a/v0.12/src/app/documentation/demos/wizard/wizard-design.demo.ts
+++ b/v0.12/src/app/documentation/demos/wizard/wizard-design.demo.ts
@@ -85,6 +85,11 @@ import { DisableFocusTrap } from "../../utils/disable-focus-trap";
             .wizdemo-color-block.active {
                 border-color: #565656;
             }
+        `,
+        `
+            :host ::ng-deep .clr-wizard.wizard-xl .modal-dialog {
+                max-height: 100%;
+            }
         `
     ]
 })

--- a/v0.13/src/app/documentation/demos/wizard/wizard-design.demo.ts
+++ b/v0.13/src/app/documentation/demos/wizard/wizard-design.demo.ts
@@ -85,6 +85,11 @@ import { DisableFocusTrap } from "../../utils/disable-focus-trap";
             .wizdemo-color-block.active {
                 border-color: #565656;
             }
+        `,
+        `
+            :host ::ng-deep .clr-wizard.wizard-xl .modal-dialog {
+                max-height: 100%;
+            }
         `
     ]
 })


### PR DESCRIPTION
I am piercing shadow DOM with ::ng-deep, which is not recommended generally,
but I'm using it exceptionally to fix an issue, that will only be available
on the website. I am protecting this change not to spread to other components
on the site by preceding it with a :host, which makes the CSS more specific.
Tested on Chrome Canary, Chrome normal, Safari, FF, Edge, IE11.
Change merged to 1.0, 0.12, 0.13, as the issue is not observed on older versions.

Signed-off-by: Ivan Donchev <idonchev@vmware.com>