### PR TITLE
[NG] fix alert visibility issue

### DIFF
--- a/src/clr-angular/emphasis/alert/alert.ts
+++ b/src/clr-angular/emphasis/alert/alert.ts
@@ -60,7 +60,9 @@ export class ClrAlert {
 
   get isHidden() {
     if (this.multiAlertService) {
-      if (this.multiAlertService.currentAlert === this) {
+      // change detection issue in production mode causes currentAlert to be undefined when only the first alert exists
+      // https://github.com/vmware/clarity/issues/2430
+      if (this.multiAlertService.currentAlert === this || this.multiAlertService.count === 0) {
         if (this.hidden === true) {
           this.previouslyHidden = true;
           this.hidden = false;


### PR DESCRIPTION
In prod mode the first alert in alert list is not visible to the user. This happens when using `enableProdMode()` and is unrelated to AOT.

The check `isHidden()` only happens once during prod mode while in dev happens multiple times. In production it looks like `isHidden` is called before the `QueryList` of the parent alerts component has updated. So when `isHidden` checks to see if there are any alerts in the `QueryList` is empty the first time. Every subsequent check seems to work normally. 

I found a "fix" but I don't think its a good solution. The code change checks if the list is empty then it can assume its the first alert in the alert list and can fall into the correct if block. Any feedback or ideas would be appreciated.

closes #2430

Signed-off-by: Cory Rylan <crylan@vmware.com>