### PR TITLE
[NG] datepicker fixes

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -521,7 +521,7 @@ export declare class ClrDateInput extends WrappedFormControl<ClrDateContainer> i
     placeholder: string;
     readonly placeholderText: string;
     protected renderer: Renderer2;
-    constructor(vcr: ViewContainerRef, injector: Injector, el: ElementRef, renderer: Renderer2, control: NgControl, container: ClrDateContainer, _dateIOService: DateIOService, _dateNavigationService: DateNavigationService, _datepickerEnabledService: DatepickerEnabledService, dateFormControlService: DateFormControlService, platformId: Object, focusService: FocusService, newFormsLayout: boolean);
+    constructor(vcr: ViewContainerRef, injector: Injector, el: ElementRef, renderer: Renderer2, control: NgControl, container: ClrDateContainer, _dateIOService: DateIOService, _dateNavigationService: DateNavigationService, _datepickerEnabledService: DatepickerEnabledService, dateFormControlService: DateFormControlService, platformId: Object, focusService: FocusService, ifOpenService: IfOpenService, newFormsLayout: boolean, datepickerFocusService: DatepickerFocusService);
     ngAfterViewInit(): void;
     ngOnInit(): void;
     onValueChange(target: HTMLInputElement): void;

--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -521,7 +521,7 @@ export declare class ClrDateInput extends WrappedFormControl<ClrDateContainer> i
     placeholder: string;
     readonly placeholderText: string;
     protected renderer: Renderer2;
-    constructor(vcr: ViewContainerRef, injector: Injector, el: ElementRef, renderer: Renderer2, control: NgControl, container: ClrDateContainer, _dateIOService: DateIOService, _dateNavigationService: DateNavigationService, _datepickerEnabledService: DatepickerEnabledService, dateFormControlService: DateFormControlService, platformId: Object, focusService: FocusService, ifOpenService: IfOpenService, newFormsLayout: boolean, datepickerFocusService: DatepickerFocusService);
+    constructor(vcr: ViewContainerRef, injector: Injector, el: ElementRef, renderer: Renderer2, control: NgControl, container: ClrDateContainer, _dateIOService: DateIOService, _dateNavigationService: DateNavigationService, _datepickerEnabledService: DatepickerEnabledService, dateFormControlService: DateFormControlService, platformId: Object, focusService: FocusService, newFormsLayout: boolean, datepickerFocusService: DatepickerFocusService);
     ngAfterViewInit(): void;
     ngOnInit(): void;
     onValueChange(target: HTMLInputElement): void;

--- a/src/clr-angular/forms/datepicker/date-input.spec.ts
+++ b/src/clr-angular/forms/datepicker/date-input.spec.ts
@@ -130,9 +130,7 @@ export default function() {
           const input: HTMLInputElement = context.testElement.querySelector('input');
           expect(document.activeElement).not.toBe(input);
 
-          ifOpenService.open = true;
-          context.detectChanges();
-          ifOpenService.open = false;
+          dateNavigationService.notifySelectedDayChanged(new DayModel(2019, 1, 1));
           context.detectChanges();
 
           expect(document.activeElement).toBe(input);

--- a/src/clr-angular/forms/datepicker/date-input.spec.ts
+++ b/src/clr-angular/forms/datepicker/date-input.spec.ts
@@ -196,7 +196,7 @@ export default function() {
           expect(context.testComponent.date.getDate()).toBe(1);
         });
 
-        it('outputs the date when the user changes the date manually in th input', () => {
+        it('outputs the date when the user changes the date manually in the input', () => {
           expect(context.testComponent.date).toBeUndefined();
 
           const input: HTMLInputElement = context.testElement.querySelector('input');
@@ -548,6 +548,22 @@ export default function() {
         expect(fixture.componentInstance.date.getFullYear()).toBe(date.getFullYear());
         expect(fixture.componentInstance.date.getMonth()).toBe(date.getMonth());
         expect(fixture.componentInstance.date.getDate()).toBe(date.getDate());
+      });
+
+      it('outputs the date appropriately when switching between user updates and programmatic updates', () => {
+        expect(fixture.componentInstance.date).toBeUndefined();
+
+        dateNavigationService.notifySelectedDayChanged(new DayModel(2015, 1, 1));
+        fixture.detectChanges();
+        expect(fixture.componentInstance.date.getFullYear()).toBe(2015);
+
+        fixture.componentInstance.date = new Date(2019, 1, 1);
+        fixture.detectChanges();
+        expect(fixture.componentInstance.date.getFullYear()).toBe(2019);
+
+        dateNavigationService.notifySelectedDayChanged(new DayModel(2015, 1, 1));
+        fixture.detectChanges();
+        expect(fixture.componentInstance.date.getFullYear()).toBe(2015);
       });
 
       // IE doesn't like event constructors

--- a/src/clr-angular/forms/datepicker/date-input.spec.ts
+++ b/src/clr-angular/forms/datepicker/date-input.spec.ts
@@ -28,6 +28,7 @@ import { DateNavigationService } from './providers/date-navigation.service';
 import { DatepickerEnabledService } from './providers/datepicker-enabled.service';
 import { MockDatepickerEnabledService } from './providers/datepicker-enabled.service.mock';
 import { LocaleHelperService } from './providers/locale-helper.service';
+import { DatepickerFocusService } from './providers/datepicker-focus.service';
 
 export default function() {
   describe('Date Input Component', () => {
@@ -39,6 +40,8 @@ export default function() {
     let ifErrorService: IfErrorService;
     let focusService: FocusService;
     let controlClassService: ControlClassService;
+    let datepickerFocusService: DatepickerFocusService;
+    let ifOpenService: IfOpenService;
     const setControlSpy = jasmine.createSpy();
 
     @Injectable()
@@ -62,6 +65,7 @@ export default function() {
           IfErrorService,
           IfOpenService,
           FocusService,
+          DatepickerFocusService,
           DateNavigationService,
           LocaleHelperService,
           DateIOService,
@@ -79,7 +83,11 @@ export default function() {
         ifErrorService = context.fixture.debugElement.injector.get(IfErrorService);
         focusService = context.fixture.debugElement.injector.get(FocusService);
         controlClassService = context.fixture.debugElement.injector.get(ControlClassService);
+        datepickerFocusService = context.fixture.debugElement.injector.get(DatepickerFocusService);
+        ifOpenService = context.fixture.debugElement.injector.get(IfOpenService);
+
         spyOn(ifErrorService, 'triggerStatusChange');
+        spyOn(datepickerFocusService, 'focusInput');
       });
 
       // @TODO Figure out how to make these tests conform to the rest of the forms tests, which test these already
@@ -116,6 +124,18 @@ export default function() {
           expect(ifErrorService.triggerStatusChange).toHaveBeenCalled();
           expect(focusState).toEqual(false);
           sub.unsubscribe();
+        });
+
+        it('should refocus input after selecting a date for a11y', () => {
+          const input: HTMLInputElement = context.testElement.querySelector('input');
+          expect(document.activeElement).not.toBe(input);
+
+          ifOpenService.open = true;
+          context.detectChanges();
+          ifOpenService.open = false;
+          context.detectChanges();
+
+          expect(document.activeElement).toBe(input);
         });
 
         it('should set override classes and remove them from the control', () => {

--- a/src/clr-angular/forms/datepicker/date-input.spec.ts
+++ b/src/clr-angular/forms/datepicker/date-input.spec.ts
@@ -41,7 +41,6 @@ export default function() {
     let focusService: FocusService;
     let controlClassService: ControlClassService;
     let datepickerFocusService: DatepickerFocusService;
-    let ifOpenService: IfOpenService;
     const setControlSpy = jasmine.createSpy();
 
     @Injectable()
@@ -84,7 +83,6 @@ export default function() {
         focusService = context.fixture.debugElement.injector.get(FocusService);
         controlClassService = context.fixture.debugElement.injector.get(ControlClassService);
         datepickerFocusService = context.fixture.debugElement.injector.get(DatepickerFocusService);
-        ifOpenService = context.fixture.debugElement.injector.get(IfOpenService);
 
         spyOn(ifErrorService, 'triggerStatusChange');
         spyOn(datepickerFocusService, 'focusInput');

--- a/src/clr-angular/forms/datepicker/date-input.ts
+++ b/src/clr-angular/forms/datepicker/date-input.ts
@@ -25,11 +25,10 @@ import {
   ViewContainerRef,
 } from '@angular/core';
 import { NgControl } from '@angular/forms';
-import { skip, filter } from 'rxjs/operators';
+import { filter } from 'rxjs/operators';
+
 import { FocusService } from '../common/providers/focus.service';
-
 import { WrappedFormControl } from '../common/wrapped-control';
-
 import { ClrDateContainer } from './date-container';
 import { DayModel } from './model/day.model';
 import { DateFormControlService } from './providers/date-form-control.service';
@@ -37,7 +36,6 @@ import { DateIOService } from './providers/date-io.service';
 import { DateNavigationService } from './providers/date-navigation.service';
 import { DatepickerEnabledService } from './providers/datepicker-enabled.service';
 import { IS_NEW_FORMS_LAYOUT } from '../common/providers/new-forms.service';
-import { IfOpenService } from './../../utils/conditional/if-open.service';
 import { DatepickerFocusService } from './providers/datepicker-focus.service';
 
 @Directive({
@@ -84,7 +82,6 @@ export class ClrDateInput extends WrappedFormControl<ClrDateContainer> implement
     @Optional() private dateFormControlService: DateFormControlService,
     @Inject(PLATFORM_ID) private platformId: Object,
     @Optional() private focusService: FocusService,
-    @Optional() private ifOpenService: IfOpenService,
     @Optional()
     @Inject(IS_NEW_FORMS_LAYOUT)
     public newFormsLayout: boolean,
@@ -111,7 +108,6 @@ export class ClrDateInput extends WrappedFormControl<ClrDateContainer> implement
       this._dateNavigationService = this.getProviderFromContainer(DateNavigationService);
       this._datepickerEnabledService = this.getProviderFromContainer(DatepickerEnabledService);
       this.dateFormControlService = this.getProviderFromContainer(DateFormControlService);
-      this.ifOpenService = this.getProviderFromContainer(IfOpenService);
     }
   }
 
@@ -350,8 +346,8 @@ export class ClrDateInput extends WrappedFormControl<ClrDateContainer> implement
 
   private listenForInputRefocus() {
     this.subscriptions.push(
-      this.ifOpenService.openChange
-        .pipe(skip(1), filter(open => !open))
+      this._dateNavigationService.selectedDayChange
+        .pipe(filter(date => !!date))
         .subscribe(v => this.datepickerFocusService.focusInput(this.el.nativeElement))
     );
   }

--- a/src/clr-angular/forms/datepicker/date-input.ts
+++ b/src/clr-angular/forms/datepicker/date-input.ts
@@ -195,6 +195,7 @@ export class ClrDateInput extends WrappedFormControl<ClrDateContainer> implement
     if (date) {
       const dayModel: DayModel = new DayModel(date.getFullYear(), date.getMonth(), date.getDate());
       if (!dayModel.isEqual(this._dateNavigationService.selectedDay)) {
+        this.previousOutput = dayModel;
         this._dateNavigationService.selectedDay = dayModel;
         this.writeDateStrToInputField(dateStr);
       }

--- a/src/clr-angular/forms/datepicker/providers/datepicker-focus.service.spec.ts
+++ b/src/clr-angular/forms/datepicker/providers/datepicker-focus.service.spec.ts
@@ -38,18 +38,33 @@ export default function() {
     it(
       'Does not focus on the button if the button does not have a tab index of 0',
       inject([PLATFORM_ID], platformId => {
-        const datepickerViewService: DatepickerFocusService = new DatepickerFocusService(mockNgZone, platformId);
+        const datepickerFocusService: DatepickerFocusService = new DatepickerFocusService(mockNgZone, platformId);
         const compInstance = fixture.debugElement.componentInstance;
         compInstance.tabIndex = '-1';
 
         fixture.detectChanges();
 
-        datepickerViewService.focusCell(compInstance.elementRef);
+        datepickerFocusService.focusCell(compInstance.elementRef);
 
         mockNgZone.stabilizeZone();
 
         expect(document.activeElement.innerHTML).not.toBe('Test Button');
         expect(document.activeElement.id).not.toBe('1');
+      })
+    );
+
+    it(
+      'should focus given input element',
+      inject([PLATFORM_ID], platformId => {
+        const datepickerFocusService: DatepickerFocusService = new DatepickerFocusService(mockNgZone, platformId);
+        const input: HTMLInputElement = fixture.debugElement.nativeElement.querySelector('input');
+
+        mockNgZone.stabilizeZone();
+        expect(document.activeElement).not.toBe(input);
+
+        datepickerFocusService.focusInput(input);
+        mockNgZone.stabilizeZone();
+        expect(document.activeElement).toBe(input);
       })
     );
   });
@@ -74,6 +89,7 @@ class MockNgZone extends NgZone {
 @Component({
   template: `
         <button id="1" [attr.tabindex]="tabIndex">Test Button</button>
+        <input type="date" />
     `,
 })
 class TestComponent {

--- a/src/clr-angular/forms/datepicker/providers/datepicker-focus.service.ts
+++ b/src/clr-angular/forms/datepicker/providers/datepicker-focus.service.ts
@@ -6,7 +6,7 @@
 
 import { isPlatformBrowser } from '@angular/common';
 import { ElementRef, Inject, Injectable, NgZone, PLATFORM_ID } from '@angular/core';
-import { first, map } from 'rxjs/operators';
+import { first, filter } from 'rxjs/operators';
 
 /**
  * This service focuses the day that is focusable in the calendar.
@@ -32,6 +32,6 @@ export class DatepickerFocusService {
 
   private ngZoneIsStableInBrowser() {
     // Credit: Material: https://github.com/angular/material2/blob/master/src/lib/datepicker/calendar.ts
-    return this._ngZone.onStable.asObservable().pipe(first(), map(() => isPlatformBrowser(this.platformId)));
+    return this._ngZone.onStable.asObservable().pipe(first(), filter(() => isPlatformBrowser(this.platformId)));
   }
 }

--- a/src/clr-angular/forms/datepicker/providers/datepicker-focus.service.ts
+++ b/src/clr-angular/forms/datepicker/providers/datepicker-focus.service.ts
@@ -6,7 +6,7 @@
 
 import { isPlatformBrowser } from '@angular/common';
 import { ElementRef, Inject, Injectable, NgZone, PLATFORM_ID } from '@angular/core';
-import { first } from 'rxjs/operators';
+import { first, map } from 'rxjs/operators';
 
 /**
  * This service focuses the day that is focusable in the calendar.
@@ -15,20 +15,23 @@ import { first } from 'rxjs/operators';
 export class DatepickerFocusService {
   constructor(private _ngZone: NgZone, @Inject(PLATFORM_ID) private platformId: Object) {}
 
-  // Credit: Material: https://github.com/angular/material2/blob/master/src/lib/datepicker/calendar.ts
   focusCell(elRef: ElementRef): void {
     this._ngZone.runOutsideAngular(() => {
-      this._ngZone.onStable
-        .asObservable()
-        .pipe(first())
-        .subscribe(() => {
-          if (isPlatformBrowser(this.platformId)) {
-            const focusEl = elRef.nativeElement.querySelector('[tabindex="0"]');
-            if (focusEl) {
-              focusEl.focus();
-            }
-          }
-        });
+      this.ngZoneIsStableInBrowser().subscribe(() => {
+        const focusEl = elRef.nativeElement.querySelector('[tabindex="0"]');
+        if (focusEl) {
+          focusEl.focus();
+        }
+      });
     });
+  }
+
+  focusInput(element: HTMLInputElement): void {
+    this._ngZone.runOutsideAngular(() => this.ngZoneIsStableInBrowser().subscribe(() => element.focus()));
+  }
+
+  private ngZoneIsStableInBrowser() {
+    // Credit: Material: https://github.com/angular/material2/blob/master/src/lib/datepicker/calendar.ts
+    return this._ngZone.onStable.asObservable().pipe(first(), map(() => isPlatformBrowser(this.platformId)));
   }
 }


### PR DESCRIPTION
- After date selected by user refocus the input.

- If updating the value from user then programmatically and back to the user, the output event
should fire properly for two way binding.

closes vmware#2792

closes vmware#2993

Signed-off-by: Cory Rylan <crylan@vmware.com>