### PR TITLE
fix lint rule for barrels

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "pretest:lint": "tsc -p tests/tslint/tsconfig.json",
     "test:lint:ts": "tslint -p . -c tslint.json \"src/**/*.ts\" -e \"src/ks-app/**\" -e \"src/schematics/**\"",
     "test:lint:styles": "stylelint \"src/**/*.scss\" \"src/**/*.css\"",
-    "test:lint": "npm-run-all test:lint:ts test:lint:styles",
+    "test:lint": "npm-run-all website:news test:lint:ts test:lint:styles",
     "test:visual": "npm-run-all 'test:visual:light -- {*}' 'test:visual:dark -- {*}' --",
     "test:visual:light": "./scripts/docker-cdc.js -t",
     "test:visual:dark": "./scripts/docker-cdc.js -t -c dark",

--- a/src/clr-angular/forms/datepicker/date-container.spec.ts
+++ b/src/clr-angular/forms/datepicker/date-container.spec.ts
@@ -26,7 +26,7 @@ import { DateNavigationService } from './providers/date-navigation.service';
 import { DatepickerEnabledService } from './providers/datepicker-enabled.service';
 import { MockDatepickerEnabledService } from './providers/datepicker-enabled.service.mock';
 import { LocaleHelperService } from './providers/locale-helper.service';
-import { ClrCommonFormsModule } from '../common';
+import { ClrCommonFormsModule } from '../common/common.module';
 
 export default function() {
   describe('Date Container Component', () => {

--- a/tests/tslint/src/noBarrelImportsRule.ts
+++ b/tests/tslint/src/noBarrelImportsRule.ts
@@ -35,14 +35,15 @@ class NoBarrelImportsWalker extends Lint.RuleWalker {
     const importFile = node.parent.getSourceFile().fileName;
     // Here we chop off the filename to get just the host directory
     const importDir = importFile.substring(0, importFile.lastIndexOf('/'));
-    // Here we get the path of the file being imported, and add `.ts` for full path
-    let path = node.moduleSpecifier.getText();
-    if (extname(path) !== '') {
-      path.replace(/'|"/gi, '') + '.ts';
-    }
+    // Here we get the path of the file being imported
+    let path = node.moduleSpecifier.getText().replace(/'|"/gi, '');
 
     // We only care if this is a relative path, otherwise its fine
     if (path.startsWith('.')) {
+      // We need to add add `.ts` for full path, unless it has one of our supported file types already
+      if (['.html', '.txt', '.ts', '.json', '.js'].indexOf(extname(path)) === -1) {
+        path = path + '.ts';
+      }
       // Try to get file stats, or else its not a file and we throw fail
       try {
         // Using resolve we get the full path of what is being imported to check if


### PR DESCRIPTION
There was an issue where we were getting all import paths wrapped in a set of quotes like `'@angular/core'` and `'../common'`, and the quotes weren't being removed properly. This removes them always, and then checks the files that are imported from relative paths if they resolve to a file or a directory. It also adds support for verifying imports of json, html, and text files.