### PR TITLE
Page First Item and Last Item of None

### DIFF
--- a/src/clr-angular/data/datagrid/datagrid-pagination.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-pagination.spec.ts
@@ -68,6 +68,9 @@ export default function(): void {
         pageService.current = 42;
         expect(component.firstItem).toBe(pageService.firstItem);
         expect(component.lastItem).toBe(pageService.lastItem);
+        pageService.totalItems = 0;
+        expect(component.firstItem).toBe(-1);
+        expect(component.lastItem).toBe(-1);
       });
 
       it('resets the page size to 0 when pagination is destroyed', () => {

--- a/src/clr-angular/data/datagrid/datagrid-pagination.ts
+++ b/src/clr-angular/data/datagrid/datagrid-pagination.ts
@@ -155,14 +155,14 @@ export class ClrDatagridPagination implements OnDestroy, OnInit {
   }
 
   /**
-   * Index of the first item displayed on the current page, starting at 0
+   * Index of the first item displayed on the current page, starting at 0, -1 if none displayed
    */
   public get firstItem(): number {
     return this.page.firstItem;
   }
 
   /**
-   * Index of the last item displayed on the current page, starting at 0
+   * Index of the last item displayed on the current page, starting at 0, -1 if none displayed
    */
   public get lastItem(): number {
     return this.page.lastItem;

--- a/src/clr-angular/data/datagrid/providers/items.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/items.spec.ts
@@ -43,6 +43,9 @@ export default function(): void {
     it('starts uninitialized', function() {
       expect(this.itemsInstance.smart).toBe(false);
       expect(this.itemsInstance.displayed.length).toBe(0);
+      expect(this.pageInstance.totalItems).toBe(0);
+      expect(this.pageInstance.firstItem).toBe(0);
+      expect(this.pageInstance.lastItem).toBe(-1);
     });
 
     it("doesn't process the items at all if not smart", function() {
@@ -58,6 +61,7 @@ export default function(): void {
     it("doesn't process the items if no filter, sort or pagination has been set", function() {
       setSmartItems(this.itemsInstance);
       expect(this.itemsInstance.displayed).toEqual(ALL_ITEMS);
+      expect(this.pageInstance.totalItems).toBe(10); // totalItems is explicitly set
     });
 
     it('filters according to the Filter provider', function() {
@@ -117,6 +121,17 @@ export default function(): void {
       expect(this.pageInstance.totalItems).toBe(10);
       this.evenFilter.toggle();
       expect(this.pageInstance.totalItems).toBe(5);
+    });
+
+    it('gets -1 of firstItem and lastItem if gets 0 item after filtering', function() {
+      const filter = new NegativeFilter();
+      this.filtersInstance.add(filter);
+      setSmartItems(this.itemsInstance);
+      expect(this.pageInstance.totalItems).toBe(10);
+      filter.toggle();
+      expect(this.pageInstance.totalItems).toBe(0);
+      expect(this.pageInstance.firstItem).toBe(-1);
+      expect(this.pageInstance.lastItem).toBe(-1);
     });
 
     it('exposes an Observable to follow items changes', function() {
@@ -206,6 +221,25 @@ class EvenFilter implements ClrDatagridFilterInterface<number> {
 
   accepts(n: number): boolean {
     return n % 2 === 0;
+  }
+}
+
+class NegativeFilter implements ClrDatagridFilterInterface<number> {
+  private active = false;
+
+  toggle() {
+    this.active = !this.active;
+    this.changes.next(this.active);
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  changes = new Subject<boolean>();
+
+  accepts(n: number): boolean {
+    return n < 0;
   }
 }
 

--- a/src/clr-angular/data/datagrid/providers/page.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/page.spec.ts
@@ -34,6 +34,14 @@ export default function(): void {
       expect(this.pageInstance.lastItem).toBe(29);
     });
 
+    it('returns -1 for the firstItem and lastItem of none items', function() {
+      this.pageInstance.size = 10;
+      this.pageInstance.totalItems = 0;
+      this.pageInstance.current = 1;
+      expect(this.pageInstance.firstItem).toBe(-1);
+      expect(this.pageInstance.lastItem).toBe(-1);
+    });
+
     it("doesn't paginate when size is 0", function() {
       this.pageInstance.next();
       expect(this.pageInstance.current).toBe(1);

--- a/src/clr-angular/data/datagrid/providers/page.ts
+++ b/src/clr-angular/data/datagrid/providers/page.ts
@@ -44,9 +44,9 @@ export class Page {
   /**
    * Total items (needed to guess the last page)
    */
-  private _totalItems = 0;
+  private _totalItems?: number;
   public get totalItems(): number {
-    return this._totalItems;
+    return this._totalItems || 0; // remains 0 if not set to avoid breaking change
   }
   public set totalItems(total: number) {
     this._totalItems = total;
@@ -124,9 +124,13 @@ export class Page {
   }
 
   /**
-   * Index of the first item displayed on the current page, starting at 0
+   * Index of the first item displayed on the current page, starting at 0, -1 if none displayed
    */
   public get firstItem(): number {
+    if (this._totalItems === 0) {
+      return -1;
+    }
+
     if (this.size === 0) {
       return 0;
     }
@@ -134,9 +138,13 @@ export class Page {
   }
 
   /**
-   * Index of the last item displayed on the current page, starting at 0
+   * Index of the last item displayed on the current page, starting at 0, -1 if none displayed
    */
   public get lastItem(): number {
+    if (this._totalItems === 0) {
+      return -1;
+    }
+
     if (this.size === 0) {
       return this.totalItems - 1;
     }


### PR DESCRIPTION
Page First Item and Last Item of None

Page's firstItem & lastItem can be used in generating page info by using the template
`{{page.firstItem + 1}} to {{page.lastItem + 1}} of {{page.totalItems}} items`

When both return -1 of none, the `1 to 20 of 0 items` bug could be fixed.

Happy new year.

Signed-off-by: KingMario <gcyyq@hotmail.com>