### PR TITLE
extend DnD to fire move positions relative to the starting positon

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -563,10 +563,7 @@ export declare class ClrDragAndDropModule {
 
 export declare class ClrDragEvent<T> {
     dragDataTransfer: T;
-    dragPosition: {
-        pageX: number;
-        pageY: number;
-    };
+    dragPosition: DragPointPosition;
     dropPointPosition: {
         pageX: number;
         pageY: number;

--- a/src/clr-angular/utils/dom-adapter/dom-adapter.ts
+++ b/src/clr-angular/utils/dom-adapter/dom-adapter.ts
@@ -16,7 +16,7 @@ import { Injectable } from '@angular/core';
 export class DomAdapter {
   userDefinedWidth(element: HTMLElement): number {
     element.classList.add('datagrid-cell-width-zero');
-    const userDefinedWidth = parseInt(getComputedStyle(element).getPropertyValue('width'), 10);
+    const userDefinedWidth = this.clientRect(element).width;
     element.classList.remove('datagrid-cell-width-zero');
     return userDefinedWidth;
   }

--- a/src/clr-angular/utils/drag-and-drop/drag-and-drop-integrated.spec.ts
+++ b/src/clr-angular/utils/drag-and-drop/drag-and-drop-integrated.spec.ts
@@ -56,7 +56,7 @@ export default function(): void {
         emulateDragEvent('mousedown', 0, 0, draggable.nativeElement);
         emulateDragEvent('mousemove', 10, 20);
         checkStaticProps(testComponent.dragStartEvent);
-        expect(testComponent.dragStartEvent.dragPosition).toEqual({ pageX: 10, pageY: 20 });
+        expect(testComponent.dragStartEvent.dragPosition).toEqual({ pageX: 10, pageY: 20, moveX: 10, moveY: 20 });
         expect(testComponent.dragStartEvent.dropPointPosition).toBeUndefined();
       });
 
@@ -65,7 +65,7 @@ export default function(): void {
         emulateDragEvent('mousemove', 10, 20);
         emulateDragEvent('mousemove', 100, 200);
         checkStaticProps(testComponent.dragMoveEvent);
-        expect(testComponent.dragMoveEvent.dragPosition).toEqual({ pageX: 100, pageY: 200 });
+        expect(testComponent.dragMoveEvent.dragPosition).toEqual({ pageX: 100, pageY: 200, moveX: 100, moveY: 200 });
 
         // offsetX = dragStart.pageX - draggable.pageX
         // offsetY = dragStart.pageY - draggable.pageY
@@ -79,7 +79,7 @@ export default function(): void {
         emulateDragEvent('mousemove', 10, 20);
         emulateDragEvent('mousemove', 500, 300);
         checkStaticProps(testComponent.dragEnterEvent);
-        expect(testComponent.dragEnterEvent.dragPosition).toEqual({ pageX: 500, pageY: 300 });
+        expect(testComponent.dragEnterEvent.dragPosition).toEqual({ pageX: 500, pageY: 300, moveX: 500, moveY: 300 });
         expect(testComponent.dragEnterEvent.dropPointPosition).toEqual({ pageX: 540, pageY: 305 });
       });
 
@@ -89,7 +89,7 @@ export default function(): void {
         emulateDragEvent('mousemove', 500, 300);
         emulateDragEvent('mousemove', 100, 200);
         checkStaticProps(testComponent.dragLeaveEvent);
-        expect(testComponent.dragLeaveEvent.dragPosition).toEqual({ pageX: 100, pageY: 200 });
+        expect(testComponent.dragLeaveEvent.dragPosition).toEqual({ pageX: 100, pageY: 200, moveX: 100, moveY: 200 });
         expect(testComponent.dragLeaveEvent.dropPointPosition).toEqual({ pageX: 140, pageY: 205 });
       });
 
@@ -100,7 +100,7 @@ export default function(): void {
         emulateDragEvent('mousemove', 100, 200);
         emulateDragEvent('mouseup', 100, 200);
         checkStaticProps(testComponent.dragEndEvent);
-        expect(testComponent.dragEndEvent.dragPosition).toEqual({ pageX: 100, pageY: 200 });
+        expect(testComponent.dragEndEvent.dragPosition).toEqual({ pageX: 100, pageY: 200, moveX: 100, moveY: 200 });
         expect(testComponent.dragEndEvent.dropPointPosition).toEqual({ pageX: 140, pageY: 205 });
       });
 
@@ -110,7 +110,7 @@ export default function(): void {
         emulateDragEvent('mousemove', 500, 300);
         emulateDragEvent('mouseup', 500, 300);
         checkStaticProps(testComponent.dropEvent);
-        expect(testComponent.dropEvent.dragPosition).toEqual({ pageX: 500, pageY: 300 });
+        expect(testComponent.dropEvent.dragPosition).toEqual({ pageX: 500, pageY: 300, moveX: 500, moveY: 300 });
         expect(testComponent.dropEvent.dropPointPosition).toEqual({ pageX: 540, pageY: 305 });
       });
     });

--- a/src/clr-angular/utils/drag-and-drop/drag-event.ts
+++ b/src/clr-angular/utils/drag-and-drop/drag-event.ts
@@ -3,12 +3,12 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { DragEventInterface } from './interfaces/drag-event.interface';
+import { DragEventInterface, DragPointPosition } from './interfaces/drag-event.interface';
 
 // This class is used to convert an internal event
 // to an external event to be emitted.
 export class ClrDragEvent<T> {
-  public dragPosition: { pageX: number; pageY: number };
+  public dragPosition: DragPointPosition;
   public group: string | string[];
   public dragDataTransfer: T;
   public dropPointPosition: { pageX: number; pageY: number };

--- a/src/clr-angular/utils/drag-and-drop/draggable/custom-ghost-integration.spec.ts
+++ b/src/clr-angular/utils/drag-and-drop/draggable/custom-ghost-integration.spec.ts
@@ -19,6 +19,7 @@ import { DraggableSnapshotService } from '../providers/draggable-snapshot.servic
 import { GlobalDragModeService } from '../providers/global-drag-mode.service';
 
 import { ClrDraggable } from './draggable';
+import { generateDragPosition } from '../helpers.spec';
 
 export default function(): void {
   describe('With Custom Draggable Ghost', function() {
@@ -26,8 +27,8 @@ export default function(): void {
     let mockDragEndEventInt: DragEventInterface<any>;
 
     beforeEach(function() {
-      mockDragStartEventInt = { type: DragEventType.DRAG_START, dragPosition: { pageX: 11, pageY: 22 } };
-      mockDragEndEventInt = { type: DragEventType.DRAG_END, dragPosition: { pageX: 77, pageY: 88 } };
+      mockDragStartEventInt = { type: DragEventType.DRAG_START, dragPosition: generateDragPosition([5, 10], [6, 11]) };
+      mockDragEndEventInt = { type: DragEventType.DRAG_END, dragPosition: generateDragPosition([5, 10], [77, 88]) };
 
       TestBed.configureTestingModule({
         imports: [ClrDragAndDropModule, ClrIconModule, NoopAnimationsModule],

--- a/src/clr-angular/utils/drag-and-drop/draggable/draggable.spec.ts
+++ b/src/clr-angular/utils/drag-and-drop/draggable/draggable.spec.ts
@@ -18,6 +18,7 @@ import { DragHandleRegistrarService } from '../providers/drag-handle-registrar.s
 import { DraggableSnapshotService } from '../providers/draggable-snapshot.service';
 import { GlobalDragModeService } from '../providers/global-drag-mode.service';
 import { ClrDraggable } from './draggable';
+import { generateDragPosition } from '../helpers.spec';
 
 export default function(): void {
   describe('Basic Draggable', function() {
@@ -30,9 +31,9 @@ export default function(): void {
     let mockDragEndEventExt: ClrDragEvent<any>;
 
     beforeEach(function() {
-      mockDragStartEventInt = { type: DragEventType.DRAG_START, dragPosition: { pageX: 11, pageY: 22 } };
-      mockDragMoveEventInt = { type: DragEventType.DRAG_MOVE, dragPosition: { pageX: 33, pageY: 44 } };
-      mockDragEndEventInt = { type: DragEventType.DRAG_END, dragPosition: { pageX: 77, pageY: 88 } };
+      mockDragStartEventInt = { type: DragEventType.DRAG_START, dragPosition: generateDragPosition([5, 10], [11, 22]) };
+      mockDragMoveEventInt = { type: DragEventType.DRAG_MOVE, dragPosition: generateDragPosition([5, 10], [33, 44]) };
+      mockDragEndEventInt = { type: DragEventType.DRAG_END, dragPosition: generateDragPosition([5, 10], [77, 88]) };
 
       mockDragStartEventExt = new ClrDragEvent(mockDragStartEventInt);
       mockDragMoveEventExt = new ClrDragEvent(mockDragMoveEventInt);

--- a/src/clr-angular/utils/drag-and-drop/draggable/ghost-and-handle-integration.spec.ts
+++ b/src/clr-angular/utils/drag-and-drop/draggable/ghost-and-handle-integration.spec.ts
@@ -12,13 +12,13 @@ import { ClrIconModule } from '../../../icon/icon.module';
 import { DomAdapter } from '../../dom-adapter/dom-adapter';
 import { ClrDragAndDropModule } from '../drag-and-drop.module';
 import { ClrDragHandle } from '../drag-handle';
+import { generateDragPosition } from '../helpers.spec';
 import { DragEventInterface, DragEventType } from '../interfaces/drag-event.interface';
 import { DragEventListenerService } from '../providers/drag-event-listener.service';
 import { MOCK_DRAG_EVENT_LISTENER_PROVIDER } from '../providers/drag-event-listener.service.mock';
 import { DragHandleRegistrarService } from '../providers/drag-handle-registrar.service';
 import { DraggableSnapshotService } from '../providers/draggable-snapshot.service';
 import { GlobalDragModeService } from '../providers/global-drag-mode.service';
-
 import { ClrDraggable } from './draggable';
 
 export default function(): void {
@@ -27,8 +27,8 @@ export default function(): void {
     let mockDragEndEventInt: DragEventInterface<any>;
 
     beforeEach(function() {
-      mockDragStartEventInt = { type: DragEventType.DRAG_START, dragPosition: { pageX: 11, pageY: 22 } };
-      mockDragEndEventInt = { type: DragEventType.DRAG_END, dragPosition: { pageX: 77, pageY: 88 } };
+      mockDragStartEventInt = { type: DragEventType.DRAG_START, dragPosition: generateDragPosition([5, 10], [11, 22]) };
+      mockDragEndEventInt = { type: DragEventType.DRAG_END, dragPosition: generateDragPosition([5, 10], [77, 88]) };
 
       TestBed.configureTestingModule({
         imports: [ClrDragAndDropModule, ClrIconModule, NoopAnimationsModule],

--- a/src/clr-angular/utils/drag-and-drop/droppable/droppable.spec.ts
+++ b/src/clr-angular/utils/drag-and-drop/droppable/droppable.spec.ts
@@ -8,6 +8,7 @@ import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { ClrDragEvent } from '../drag-event';
+import { generateDragPosition } from '../helpers.spec';
 import { DragEventInterface, DragEventType } from '../interfaces/drag-event.interface';
 import { ClrDropToleranceInterface } from '../interfaces/drop-tolerance.interface';
 import { DragAndDropEventBusService } from '../providers/drag-and-drop-event-bus.service';
@@ -24,9 +25,9 @@ export default function(): void {
   let mockDragEndEventExt: ClrDragEvent<any>;
 
   beforeEach(function() {
-    mockDragStartEventInt = { type: DragEventType.DRAG_START, dragPosition: { pageX: 11, pageY: 22 } };
-    mockDragMoveEventInt = { type: DragEventType.DRAG_MOVE, dragPosition: { pageX: 33, pageY: 44 } };
-    mockDragEndEventInt = { type: DragEventType.DRAG_END, dragPosition: { pageX: 77, pageY: 88 } };
+    mockDragStartEventInt = { type: DragEventType.DRAG_START, dragPosition: generateDragPosition([5, 10], [11, 22]) };
+    mockDragMoveEventInt = { type: DragEventType.DRAG_MOVE, dragPosition: generateDragPosition([5, 10], [33, 44]) };
+    mockDragEndEventInt = { type: DragEventType.DRAG_END, dragPosition: generateDragPosition([5, 10], [77, 88]) };
 
     mockDragStartEventExt = new ClrDragEvent(mockDragStartEventInt);
     mockDragMoveEventExt = new ClrDragEvent(mockDragMoveEventInt);

--- a/src/clr-angular/utils/drag-and-drop/helpers.spec.ts
+++ b/src/clr-angular/utils/drag-and-drop/helpers.spec.ts
@@ -4,6 +4,28 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
+import { DragPointPosition } from './interfaces/drag-event.interface';
+
+export const generateDragPosition = (
+  startPosition: [number, number],
+  movePosition?: [number, number]
+): DragPointPosition => {
+  if (!movePosition) {
+    return {
+      pageX: startPosition[0],
+      pageY: startPosition[1],
+      moveX: startPosition[0],
+      moveY: startPosition[1],
+    };
+  }
+  return {
+    pageX: movePosition[0],
+    pageY: movePosition[1],
+    moveX: movePosition[0] - startPosition[0],
+    moveY: movePosition[1] - startPosition[1],
+  };
+};
+
 export const emulateDragEvent = (
   eventName: string,
   pageX: number = 0,

--- a/src/clr-angular/utils/drag-and-drop/interfaces/drag-event.interface.ts
+++ b/src/clr-angular/utils/drag-and-drop/interfaces/drag-event.interface.ts
@@ -15,8 +15,8 @@ export enum DragEventType {
 export interface DragPointPosition {
   pageX: number;
   pageY: number;
-  moveX?: number;
-  moveY?: number;
+  moveX: number;
+  moveY: number;
 }
 
 export interface DragEventInterface<T> {

--- a/src/clr-angular/utils/drag-and-drop/interfaces/drag-event.interface.ts
+++ b/src/clr-angular/utils/drag-and-drop/interfaces/drag-event.interface.ts
@@ -12,11 +12,18 @@ export enum DragEventType {
   DROP,
 }
 
+export interface DragPointPosition {
+  pageX: number;
+  pageY: number;
+  moveX?: number;
+  moveY?: number;
+}
+
 export interface DragEventInterface<T> {
   type: DragEventType;
   group?: string | string[];
   ghostElement?: any;
-  dragPosition: { pageX: number; pageY: number };
+  dragPosition: DragPointPosition;
   dragDataTransfer?: T;
   // For default ghosts, this dropPointPosition denotes the center point of the ghost element.
   // This center point is used to determine whether the ghost is over droppable elements or not.

--- a/src/clr-angular/utils/drag-and-drop/providers/drag-and-drop-event-bus.service.spec.ts
+++ b/src/clr-angular/utils/drag-and-drop/providers/drag-and-drop-event-bus.service.spec.ts
@@ -5,6 +5,7 @@
  */
 import { DragEventInterface, DragEventType } from '../interfaces/drag-event.interface';
 import { DragAndDropEventBusService } from './drag-and-drop-event-bus.service';
+import { generateDragPosition } from '../helpers.spec';
 
 type DragTransfer = {
   data: any;
@@ -17,7 +18,11 @@ export default function(): void {
       dragEventType: DragEventType,
       dragDataTransfer?: DragTransfer
     ): DragEventInterface<DragTransfer> => {
-      return { type: dragEventType, dragPosition: { pageX: 0, pageY: 0 }, dragDataTransfer: dragDataTransfer };
+      return {
+        type: dragEventType,
+        dragPosition: generateDragPosition([5, 10], [11, 22]),
+        dragDataTransfer: dragDataTransfer,
+      };
     };
     let isEmitted: boolean;
 

--- a/src/clr-angular/utils/drag-and-drop/providers/drag-event-listener.service.spec.ts
+++ b/src/clr-angular/utils/drag-and-drop/providers/drag-event-listener.service.spec.ts
@@ -7,30 +7,13 @@ import { Component, ElementRef, NgZone, OnDestroy, OnInit, Renderer2, ViewChild 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Subscription } from 'rxjs';
 
-import { emulateDragEvent } from '../helpers.spec';
+import { emulateDragEvent, generateDragPosition } from '../helpers.spec';
 import { DragEventInterface, DragPointPosition } from '../interfaces/drag-event.interface';
 import { DragAndDropEventBusService } from './drag-and-drop-event-bus.service';
 import { DragEventListenerService } from './drag-event-listener.service';
 
 type DragTransfer = {
   data: any;
-};
-
-const generateDragPosition = (startPosition: [number, number], movePosition?: [number, number]): DragPointPosition => {
-  if (!movePosition) {
-    return {
-      pageX: startPosition[0],
-      pageY: startPosition[1],
-      moveX: startPosition[0],
-      moveY: startPosition[1],
-    };
-  }
-  return {
-    pageX: movePosition[0],
-    pageY: movePosition[1],
-    moveX: movePosition[0] - startPosition[0],
-    moveY: movePosition[1] - startPosition[1],
-  };
 };
 
 const expectEventPropValues = <T>(event: DragEventInterface<T>) => {
@@ -70,7 +53,7 @@ export default function(): void {
 
     // the position when the mouseup/touchend event gets registered
     // right after the mousedown/touchstart event with no prior registered mousemove/touchmove events
-    const preMatureEndPosition: [number, number] = startPosition;
+    const prematureEndPosition: [number, number] = startPosition;
 
     // the position for the mousemove/touchmove event after the dragstart event gets registered
     const movePosition: [number, number] = [44, 55];
@@ -165,7 +148,7 @@ export default function(): void {
 
         // mousedown+mouseup means it just ended prematurely
         emulateDragEvent(startEvent, ...startPosition, draggableButton);
-        emulateDragEvent(endEvent, ...preMatureEndPosition);
+        emulateDragEvent(endEvent, ...prematureEndPosition);
 
         // mousedown+mousemove should fire dragstart
         emulateDragEvent(startEvent, ...startPosition, draggableButton);

--- a/src/clr-angular/utils/drag-and-drop/providers/drag-event-listener.service.spec.ts
+++ b/src/clr-angular/utils/drag-and-drop/providers/drag-event-listener.service.spec.ts
@@ -8,7 +8,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Subscription } from 'rxjs';
 
 import { emulateDragEvent } from '../helpers.spec';
-import { DragEventInterface } from '../interfaces/drag-event.interface';
+import { DragEventInterface, DragPointPosition } from '../interfaces/drag-event.interface';
 import { DragAndDropEventBusService } from './drag-and-drop-event-bus.service';
 import { DragEventListenerService } from './drag-event-listener.service';
 
@@ -16,11 +16,27 @@ type DragTransfer = {
   data: any;
 };
 
+const generateDragPosition = (startPosition: [number, number], movePosition?: [number, number]): DragPointPosition => {
+  if (!movePosition) {
+    return {
+      pageX: startPosition[0],
+      pageY: startPosition[1],
+      moveX: startPosition[0],
+      moveY: startPosition[1],
+    };
+  }
+  return {
+    pageX: movePosition[0],
+    pageY: movePosition[1],
+    moveX: movePosition[0] - startPosition[0],
+    moveY: movePosition[1] - startPosition[1],
+  };
+};
+
 const expectEventPropValues = <T>(event: DragEventInterface<T>) => {
   return {
-    toBe: (element: Node, pageX: number, pageY: number, dragTransfer?: T, group?: string | string[]) => {
-      expect(event.dragPosition.pageX).toBe(pageX);
-      expect(event.dragPosition.pageY).toBe(pageY);
+    toBe: (element: Node, dragPosition: DragPointPosition, dragTransfer?: T, group?: string | string[]) => {
+      expect(event.dragPosition).toEqual(dragPosition);
 
       if (group) {
         expect(event.group).toEqual(group);
@@ -46,6 +62,25 @@ export default function(): void {
 
     let draggableButton: any;
 
+    // the position for the mousedown/touchstart event
+    const startPosition: [number, number] = [5, 10];
+
+    // the first move event that creates a dragstart event
+    const firstMovePosition: [number, number] = [6, 11];
+
+    // the position when the mouseup/touchend event gets registered
+    // right after the mousedown/touchstart event with no prior registered mousemove/touchmove events
+    const preMatureEndPosition: [number, number] = startPosition;
+
+    // the position for the mousemove/touchmove event after the dragstart event gets registered
+    const movePosition: [number, number] = [44, 55];
+
+    // the positions for the consecutive mousemove/touchmove events that consequently create dragmove events
+    const movePositions: [number, number][] = [[11, 22], [33, 44], [55, 66], [77, 88], [99, 0]];
+
+    // the position for the mouseup/touchend event that creates dragend event
+    const endPosition: [number, number] = [22, 33];
+
     beforeEach(function() {
       TestBed.configureTestingModule({ declarations: [TestComponent], providers: [DragAndDropEventBusService] });
 
@@ -64,44 +99,49 @@ export default function(): void {
     afterEach(() => {
       fixture.destroy();
       draggableButton = null;
-      // emulateDragEvent("mouseup", 0, 0, draggableButton);
-      // emulateDragEvent("touchend", 0, 0, draggableButton);
     });
 
     function testCases(startEvent: string, moveEvent: string, endEvent: string) {
       it(`shouldn't broadcast any drag events on single ${startEvent}`, function() {
-        emulateDragEvent(startEvent, 0, 0, draggableButton);
+        emulateDragEvent(startEvent, ...startPosition, draggableButton);
         expect(testComponent.dragStartFired).toBeFalsy();
         expect(testComponent.dragMoveFired).toBeFalsy();
         expect(testComponent.dragEndFired).toBeFalsy();
       });
 
       it(`should broadcast dragstart on ${startEvent} and first ${moveEvent}`, function() {
-        emulateDragEvent(startEvent, 0, 0, draggableButton);
-        emulateDragEvent(moveEvent, 22, 33);
+        emulateDragEvent(startEvent, ...startPosition, draggableButton);
+        emulateDragEvent(moveEvent, ...firstMovePosition);
 
         expect(testComponent.dragStartFired).toBeTruthy();
-        expectEventPropValues(testComponent.dragEvent).toBe(draggableButton, 22, 33, null);
+        expectEventPropValues(testComponent.dragEvent).toBe(
+          draggableButton,
+          generateDragPosition(startPosition, firstMovePosition),
+          null
+        );
 
         expect(testComponent.dragMoveFired).toBeFalsy();
         expect(testComponent.dragEndFired).toBeFalsy();
       });
 
       it(`should broadcast consecutive dragmove events on ${moveEvent} after dragstart`, function() {
-        const testPositions = [[11, 22], [33, 44], [55, 66], [77, 88], [99, 0]];
-        const nbDragMoveFired = testPositions.length;
+        const nbDragMoveFired = movePositions.length;
 
         // dragstart
-        emulateDragEvent(startEvent, 0, 0, draggableButton);
-        emulateDragEvent(moveEvent, 0, 0);
+        emulateDragEvent(startEvent, ...startPosition, draggableButton);
+        emulateDragEvent(moveEvent, ...firstMovePosition);
 
         expect(testComponent.dragStartFired).toBeTruthy();
 
         // consecutive dragmove events
-        while (testPositions.length > 0) {
-          const testPosition = testPositions.pop();
-          emulateDragEvent(moveEvent, testPosition[0], testPosition[1]);
-          expectEventPropValues(testComponent.dragEvent).toBe(draggableButton, testPosition[0], testPosition[1], null);
+        while (movePositions.length > 0) {
+          const testPosition: [number, number] = movePositions.pop();
+          emulateDragEvent(moveEvent, ...testPosition);
+          expectEventPropValues(testComponent.dragEvent).toBe(
+            draggableButton,
+            generateDragPosition(startPosition, testPosition),
+            null
+          );
         }
 
         expect(testComponent.nbDragMoveFired).toBe(nbDragMoveFired);
@@ -110,10 +150,10 @@ export default function(): void {
 
       it(`shouldn't broadcast any dragmove events on ${moveEvent} after ${startEvent} and ${endEvent}`, function() {
         // mousedown+mouseup means it just ended prematurely before firing dragstart
-        emulateDragEvent(startEvent, 0, 0, draggableButton);
-        emulateDragEvent(endEvent, 0, 0);
+        emulateDragEvent(startEvent, ...startPosition, draggableButton);
+        emulateDragEvent(endEvent, ...firstMovePosition);
 
-        emulateDragEvent(moveEvent, 0, 0);
+        emulateDragEvent(moveEvent, ...startPosition);
 
         expect(testComponent.dragStartFired).toBeFalsy();
         expect(testComponent.dragMoveFired).toBeFalsy();
@@ -121,39 +161,42 @@ export default function(): void {
       });
 
       it(`can broadcast proper dragstart and dragmove events after ${startEvent} and ${endEvent}`, function() {
-        const testPositions = [[11, 22], [33, 44], [55, 66], [77, 88], [99, 0]];
-        const nbDragMoveFired = testPositions.length;
+        const nbDragMoveFired = movePositions.length;
 
         // mousedown+mouseup means it just ended prematurely
-        emulateDragEvent(startEvent, 0, 0, draggableButton);
-        emulateDragEvent(endEvent, 0, 0);
+        emulateDragEvent(startEvent, ...startPosition, draggableButton);
+        emulateDragEvent(endEvent, ...preMatureEndPosition);
 
         // mousedown+mousemove should fire dragstart
-        emulateDragEvent(startEvent, 0, 0, draggableButton);
-        emulateDragEvent(moveEvent, 0, 0);
+        emulateDragEvent(startEvent, ...startPosition, draggableButton);
+        emulateDragEvent(moveEvent, ...firstMovePosition);
 
         expect(testComponent.nbDragMoveFired).toBe(0);
 
         expect(testComponent.dragStartFired).toBeTruthy();
 
-        while (testPositions.length > 0) {
-          const testPosition = testPositions.pop();
+        while (movePositions.length > 0) {
+          const testPosition: [number, number] = movePositions.pop();
           emulateDragEvent(moveEvent, testPosition[0], testPosition[1]);
-          expectEventPropValues(testComponent.dragEvent).toBe(draggableButton, testPosition[0], testPosition[1], null);
+          expectEventPropValues(testComponent.dragEvent).toBe(
+            draggableButton,
+            generateDragPosition(startPosition, testPosition),
+            null
+          );
         }
         expect(testComponent.nbDragMoveFired).toBe(nbDragMoveFired);
 
-        emulateDragEvent(endEvent, 22, 33);
+        emulateDragEvent(endEvent, ...endPosition);
         expect(testComponent.dragEndFired).toBeTruthy();
       });
 
       it('can broadcast dragend event on ' + endEvent + ' after dragstart registered', function() {
         // dragstart
-        emulateDragEvent(startEvent, 0, 0, draggableButton);
-        emulateDragEvent(moveEvent, 0, 0);
+        emulateDragEvent(startEvent, ...startPosition, draggableButton);
+        emulateDragEvent(moveEvent, ...firstMovePosition);
 
         // dragend
-        emulateDragEvent(endEvent, 22, 33);
+        emulateDragEvent(endEvent, ...endPosition);
 
         expect(testComponent.dragStartFired).toBeTruthy();
         expect(testComponent.dragMoveFired).toBeFalsy();
@@ -162,14 +205,14 @@ export default function(): void {
 
       it('can broadcast dragend event on ' + endEvent + ' after dragstart and dragmove registered', function() {
         // dragstart
-        emulateDragEvent(startEvent, 0, 0, draggableButton);
-        emulateDragEvent(moveEvent, 0, 0);
+        emulateDragEvent(startEvent, ...startPosition, draggableButton);
+        emulateDragEvent(moveEvent, ...firstMovePosition);
 
         // dragmove
-        emulateDragEvent(moveEvent, 44, 55);
+        emulateDragEvent(moveEvent, ...movePosition);
 
         // dragend
-        emulateDragEvent(endEvent, 22, 33);
+        emulateDragEvent(endEvent, ...endPosition);
 
         expect(testComponent.dragStartFired).toBeTruthy();
         expect(testComponent.dragMoveFired).toBeTruthy();
@@ -187,28 +230,43 @@ export default function(): void {
 
         dragEventListenerService.dragDataTransfer = dataOnDragStart;
         dragEventListenerService.group = groupOnDragStart;
-        emulateDragEvent(startEvent, 0, 0, draggableButton);
-        emulateDragEvent(moveEvent, 11, 22);
+        emulateDragEvent(startEvent, ...startPosition, draggableButton);
+        emulateDragEvent(moveEvent, ...firstMovePosition);
 
-        expectEventPropValues(testComponent.dragEvent).toBe(draggableButton, 11, 22, dataOnDragStart, groupOnDragStart);
+        expectEventPropValues(testComponent.dragEvent).toBe(
+          draggableButton,
+          generateDragPosition(startPosition, firstMovePosition),
+          dataOnDragStart,
+          groupOnDragStart
+        );
 
         dragEventListenerService.dragDataTransfer = dataOnDragMove;
         dragEventListenerService.group = groupOnDragMove;
-        emulateDragEvent(moveEvent, 33, 44);
+        emulateDragEvent(moveEvent, ...movePosition);
 
-        expectEventPropValues(testComponent.dragEvent).toBe(draggableButton, 33, 44, dataOnDragMove, groupOnDragMove);
+        expectEventPropValues(testComponent.dragEvent).toBe(
+          draggableButton,
+          generateDragPosition(startPosition, movePosition),
+          dataOnDragMove,
+          groupOnDragMove
+        );
 
         dragEventListenerService.dragDataTransfer = dataOnDragEnd;
         dragEventListenerService.group = groupOnDragEnd;
-        emulateDragEvent(endEvent, 55, 66);
-        expectEventPropValues(testComponent.dragEvent).toBe(draggableButton, 55, 66, dataOnDragEnd, groupOnDragEnd);
+        emulateDragEvent(endEvent, ...endPosition);
+        expectEventPropValues(testComponent.dragEvent).toBe(
+          draggableButton,
+          generateDragPosition(startPosition, endPosition),
+          dataOnDragEnd,
+          groupOnDragEnd
+        );
       });
 
       it('should dispatch to Event Bus on each drag events', function() {
-        emulateDragEvent(startEvent, 0, 0, draggableButton);
-        emulateDragEvent(moveEvent, 0, 0);
-        emulateDragEvent(moveEvent, 0, 0);
-        emulateDragEvent(endEvent, 0, 0);
+        emulateDragEvent(startEvent, ...startPosition, draggableButton);
+        emulateDragEvent(moveEvent, ...firstMovePosition);
+        emulateDragEvent(moveEvent, ...movePosition);
+        emulateDragEvent(endEvent, ...endPosition);
 
         expect(testComponent.dragStartDispatched).toBeTruthy();
         expect(testComponent.dragMoveDispatched).toBeTruthy();
@@ -219,14 +277,14 @@ export default function(): void {
         dragEventListenerService.detachDragListeners();
 
         // dragstart shouldn't fire
-        emulateDragEvent(startEvent, 0, 0, draggableButton);
-        emulateDragEvent(moveEvent, 0, 0);
+        emulateDragEvent(startEvent, ...startPosition, draggableButton);
+        emulateDragEvent(moveEvent, ...firstMovePosition);
 
         // dragmove shouldn't fire
-        emulateDragEvent(moveEvent, 0, 0);
+        emulateDragEvent(moveEvent, ...movePosition);
 
         // dragend shouldn't fire
-        emulateDragEvent(endEvent, 0, 0);
+        emulateDragEvent(endEvent, ...endPosition);
 
         expect(testComponent.dragStartFired).toBeFalsy();
         expect(testComponent.dragMoveFired).toBeFalsy();


### PR DESCRIPTION
DnD used to fire only absolute positions on the page. So if users needed to get positions relative to the initial position, they had to save the position from from `mousedown/touchstart` and subtract that from `mousemove/touchmove` positions, which makes their code complex. With this PR, DnD will also fire positions relative to its initial position. This feature is going to be very useful for refactoring the column resize feature with DnD.

Signed-off-by: stsogoo <stsogoo@vmware.com>