### PR TITLE
[WEB] Fix typo in import statement (v0.12, v0.13, v1.0)

### DIFF
--- a/latest/src/app/documentation/demos/login/login-example.demo.ts
+++ b/latest/src/app/documentation/demos/login/login-example.demo.ts
@@ -16,8 +16,9 @@ const EXAMPLE = `
         <div class="login-group">
             <clr-select-container>
                 <select clrSelect name="type" [(ngModel)]="form.type">
-                <option value="local">Local Users</option>
-                <option value="admin">Administrator</option>
+                    <option value="local">Local Users</option>
+                    <option value="admin">Administrator</option>
+                </select>
             </clr-select-container>
             <clr-input-container>
                 <input type="text" name="username" clrInput placeholder="Username" [(ngModel)]="form.username"/>

--- a/latest/src/app/documentation/get-started/get-started.component.ts
+++ b/latest/src/app/documentation/get-started/get-started.component.ts
@@ -3,7 +3,7 @@ import {Component} from "@angular/core";
 const NG_MODULE_EXAMPLE = `
 import { NgModule } from "@angular/core";
 import { BrowserModule } from "@angular/platform-browser";
-import { BrowserAminationsModule } from "@angular/platform-browser/animations";
+import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { ClarityModule } from "@clr/angular";
 import { AppComponent } from "./app.component";
 

--- a/v0.12/src/app/documentation/get-started/get-started.component.ts
+++ b/v0.12/src/app/documentation/get-started/get-started.component.ts
@@ -3,7 +3,7 @@ import {Component} from "@angular/core";
 const NG_MODULE_EXAMPLE = `
 import { NgModule } from "@angular/core";
 import { BrowserModule } from "@angular/platform-browser";
-import { BrowserAminationsModule } from "@angular/platform-browser/animations";
+import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { ClarityModule } from "@clr/angular";
 import { AppComponent } from "./app.component";
 

--- a/v0.13/src/app/documentation/get-started/get-started.component.ts
+++ b/v0.13/src/app/documentation/get-started/get-started.component.ts
@@ -3,7 +3,7 @@ import {Component} from "@angular/core";
 const NG_MODULE_EXAMPLE = `
 import { NgModule } from "@angular/core";
 import { BrowserModule } from "@angular/platform-browser";
-import { BrowserAminationsModule } from "@angular/platform-browser/animations";
+import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { ClarityModule } from "@clr/angular";
 import { AppComponent } from "./app.component";
 


### PR DESCRIPTION
Fixing typo in BrowserAminationsModule import statement of the Get Started document.

`import { BrowserAminationsModule } from "@angular/platform-browser/animations";`

https://vmware.github.io/clarity/documentation/v0.13/get-started