### PR TITLE
[NG] fix button animation issue

### DIFF
--- a/src/clr-angular/button/button-loading/loading-button.ts
+++ b/src/clr-angular/button/button-loading/loading-button.ts
@@ -73,12 +73,14 @@ export class ClrLoadingButton implements LoadingListener {
     switch (state) {
       case ClrLoadingState.DEFAULT:
         this.renderer.removeStyle(this.el.nativeElement, 'width');
+        this.renderer.removeStyle(this.el.nativeElement, 'transform'); // for chromium render bug see issue https://github.com/vmware/clarity/issues/2700
         if (!this.disabled) {
           this.renderer.removeAttribute(this.el.nativeElement, 'disabled');
         }
         break;
       case ClrLoadingState.LOADING:
         this.setExplicitButtonWidth();
+        this.renderer.setStyle(this.el.nativeElement, 'transform', 'translatez(0)'); // for chromium render bug see issue https://github.com/vmware/clarity/issues/2700
         this.renderer.setAttribute(this.el.nativeElement, 'disabled', '');
         break;
       case ClrLoadingState.SUCCESS:


### PR DESCRIPTION
In Chromium browsers button loading animation would not be visible with CSS multi-columns. Here is a minimal CSS/HTML only reproduction of the bug.

https://stackblitz.com/edit/js-bbvdrm?file=style.scss

It looks to be some kind of rendering bug. Changing certain properties cause the loader to render properly. Using `transform: translatez(0);` seems to fix the issue while not altering any of the existing rendered styles. This might also help the animation render performance as translatez will create a new layer for the browser to render with. We would want to use this dynamically as it's not ideal for every button to create its own layer.

closes #2700

Signed-off-by: Cory Rylan <crylan@vmware.com>