### PR TITLE
[WEB] Add missing select close tag in login example code

### DIFF
--- a/latest/src/app/documentation/demos/login/login-example.demo.ts
+++ b/latest/src/app/documentation/demos/login/login-example.demo.ts
@@ -16,8 +16,9 @@ const EXAMPLE = `
         <div class="login-group">
             <clr-select-container>
                 <select clrSelect name="type" [(ngModel)]="form.type">
-                <option value="local">Local Users</option>
-                <option value="admin">Administrator</option>
+                    <option value="local">Local Users</option>
+                    <option value="admin">Administrator</option>
+                </select>
             </clr-select-container>
             <clr-input-container>
                 <input type="text" name="username" clrInput placeholder="Username" [(ngModel)]="form.username"/>


### PR DESCRIPTION
The login example code provided is missing the close tag for select which results in throwing error in the browser when using the example code in my app

More info can be found in the issue #2849 