### PR TITLE
tooltip style fix

### DIFF
--- a/src/clr-angular/popover/tooltip/_tooltips.clarity.scss
+++ b/src/clr-angular/popover/tooltip/_tooltips.clarity.scss
@@ -31,7 +31,7 @@
 
   &::before {
     position: absolute;
-    #{$oppA}: -0.375rem;
+    #{$oppA}: -0.35rem;
     #{$oppB}: 0;
     #{$dirA}: auto;
     #{$dirB}: auto;

--- a/src/clr-angular/popover/tooltip/_tooltips.clarity.scss
+++ b/src/clr-angular/popover/tooltip/_tooltips.clarity.scss
@@ -89,12 +89,6 @@
       z-index: map-get($clr-layers, tooltips);
     }
 
-    //Needed for IE10. Cannot add styles directly to &:hover::after,&:hover::before before adding styles to &:hover.
-    // TODO: is this still needed? we no longer support IE10...
-    &:hover {
-      background: url('data:image/svg+xml;charset=UTF-8,%3Csvg+xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22+width%3D%221%22+height%3D%221%22+viewBox%3D%220+0+1+1%22%3E%3Ctitle%3Etransparent+bcg%3C%2Ftitle%3E%3C%2Fsvg%3E');
-    }
-
     &:hover > .tooltip-content,
     &:focus > .tooltip-content {
       visibility: visible;


### PR DESCRIPTION
Fix small gap rendered between tooltip body and arrow in Safari. Also removed unnecessary ie10 style.
Tested in Chrome, Firefox, Safari, IE11 and Edge.

closes vmware#2715