### PR TITLE
 [KS-APP][A11Y] A group of small a11y fixes on the ks-app (#1954)

### DIFF
--- a/src/ks-app/src/app/app.component.html
+++ b/src/ks-app/src/app/app.component.html
@@ -39,16 +39,17 @@
     </div>
   </clr-header>
   <div class="content-container">
-    <main class="content-area">
-      <router-outlet></router-outlet>
-    </main>
     <clr-vertical-nav [clr-nav-level]="2">
+      <a clrVerticalNavLink href="javascript://" (click)="skipToContent()" class="skip-handler">Skip to content</a>
       <a *ngFor="let nav of links"
          clrVerticalNavLink
          [routerLink]="nav.path"
          routerLinkActive="active">{{nav.title}}
       </a>
     </clr-vertical-nav>
+    <main class="content-area" #main tabindex="-1">
+      <router-outlet></router-outlet>
+    </main>
   </div>
 </clr-main-container>
 

--- a/src/ks-app/src/app/app.component.scss
+++ b/src/ks-app/src/app/app.component.scss
@@ -1,3 +1,13 @@
 // Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
+
+.skip-handler {
+  left: -999px;
+  position: absolute;
+}
+
+.skip-handler:focus,
+.skip-handler:active {
+  position: initial;
+}

--- a/src/ks-app/src/app/app.component.ts
+++ b/src/ks-app/src/app/app.component.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { Component } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 import { ClrIconCustomTag, ClrLoading, ClrMainContainer } from '@clr/angular';
 import { ClarityIcons } from '@clr/icons';
 import { ClrShapeStore } from '@clr/icons/shapes/commerce-shapes';
@@ -69,5 +69,11 @@ export class AppComponent {
       car: ClrShapeCar,
       helix: ClrShapeHelix,
     });
+  }
+
+  @ViewChild('main') main: ElementRef;
+
+  skipToContent() {
+    this.main.nativeElement.focus();
   }
 }

--- a/src/ks-app/src/app/containers/cards/cards.component.html
+++ b/src/ks-app/src/app/containers/cards/cards.component.html
@@ -31,7 +31,7 @@
   <div class="col-xs-12 col-lg-4">
     <a href="javascript://" class="card clickable">
       <div class="card-img">
-        <img src="assets/placeholder_480x200.png">
+        <img src="assets/placeholder_480x200.png" alt="Big placeholder image">
       </div>
       <div class="card-block">
         <p class="card-text">
@@ -47,7 +47,7 @@
       </div>
       <div class="card-block">
         <div class="card-media-block">
-          <img src="assets/placeholder_60x60.png" />
+          <img src="assets/placeholder_60x60.png" alt="Small placeholder image"/>
           <div class="card-media-description">
                             <span class="card-media-title">
                                 Project A

--- a/src/ks-app/src/app/containers/forms/radios.component.html
+++ b/src/ks-app/src/app/containers/forms/radios.component.html
@@ -8,8 +8,8 @@
 <form>
     <section class="form-block">
         <label>Radio Buttons</label>
-        <div class="form-group">
-            <label>Default/Stacked radio button group</label>
+        <div class="form-group" role="radiogroup" aria-labelledby="label_1">
+            <label id="label_1">Default/Stacked radio button group</label>
             <div class="radio">
                 <input type="radio" name="gridRadios" id="checkrads_9">
                 <label for="checkrads_9">Radio option 1</label>
@@ -19,8 +19,8 @@
                 <label for="checkrads_10">Radio option 2 (checked)</label>
             </div>
         </div>
-        <div class="form-group">
-            <label>Inline radio button group</label>
+        <div class="form-group" role="radiogroup" aria-labelledby="label_2">
+            <label id="label_2">Inline radio button group</label>
             <div class="radio-inline">
                 <input type="radio" name="gridRadios1" id="checkrads_11">
                 <label for="checkrads_11">Radio option 1</label>
@@ -30,8 +30,8 @@
                 <label for="checkrads_12">Radio option 2 (checked)</label>
             </div>
         </div>
-        <div class="form-group">
-            <label>These are disabled radio buttons</label>
+        <div class="form-group" role="radiogroup" aria-labelledby="label_3">
+            <label id="label_3">These are disabled radio buttons</label>
             <div class="radio disabled">
                 <input type="radio" name="gridRadios2" id="checkrads_13" disabled>
                 <label for="checkrads_13">Radio option disabled and unchecked</label>

--- a/src/ks-app/src/app/containers/forms/selects.component.html
+++ b/src/ks-app/src/app/containers/forms/selects.component.html
@@ -24,6 +24,7 @@
             <label for="selects_2">Text field paired with a select</label>
             <input type="text" id="selects_2" placeholder="Test">
             <div class="select">
+                <label for="selects_3" style="position: absolute; left: -9999px;">Select paired with a text field</label>
                 <select id="selects_3">
                     <option>New York</option>
                     <option>San Francisco</option>
@@ -50,7 +51,7 @@
     <section class="form-block">
         <label>Multi Select</label>
         <div class="form-group">
-            <label for="selects_1">Multi Select</label>
+            <label for="selects_5">Multi Select</label>
             <div class="select multiple">
                 <select id="selects_5" multiple>
                     <option>1</option>
@@ -62,7 +63,7 @@
             </div>
         </div>
         <div class="form-group">
-            <label for="selects_4">Disabled select</label>
+            <label for="selects_6">Disabled select</label>
             <div class="select multiple disabled">
                 <select id="selects_6" multiple disabled>
                     <option>New York</option>

--- a/src/ks-app/src/app/containers/progress/progress-bars.component.html
+++ b/src/ks-app/src/app/containers/progress/progress-bars.component.html
@@ -124,7 +124,7 @@
               <div class="progress-static top">
                 <div class="progress-meter" [attr.data-value]="value1"></div>
               </div>
-                <h4 class="card-title">Card title</h4>
+                <h5 class="card-title">Card title</h5>
                 <p class="card-text">Here is a progress bar at the very top of a card.</p>
                 <div class="progress-block">
                     <label>Label</label>

--- a/src/ks-app/src/app/containers/tables/tables.component.html
+++ b/src/ks-app/src/app/containers/tables/tables.component.html
@@ -9,10 +9,10 @@
 <table class="table">
     <thead>
     <tr>
-        <th>Decimal</th>
-        <th>Hexadecimal</th>
-        <th>Binary</th>
-        <th class="hidden-xs-down">Roman Numeral</th>
+        <th scope="col">Decimal</th>
+        <th scope="col">Hexadecimal</th>
+        <th scope="col">Binary</th>
+        <th scope="col" class="hidden-xs-down">Roman Numeral</th>
     </tr>
     </thead>
     <tbody>
@@ -47,10 +47,10 @@
 <table class="table table-compact">
     <thead>
     <tr>
-        <th class="left">Monster</th>
-        <th class="hidden-xs-down">Home</th>
-        <th>Likes Cookies</th>
-        <th class="left hidden-xs-down">Fun to Play With</th>
+        <th scope="col" class="left">Monster</th>
+        <th scope="col" class="hidden-xs-down">Home</th>
+        <th scope="col">Likes Cookies</th>
+        <th scope="col" class="left hidden-xs-down">Fun to Play With</th>
     </tr>
     </thead>
     <tbody>
@@ -85,10 +85,10 @@
 <table class="table table-compact table-noborder">
     <thead>
     <tr>
-        <th class="left">Monster</th>
-        <th class="hidden-xs-down">Home</th>
-        <th>Likes Cookies</th>
-        <th class="left hidden-xs-down">Fun to Play With</th>
+        <th scope="col" class="left">Monster</th>
+        <th scope="col" class="hidden-xs-down">Home</th>
+        <th scope="col">Likes Cookies</th>
+        <th scope="col" class="left hidden-xs-down">Fun to Play With</th>
     </tr>
     </thead>
     <tbody>
@@ -123,10 +123,10 @@
 <table class="table">
     <thead>
     <tr>
-        <th class="left">Wizard</th>
-        <th>Allegiance</th>
-        <th class="hidden-xs-down">Triwizard Champion?</th>
-        <th>Can Cast Fireball</th>
+        <th scope="col" class="left">Wizard</th>
+        <th scope="col">Allegiance</th>
+        <th scope="col" class="hidden-xs-down">Triwizard Champion?</th>
+        <th scope="col">Can Cast Fireball</th>
     </tr>
     </thead>
     <tbody>
@@ -161,9 +161,9 @@
 <table class="table">
     <thead>
     <tr>
-        <th class="left">Name</th>
-        <th class="hidden-xs-down">A/B</th>
-        <th class="left">Comment</th>
+        <th scope="col" class="left">Name</th>
+        <th scope="col" class="hidden-xs-down">A/B</th>
+        <th scope="col" class="left">Comment</th>
     </tr>
     </thead>
     <tbody>
@@ -189,10 +189,10 @@
 <table class="table table-noborder">
     <thead>
     <tr>
-        <th class="left">Monster</th>
-        <th class="hidden-xs-down">Home</th>
-        <th>Likes Cookies</th>
-        <th class="left hidden-xs-down">Fun to Play With</th>
+        <th scope="col" class="left">Monster</th>
+        <th scope="col" class="hidden-xs-down">Home</th>
+        <th scope="col">Likes Cookies</th>
+        <th scope="col" class="left hidden-xs-down">Fun to Play With</th>
     </tr>
     </thead>
     <tbody>
@@ -227,27 +227,27 @@
 <table class="table table-vertical">
     <tbody>
     <tr>
-        <th>Basic table</th>
+        <th scope="row">Basic table</th>
         <td>.table</td>
         <td>The classname used to apply general styling of Clarity tables to an HTML table.</td>
     </tr>
     <tr>
-        <th>Left-aligned table cells</th>
+        <th scope="row">Left-aligned table cells</th>
         <td>.left</td>
         <td>Use this classname on a <code class="clr-code">td</code> to align its contents to the left edge of the table data cell.<br>This is not necessary for vertical tables.</td>
     </tr>
     <tr>
-        <th>Tables without borders</th>
+        <th scope="row">Tables without borders</th>
         <td>.table-noborder</td>
         <td>This classname will remove borders between table rows as well as the border around the edge of the table.<br>Also removes the background so that the table will be transparent over the background its container has.</td>
     </tr>
     <tr>
-        <th>Compact tables</th>
+        <th scope="row">Compact tables</th>
         <td>.table-compact</td>
         <td>This classname changes is the height of the table rows from 36px to 24px.</td>
     </tr>
     <tr>
-        <th>Vertical tables</th>
+        <th scope="row">Vertical tables</th>
         <td>.table-vertical</td>
         <td>This classname removes the table header and applies table header styles to the left-most column.</td>
     </tr>
@@ -258,27 +258,27 @@
 <table class="table table-vertical table-noborder table-compact">
     <tbody>
     <tr>
-        <th>Basic table</th>
+        <th scope="row">Basic table</th>
         <td>.table</td>
         <td>The classname for applying general styling of Clarity tables to an HTML table.</td>
     </tr>
     <tr>
-        <th>Left-aligned table cells</th>
+        <th scope="row">Left-aligned table cells</th>
         <td>.left</td>
         <td>This classname on a <code class="clr-code">td</code> aligns content to the left edge of the table cell.<br>This is not necessary for vertical tables.</td>
     </tr>
     <tr>
-        <th>Tables without borders</th>
+        <th scope="row">Tables without borders</th>
         <td>.table-noborder</td>
         <td>This classname removes borders between table rows and the border around the table.<br>It also removes the background so that the table is transparent over its container background.</td>
     </tr>
     <tr>
-        <th>Compact tables</th>
+        <th scope="row">Compact tables</th>
         <td>.table-compact</td>
         <td>This classname changes the height of the table rows from 36px to 24px.</td>
     </tr>
     <tr>
-        <th>Vertical tables</th>
+        <th scope="row">Vertical tables</th>
         <td>.table-vertical</td>
         <td>This classname removes the table header and applies table header styles to the left-most column.</td>
     </tr>
@@ -291,10 +291,10 @@
         <table class="table">
             <thead>
             <tr>
-                <th class="left">Language</th>
-                <th>Foo</th>
-                <th>Bar</th>
-                <th>Baz</th>
+                <th scope="col" class="left">Language</th>
+                <th scope="col">Foo</th>
+                <th scope="col">Bar</th>
+                <th scope="col">Baz</th>
             </tr>
             </thead>
             <tbody>
@@ -323,10 +323,10 @@
         <table class="table">
             <thead>
             <tr>
-                <th class="left">Color</th>
-                <th>R</th>
-                <th>G</th>
-                <th>B</th>
+                <th scope="col" class="left">Color</th>
+                <th scope="col">R</th>
+                <th scope="col">G</th>
+                <th scope="col">B</th>
             </tr>
             </thead>
             <tbody>
@@ -355,8 +355,8 @@
         <table class="table">
             <thead>
             <tr>
-                <th class="left">Name</th>
-                <th class="left">Weakness</th>
+                <th scope="col" class="left">Name</th>
+                <th scope="col" class="left">Weakness</th>
             </tr>
             </thead>
             <tbody>

--- a/src/ks-app/src/app/containers/typography/typography.component.html
+++ b/src/ks-app/src/app/containers/typography/typography.component.html
@@ -9,9 +9,9 @@
 <table class="table">
     <thead>
     <tr>
-        <th class="left">Font</th>
-        <th>Font Weight</th>
-        <th class="left">Usage</th>
+        <th scope="col" class="left">Font</th>
+        <th scope="col">Font Weight</th>
+        <th scope="col" class="left">Usage</th>
     </tr>
     </thead>
     <tbody>
@@ -42,10 +42,10 @@
 <table class="table typography-demo-table">
     <thead>
     <tr>
-        <th class="left">Style Name</th>
-        <th class="left">Attributes</th>
-        <th class="left">Selectors</th>
-        <th class="left">Used For</th>
+        <th scope="col" class="left">Style Name</th>
+        <th scope="col" class="left">Attributes</th>
+        <th scope="col" class="left">Selectors</th>
+        <th scope="col" class="left">Used For</th>
     </tr>
     </thead>
     <tbody>
@@ -163,10 +163,10 @@
 <table class="table typography-demo-table">
     <thead>
     <tr>
-        <th class="left">Style Name</th>
-        <th class="left">Attributes</th>
-        <th class="left">Selectors</th>
-        <th class="left">Used For</th>
+        <th scope="col" class="left">Style Name</th>
+        <th scope="col" class="left">Attributes</th>
+        <th scope="col" class="left">Selectors</th>
+        <th scope="col" class="left">Used For</th>
     </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
[KS-APP][A11Y] Skip repetitive content (#1936)
[KS-APP][A11Y] Heading levels in progress bar page (#1940)
[KS-APP][A11Y] Add scopes to table headers (#1934)
[KS-APP][A11Y] Label for="id" fix at Selects page (#1921)
[KS-APP][A11Y] Radiogroup labels ignored on Radios page (#1916)
[KS-APP][A11Y] Cards view - provide image alt (#1914)