### PR TITLE
[WEB] Fix doc default version

### DIFF
--- a/latest/src/environments/environment.prod.ts
+++ b/latest/src/environments/environment.prod.ts
@@ -1,7 +1,7 @@
 export const environment = {
   production: true,
   version: 'v1.0',
-  default: 'v01.0',
+  default: 'v1.0',
   versions_url: '/clarity/versions.json',
   base: '/clarity'
 };


### PR DESCRIPTION
Typo in the default leads to 404 after click on [Documentation] button at Clarity site

Signed-off-by: Ivan Donchev <idonchev@vmware.com>