### PR TITLE
[NG] Tree view: Asynchronous cases

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -1119,6 +1119,7 @@ export declare class ClrTreeNode<T> implements OnInit, OnDestroy {
     readonly ariaSelected: boolean;
     commonStrings: ClrCommonStrings;
     expandService: Expand;
+    expandable: boolean | undefined;
     expanded: boolean;
     expandedChange: EventEmitter<boolean>;
     featuresService: TreeFeaturesService<T>;

--- a/src/clr-angular/data/tree-view/tree-node.html
+++ b/src/clr-angular/data/tree-view/tree-node.html
@@ -6,7 +6,7 @@
 
 <div class="clr-tree-node-content-container">
   <button
-    *ngIf="isExpandable()"
+    *ngIf="isExpandable() && !_model.loading && !expandService.loading"
     type="button"
     class="clr-treenode-caret"
     (click)="expandService.toggle()"
@@ -17,6 +17,9 @@
       [attr.dir]="expandService.expanded ? 'down' : 'right'"
       [attr.title]="expandService.expanded ? commonStrings.collapse : commonStrings.expand"></clr-icon>
   </button>
+  <div class="clr-treenode-spinner-container" *ngIf="expandService.loading || _model.loading">
+        <span class="clr-treenode-spinner spinner"></span>
+  </div>
   <div class="clr-checkbox-wrapper clr-treenode-checkbox" *ngIf="featuresService.selectable">
     <input type="checkbox" id="{{nodeId}}-check" class="clr-checkbox" [attr.aria-labelledby]="nodeId"
            [checked]="_model.selected.value === STATES.SELECTED"

--- a/src/clr-angular/data/tree-view/tree-node.ts
+++ b/src/clr-angular/data/tree-view/tree-node.ts
@@ -69,6 +69,9 @@ export class ClrTreeNode<T> implements OnInit, OnDestroy {
   _model: TreeNodeModel<T>;
 
   isExpandable() {
+    if (typeof this.expandable !== 'undefined') {
+      return this.expandable;
+    }
     return !!this.expandService.expandable || this._model.children.length > 0;
   }
 
@@ -112,6 +115,10 @@ export class ClrTreeNode<T> implements OnInit, OnDestroy {
   get ariaSelected(): boolean {
     return this.featuresService.selectable ? this._model.selected.value === ClrSelectedState.SELECTED : null;
   }
+
+  // Allows the consumer to override our logic deciding if a node is expandable.
+  // Useful for recursive trees that don't want to pre-load one level ahead just to know which nodes are expandable.
+  @Input('clrExpandable') expandable: boolean | undefined;
 
   // I'm caving on this, for tree nodes I think we can tolerate having a two-way binding on the component
   // rather than enforce the clrIfExpanded structural directive for dynamic cases. Mostly because for the smart

--- a/src/clr-angular/data/tree-view/tree-view.module.ts
+++ b/src/clr-angular/data/tree-view/tree-view.module.ts
@@ -8,6 +8,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule, Type } from '@angular/core';
 
 import { ClrIconModule } from '../../icon/icon.module';
+import { ClrLoadingModule } from '../../utils/loading/loading.module';
 import { ClrIfExpandModule } from '../../utils/expand/if-expand.module';
 import { ClrTreeNode } from './tree-node';
 import { ClrTree } from './tree';
@@ -17,7 +18,7 @@ import { RecursiveChildren } from './recursive-children';
 export const CLR_TREE_VIEW_DIRECTIVES: Type<any>[] = [ClrTree, ClrTreeNode, ClrRecursiveForOf];
 
 @NgModule({
-  imports: [CommonModule, ClrIconModule],
+  imports: [CommonModule, ClrIconModule, ClrLoadingModule],
   declarations: [CLR_TREE_VIEW_DIRECTIVES, RecursiveChildren],
   exports: [CLR_TREE_VIEW_DIRECTIVES, ClrIfExpandModule],
 })

--- a/src/dev/src/app/tree-view/lazy-declarative-tree/lazy-declarative-tree.html
+++ b/src/dev/src/app/tree-view/lazy-declarative-tree/lazy-declarative-tree.html
@@ -52,3 +52,33 @@
     </clr-tree-node>
   </clr-tree>
 </div>
+
+<h4>Asynchronous</h4>
+<p>
+  Selected: {{asyncTree.selected.join(', ')}}
+</p>
+<div class="clr-example">
+  <clr-tree [clrLazy]="true">
+    <clr-tree-node *ngFor="let node of asyncTree.root"
+                   [clrLoading]="loading[node]"
+                   [clrSelected]="asyncTree.isSelected(node)"
+                   (clrSelectedChange)="asyncTree.select(node, $event)">
+      {{node}}
+      <ng-template clrIfExpanded (clrIfExpandedChange)="fetchChildren(node, $event)">
+        <clr-tree-node *ngFor="let child of children[node] | async"
+                       [clrLoading]="loading[child]"
+                       [clrSelected]="asyncTree.isSelected(child)"
+                       (clrSelectedChange)="asyncTree.select(child, $event)">
+          {{child}}
+          <ng-template clrIfExpanded (clrIfExpandedChange)="fetchChildren(child, $event)">
+            <clr-tree-node *ngFor="let child of children[child] | async"
+                           [clrSelected]="asyncTree.isSelected(child)"
+                           (clrSelectedChange)="asyncTree.select(child, $event)">
+              {{child}}
+            </clr-tree-node>
+          </ng-template>
+        </clr-tree-node>
+      </ng-template>
+    </clr-tree-node>
+  </clr-tree>
+</div>

--- a/src/dev/src/app/tree-view/lazy-declarative-tree/lazy-declarative-tree.ts
+++ b/src/dev/src/app/tree-view/lazy-declarative-tree/lazy-declarative-tree.ts
@@ -4,8 +4,11 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { Component } from '@angular/core';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
 
 import { InfiniteTree } from '../utils/infinite-tree';
+import { AsyncInfiniteTree } from '../utils/async-infinite-tree';
 
 @Component({
   selector: 'clr-lazy-declarative-tree-demo',
@@ -14,4 +17,17 @@ import { InfiniteTree } from '../utils/infinite-tree';
 })
 export class LazyDeclarativeTreeDemo {
   tree = new InfiniteTree(9);
+
+  asyncTree = new AsyncInfiniteTree(3, 500);
+
+  loading: { [key: string]: boolean } = {};
+  children: { [key: string]: Observable<string[]> } = {};
+
+  fetchChildren(node: string, justDoIt: boolean) {
+    if (!justDoIt) {
+      return;
+    }
+    this.loading[node] = true;
+    this.children[node] = this.asyncTree.fetchChildren(node).pipe(tap(_ => (this.loading[node] = false)));
+  }
 }

--- a/src/dev/src/app/tree-view/lazy-recursive-tree/lazy-recursive-tree.html
+++ b/src/dev/src/app/tree-view/lazy-recursive-tree/lazy-recursive-tree.html
@@ -16,3 +16,31 @@
     </clr-tree-node>
   </clr-tree>
 </div>
+
+
+<h4>Asynchronous, pre-loading 1 level ahead</h4>
+<p>
+  Selected: {{asyncTree.selected.join(', ')}}
+</p>
+<div class="clr-example">
+  <clr-tree [clrLazy]="true">
+    <clr-tree-node *clrRecursiveFor="let node of asyncTree.root; getChildren: asynchronousChildren"
+                   [clrSelected]="asyncTree.isSelected(node)" (clrSelectedChange)="asyncTree.select(node, $event)">
+      {{node}}
+    </clr-tree-node>
+  </clr-tree>
+</div>
+
+<h4>Asynchronous, loading exactly what's visible</h4>
+<p>
+  Selected: {{lazierTree.selected.join(', ')}}
+</p>
+<div class="clr-example">
+  <clr-tree [clrLazy]="true">
+    <clr-tree-node *clrRecursiveFor="let node of lazierTree.root; getChildren: lazierChildren"
+                   [clrExpandable]="true"
+                   [clrSelected]="lazierTree.isSelected(node)" (clrSelectedChange)="lazierTree.select(node, $event)">
+      {{node}}
+    </clr-tree-node>
+  </clr-tree>
+</div>

--- a/src/dev/src/app/tree-view/lazy-recursive-tree/lazy-recursive-tree.ts
+++ b/src/dev/src/app/tree-view/lazy-recursive-tree/lazy-recursive-tree.ts
@@ -6,6 +6,7 @@
 import { Component } from '@angular/core';
 
 import { InfiniteTree } from '../utils/infinite-tree';
+import { AsyncInfiniteTree } from '../utils/async-infinite-tree';
 
 @Component({
   selector: 'clr-lazy-recursive-tree-demo',
@@ -16,4 +17,12 @@ export class LazyRecursiveTreeDemo {
   tree = new InfiniteTree(3);
 
   synchronousChildren = (node: string) => this.tree.getChildren(node);
+
+  asyncTree = new AsyncInfiniteTree(3, 500);
+
+  asynchronousChildren = (node: string) => this.asyncTree.fetchChildren(node);
+
+  lazierTree = new AsyncInfiniteTree(3, 500);
+
+  lazierChildren = (node: string) => this.lazierTree.fetchChildren(node);
 }

--- a/src/dev/src/app/tree-view/utils/async-infinite-tree.ts
+++ b/src/dev/src/app/tree-view/utils/async-infinite-tree.ts
@@ -11,7 +11,7 @@ import { Observable, timer } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 export class AsyncInfiniteTree {
-  constructor(width: number, latency = 0) {
+  constructor(width: number, latency = 100) {
     this.tree = new InfiniteTree(width);
     this.delay = timer(latency);
   }

--- a/src/dev/src/app/tree-view/utils/async-infinite-tree.ts
+++ b/src/dev/src/app/tree-view/utils/async-infinite-tree.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { ClrSelectedState } from '@clr/angular';
+
+import { InfiniteTree } from './infinite-tree';
+import { Observable, timer } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+export class AsyncInfiniteTree {
+  constructor(width: number, latency = 0) {
+    this.tree = new InfiniteTree(width);
+    this.delay = timer(latency);
+  }
+
+  /*
+   * Pure proxy for synchronous behaviors
+   */
+
+  private tree: InfiniteTree;
+
+  get root() {
+    return this.tree.root;
+  }
+
+  get selected() {
+    return this.tree.selected;
+  }
+
+  isSelected(node: string): ClrSelectedState {
+    return this.tree.isSelected(node);
+  }
+
+  select(node: string, state: ClrSelectedState): void {
+    return this.tree.select(node, state);
+  }
+
+  /*
+   * Async behaviors
+   */
+  private delay: Observable<number>;
+
+  fetchChildren(node: string): Observable<string[]> {
+    return this.delay.pipe(map(_ => this.tree.getChildren(node)));
+  }
+}


### PR DESCRIPTION
This commit adds the integration of our loading directive to the tree, to display a nice spinner instead of a caret when waiting for the children to be fetched. Works for both the declarative and recursive cases.

No gemini tests because spinners...