### PR TITLE
[WEB] Error when leaving server driven datagrid page (#2911)

### DIFF
--- a/latest/src/app/documentation/demos/datagrid/server-driven/server-driven.ts
+++ b/latest/src/app/documentation/demos/datagrid/server-driven/server-driven.ts
@@ -29,6 +29,10 @@ export class DatagridServerDrivenDemo {
     }
 
     refresh(state: ClrDatagridStateInterface) {
+        // Prevent console errors related to "clrDgRefresh call on component destroyed" issue
+        if (!(state.page || state.filters)) {
+            return;
+        }
         this.loading = true;
         let filters: {[prop: string]: any[]} = {};
         if (state.filters) {


### PR DESCRIPTION
Added a check on the "state" object, so we don't get errors can not find property "from of undefined".

Signed-off-by: Ivan Donchev <idonchev@vmware.com>