### PR TITLE
[NG] Error on auto expanding row details in datagrid (#2904)

### DIFF
--- a/src/clr-angular/data/datagrid/animation-hack/row-expand-animation.ts
+++ b/src/clr-angular/data/datagrid/animation-hack/row-expand-animation.ts
@@ -53,6 +53,11 @@ export class DatagridRowExpandAnimation {
     }
 
     this.oldHeight = this.domAdapter.computedHeight(this.el.nativeElement);
+    // In case height has not yet been set. When starting expanded, for example.
+    // See https://github.com/vmware/clarity/issues/2904
+    if (isNaN(this.oldHeight)) {
+      this.oldHeight = 0;
+    }
     // We set the height of the element immediately to avoid a flicker before the animation starts.
     this.renderer.setStyle(this.el.nativeElement, 'height', this.oldHeight + 'px');
     this.renderer.setStyle(this.el.nativeElement, 'overflow-y', 'hidden');

--- a/src/clr-angular/data/datagrid/datagrid.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid.spec.ts
@@ -5,6 +5,7 @@
  */
 import { ChangeDetectionStrategy, Component, Input, Renderer2 } from '@angular/core';
 import { Subject } from 'rxjs';
+import { async } from '@angular/core/testing';
 
 import { DatagridPropertyStringFilter } from './built-in/filters/datagrid-property-string-filter';
 import { DatagridStringFilterImpl } from './built-in/filters/datagrid-string-filter-impl';
@@ -189,6 +190,25 @@ class ActionableRowTest {
 })
 class ExpandableRowTest {
   items = [1, 2, 3];
+  expandable = true;
+}
+
+@Component({
+  template: `
+    <clr-datagrid>
+        <clr-dg-column>First</clr-dg-column>
+        <clr-dg-column>Second</clr-dg-column>
+
+        <clr-dg-row>
+          <clr-dg-cell>First item</clr-dg-cell>
+          <clr-dg-cell>Second item</clr-dg-cell>
+          <clr-dg-row-detail *clrIfExpanded="true">Detail</clr-dg-row-detail>
+        </clr-dg-row>
+        <clr-dg-footer></clr-dg-footer>
+    </clr-datagrid>
+`,
+})
+class ExpandedOnInitTest {
   expandable = true;
 }
 
@@ -603,6 +623,15 @@ export default function(): void {
         expect(globalExpandableRows.hasExpandableRow).toBe(false);
         expect(context.clarityElement.querySelector('.datagrid-column.datagrid-expandable-caret')).toBeNull();
       });
+
+      it('can expand rows on initialization', async(function() {
+        const context = this.create(ClrDatagrid, ExpandedOnInitTest, [HideableColumnService]);
+        const caretIcon = context.clarityElement.querySelector('.datagrid-expandable-caret-icon');
+        expect(caretIcon).not.toBeNull();
+        expect(caretIcon.getAttribute('dir')).toBe('down');
+        const rowDetail = context.clarityElement.querySelector('.datagrid-row-detail');
+        expect(rowDetail).not.toBeNull();
+      }));
     });
 
     describe('Single selection', function() {


### PR DESCRIPTION
The initial height may be '', if we start expanded, which leads to NaN during evaluation. I could do this.oldHeight = ... || 0; but this is more verbose and maintainable.
The test must be async to cover the rogue run() call of the animation which lives inside a setTimeout.

Signed-off-by: Ivan Donchev <idonchev@vmware.com>