### PR TITLE
Reorder column droppable

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -292,8 +292,8 @@ export declare class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<
     readonly ariaSort: "none" | "ascending" | "descending";
     readonly asc: boolean;
     readonly columnDropData: ColumnOrderModelService;
+    readonly columnGroupId: string;
     columnId: string;
-    readonly columnOrderDropKey: string;
     customFilter: boolean;
     readonly desc: boolean;
     field: string;

--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -291,7 +291,9 @@ export declare class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<
     readonly _view: any;
     readonly ariaSort: "none" | "ascending" | "descending";
     readonly asc: boolean;
+    readonly columnDropData: ColumnOrderModelService;
     columnId: string;
+    readonly columnOrderDropKey: string;
     customFilter: boolean;
     readonly desc: boolean;
     field: string;
@@ -299,7 +301,9 @@ export declare class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<
     filterValueChange: EventEmitter<{}>;
     readonly hidden: boolean;
     hideable: DatagridHideableColumnModel;
+    readonly leftReorderDroppable: ColumnHeaderSides;
     projectedFilter: any;
+    readonly rightReorderDroppable: ColumnHeaderSides;
     sortBy: ClrDatagridComparatorInterface<T> | string;
     sortOrder: ClrDatagridSortOrder;
     sortOrderChange: EventEmitter<ClrDatagridSortOrder>;
@@ -307,7 +311,7 @@ export declare class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<
     /** @deprecated */ sorted: boolean;
     /** @deprecated */ sortedChange: EventEmitter<boolean>;
     updateFilterValue: string;
-    constructor(_sort: Sort<T>, filters: FiltersProvider<T>, vcr: ViewContainerRef);
+    constructor(_sort: Sort<T>, filters: FiltersProvider<T>, vcr: ViewContainerRef, columnOrderModel: ColumnOrderModelService);
     ngOnDestroy(): void;
     ngOnInit(): void;
     sort(reverse?: boolean): void;
@@ -640,6 +644,7 @@ export declare class ClrDroppable<T> implements OnInit, OnDestroy {
     dropEmitter: EventEmitter<ClrDragEvent<T>>;
     dropTolerance: number | string | ClrDropToleranceInterface;
     group: string | string[];
+    readonly isDraggableMatch: boolean;
     isDraggableOver: boolean;
     constructor(el: ElementRef, eventBus: DragAndDropEventBusService<T>, domAdapter: DomAdapter, renderer: Renderer2);
     ngOnDestroy(): void;

--- a/src/clr-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clr-angular/data/datagrid/_datagrid.clarity.scss
@@ -340,6 +340,41 @@
         }
       }
 
+      .datagrid-column-reorder-droppable {
+        //Display
+        flex: 0 0 auto;
+
+        //Position
+        position: relative;
+        top: 0;
+        right: 0;
+
+        //Dims
+        // This droppable area shouldn't be visible.
+        // Although it has no width (we will use dropTolerance on the width), having the full spanning height of
+        // the column is important to have an ample space of droppable area.
+        width: 0px;
+        height: 100%;
+
+        //Other
+        border: none;
+        transform: translateZ(0);
+
+        .datagrid-column-drop-line {
+          //Position
+          position: absolute;
+          top: 0;
+          left: -1px;
+
+          //Dims
+          width: 2px;
+          height: 0px;
+
+          //Others
+          background: $clr-action-purple-dark;
+        }
+      }
+
       .draggable-ghost .datagrid-column-wrapper {
         position: relative;
         background-color: $clr-thead-bgcolor;

--- a/src/clr-angular/data/datagrid/all.spec.ts
+++ b/src/clr-angular/data/datagrid/all.spec.ts
@@ -61,10 +61,10 @@ import WrappedCellSpec from './wrapped-cell.spec';
 import WrappedColumnSpec from './wrapped-column.spec';
 import WrappedRowSpec from './wrapped-row.spec';
 
-describe('Datagrid', function() {
+fdescribe('Datagrid', function() {
   addHelpers();
 
-  describe('Providers', function() {
+  fdescribe('Providers', function() {
     SortProviderSpecs();
     FiltersProviderSpecs();
     PageProviderSpecs();

--- a/src/clr-angular/data/datagrid/all.spec.ts
+++ b/src/clr-angular/data/datagrid/all.spec.ts
@@ -61,10 +61,10 @@ import WrappedCellSpec from './wrapped-cell.spec';
 import WrappedColumnSpec from './wrapped-column.spec';
 import WrappedRowSpec from './wrapped-row.spec';
 
-fdescribe('Datagrid', function() {
+describe('Datagrid', function() {
   addHelpers();
 
-  fdescribe('Providers', function() {
+  describe('Providers', function() {
     SortProviderSpecs();
     FiltersProviderSpecs();
     PageProviderSpecs();

--- a/src/clr-angular/data/datagrid/all.spec.ts
+++ b/src/clr-angular/data/datagrid/all.spec.ts
@@ -23,6 +23,7 @@ import DatagridColumnToggleButtonSpecs from './datagrid-column-toggle-button.spe
 import DatagridColumnToggleSpecs from './datagrid-column-toggle.spec';
 import DatagridColumnSpecs from './datagrid-column.spec';
 import DatagridColumnSeparatorSpecs from './datagrid-column-separator.spec';
+import DatagridColumnReorderDroppableSpecs from './datagrid-column-reorder-droppable.spec';
 import DatagridFilterSpecs from './datagrid-filter.spec';
 import DatagridFooterSpecs from './datagrid-footer.spec';
 import DatagridHideableColumnSpec from './datagrid-hideable-column.model.spec';
@@ -45,6 +46,10 @@ import PageProviderSpecs from './providers/page.spec';
 import SelectionProviderSpecs from './providers/selection.spec';
 import SortProviderSpecs from './providers/sort.spec';
 import TableSizeServiceSpec from './providers/table-size.service.spec';
+import ColumnResizerServiceSpecs from './providers/column-resizer.service.spec';
+import ColumnOrdersCoordinatorServiceSpecs from './providers/column-orders-coordinator.service.spec';
+import ColumnOrderModelServiceSpecs from './providers/column-order-model.service.spec';
+
 import DatagridCellRendererSpecs from './render/cell-renderer.spec';
 import DomAdapterSpecs from '../../utils/dom-adapter/dom-adapter.spec';
 import DatagridHeaderRendererSpecs from './render/header-renderer.spec';
@@ -55,7 +60,6 @@ import DatagridRowRendererSpecs from './render/row-renderer.spec';
 import WrappedCellSpec from './wrapped-cell.spec';
 import WrappedColumnSpec from './wrapped-column.spec';
 import WrappedRowSpec from './wrapped-row.spec';
-import ColumnResizerServiceSpecs from './providers/column-resizer.service.spec';
 
 describe('Datagrid', function() {
   addHelpers();
@@ -71,6 +75,8 @@ describe('Datagrid', function() {
     DisplayModeServiceSpecs();
     TableSizeServiceSpec();
     ColumnResizerServiceSpecs();
+    ColumnOrdersCoordinatorServiceSpecs();
+    ColumnOrderModelServiceSpecs();
   });
   describe('Components', function() {
     DatagridActionBarSpecs();
@@ -79,6 +85,7 @@ describe('Datagrid', function() {
     DatagridFilterSpecs();
     DatagridColumnSpecs();
     DatagridColumnSeparatorSpecs();
+    DatagridColumnReorderDroppableSpecs();
     DatagridItemsSpecs();
     DatagridItemsTrackBySpecs();
     DatagridRowSpecs();

--- a/src/clr-angular/data/datagrid/datagrid-column-reorder-droppable.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-reorder-droppable.spec.ts
@@ -13,6 +13,7 @@ import { DomAdapter } from '../../utils/dom-adapter/dom-adapter';
 import { MOCK_TABLE_SIZE_PROVIDER, MockTableSizeService } from './providers/table-size.service.mock';
 
 import {
+  destroyMockHeaderEl,
   MOCK_COLUMN_ORDER_MODEL_PROVIDER,
   MockColumnOrderModelService,
   populateMockProps,
@@ -55,10 +56,21 @@ export default function(): void {
 
     afterEach(function() {
       context.fixture.destroy();
+
+      destroyMockHeaderEl(columnOrderModelService.headerEl);
+
+      // the last column model service wouldn't have the next column model so we have to check.
+      if (columnOrderModelService.nextVisibleColumnModel) {
+        destroyMockHeaderEl(columnOrderModelService.nextVisibleColumnModel.headerEl);
+      }
+      // the first column model service wouldn't have the previous column model so we have to check.
+      if (columnOrderModelService.previousVisibleColumnModel) {
+        destroyMockHeaderEl(columnOrderModelService.previousVisibleColumnModel.headerEl);
+      }
     });
 
     it('has column group id', function() {
-      expect(context.clarityDirective.columnOrderDropKey).toBe('dg-mock-group-id');
+      expect(context.clarityDirective.columnGroupId).toBe('dg-mock-group-id');
     });
 
     it('both droppables should have no drop area for draggable from same column', function() {

--- a/src/clr-angular/data/datagrid/datagrid-column-reorder-droppable.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-reorder-droppable.spec.ts
@@ -83,12 +83,28 @@ export default function(): void {
       expect(context.clarityDirective.dropTolerance).toBe(-1);
     });
 
+    it('right droppable should have no drop area for draggable from next column', function() {
+      const dragEvent = { dragDataTransfer: columnOrderModelService.nextVisibleColumnModel };
+      componentInstance.side = ColumnHeaderSides.RIGHT;
+      context.detectChanges();
+      reorderDroppable.setDropTolerance(dragEvent);
+      expect(context.clarityDirective.dropTolerance).toBe(-1);
+    });
+
     it('left droppable should have proper drop area for draggable from next column', function() {
       const dragEvent = { dragDataTransfer: columnOrderModelService.nextVisibleColumnModel };
       componentInstance.side = ColumnHeaderSides.LEFT;
       context.detectChanges();
       reorderDroppable.setDropTolerance(dragEvent);
-      expect(context.clarityDirective.dropTolerance).toEqual({ left: 200, right: 100 });
+      expect(context.clarityDirective.dropTolerance).toEqual({ left: 0, right: 200 });
+    });
+
+    it('right droppable should have proper drop area for draggable from previous column', function() {
+      const dragEvent = { dragDataTransfer: columnOrderModelService.previousVisibleColumnModel };
+      componentInstance.side = ColumnHeaderSides.RIGHT;
+      context.detectChanges();
+      reorderDroppable.setDropTolerance(dragEvent);
+      expect(context.clarityDirective.dropTolerance).toEqual({ left: 200, right: 0 });
     });
 
     it('far left droppable should have proper drop area for draggable from next column', function() {
@@ -98,23 +114,7 @@ export default function(): void {
       componentInstance.side = ColumnHeaderSides.LEFT;
       context.detectChanges();
       reorderDroppable.setDropTolerance(dragEvent);
-      expect(context.clarityDirective.dropTolerance).toEqual({ left: 0, right: 100 });
-    });
-
-    it('right droppable should have no drop area for draggable from next column', function() {
-      const dragEvent = { dragDataTransfer: columnOrderModelService.nextVisibleColumnModel };
-      componentInstance.side = ColumnHeaderSides.RIGHT;
-      context.detectChanges();
-      reorderDroppable.setDropTolerance(dragEvent);
-      expect(context.clarityDirective.dropTolerance).toBe(-1);
-    });
-
-    it('right droppable should have proper drop area for draggable from previous column', function() {
-      const dragEvent = { dragDataTransfer: columnOrderModelService.previousVisibleColumnModel };
-      componentInstance.side = ColumnHeaderSides.RIGHT;
-      context.detectChanges();
-      reorderDroppable.setDropTolerance(dragEvent);
-      expect(context.clarityDirective.dropTolerance).toEqual({ left: 100, right: 150 });
+      expect(context.clarityDirective.dropTolerance).toEqual({ left: 0, right: 200 });
     });
 
     it('far right droppable should have proper drop area for draggable from previous column', function() {
@@ -124,7 +124,7 @@ export default function(): void {
       componentInstance.side = ColumnHeaderSides.RIGHT;
       context.detectChanges();
       reorderDroppable.setDropTolerance(dragEvent);
-      expect(context.clarityDirective.dropTolerance).toEqual({ left: 100, right: 0 });
+      expect(context.clarityDirective.dropTolerance).toEqual({ left: 200, right: 0 });
     });
 
     it('gives dropLine height of datagrid table if showHighlight is called', function() {

--- a/src/clr-angular/data/datagrid/datagrid-column-reorder-droppable.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-reorder-droppable.spec.ts
@@ -61,18 +61,6 @@ export default function(): void {
       expect(context.clarityDirective.columnOrderDropKey).toBe('dg-mock-group-id');
     });
 
-    it('can return width of its own column', function() {
-      expect(context.clarityDirective.headerWidth).toBe(200);
-    });
-
-    it('can return width of previous column', function() {
-      expect(context.clarityDirective.previousVisibleHeaderWidth).toBe(400);
-    });
-
-    it('can return width of next column', function() {
-      expect(context.clarityDirective.nextVisibleHeaderWidth).toBe(300);
-    });
-
     it('both droppables should have no drop area for draggable from same column', function() {
       const dragEvent = { dragDataTransfer: columnOrderModelService };
 

--- a/src/clr-angular/data/datagrid/datagrid-column-reorder-droppable.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-reorder-droppable.spec.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import { Component } from '@angular/core';
+import { ClrDatagridColumnReorderDroppable, ColumnHeaderSides } from './datagrid-column-reorder-droppable';
+import { TestContext } from '../../utils/testing/helpers.spec';
+import { ColumnOrderModelService } from './providers/column-order-model.service';
+import { TableSizeService } from './providers/table-size.service';
+import { DomAdapter } from '../../utils/dom-adapter/dom-adapter';
+import { MOCK_TABLE_SIZE_PROVIDER, MockTableSizeService } from './providers/table-size.service.mock';
+
+import {
+  MOCK_COLUMN_ORDER_MODEL_PROVIDER,
+  MockColumnOrderModelService,
+  populateMockProps,
+} from './providers/column-order-model.service.mock';
+
+@Component({
+  template: `<clr-dg-column-reorder-droppable [side]="side"></clr-dg-column-reorder-droppable>`,
+})
+class TestComponent {
+  side: ColumnHeaderSides;
+}
+
+export default function(): void {
+  describe('ClrDatagridColumnReorderDroppable component', function() {
+    let context: TestContext<ClrDatagridColumnReorderDroppable, TestComponent>;
+    let componentInstance: TestComponent;
+    let reorderDroppable: ClrDatagridColumnReorderDroppable;
+    let columnOrderModelService: MockColumnOrderModelService;
+    let tableSizeService: MockTableSizeService;
+
+    beforeEach(function() {
+      const PROVIDERS_NEEDED = [MOCK_TABLE_SIZE_PROVIDER, MOCK_COLUMN_ORDER_MODEL_PROVIDER, DomAdapter];
+
+      context = this.create(ClrDatagridColumnReorderDroppable, TestComponent, PROVIDERS_NEEDED);
+      componentInstance = context.fixture.componentInstance;
+      reorderDroppable = context.clarityDirective;
+      columnOrderModelService = context.getClarityProvider(ColumnOrderModelService);
+      tableSizeService = context.getClarityProvider(TableSizeService);
+
+      columnOrderModelService.nextVisibleColumnModel = new MockColumnOrderModelService();
+      columnOrderModelService.previousVisibleColumnModel = new MockColumnOrderModelService();
+
+      populateMockProps(columnOrderModelService.previousVisibleColumnModel, 'dg-mock-group-id', 0, 400);
+      populateMockProps(columnOrderModelService, 'dg-mock-group-id', 1, 200);
+      populateMockProps(columnOrderModelService.nextVisibleColumnModel, 'dg-mock-group-id', 2, 300);
+
+      context.detectChanges();
+    });
+
+    afterEach(function() {
+      context.fixture.destroy();
+    });
+
+    it('has column group id', function() {
+      expect(context.clarityDirective.columnOrderDropKey).toBe('dg-mock-group-id');
+    });
+
+    it('can return width of its own column', function() {
+      expect(context.clarityDirective.headerWidth).toBe(200);
+    });
+
+    it('can return width of previous column', function() {
+      expect(context.clarityDirective.previousVisibleHeaderWidth).toBe(400);
+    });
+
+    it('can return width of next column', function() {
+      expect(context.clarityDirective.nextVisibleHeaderWidth).toBe(300);
+    });
+
+    it('both droppables should have no drop area for draggable from same column', function() {
+      const dragEvent = { dragDataTransfer: columnOrderModelService };
+
+      componentInstance.side = ColumnHeaderSides.Left;
+      context.detectChanges();
+      reorderDroppable.setDropTolerance(dragEvent);
+      expect(context.clarityDirective.dropTolerance).toBe(-1);
+
+      componentInstance.side = ColumnHeaderSides.Right;
+      context.detectChanges();
+      reorderDroppable.setDropTolerance(dragEvent);
+      expect(context.clarityDirective.dropTolerance).toBe(-1);
+    });
+
+    it('left droppable should have no drop area for draggable from previous column', function() {
+      const dragEvent = { dragDataTransfer: columnOrderModelService.previousVisibleColumnModel };
+      componentInstance.side = ColumnHeaderSides.Left;
+      context.detectChanges();
+      reorderDroppable.setDropTolerance(dragEvent);
+      expect(context.clarityDirective.dropTolerance).toBe(-1);
+    });
+
+    it('left droppable should have proper drop area for draggable from next column', function() {
+      const dragEvent = { dragDataTransfer: columnOrderModelService.nextVisibleColumnModel };
+      componentInstance.side = ColumnHeaderSides.Left;
+      context.detectChanges();
+      reorderDroppable.setDropTolerance(dragEvent);
+      const halfOfOwnWidth = context.clarityDirective.headerWidth / 2;
+      const halfOfPreviousWidth = context.clarityDirective.previousVisibleHeaderWidth / 2;
+      expect(context.clarityDirective.dropTolerance).toEqual({ left: halfOfPreviousWidth, right: halfOfOwnWidth });
+    });
+
+    it('right droppable should have no drop area for draggable from next column', function() {
+      const dragEvent = { dragDataTransfer: columnOrderModelService.nextVisibleColumnModel };
+      componentInstance.side = ColumnHeaderSides.Right;
+      context.detectChanges();
+      reorderDroppable.setDropTolerance(dragEvent);
+      expect(context.clarityDirective.dropTolerance).toBe(-1);
+    });
+
+    it('right droppable should have proper drop area for draggable from previous column', function() {
+      const dragEvent = { dragDataTransfer: columnOrderModelService.previousVisibleColumnModel };
+      componentInstance.side = ColumnHeaderSides.Right;
+      context.detectChanges();
+      reorderDroppable.setDropTolerance(dragEvent);
+      const halfOfOwnWidth = context.clarityDirective.headerWidth / 2;
+      const halfOfNextWidth = context.clarityDirective.nextVisibleHeaderWidth / 2;
+      expect(context.clarityDirective.dropTolerance).toEqual({ left: halfOfOwnWidth, right: halfOfNextWidth });
+    });
+
+    it('gives dropLine height of datagrid table if showHighlight is called', function() {
+      const dropLine = context.clarityElement.querySelector('.datagrid-column-drop-line');
+      expect(getComputedStyle(dropLine).height).toBe('0px');
+      context.clarityDirective.showHighlight(dropLine);
+      expect(getComputedStyle(dropLine).height).toBe(tableSizeService.getColumnDragHeight());
+    });
+
+    it('reduces dropLine height to 0 if hideHighlight is called', function() {
+      const dropLine = context.clarityElement.querySelector('.datagrid-column-drop-line');
+      context.clarityDirective.showHighlight(dropLine);
+      expect(getComputedStyle(dropLine).height).toBe(tableSizeService.getColumnDragHeight());
+      context.clarityDirective.hideHighlight(dropLine);
+      expect(getComputedStyle(dropLine).height).toBe('0px');
+    });
+
+    it('calls dropReceived method of columnOrderModel and hideHighlight if updateOrder is called', function() {
+      const dropLine = context.clarityElement.querySelector('.datagrid-column-drop-line');
+      spyOn(columnOrderModelService, 'dropReceived');
+      spyOn(context.clarityDirective, 'hideHighlight');
+      context.clarityDirective.updateOrder(columnOrderModelService.previousVisibleColumnModel, dropLine);
+      expect(columnOrderModelService.dropReceived).toHaveBeenCalledWith(
+        columnOrderModelService.previousVisibleColumnModel
+      );
+      expect(context.clarityDirective.hideHighlight).toHaveBeenCalledWith(dropLine);
+    });
+  });
+}

--- a/src/clr-angular/data/datagrid/datagrid-column-reorder-droppable.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-reorder-droppable.spec.ts
@@ -3,11 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-/*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
+
 import { Component } from '@angular/core';
 import { ClrDatagridColumnReorderDroppable, ColumnHeaderSides } from './datagrid-column-reorder-droppable';
 import { TestContext } from '../../utils/testing/helpers.spec';

--- a/src/clr-angular/data/datagrid/datagrid-column-reorder-droppable.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-reorder-droppable.spec.ts
@@ -5,7 +5,7 @@
  */
 
 import { Component } from '@angular/core';
-import { ClrDatagridColumnReorderDroppable, ColumnHeaderSides } from './datagrid-column-reorder-droppable';
+import { ClrDatagridColumnReorderDroppable } from './datagrid-column-reorder-droppable';
 import { TestContext } from '../../utils/testing/helpers.spec';
 import { ColumnOrderModelService } from './providers/column-order-model.service';
 import { TableSizeService } from './providers/table-size.service';
@@ -17,6 +17,7 @@ import {
   MockColumnOrderModelService,
   populateMockProps,
 } from './providers/column-order-model.service.mock';
+import { ColumnHeaderSides } from './enums/header-sides.enum';
 
 @Component({
   template: `<clr-dg-column-reorder-droppable [side]="side"></clr-dg-column-reorder-droppable>`,
@@ -75,12 +76,12 @@ export default function(): void {
     it('both droppables should have no drop area for draggable from same column', function() {
       const dragEvent = { dragDataTransfer: columnOrderModelService };
 
-      componentInstance.side = ColumnHeaderSides.Left;
+      componentInstance.side = ColumnHeaderSides.LEFT;
       context.detectChanges();
       reorderDroppable.setDropTolerance(dragEvent);
       expect(context.clarityDirective.dropTolerance).toBe(-1);
 
-      componentInstance.side = ColumnHeaderSides.Right;
+      componentInstance.side = ColumnHeaderSides.RIGHT;
       context.detectChanges();
       reorderDroppable.setDropTolerance(dragEvent);
       expect(context.clarityDirective.dropTolerance).toBe(-1);
@@ -88,7 +89,7 @@ export default function(): void {
 
     it('left droppable should have no drop area for draggable from previous column', function() {
       const dragEvent = { dragDataTransfer: columnOrderModelService.previousVisibleColumnModel };
-      componentInstance.side = ColumnHeaderSides.Left;
+      componentInstance.side = ColumnHeaderSides.LEFT;
       context.detectChanges();
       reorderDroppable.setDropTolerance(dragEvent);
       expect(context.clarityDirective.dropTolerance).toBe(-1);
@@ -96,17 +97,25 @@ export default function(): void {
 
     it('left droppable should have proper drop area for draggable from next column', function() {
       const dragEvent = { dragDataTransfer: columnOrderModelService.nextVisibleColumnModel };
-      componentInstance.side = ColumnHeaderSides.Left;
+      componentInstance.side = ColumnHeaderSides.LEFT;
       context.detectChanges();
       reorderDroppable.setDropTolerance(dragEvent);
-      const halfOfOwnWidth = context.clarityDirective.headerWidth / 2;
-      const halfOfPreviousWidth = context.clarityDirective.previousVisibleHeaderWidth / 2;
-      expect(context.clarityDirective.dropTolerance).toEqual({ left: halfOfPreviousWidth, right: halfOfOwnWidth });
+      expect(context.clarityDirective.dropTolerance).toEqual({ left: 200, right: 100 });
+    });
+
+    it('far left droppable should have proper drop area for draggable from next column', function() {
+      // the first column wouldn't have a previous model.
+      columnOrderModelService.previousVisibleColumnModel = null;
+      const dragEvent = { dragDataTransfer: columnOrderModelService.nextVisibleColumnModel };
+      componentInstance.side = ColumnHeaderSides.LEFT;
+      context.detectChanges();
+      reorderDroppable.setDropTolerance(dragEvent);
+      expect(context.clarityDirective.dropTolerance).toEqual({ left: 0, right: 100 });
     });
 
     it('right droppable should have no drop area for draggable from next column', function() {
       const dragEvent = { dragDataTransfer: columnOrderModelService.nextVisibleColumnModel };
-      componentInstance.side = ColumnHeaderSides.Right;
+      componentInstance.side = ColumnHeaderSides.RIGHT;
       context.detectChanges();
       reorderDroppable.setDropTolerance(dragEvent);
       expect(context.clarityDirective.dropTolerance).toBe(-1);
@@ -114,12 +123,20 @@ export default function(): void {
 
     it('right droppable should have proper drop area for draggable from previous column', function() {
       const dragEvent = { dragDataTransfer: columnOrderModelService.previousVisibleColumnModel };
-      componentInstance.side = ColumnHeaderSides.Right;
+      componentInstance.side = ColumnHeaderSides.RIGHT;
       context.detectChanges();
       reorderDroppable.setDropTolerance(dragEvent);
-      const halfOfOwnWidth = context.clarityDirective.headerWidth / 2;
-      const halfOfNextWidth = context.clarityDirective.nextVisibleHeaderWidth / 2;
-      expect(context.clarityDirective.dropTolerance).toEqual({ left: halfOfOwnWidth, right: halfOfNextWidth });
+      expect(context.clarityDirective.dropTolerance).toEqual({ left: 100, right: 150 });
+    });
+
+    it('far right droppable should have proper drop area for draggable from previous column', function() {
+      // the lastq column wouldn't have a previous model.
+      columnOrderModelService.nextVisibleColumnModel = null;
+      const dragEvent = { dragDataTransfer: columnOrderModelService.previousVisibleColumnModel };
+      componentInstance.side = ColumnHeaderSides.RIGHT;
+      context.detectChanges();
+      reorderDroppable.setDropTolerance(dragEvent);
+      expect(context.clarityDirective.dropTolerance).toEqual({ left: 100, right: 0 });
     });
 
     it('gives dropLine height of datagrid table if showHighlight is called', function() {

--- a/src/clr-angular/data/datagrid/datagrid-column-reorder-droppable.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-reorder-droppable.ts
@@ -4,12 +4,118 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component } from '@angular/core';
+import { Component, Input, Renderer2 } from '@angular/core';
+import { TableSizeService } from './providers/table-size.service';
+import { ColumnOrderModelService } from './providers/column-order-model.service';
+import { DomAdapter } from '../../utils/dom-adapter/dom-adapter';
+
+export const enum ColumnHeaderSides {
+  Left,
+  Right,
+}
 
 @Component({
   selector: 'clr-dg-column-reorder-droppable',
   template: `
-        <div class="datagrid-column-reorder-droppable"></div>
-    `,
+    <div class="datagrid-column-reorder-droppable" clrDroppable [clrGroup]="columnOrderDropKey"
+         (clrDragStart)="setDropTolerance($event)"
+         (clrDragEnter)="showHighlight(dropLine)"
+         (clrDragLeave)="hideHighlight(dropLine)"
+         (clrDrop)="updateOrder($event, dropLine)" [clrDropTolerance]="dropTolerance">
+      <div class="datagrid-column-drop-line" #dropLine></div>
+    </div>
+  `,
 })
-export class ClrDatagridColumnReorderDroppable {}
+export class ClrDatagridColumnReorderDroppable {
+  constructor(
+    private tableSizeService: TableSizeService,
+    private columnOrderModel: ColumnOrderModelService,
+    private renderer: Renderer2,
+    private domAdapter: DomAdapter
+  ) {}
+
+  public get columnOrderDropKey(): string {
+    return this.columnOrderModel.columnGroupId;
+  }
+
+  public dropTolerance: any;
+
+  // Each column headers will have this clr-dg-column-reorder-droppable component on each of its sides.
+  // We need a way to distinguish which side of the header that this droppable is on.
+
+  @Input('side') side: ColumnHeaderSides;
+
+  public showHighlight(dropLineEl: any): void {
+    // The drop line is 2px wide and appears right between columns with left: -1px.
+    this.renderer.setStyle(dropLineEl, 'height', `${this.tableSizeService.getColumnDragHeight()}`);
+
+    // the drop line should fully appear at first and end columns
+    if (this.columnOrderModel.isAtFirst) {
+      this.renderer.setStyle(dropLineEl, 'left', `0px`);
+    }
+    if (this.columnOrderModel.isAtEnd) {
+      this.renderer.setStyle(dropLineEl, 'left', `-2px`);
+    }
+  }
+
+  public hideHighlight(dropLineEl: any): void {
+    this.renderer.setStyle(dropLineEl, 'height', `0px`);
+    this.renderer.setStyle(dropLineEl, 'left', `-1px`);
+  }
+
+  public updateOrder(droppedColumnModel: ColumnOrderModelService, dropLineEl: any): void {
+    this.columnOrderModel.dropReceived(droppedColumnModel);
+    this.hideHighlight(dropLineEl);
+  }
+
+  public setDropTolerance(event: any): void {
+    const draggedFrom: number = event.dragDataTransfer.flexOrder;
+
+    if (draggedFrom < this.columnOrderModel.flexOrder) {
+      // if the dragged header is from the left side, the droppable at the right side in the current header
+      // would get a proper dropTolerance value and the left side one would be disabled with value of -1.
+
+      if (this.side === ColumnHeaderSides.Right) {
+        this.dropTolerance = { left: this.headerWidth / 2, right: this.nextVisibleHeaderWidth / 2 };
+      } else if (this.side === ColumnHeaderSides.Left) {
+        this.dropTolerance = -1; // a negative drop tolerance means no drop area
+      }
+    } else if (draggedFrom > this.columnOrderModel.flexOrder) {
+      // if the dragged header is from the right side, the droppable at the left side in the current header
+      // would get a proper dropTolerance value and the right side one would be disabled with value of -1.
+
+      if (this.side === ColumnHeaderSides.Left) {
+        this.dropTolerance = { right: this.headerWidth / 2, left: this.previousVisibleHeaderWidth / 2 };
+      } else if (this.side === ColumnHeaderSides.Right) {
+        this.dropTolerance = -1; // a negative drop tolerance means no drop area
+      }
+    } else {
+      // A reorder droppable shouldn't have a droppable area for the draggable header from the same column.
+      // So if the draggable is from the same header, disable the dropTolerance
+      this.dropTolerance = -1; // a negative drop tolerance means no drop area
+    }
+  }
+
+  get headerWidth(): number {
+    const headerEl = this.columnOrderModel.headerEl;
+    return this.domAdapter.clientRect(headerEl).width || 0;
+  }
+
+  get nextVisibleHeaderWidth(): number {
+    if (this.columnOrderModel.nextVisibleColumnModel) {
+      const headerEl = this.columnOrderModel.nextVisibleColumnModel.headerEl;
+      return this.domAdapter.clientRect(headerEl).width;
+    } else {
+      return 0;
+    }
+  }
+
+  get previousVisibleHeaderWidth(): number {
+    if (this.columnOrderModel.previousVisibleColumnModel) {
+      const headerEl = this.columnOrderModel.previousVisibleColumnModel.headerEl;
+      return this.domAdapter.clientRect(headerEl).width;
+    } else {
+      return 0;
+    }
+  }
+}

--- a/src/clr-angular/data/datagrid/datagrid-column-reorder-droppable.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-reorder-droppable.ts
@@ -7,8 +7,8 @@
 import { Component, Input, Renderer2 } from '@angular/core';
 import { TableSizeService } from './providers/table-size.service';
 import { ColumnOrderModelService } from './providers/column-order-model.service';
-import { DomAdapter } from '../../utils/dom-adapter/dom-adapter';
 import { ColumnHeaderSides } from './enums/header-sides.enum';
+import { ClrDropToleranceInterface } from '@clr/angular';
 
 @Component({
   selector: 'clr-dg-column-reorder-droppable',
@@ -33,7 +33,7 @@ export class ClrDatagridColumnReorderDroppable {
     return this.columnOrderModel.columnGroupId;
   }
 
-  public dropTolerance: any;
+  public dropTolerance: -1 | ClrDropToleranceInterface;
 
   // Each column headers will have this clr-dg-column-reorder-droppable component on each of its sides.
   // We need a way to distinguish which side of the header that this droppable is on.
@@ -72,8 +72,8 @@ export class ClrDatagridColumnReorderDroppable {
 
       if (this.side === ColumnHeaderSides.RIGHT) {
         this.dropTolerance = {
-          left: this.columnOrderModel.headerWidth / 2,
-          right: this.columnOrderModel.nextVisibleHeaderWidth / 2,
+          left: this.columnOrderModel.headerWidth,
+          right: 0,
         };
       } else if (this.side === ColumnHeaderSides.LEFT) {
         this.dropTolerance = -1; // a negative drop tolerance means no drop area
@@ -84,8 +84,8 @@ export class ClrDatagridColumnReorderDroppable {
 
       if (this.side === ColumnHeaderSides.LEFT) {
         this.dropTolerance = {
-          right: this.columnOrderModel.headerWidth / 2,
-          left: this.columnOrderModel.previousVisibleHeaderWidth / 2,
+          right: this.columnOrderModel.headerWidth,
+          left: 0,
         };
       } else if (this.side === ColumnHeaderSides.RIGHT) {
         this.dropTolerance = -1; // a negative drop tolerance means no drop area

--- a/src/clr-angular/data/datagrid/datagrid-column-reorder-droppable.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-reorder-droppable.ts
@@ -26,8 +26,7 @@ export class ClrDatagridColumnReorderDroppable {
   constructor(
     private tableSizeService: TableSizeService,
     private columnOrderModel: ColumnOrderModelService,
-    private renderer: Renderer2,
-    private domAdapter: DomAdapter
+    private renderer: Renderer2
   ) {}
 
   public get columnOrderDropKey(): string {
@@ -72,7 +71,10 @@ export class ClrDatagridColumnReorderDroppable {
       // would get a proper dropTolerance value and the left side one would be disabled with value of -1.
 
       if (this.side === ColumnHeaderSides.RIGHT) {
-        this.dropTolerance = { left: this.headerWidth / 2, right: this.nextVisibleHeaderWidth / 2 };
+        this.dropTolerance = {
+          left: this.columnOrderModel.headerWidth / 2,
+          right: this.columnOrderModel.nextVisibleHeaderWidth / 2,
+        };
       } else if (this.side === ColumnHeaderSides.LEFT) {
         this.dropTolerance = -1; // a negative drop tolerance means no drop area
       }
@@ -81,7 +83,10 @@ export class ClrDatagridColumnReorderDroppable {
       // would get a proper dropTolerance value and the right side one would be disabled with value of -1.
 
       if (this.side === ColumnHeaderSides.LEFT) {
-        this.dropTolerance = { right: this.headerWidth / 2, left: this.previousVisibleHeaderWidth / 2 };
+        this.dropTolerance = {
+          right: this.columnOrderModel.headerWidth / 2,
+          left: this.columnOrderModel.previousVisibleHeaderWidth / 2,
+        };
       } else if (this.side === ColumnHeaderSides.RIGHT) {
         this.dropTolerance = -1; // a negative drop tolerance means no drop area
       }
@@ -89,29 +94,6 @@ export class ClrDatagridColumnReorderDroppable {
       // A reorder droppable shouldn't have a droppable area for the draggable header from the same column.
       // So if the draggable is from the same header, disable the dropTolerance
       this.dropTolerance = -1; // a negative drop tolerance means no drop area
-    }
-  }
-
-  get headerWidth(): number {
-    const headerEl = this.columnOrderModel.headerEl;
-    return this.domAdapter.clientRect(headerEl).width;
-  }
-
-  get nextVisibleHeaderWidth(): number {
-    if (this.columnOrderModel.nextVisibleColumnModel) {
-      const headerEl = this.columnOrderModel.nextVisibleColumnModel.headerEl;
-      return this.domAdapter.clientRect(headerEl).width;
-    } else {
-      return 0;
-    }
-  }
-
-  get previousVisibleHeaderWidth(): number {
-    if (this.columnOrderModel.previousVisibleColumnModel) {
-      const headerEl = this.columnOrderModel.previousVisibleColumnModel.headerEl;
-      return this.domAdapter.clientRect(headerEl).width;
-    } else {
-      return 0;
     }
   }
 }

--- a/src/clr-angular/data/datagrid/datagrid-column-reorder-droppable.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-reorder-droppable.ts
@@ -12,15 +12,16 @@ import { ClrDropToleranceInterface } from '@clr/angular';
 
 @Component({
   selector: 'clr-dg-column-reorder-droppable',
-  template: `<div class="datagrid-column-reorder-droppable" clrDroppable 
-                  [clrGroup]="columnOrderDropKey"
-                  [clrDropTolerance]="dropTolerance" 
-                  (clrDragStart)="setDropTolerance($event)" 
-                  (clrDragEnter)="showHighlight(dropLine)" 
-                  (clrDragLeave)="hideHighlight(dropLine)"
-                  (clrDrop)="updateOrder($event, dropLine)">
-    <div class="datagrid-column-drop-line" #dropLine></div>
-  </div>`,
+  template: `
+    <div class="datagrid-column-reorder-droppable" clrDroppable
+         [clrGroup]="columnGroupId"
+         [clrDropTolerance]="dropTolerance"
+         (clrDragStart)="setDropTolerance($event)"
+         (clrDragEnter)="showHighlight(dropLine)"
+         (clrDragLeave)="hideHighlight(dropLine)"
+         (clrDrop)="updateOrder($event, dropLine)">
+      <div class="datagrid-column-drop-line" #dropLine></div>
+    </div>`,
 })
 export class ClrDatagridColumnReorderDroppable {
   constructor(
@@ -29,7 +30,7 @@ export class ClrDatagridColumnReorderDroppable {
     private renderer: Renderer2
   ) {}
 
-  public get columnOrderDropKey(): string {
+  public get columnGroupId(): string {
     return this.columnOrderModel.columnGroupId;
   }
 

--- a/src/clr-angular/data/datagrid/datagrid-column-reorder-droppable.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-reorder-droppable.ts
@@ -3,12 +3,12 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-
 import { Component, Input, Renderer2 } from '@angular/core';
-import { TableSizeService } from './providers/table-size.service';
-import { ColumnOrderModelService } from './providers/column-order-model.service';
+
+import { ClrDropToleranceInterface } from '../../utils/drag-and-drop/interfaces/drop-tolerance.interface';
 import { ColumnHeaderSides } from './enums/header-sides.enum';
-import { ClrDropToleranceInterface } from '@clr/angular';
+import { ColumnOrderModelService } from './providers/column-order-model.service';
+import { TableSizeService } from './providers/table-size.service';
 
 @Component({
   selector: 'clr-dg-column-reorder-droppable',

--- a/src/clr-angular/data/datagrid/datagrid-column-reorder-droppable.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-reorder-droppable.ts
@@ -8,23 +8,19 @@ import { Component, Input, Renderer2 } from '@angular/core';
 import { TableSizeService } from './providers/table-size.service';
 import { ColumnOrderModelService } from './providers/column-order-model.service';
 import { DomAdapter } from '../../utils/dom-adapter/dom-adapter';
-
-export const enum ColumnHeaderSides {
-  Left,
-  Right,
-}
+import { ColumnHeaderSides } from './enums/header-sides.enum';
 
 @Component({
   selector: 'clr-dg-column-reorder-droppable',
-  template: `
-    <div class="datagrid-column-reorder-droppable" clrDroppable [clrGroup]="columnOrderDropKey"
-         (clrDragStart)="setDropTolerance($event)"
-         (clrDragEnter)="showHighlight(dropLine)"
-         (clrDragLeave)="hideHighlight(dropLine)"
-         (clrDrop)="updateOrder($event, dropLine)" [clrDropTolerance]="dropTolerance">
-      <div class="datagrid-column-drop-line" #dropLine></div>
-    </div>
-  `,
+  template: `<div class="datagrid-column-reorder-droppable" clrDroppable 
+                  [clrGroup]="columnOrderDropKey"
+                  [clrDropTolerance]="dropTolerance" 
+                  (clrDragStart)="setDropTolerance($event)" 
+                  (clrDragEnter)="showHighlight(dropLine)" 
+                  (clrDragLeave)="hideHighlight(dropLine)"
+                  (clrDrop)="updateOrder($event, dropLine)">
+    <div class="datagrid-column-drop-line" #dropLine></div>
+  </div>`,
 })
 export class ClrDatagridColumnReorderDroppable {
   constructor(
@@ -75,18 +71,18 @@ export class ClrDatagridColumnReorderDroppable {
       // if the dragged header is from the left side, the droppable at the right side in the current header
       // would get a proper dropTolerance value and the left side one would be disabled with value of -1.
 
-      if (this.side === ColumnHeaderSides.Right) {
+      if (this.side === ColumnHeaderSides.RIGHT) {
         this.dropTolerance = { left: this.headerWidth / 2, right: this.nextVisibleHeaderWidth / 2 };
-      } else if (this.side === ColumnHeaderSides.Left) {
+      } else if (this.side === ColumnHeaderSides.LEFT) {
         this.dropTolerance = -1; // a negative drop tolerance means no drop area
       }
     } else if (draggedFrom > this.columnOrderModel.flexOrder) {
       // if the dragged header is from the right side, the droppable at the left side in the current header
       // would get a proper dropTolerance value and the right side one would be disabled with value of -1.
 
-      if (this.side === ColumnHeaderSides.Left) {
+      if (this.side === ColumnHeaderSides.LEFT) {
         this.dropTolerance = { right: this.headerWidth / 2, left: this.previousVisibleHeaderWidth / 2 };
-      } else if (this.side === ColumnHeaderSides.Right) {
+      } else if (this.side === ColumnHeaderSides.RIGHT) {
         this.dropTolerance = -1; // a negative drop tolerance means no drop area
       }
     } else {
@@ -98,7 +94,7 @@ export class ClrDatagridColumnReorderDroppable {
 
   get headerWidth(): number {
     const headerEl = this.columnOrderModel.headerEl;
-    return this.domAdapter.clientRect(headerEl).width || 0;
+    return this.domAdapter.clientRect(headerEl).width;
   }
 
   get nextVisibleHeaderWidth(): number {

--- a/src/clr-angular/data/datagrid/datagrid-column.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column.spec.ts
@@ -25,6 +25,8 @@ import { StateDebouncer } from './providers/state-debouncer.provider';
 import { TableSizeService } from './providers/table-size.service';
 import { DomAdapter } from '../../utils/dom-adapter/dom-adapter';
 import { DatagridRenderOrganizer } from './render/render-organizer';
+import { ColumnOrderModelService } from './providers/column-order-model.service';
+import { ColumnOrdersCoordinatorService } from './providers/column-orders-coordinator.service';
 
 const PROVIDERS_NEEDED = [
   Sort,
@@ -35,6 +37,7 @@ const PROVIDERS_NEEDED = [
   StateDebouncer,
   TableSizeService,
   Renderer2,
+  ColumnOrdersCoordinatorService,
 ];
 
 export default function(): void {
@@ -44,13 +47,15 @@ export default function(): void {
       let filtersService: FiltersProvider<number>;
       let comparator: TestComparator;
       let component: ClrDatagridColumn<number>;
+      let columnOrderModelService: ColumnOrderModelService;
 
       beforeEach(function() {
         const stateDebouncer = new StateDebouncer();
         sortService = new Sort(stateDebouncer);
         filtersService = new FiltersProvider(new Page(stateDebouncer), stateDebouncer);
+        columnOrderModelService = new ColumnOrderModelService(new ColumnOrdersCoordinatorService());
         comparator = new TestComparator();
-        component = new ClrDatagridColumn(sortService, filtersService, null);
+        component = new ClrDatagridColumn(sortService, filtersService, null, columnOrderModelService);
       });
 
       it('has an id for identification', function() {

--- a/src/clr-angular/data/datagrid/datagrid-column.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column.spec.ts
@@ -53,7 +53,7 @@ export default function(): void {
         const stateDebouncer = new StateDebouncer();
         sortService = new Sort(stateDebouncer);
         filtersService = new FiltersProvider(new Page(stateDebouncer), stateDebouncer);
-        columnOrderModelService = new ColumnOrderModelService(new ColumnOrdersCoordinatorService());
+        columnOrderModelService = new ColumnOrderModelService(new ColumnOrdersCoordinatorService(), new DomAdapter());
         comparator = new TestComparator();
         component = new ClrDatagridColumn(sortService, filtersService, null, columnOrderModelService);
       });

--- a/src/clr-angular/data/datagrid/datagrid-column.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column.ts
@@ -38,32 +38,32 @@ let nbCount: number = 0;
   selector: 'clr-dg-column',
   template: `
     <clr-dg-column-reorder-droppable [side]="leftReorderDroppable"></clr-dg-column-reorder-droppable>
-    <div class="datagrid-column-wrapper" [clrDraggable]="columnDropData" [clrGroup]="columnOrderDropKey">
-        <div class="datagrid-column-flex">
-            <!-- I'm really not happy with that select since it's not very scalable -->
-            <ng-content select="clr-dg-filter, clr-dg-string-filter"></ng-content>
+    <div class="datagrid-column-wrapper" [clrDraggable]="columnDropData" [clrGroup]="columnGroupId">
+      <div class="datagrid-column-flex">
+        <!-- I'm really not happy with that select since it's not very scalable -->
+        <ng-content select="clr-dg-filter, clr-dg-string-filter"></ng-content>
 
-            <clr-dg-string-filter
-                    *ngIf="field && !customFilter"
-                    [clrDgStringFilter]="registered"
-                    [(clrFilterValue)]="filterValue"></clr-dg-string-filter>
+        <clr-dg-string-filter
+          *ngIf="field && !customFilter"
+          [clrDgStringFilter]="registered"
+          [(clrFilterValue)]="filterValue"></clr-dg-string-filter>
 
-            <ng-template #columnTitle>
-                <ng-content></ng-content>
-            </ng-template>
+        <ng-template #columnTitle>
+          <ng-content></ng-content>
+        </ng-template>
 
-            <button class="datagrid-column-title" *ngIf="sortable" (click)="sort()" type="button">
-                <ng-container *ngTemplateOutlet="columnTitle"></ng-container>
-            </button>
+        <button class="datagrid-column-title" *ngIf="sortable" (click)="sort()" type="button">
+          <ng-container *ngTemplateOutlet="columnTitle"></ng-container>
+        </button>
 
-            <span class="datagrid-column-title" *ngIf="!sortable">
+        <span class="datagrid-column-title" *ngIf="!sortable">
                <ng-container *ngTemplateOutlet="columnTitle"></ng-container>
             </span>
-        </div>
+      </div>
     </div>
     <clr-dg-column-separator></clr-dg-column-separator>
     <clr-dg-column-reorder-droppable [side]="rightReorderDroppable"></clr-dg-column-reorder-droppable>
-    `,
+  `,
   host: {
     '[class.datagrid-column]': 'true',
     '[class.datagrid-column--hidden]': 'hidden',
@@ -111,7 +111,7 @@ export class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<T, Datag
     return this.columnOrderModel;
   }
 
-  public get columnOrderDropKey() {
+  public get columnGroupId() {
     return this.columnOrderModel.columnGroupId;
   }
 

--- a/src/clr-angular/data/datagrid/datagrid-column.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column.ts
@@ -30,7 +30,7 @@ import { Sort } from './providers/sort';
 import { DatagridFilterRegistrar } from './utils/datagrid-filter-registrar';
 import { WrappedColumn } from './wrapped-column';
 import { ColumnOrderModelService } from './providers/column-order-model.service';
-import { ColumnHeaderSides } from './datagrid-column-reorder-droppable';
+import { ColumnHeaderSides } from './enums/header-sides.enum';
 
 let nbCount: number = 0;
 
@@ -100,11 +100,11 @@ export class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<T, Datag
   }
 
   public get leftReorderDroppable() {
-    return ColumnHeaderSides.Left;
+    return ColumnHeaderSides.LEFT;
   }
 
   public get rightReorderDroppable() {
-    return ColumnHeaderSides.Right;
+    return ColumnHeaderSides.RIGHT;
   }
 
   public get columnDropData() {

--- a/src/clr-angular/data/datagrid/datagrid-hideable-column.model.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-hideable-column.model.spec.ts
@@ -15,6 +15,7 @@ import { StateDebouncer } from './providers/state-debouncer.provider';
 import { TableSizeService } from './providers/table-size.service';
 import { DomAdapter } from '../../utils/dom-adapter/dom-adapter';
 import { DatagridRenderOrganizer } from './render/render-organizer';
+import { ColumnOrdersCoordinatorService } from './providers/column-orders-coordinator.service';
 
 const PROVIDERS_NEEDED = [
   Sort,
@@ -25,6 +26,7 @@ const PROVIDERS_NEEDED = [
   StateDebouncer,
   TableSizeService,
   Renderer2,
+  ColumnOrdersCoordinatorService,
 ];
 
 export default function(): void {

--- a/src/clr-angular/data/datagrid/datagrid-hideable-column.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-hideable-column.spec.ts
@@ -15,6 +15,7 @@ import { StateDebouncer } from './providers/state-debouncer.provider';
 import { TableSizeService } from './providers/table-size.service';
 import { DomAdapter } from '../../utils/dom-adapter/dom-adapter';
 import { DatagridRenderOrganizer } from './render/render-organizer';
+import { ColumnOrdersCoordinatorService } from './providers/column-orders-coordinator.service';
 
 const PROVIDERS_NEEDED = [
   Sort,
@@ -25,6 +26,7 @@ const PROVIDERS_NEEDED = [
   StateDebouncer,
   TableSizeService,
   Renderer2,
+  ColumnOrdersCoordinatorService,
 ];
 
 export default function(): void {

--- a/src/clr-angular/data/datagrid/datagrid-hideable-column.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-hideable-column.spec.ts
@@ -16,6 +16,7 @@ import { TableSizeService } from './providers/table-size.service';
 import { DomAdapter } from '../../utils/dom-adapter/dom-adapter';
 import { DatagridRenderOrganizer } from './render/render-organizer';
 import { ColumnOrdersCoordinatorService } from './providers/column-orders-coordinator.service';
+import { ColumnOrderModelService } from './providers/column-order-model.service';
 
 const PROVIDERS_NEEDED = [
   Sort,
@@ -57,6 +58,12 @@ export default function(): void {
 
       it('correctly populates the DatagridHideableColumn instance with an id', function() {
         expect(context.clarityDirective.columnId).toEqual(context.clarityDirective.hideable.id);
+      });
+
+      it('assigns DatagridHideableColumn model to ColumnOrderModelService', function() {
+        expect(context.getClarityProvider(ColumnOrderModelService).hideableColumnModel).toBe(
+          context.clarityDirective.hideable
+        );
       });
     });
 

--- a/src/clr-angular/data/datagrid/datagrid.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid.spec.ts
@@ -31,6 +31,7 @@ import { StateDebouncer } from './providers/state-debouncer.provider';
 import { StateProvider } from './providers/state.provider';
 import { TableSizeService } from './providers/table-size.service';
 import { DatagridRenderOrganizer } from './render/render-organizer';
+import { ColumnOrdersCoordinatorService } from './providers/column-orders-coordinator.service';
 
 @Component({
   template: `
@@ -344,6 +345,7 @@ const PROVIDERS = [
   StateProvider,
   ColumnToggleButtonsService,
   TableSizeService,
+  ColumnOrdersCoordinatorService,
 ];
 
 export default function(): void {

--- a/src/clr-angular/data/datagrid/datagrid.ts
+++ b/src/clr-angular/data/datagrid/datagrid.ts
@@ -28,6 +28,7 @@ import { ClrDatagridRow } from './datagrid-row';
 import { DatagridDisplayMode } from './enums/display-mode.enum';
 import { ClrDatagridStateInterface } from './interfaces/state.interface';
 import { ColumnToggleButtonsService } from './providers/column-toggle-buttons.service';
+import { ColumnOrdersCoordinatorService } from './providers/column-orders-coordinator.service';
 import { DisplayModeService } from './providers/display-mode.service';
 import { FiltersProvider } from './providers/filters';
 import { ExpandableRowsCount } from './providers/global-expandable-rows';
@@ -59,6 +60,7 @@ import { ClrCommonStrings } from '../../utils/i18n/common-strings.interface';
     StateDebouncer,
     StateProvider,
     ColumnToggleButtonsService,
+    ColumnOrdersCoordinatorService,
     TableSizeService,
     DisplayModeService,
   ],

--- a/src/clr-angular/data/datagrid/enums/header-sides.enum.ts
+++ b/src/clr-angular/data/datagrid/enums/header-sides.enum.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+export const enum ColumnHeaderSides {
+  LEFT,
+  RIGHT,
+}

--- a/src/clr-angular/data/datagrid/providers/column-order-model.service.mock.ts
+++ b/src/clr-angular/data/datagrid/providers/column-order-model.service.mock.ts
@@ -5,15 +5,18 @@
  */
 
 import { ColumnOrderModelService } from './column-order-model.service';
+import { DatagridHideableColumnModel } from '../datagrid-hideable-column.model';
 
-export class MockColumnOrderModelService {
+export class MockColumnOrderModelService implements Pick<ColumnOrderModelService, keyof ColumnOrderModelService> {
   public flexOrder: number;
   public columnGroupId: string;
   public headerEl: any;
+  public hideableColumnModel: DatagridHideableColumnModel;
   public nextVisibleColumnModel: any;
   public previousVisibleColumnModel: any;
   public isAtFirst: boolean = false;
   public isAtEnd: boolean = false;
+  public isHidden: boolean;
 
   get headerWidth(): number {
     return this.headerEl.getBoundingClientRect().width;

--- a/src/clr-angular/data/datagrid/providers/column-order-model.service.mock.ts
+++ b/src/clr-angular/data/datagrid/providers/column-order-model.service.mock.ts
@@ -14,6 +14,18 @@ export class MockColumnOrderModelService {
   public previousVisibleColumnModel: any;
   public isAtFirst: boolean = false;
   public isAtEnd: boolean = false;
+
+  get headerWidth(): number {
+    return this.headerEl.getBoundingClientRect().width;
+  }
+
+  get nextVisibleHeaderWidth(): number {
+    return this.nextVisibleColumnModel ? this.nextVisibleColumnModel.headerWidth : 0;
+  }
+
+  get previousVisibleHeaderWidth(): number {
+    return this.previousVisibleColumnModel ? this.previousVisibleColumnModel.headerWidth : 0;
+  }
   public dropReceived(event) {}
 }
 

--- a/src/clr-angular/data/datagrid/providers/column-order-model.service.mock.ts
+++ b/src/clr-angular/data/datagrid/providers/column-order-model.service.mock.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { ColumnOrderModelService } from './column-order-model.service';
+
+export class MockColumnOrderModelService {
+  public flexOrder: number;
+  public columnGroupId: string;
+  public headerEl: any;
+  public nextVisibleColumnModel: any;
+  public previousVisibleColumnModel: any;
+  public isAtFirst: boolean = false;
+  public isAtEnd: boolean = false;
+  public dropReceived(event) {}
+}
+
+export function populateMockProps(
+  mockService: MockColumnOrderModelService,
+  id: string,
+  flexOrder: number,
+  width: number
+) {
+  mockService.columnGroupId = id;
+  mockService.flexOrder = flexOrder;
+  mockService.headerEl = document.createElement('div');
+  document.body.appendChild(mockService.headerEl);
+  mockService.headerEl.style.position = 'absolute';
+  mockService.headerEl.style.width = width + 'px';
+  mockService.headerEl.style.height = '40px';
+}
+
+export const MOCK_COLUMN_ORDER_MODEL_PROVIDER = {
+  provide: ColumnOrderModelService,
+  useClass: MockColumnOrderModelService,
+};

--- a/src/clr-angular/data/datagrid/providers/column-order-model.service.mock.ts
+++ b/src/clr-angular/data/datagrid/providers/column-order-model.service.mock.ts
@@ -17,6 +17,15 @@ export class MockColumnOrderModelService {
   public dropReceived(event) {}
 }
 
+export function mockHeaderEl(width: number, height: number) {
+  const headerEl = document.createElement('div');
+  document.body.appendChild(headerEl);
+  headerEl.style.position = 'absolute';
+  headerEl.style.width = width + 'px';
+  headerEl.style.height = height + 'px';
+  return headerEl;
+}
+
 export function populateMockProps(
   mockService: MockColumnOrderModelService,
   id: string,
@@ -25,11 +34,7 @@ export function populateMockProps(
 ) {
   mockService.columnGroupId = id;
   mockService.flexOrder = flexOrder;
-  mockService.headerEl = document.createElement('div');
-  document.body.appendChild(mockService.headerEl);
-  mockService.headerEl.style.position = 'absolute';
-  mockService.headerEl.style.width = width + 'px';
-  mockService.headerEl.style.height = '40px';
+  mockService.headerEl = mockHeaderEl(width, 40);
 }
 
 export const MOCK_COLUMN_ORDER_MODEL_PROVIDER = {

--- a/src/clr-angular/data/datagrid/providers/column-order-model.service.mock.ts
+++ b/src/clr-angular/data/datagrid/providers/column-order-model.service.mock.ts
@@ -26,16 +26,22 @@ export class MockColumnOrderModelService {
   get previousVisibleHeaderWidth(): number {
     return this.previousVisibleColumnModel ? this.previousVisibleColumnModel.headerWidth : 0;
   }
+
   public dropReceived(event) {}
 }
 
-export function mockHeaderEl(width: number, height: number) {
+export function createMockHeaderEl(width: number, height: number): Node {
   const headerEl = document.createElement('div');
   document.body.appendChild(headerEl);
-  headerEl.style.position = 'absolute';
   headerEl.style.width = width + 'px';
   headerEl.style.height = height + 'px';
   return headerEl;
+}
+
+export function destroyMockHeaderEl(el: Node): void {
+  if (document.body.contains(el)) {
+    document.body.removeChild(el);
+  }
 }
 
 export function populateMockProps(
@@ -46,7 +52,7 @@ export function populateMockProps(
 ) {
   mockService.columnGroupId = id;
   mockService.flexOrder = flexOrder;
-  mockService.headerEl = mockHeaderEl(width, 40);
+  mockService.headerEl = createMockHeaderEl(width, 40);
 }
 
 export const MOCK_COLUMN_ORDER_MODEL_PROVIDER = {

--- a/src/clr-angular/data/datagrid/providers/column-order-model.service.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/column-order-model.service.spec.ts
@@ -8,10 +8,10 @@ import { ColumnOrderModelService } from './column-order-model.service';
 import { ColumnOrdersCoordinatorService } from './column-orders-coordinator.service';
 import { DatagridHideableColumnModel } from '../datagrid-hideable-column.model';
 import { DomAdapter } from '../../../utils/dom-adapter/dom-adapter';
-import { mockHeaderEl } from './column-order-model.service.mock';
+import { createMockHeaderEl, destroyMockHeaderEl } from './column-order-model.service.mock';
 
 export default function(): void {
-  describe('ColumnOrderCoordinatorService', function() {
+  describe('ColumnOrderModelService', function() {
     let columnOrdersCoordinatorService = new ColumnOrdersCoordinatorService();
     let columnOrderModelService: ColumnOrderModelService;
     let columnOrderModelServicePrev: ColumnOrderModelService;
@@ -27,17 +27,23 @@ export default function(): void {
       // Here visually their columns would appear in the following order:
       // columnOrderModelServicePrev, columnOrderModelService, columnOrderModelServiceNext;
       columnOrderModelService.flexOrder = 1;
-      columnOrderModelService.headerEl = mockHeaderEl(200, 40);
+      columnOrderModelService.headerEl = createMockHeaderEl(200, 40);
 
       columnOrderModelServicePrev.flexOrder = 0;
-      columnOrderModelServicePrev.headerEl = mockHeaderEl(400, 40);
+      columnOrderModelServicePrev.headerEl = createMockHeaderEl(400, 40);
 
       columnOrderModelServiceNext.flexOrder = 2;
-      columnOrderModelServiceNext.headerEl = mockHeaderEl(300, 40);
+      columnOrderModelServiceNext.headerEl = createMockHeaderEl(300, 40);
 
       columnOrdersCoordinatorService.orderModels.push(columnOrderModelService);
       columnOrdersCoordinatorService.orderModels.push(columnOrderModelServicePrev);
       columnOrdersCoordinatorService.orderModels.push(columnOrderModelServiceNext);
+    });
+
+    afterEach(function() {
+      destroyMockHeaderEl(columnOrderModelService.headerEl);
+      destroyMockHeaderEl(columnOrderModelServicePrev.headerEl);
+      destroyMockHeaderEl(columnOrderModelServiceNext.headerEl);
     });
 
     it('should have column group id from column order coordinator service', function() {

--- a/src/clr-angular/data/datagrid/providers/column-order-model.service.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/column-order-model.service.spec.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { ColumnOrderModelService } from './column-order-model.service';
+import { ColumnOrdersCoordinatorService } from './column-orders-coordinator.service';
+import { DatagridHideableColumnModel } from '../datagrid-hideable-column.model';
+
+export default function(): void {
+  describe('ColumnOrderCoordinatorService', function() {
+    let columnOrdersCoordinatorService = new ColumnOrdersCoordinatorService();
+    let columnOrderModelService1: ColumnOrderModelService;
+    let columnOrderModelService2: ColumnOrderModelService;
+    let columnOrderModelService3: ColumnOrderModelService;
+
+    beforeEach(function() {
+      columnOrdersCoordinatorService = new ColumnOrdersCoordinatorService();
+
+      columnOrderModelService1 = new ColumnOrderModelService(columnOrdersCoordinatorService);
+      columnOrderModelService2 = new ColumnOrderModelService(columnOrdersCoordinatorService);
+      columnOrderModelService3 = new ColumnOrderModelService(columnOrdersCoordinatorService);
+
+      // Here visually their columns would appear in the following order:
+      // columnOrderModelService2, columnOrderModelService1, columnOrderModelService3;
+      columnOrderModelService1.flexOrder = 1;
+      columnOrderModelService2.flexOrder = 0;
+      columnOrderModelService3.flexOrder = 2;
+
+      columnOrdersCoordinatorService.orderModels.push(columnOrderModelService1);
+      columnOrdersCoordinatorService.orderModels.push(columnOrderModelService2);
+      columnOrdersCoordinatorService.orderModels.push(columnOrderModelService3);
+    });
+
+    it('should have column group id from column order coordinator service', function() {
+      expect(columnOrderModelService1.columnGroupId).toBe(columnOrdersCoordinatorService.columnGroupId);
+      expect(columnOrderModelService2.columnGroupId).toBe(columnOrdersCoordinatorService.columnGroupId);
+      expect(columnOrderModelService3.columnGroupId).toBe(columnOrdersCoordinatorService.columnGroupId);
+    });
+
+    it('returns correct boolean value if column appears at first', function() {
+      expect(columnOrderModelService1.isAtFirst).toBeFalsy();
+      expect(columnOrderModelService2.isAtFirst).toBeTruthy();
+      expect(columnOrderModelService3.isAtFirst).toBeFalsy();
+    });
+
+    it('returns correct boolean value if column appears at end', function() {
+      expect(columnOrderModelService1.isAtEnd).toBeFalsy();
+      expect(columnOrderModelService2.isAtEnd).toBeFalsy();
+      expect(columnOrderModelService3.isAtEnd).toBeTruthy();
+    });
+
+    it('returns correct boolean value if column is hidden', function() {
+      columnOrderModelService1.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', true);
+      columnOrderModelService2.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', false);
+      columnOrderModelService3.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', true);
+      expect(columnOrderModelService1.isHidden).toBeTruthy();
+      expect(columnOrderModelService2.isHidden).toBeFalsy();
+      expect(columnOrderModelService3.isHidden).toBeTruthy();
+    });
+
+    it('returns correct next visible model', function() {
+      // visually the middle one and hidden
+      columnOrderModelService1.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', true);
+
+      // visually the first one
+      columnOrderModelService2.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', false);
+
+      // visually the last one
+      columnOrderModelService3.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', false);
+
+      expect(columnOrderModelService2.nextVisibleColumnModel).toBe(columnOrderModelService3);
+      expect(columnOrderModelService3.nextVisibleColumnModel).toBeUndefined();
+    });
+
+    it('returns undefined if it has no next visible column', function() {
+      columnOrderModelService1.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', true);
+      columnOrderModelService2.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', false);
+      columnOrderModelService3.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', true);
+      expect(columnOrderModelService2.nextVisibleColumnModel).toBeUndefined();
+    });
+
+    it('returns correct previous visible model', function() {
+      columnOrderModelService1.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', true);
+      columnOrderModelService2.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', false);
+      columnOrderModelService3.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', false);
+      expect(columnOrderModelService3.previousVisibleColumnModel).toBe(columnOrderModelService2);
+      expect(columnOrderModelService2.previousVisibleColumnModel).toBeUndefined();
+    });
+
+    it('returns undefined if it has no previous visible column', function() {
+      columnOrderModelService1.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', true);
+      columnOrderModelService2.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', true);
+      columnOrderModelService3.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', false);
+      expect(columnOrderModelService3.previousVisibleColumnModel).toBeUndefined();
+    });
+  });
+}

--- a/src/clr-angular/data/datagrid/providers/column-order-model.service.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/column-order-model.service.spec.ts
@@ -7,93 +7,120 @@
 import { ColumnOrderModelService } from './column-order-model.service';
 import { ColumnOrdersCoordinatorService } from './column-orders-coordinator.service';
 import { DatagridHideableColumnModel } from '../datagrid-hideable-column.model';
+import { DomAdapter } from '../../../utils/dom-adapter/dom-adapter';
+import { mockHeaderEl } from './column-order-model.service.mock';
 
 export default function(): void {
-  describe('ColumnOrderCoordinatorService', function() {
+  fdescribe('ColumnOrderCoordinatorService', function() {
     let columnOrdersCoordinatorService = new ColumnOrdersCoordinatorService();
-    let columnOrderModelService1: ColumnOrderModelService;
-    let columnOrderModelService2: ColumnOrderModelService;
-    let columnOrderModelService3: ColumnOrderModelService;
+    let columnOrderModelService: ColumnOrderModelService;
+    let columnOrderModelServicePrev: ColumnOrderModelService;
+    let columnOrderModelServiceNext: ColumnOrderModelService;
 
     beforeEach(function() {
       columnOrdersCoordinatorService = new ColumnOrdersCoordinatorService();
 
-      columnOrderModelService1 = new ColumnOrderModelService(columnOrdersCoordinatorService);
-      columnOrderModelService2 = new ColumnOrderModelService(columnOrdersCoordinatorService);
-      columnOrderModelService3 = new ColumnOrderModelService(columnOrdersCoordinatorService);
+      columnOrderModelService = new ColumnOrderModelService(columnOrdersCoordinatorService, new DomAdapter());
+      columnOrderModelServicePrev = new ColumnOrderModelService(columnOrdersCoordinatorService, new DomAdapter());
+      columnOrderModelServiceNext = new ColumnOrderModelService(columnOrdersCoordinatorService, new DomAdapter());
 
       // Here visually their columns would appear in the following order:
-      // columnOrderModelService2, columnOrderModelService1, columnOrderModelService3;
-      columnOrderModelService1.flexOrder = 1;
-      columnOrderModelService2.flexOrder = 0;
-      columnOrderModelService3.flexOrder = 2;
+      // columnOrderModelServicePrev, columnOrderModelService, columnOrderModelServiceNext;
+      columnOrderModelService.flexOrder = 1;
+      columnOrderModelService.headerEl = mockHeaderEl(200, 40);
 
-      columnOrdersCoordinatorService.orderModels.push(columnOrderModelService1);
-      columnOrdersCoordinatorService.orderModels.push(columnOrderModelService2);
-      columnOrdersCoordinatorService.orderModels.push(columnOrderModelService3);
+      columnOrderModelServicePrev.flexOrder = 0;
+      columnOrderModelServicePrev.headerEl = mockHeaderEl(400, 40);
+
+      columnOrderModelServiceNext.flexOrder = 2;
+      columnOrderModelServiceNext.headerEl = mockHeaderEl(300, 40);
+
+      columnOrdersCoordinatorService.orderModels.push(columnOrderModelService);
+      columnOrdersCoordinatorService.orderModels.push(columnOrderModelServicePrev);
+      columnOrdersCoordinatorService.orderModels.push(columnOrderModelServiceNext);
     });
 
     it('should have column group id from column order coordinator service', function() {
-      expect(columnOrderModelService1.columnGroupId).toBe(columnOrdersCoordinatorService.columnGroupId);
-      expect(columnOrderModelService2.columnGroupId).toBe(columnOrdersCoordinatorService.columnGroupId);
-      expect(columnOrderModelService3.columnGroupId).toBe(columnOrdersCoordinatorService.columnGroupId);
+      expect(columnOrderModelService.columnGroupId).toBe(columnOrdersCoordinatorService.columnGroupId);
+      expect(columnOrderModelServicePrev.columnGroupId).toBe(columnOrdersCoordinatorService.columnGroupId);
+      expect(columnOrderModelServiceNext.columnGroupId).toBe(columnOrdersCoordinatorService.columnGroupId);
     });
 
     it('returns correct boolean value if column appears at first', function() {
-      expect(columnOrderModelService1.isAtFirst).toBeFalsy();
-      expect(columnOrderModelService2.isAtFirst).toBeTruthy();
-      expect(columnOrderModelService3.isAtFirst).toBeFalsy();
+      expect(columnOrderModelService.isAtFirst).toBeFalsy();
+      expect(columnOrderModelServicePrev.isAtFirst).toBeTruthy();
+      expect(columnOrderModelServiceNext.isAtFirst).toBeFalsy();
     });
 
     it('returns correct boolean value if column appears at end', function() {
-      expect(columnOrderModelService1.isAtEnd).toBeFalsy();
-      expect(columnOrderModelService2.isAtEnd).toBeFalsy();
-      expect(columnOrderModelService3.isAtEnd).toBeTruthy();
+      expect(columnOrderModelService.isAtEnd).toBeFalsy();
+      expect(columnOrderModelServicePrev.isAtEnd).toBeFalsy();
+      expect(columnOrderModelServiceNext.isAtEnd).toBeTruthy();
+    });
+
+    it('returns width of its own column', function() {
+      expect(columnOrderModelService.headerWidth).toBe(200);
+    });
+
+    it('returns width of previous column', function() {
+      expect(columnOrderModelService.previousVisibleHeaderWidth).toBe(400);
+    });
+
+    it('returns width of next column', function() {
+      expect(columnOrderModelService.nextVisibleHeaderWidth).toBe(300);
+    });
+
+    it('returns 0 for the previousVisibleHeaderWidth of the very first visible column', function() {
+      expect(columnOrderModelServicePrev.previousVisibleHeaderWidth).toBe(0);
+    });
+
+    it('returns 0 for the nextVisibleHeaderWidth of the very last visible column', function() {
+      expect(columnOrderModelServiceNext.nextVisibleHeaderWidth).toBe(0);
     });
 
     it('returns correct boolean value if column is hidden', function() {
-      columnOrderModelService1.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', true);
-      columnOrderModelService2.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', false);
-      columnOrderModelService3.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', true);
-      expect(columnOrderModelService1.isHidden).toBeTruthy();
-      expect(columnOrderModelService2.isHidden).toBeFalsy();
-      expect(columnOrderModelService3.isHidden).toBeTruthy();
+      columnOrderModelService.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', true);
+      columnOrderModelServicePrev.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', false);
+      columnOrderModelServiceNext.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', true);
+      expect(columnOrderModelService.isHidden).toBeTruthy();
+      expect(columnOrderModelServicePrev.isHidden).toBeFalsy();
+      expect(columnOrderModelServiceNext.isHidden).toBeTruthy();
     });
 
     it('returns correct next visible model', function() {
       // visually the middle one and hidden
-      columnOrderModelService1.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', true);
+      columnOrderModelService.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', true);
 
       // visually the first one
-      columnOrderModelService2.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', false);
+      columnOrderModelServicePrev.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', false);
 
       // visually the last one
-      columnOrderModelService3.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', false);
+      columnOrderModelServiceNext.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', false);
 
-      expect(columnOrderModelService2.nextVisibleColumnModel).toBe(columnOrderModelService3);
-      expect(columnOrderModelService3.nextVisibleColumnModel).toBeUndefined();
+      expect(columnOrderModelServicePrev.nextVisibleColumnModel).toBe(columnOrderModelServiceNext);
+      expect(columnOrderModelServiceNext.nextVisibleColumnModel).toBeUndefined();
     });
 
     it('returns undefined if it has no next visible column', function() {
-      columnOrderModelService1.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', true);
-      columnOrderModelService2.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', false);
-      columnOrderModelService3.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', true);
-      expect(columnOrderModelService2.nextVisibleColumnModel).toBeUndefined();
+      columnOrderModelService.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', true);
+      columnOrderModelServicePrev.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', false);
+      columnOrderModelServiceNext.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', true);
+      expect(columnOrderModelServicePrev.nextVisibleColumnModel).toBeUndefined();
     });
 
     it('returns correct previous visible model', function() {
-      columnOrderModelService1.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', true);
-      columnOrderModelService2.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', false);
-      columnOrderModelService3.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', false);
-      expect(columnOrderModelService3.previousVisibleColumnModel).toBe(columnOrderModelService2);
-      expect(columnOrderModelService2.previousVisibleColumnModel).toBeUndefined();
+      columnOrderModelService.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', true);
+      columnOrderModelServicePrev.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', false);
+      columnOrderModelServiceNext.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', false);
+      expect(columnOrderModelServiceNext.previousVisibleColumnModel).toBe(columnOrderModelServicePrev);
+      expect(columnOrderModelServicePrev.previousVisibleColumnModel).toBeUndefined();
     });
 
     it('returns undefined if it has no previous visible column', function() {
-      columnOrderModelService1.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', true);
-      columnOrderModelService2.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', true);
-      columnOrderModelService3.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', false);
-      expect(columnOrderModelService3.previousVisibleColumnModel).toBeUndefined();
+      columnOrderModelService.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', true);
+      columnOrderModelServicePrev.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', true);
+      columnOrderModelServiceNext.hideableColumnModel = new DatagridHideableColumnModel(null, 'dg-col-0', false);
+      expect(columnOrderModelServiceNext.previousVisibleColumnModel).toBeUndefined();
     });
   });
 }

--- a/src/clr-angular/data/datagrid/providers/column-order-model.service.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/column-order-model.service.spec.ts
@@ -11,7 +11,7 @@ import { DomAdapter } from '../../../utils/dom-adapter/dom-adapter';
 import { mockHeaderEl } from './column-order-model.service.mock';
 
 export default function(): void {
-  fdescribe('ColumnOrderCoordinatorService', function() {
+  describe('ColumnOrderCoordinatorService', function() {
     let columnOrdersCoordinatorService = new ColumnOrdersCoordinatorService();
     let columnOrderModelService: ColumnOrderModelService;
     let columnOrderModelServicePrev: ColumnOrderModelService;

--- a/src/clr-angular/data/datagrid/providers/column-order-model.service.ts
+++ b/src/clr-angular/data/datagrid/providers/column-order-model.service.ts
@@ -9,9 +9,9 @@ import { DatagridHideableColumnModel } from '../datagrid-hideable-column.model';
 
 /**
  * This is a model service that's responsible for:
- * 1. Accessing and providing common id for its reorder draggable and droppables
- * 2. Sharing the flex order data between datagrid-column and reorderabble-droppable
- * 3. Updating the flex order data and tells ColumnOrderCoordinatorService when it should broadcast
+ * 1. Sharing the flex order data between datagrid-column and reorderabble-droppable
+ * 2. Updating the flex order data and tells ColumnOrderCoordinatorService when it should broadcast
+ * 3. Returning models at the previous and next flex orders
  */
 
 @Injectable()

--- a/src/clr-angular/data/datagrid/providers/column-order-model.service.ts
+++ b/src/clr-angular/data/datagrid/providers/column-order-model.service.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import { Injectable } from '@angular/core';
+import { ColumnOrdersCoordinatorService } from './column-orders-coordinator.service';
+import { DatagridHideableColumnModel } from '../datagrid-hideable-column.model';
+
+/**
+ * This is a model service that's responsible for:
+ * 1. Accessing and providing common id for its reorder draggable and droppables
+ * 2. Sharing the flex order data between datagrid-column and reorderabble-droppable
+ * 3. Updating the flex order data and tells ColumnOrderCoordinatorService when it should broadcast
+ */
+
+@Injectable()
+export class ColumnOrderModelService {
+  constructor(private columnOrderCoordinatorService: ColumnOrdersCoordinatorService) {}
+
+  public flexOrder: number;
+
+  public headerEl: any;
+
+  public hideableColumnModel: DatagridHideableColumnModel;
+
+  public get columnGroupId() {
+    return this.columnOrderCoordinatorService.columnGroupId;
+  }
+
+  get isAtFirst(): boolean {
+    return this.flexOrder === 0;
+  }
+
+  get isAtEnd(): boolean {
+    return this.flexOrder === this.columnOrderCoordinatorService.orderModels.length - 1;
+  }
+
+  get isHidden(): boolean {
+    return this.hideableColumnModel && this.hideableColumnModel.hidden;
+  }
+
+  dropReceived(dropData: any) {
+    // updates column orders
+    // broadcasts updated order changes
+    console.log(dropData);
+  }
+
+  get nextVisibleColumnModel(): ColumnOrderModelService {
+    // collect all columns that appears after this column
+    // that means collect all models with greater flex order value
+    const nextVisibleColumnModels = this.columnOrderCoordinatorService.orderModels.filter(
+      model => model.flexOrder > this.flexOrder && !model.isHidden
+    );
+
+    // current column could be the one that visually appears at the end;
+    if (nextVisibleColumnModels.length === 0) {
+      return;
+    }
+
+    // to find the next immediate visible columns model
+    // find the model with the smallest flexorder value from nextVisibleColumnModels
+    return nextVisibleColumnModels.reduce((smallestFlexOrderModel, currentModel) => {
+      if (smallestFlexOrderModel.flexOrder > currentModel.flexOrder) {
+        return currentModel;
+      }
+      return smallestFlexOrderModel;
+    });
+  }
+
+  get previousVisibleColumnModel(): ColumnOrderModelService {
+    // collect all columns that appears before this column
+    // that means collect all models with smaller flex order value
+    const previousVisibleColumnModels = this.columnOrderCoordinatorService.orderModels.filter(
+      model => model.flexOrder < this.flexOrder && !model.isHidden
+    );
+
+    // current column could be the one that visually appears at the first;
+    if (previousVisibleColumnModels.length === 0) {
+      return;
+    }
+
+    // to find the previous immediate visible columns model
+    // find the model with the largest flexorder value from previousVisibleColumnModels
+    return previousVisibleColumnModels.reduce((largestFlexOrderModel, currentModel) => {
+      if (largestFlexOrderModel.flexOrder < currentModel.flexOrder) {
+        return currentModel;
+      }
+      return largestFlexOrderModel;
+    });
+  }
+
+  // TODO: This service will be expanded in the next PR
+}

--- a/src/clr-angular/data/datagrid/providers/column-order-model.service.ts
+++ b/src/clr-angular/data/datagrid/providers/column-order-model.service.ts
@@ -6,6 +6,7 @@
 import { Injectable } from '@angular/core';
 import { ColumnOrdersCoordinatorService } from './column-orders-coordinator.service';
 import { DatagridHideableColumnModel } from '../datagrid-hideable-column.model';
+import { DomAdapter } from '../../../utils/dom-adapter/dom-adapter';
 
 /**
  * This is a model service that's responsible for:
@@ -16,7 +17,7 @@ import { DatagridHideableColumnModel } from '../datagrid-hideable-column.model';
 
 @Injectable()
 export class ColumnOrderModelService {
-  constructor(private columnOrderCoordinatorService: ColumnOrdersCoordinatorService) {}
+  constructor(private columnOrderCoordinatorService: ColumnOrdersCoordinatorService, private domAdapter: DomAdapter) {}
 
   public flexOrder: number;
 
@@ -24,7 +25,7 @@ export class ColumnOrderModelService {
 
   public hideableColumnModel: DatagridHideableColumnModel;
 
-  public get columnGroupId() {
+  get columnGroupId() {
     return this.columnOrderCoordinatorService.columnGroupId;
   }
 
@@ -40,7 +41,7 @@ export class ColumnOrderModelService {
     return this.hideableColumnModel && this.hideableColumnModel.hidden;
   }
 
-  dropReceived(dropData: any) {
+  public dropReceived(dropData: any) {
     // updates column orders
     // broadcasts updated order changes
     console.log(dropData);
@@ -88,6 +89,18 @@ export class ColumnOrderModelService {
       }
       return largestFlexOrderModel;
     });
+  }
+
+  get headerWidth(): number {
+    return this.headerEl ? this.domAdapter.clientRect(this.headerEl).width : 0;
+  }
+
+  get nextVisibleHeaderWidth(): number {
+    return this.nextVisibleColumnModel ? this.nextVisibleColumnModel.headerWidth : 0;
+  }
+
+  get previousVisibleHeaderWidth(): number {
+    return this.previousVisibleColumnModel ? this.previousVisibleColumnModel.headerWidth : 0;
   }
 
   // TODO: This service will be expanded in the next PR

--- a/src/clr-angular/data/datagrid/providers/column-order-model.service.ts
+++ b/src/clr-angular/data/datagrid/providers/column-order-model.service.ts
@@ -49,7 +49,7 @@ export class ColumnOrderModelService {
 
   private findAdjacentVisibleModel(prev = false): ColumnOrderModelService {
     const filteredVisibleColumnModels = this.columnOrderCoordinatorService.orderModels
-      .filter(model => (!model.isHidden && prev ? model.flexOrder < this.flexOrder : model.flexOrder > this.flexOrder))
+      .filter(model => !model.isHidden && (prev ? model.flexOrder < this.flexOrder : model.flexOrder > this.flexOrder))
       .sort(model => model.flexOrder);
 
     return prev ? filteredVisibleColumnModels[filteredVisibleColumnModels.length - 1] : filteredVisibleColumnModels[0];

--- a/src/clr-angular/data/datagrid/providers/column-order-model.service.ts
+++ b/src/clr-angular/data/datagrid/providers/column-order-model.service.ts
@@ -47,40 +47,20 @@ export class ColumnOrderModelService {
     console.log(dropData);
   }
 
-  private findVisibleColumnModelHasMet(
-    filterCondition: (_model: ColumnOrderModelService) => boolean,
-    reduceCondition: (_reducedModel: ColumnOrderModelService, _currentModel: ColumnOrderModelService) => boolean
-  ): ColumnOrderModelService {
-    const filteredVisibleColumnModels = this.columnOrderCoordinatorService.orderModels.filter(
-      model => !model.isHidden && filterCondition(model)
-    );
+  private findAdjacentVisibleModel(prev = false): ColumnOrderModelService {
+    const filteredVisibleColumnModels = this.columnOrderCoordinatorService.orderModels
+      .filter(model => (!model.isHidden && prev ? model.flexOrder < this.flexOrder : model.flexOrder > this.flexOrder))
+      .sort(model => model.flexOrder);
 
-    if (filteredVisibleColumnModels.length === 0) {
-      return;
-    }
-
-    return filteredVisibleColumnModels.reduce((reducedModel, currentModel) => {
-      if (reduceCondition(reducedModel, currentModel)) {
-        return currentModel;
-      }
-      return reducedModel;
-    });
+    return prev ? filteredVisibleColumnModels[filteredVisibleColumnModels.length - 1] : filteredVisibleColumnModels[0];
   }
 
   get nextVisibleColumnModel(): ColumnOrderModelService {
-    return this.findVisibleColumnModelHasMet(
-      (model: ColumnOrderModelService) => model.flexOrder > this.flexOrder,
-      (smallestFlexOrderModel: ColumnOrderModelService, currentModel: ColumnOrderModelService) =>
-        smallestFlexOrderModel.flexOrder > currentModel.flexOrder
-    );
+    return this.findAdjacentVisibleModel(false);
   }
 
   get previousVisibleColumnModel(): ColumnOrderModelService {
-    return this.findVisibleColumnModelHasMet(
-      (model: ColumnOrderModelService) => model.flexOrder < this.flexOrder,
-      (largestFlexOrderModel: ColumnOrderModelService, currentModel: ColumnOrderModelService) =>
-        largestFlexOrderModel.flexOrder < currentModel.flexOrder
-    );
+    return this.findAdjacentVisibleModel(true);
   }
 
   private _headerWidth: number;

--- a/src/clr-angular/data/datagrid/providers/column-orders-coordinator.service.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/column-orders-coordinator.service.spec.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { ColumnOrdersCoordinatorService } from './column-orders-coordinator.service';
+
+export default function(): void {
+  describe('ColumnOrdersCoordinatorService', function() {
+    let service: ColumnOrdersCoordinatorService;
+
+    beforeEach(function() {
+      service = new ColumnOrdersCoordinatorService();
+    });
+
+    it('should have unique group id for columns', function() {
+      expect(service.columnGroupId).not.toBeUndefined();
+    });
+  });
+}

--- a/src/clr-angular/data/datagrid/providers/column-orders-coordinator.service.ts
+++ b/src/clr-angular/data/datagrid/providers/column-orders-coordinator.service.ts
@@ -10,9 +10,8 @@ let nbColumnGroup = 0;
 
 /**
  * This service is responsible for:
- * 1. Providing the common group id for all headers' draggables and droppables
- * 2. Sharing order model data across headers and cells
- * 3. Broadcasting order model update
+ * 1. Sharing order model data across headers and cells
+ * 2. Broadcasting order model update
  */
 
 @Injectable()

--- a/src/clr-angular/data/datagrid/providers/column-orders-coordinator.service.ts
+++ b/src/clr-angular/data/datagrid/providers/column-orders-coordinator.service.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import { Injectable } from '@angular/core';
+import { ColumnOrderModelService } from './column-order-model.service';
+
+let nbColumnGroup = 0;
+
+/**
+ * This service is responsible for:
+ * 1. Providing the common group id for all headers' draggables and droppables
+ * 2. Sharing order model data across headers and cells
+ * 3. Broadcasting order model update
+ */
+
+@Injectable()
+export class ColumnOrdersCoordinatorService {
+  // Here, the order of the items inside the array below should
+  // match the order of the QueryList of headers.
+  public orderModels: ColumnOrderModelService[] = [];
+
+  // the common group id that will be shared across Datagrids all reorder draggable and droppables
+  private _columnGroupId: string;
+
+  get columnGroupId() {
+    return this._columnGroupId;
+  }
+
+  constructor() {
+    this._columnGroupId = 'dg-column-group-' + nbColumnGroup++;
+  }
+
+  // TODO: This service will be expanded in the next PR
+}

--- a/src/clr-angular/data/datagrid/providers/column-resizer.service.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/column-resizer.service.spec.ts
@@ -16,7 +16,7 @@ import { ColumnResizerService } from './column-resizer.service';
 @Component({
   providers: [ColumnResizerService, DomAdapter, DatagridRenderOrganizer], // Should be declared here in a component level, not in the TestBed because Renderer2 wouldn't be present
   template: `<div></div>`,
-  styles: [':host { position: position; width: 200px; height: 400px;}'],
+  styles: [':host { position: absolute; width: 200px; height: 400px;}'],
 })
 class TestComponent {
   constructor(el: ElementRef, renderer: Renderer2, domAdapter: DomAdapter, organizer: DatagridRenderOrganizer) {}

--- a/src/clr-angular/data/datagrid/providers/table-size.service.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/table-size.service.spec.ts
@@ -16,6 +16,7 @@ import { Sort } from './sort';
 import { StateDebouncer } from './state-debouncer.provider';
 import { TableSizeService } from './table-size.service';
 import { ClrDatagridModule } from '../datagrid.module';
+import { ColumnOrdersCoordinatorService } from './column-orders-coordinator.service';
 
 @Component({
   template: `
@@ -40,7 +41,15 @@ interface TestContext {
   table: HTMLElement;
 }
 
-const PROVIDERS_NEEDED = [Sort, FiltersProvider, DatagridRenderOrganizer, DomAdapter, Page, StateDebouncer];
+const PROVIDERS_NEEDED = [
+  Sort,
+  FiltersProvider,
+  DatagridRenderOrganizer,
+  DomAdapter,
+  Page,
+  StateDebouncer,
+  ColumnOrdersCoordinatorService,
+];
 
 export default function(): void {
   describe('TableSizeService', function() {

--- a/src/clr-angular/data/datagrid/render/header-renderer.spec.ts
+++ b/src/clr-angular/data/datagrid/render/header-renderer.spec.ts
@@ -24,6 +24,7 @@ import { STRICT_WIDTH_CLASS } from './constants';
 import { DatagridHeaderRenderer } from './header-renderer';
 import { DatagridRenderOrganizer } from './render-organizer';
 import { MOCK_ORGANIZER_PROVIDER, MockDatagridRenderOrganizer } from './render-organizer.mock';
+import { ColumnOrdersCoordinatorService } from '../providers/column-orders-coordinator.service';
 
 @Component({ template: `<clr-dg-column>Hello world</clr-dg-column>` })
 class SimpleTest {}
@@ -71,6 +72,7 @@ export default function(): void {
         StateDebouncer,
         TableSizeService,
         Renderer2,
+        ColumnOrdersCoordinatorService,
       ]);
       domAdapter = <MockDomAdapter>context.getClarityProvider(DomAdapter);
       organizer = <MockDatagridRenderOrganizer>context.getClarityProvider(DatagridRenderOrganizer);

--- a/src/clr-angular/data/datagrid/render/header-renderer.ts
+++ b/src/clr-angular/data/datagrid/render/header-renderer.ts
@@ -11,6 +11,7 @@ import { DatagridRenderStep } from '../enums/render-step.enum';
 import { ColumnResizerService } from '../providers/column-resizer.service';
 import { STRICT_WIDTH_CLASS } from './constants';
 import { DatagridRenderOrganizer } from './render-organizer';
+import { ColumnOrderModelService } from '../providers/column-order-model.service';
 
 @Directive({ selector: 'clr-dg-column', providers: [ColumnResizerService] })
 export class DatagridHeaderRenderer implements OnDestroy {
@@ -19,7 +20,8 @@ export class DatagridHeaderRenderer implements OnDestroy {
     private renderer: Renderer2,
     private organizer: DatagridRenderOrganizer,
     private domAdapter: DomAdapter,
-    private columnResizerService: ColumnResizerService
+    private columnResizerService: ColumnResizerService,
+    private columnOrderModel: ColumnOrderModelService
   ) {
     this.subscriptions.push(
       this.organizer.filterRenderSteps(DatagridRenderStep.CLEAR_WIDTHS).subscribe(() => this.clearWidth())
@@ -29,6 +31,8 @@ export class DatagridHeaderRenderer implements OnDestroy {
         .filterRenderSteps(DatagridRenderStep.DETECT_STRICT_WIDTHS)
         .subscribe(() => this.detectStrictWidth())
     );
+
+    columnOrderModel.headerEl = el.nativeElement;
   }
 
   @Output('clrDgColumnResize') resizeEmitter: EventEmitter<number> = new EventEmitter();
@@ -81,5 +85,13 @@ export class DatagridHeaderRenderer implements OnDestroy {
     this.renderer.removeClass(this.el.nativeElement, STRICT_WIDTH_CLASS);
     this.renderer.setStyle(this.el.nativeElement, 'width', width + 'px');
     this.widthSet = true;
+  }
+
+  public get orderModel() {
+    return this.columnOrderModel;
+  }
+
+  public setFlexOrder(flexOrder: number) {
+    this.columnOrderModel.flexOrder = flexOrder;
   }
 }

--- a/src/clr-angular/data/datagrid/render/header-renderer.ts
+++ b/src/clr-angular/data/datagrid/render/header-renderer.ts
@@ -31,8 +31,7 @@ export class DatagridHeaderRenderer implements OnDestroy {
         .filterRenderSteps(DatagridRenderStep.DETECT_STRICT_WIDTHS)
         .subscribe(() => this.detectStrictWidth())
     );
-
-    columnOrderModel.headerEl = el.nativeElement;
+    this.columnOrderModel.headerEl = el.nativeElement;
   }
 
   @Output('clrDgColumnResize') resizeEmitter: EventEmitter<number> = new EventEmitter();
@@ -53,6 +52,8 @@ export class DatagridHeaderRenderer implements OnDestroy {
     if (this.widthSet && !this.columnResizerService.resizedBy) {
       this.renderer.setStyle(this.el.nativeElement, 'width', null);
     }
+
+    this.columnOrderModel.headerWidth = 0;
   }
 
   private detectStrictWidth() {
@@ -80,10 +81,15 @@ export class DatagridHeaderRenderer implements OnDestroy {
       }
       // Don't set width if there is a user-defined one. Just add the strict width class.
       this.renderer.addClass(this.el.nativeElement, STRICT_WIDTH_CLASS);
+
+      // Here, the actual should be equal to the strictWidth.
+      this.columnOrderModel.headerWidth = width;
+
       return;
     }
     this.renderer.removeClass(this.el.nativeElement, STRICT_WIDTH_CLASS);
     this.renderer.setStyle(this.el.nativeElement, 'width', width + 'px');
+
     this.widthSet = true;
   }
 

--- a/src/clr-angular/data/datagrid/render/main-renderer.ts
+++ b/src/clr-angular/data/datagrid/render/main-renderer.ts
@@ -202,7 +202,7 @@ export class DatagridMainRenderer<T = any> implements AfterContentInit, AfterVie
     });
 
     // set orders array with headers ColumnOrder
-    this.columnOrderCoordinatorService.orderModels = this.headers.map((header, index) => {
+    this.columnOrderCoordinatorService.orderModels = this.headers.map(header => {
       return header.orderModel;
     });
   }

--- a/src/clr-angular/data/datagrid/render/main-renderer.ts
+++ b/src/clr-angular/data/datagrid/render/main-renderer.ts
@@ -28,6 +28,7 @@ import { DomAdapter } from '../../../utils/dom-adapter/dom-adapter';
 import { DatagridHeaderRenderer } from './header-renderer';
 import { NoopDomAdapter } from './noop-dom-adapter';
 import { DatagridRenderOrganizer } from './render-organizer';
+import { ColumnOrdersCoordinatorService } from '../providers/column-orders-coordinator.service';
 
 // Fixes build error
 // @dynamic (https://github.com/angular/angular/issues/19698#issuecomment-338340211)
@@ -53,7 +54,8 @@ export class DatagridMainRenderer<T = any> implements AfterContentInit, AfterVie
     private domAdapter: DomAdapter,
     private el: ElementRef,
     private renderer: Renderer2,
-    private tableSizeService: TableSizeService
+    private tableSizeService: TableSizeService,
+    private columnOrderCoordinatorService: ColumnOrdersCoordinatorService
   ) {
     this.subscriptions.push(
       this.organizer
@@ -82,6 +84,9 @@ export class DatagridMainRenderer<T = any> implements AfterContentInit, AfterVie
         this.stabilizeColumns();
       })
     );
+
+    // set initial order of the header
+    this.setHeaderOrders();
   }
 
   // Initialize and set Table width for horizontal scrolling here.
@@ -188,5 +193,17 @@ export class DatagridMainRenderer<T = any> implements AfterContentInit, AfterVie
       this.organizer.resize();
       this.columnsSizesStable = true;
     }
+  }
+
+  private setHeaderOrders(): void {
+    this.headers.forEach((header, index) => {
+      // set initial flex order
+      header.setFlexOrder(index);
+    });
+
+    // set orders array with headers ColumnOrder
+    this.columnOrderCoordinatorService.orderModels = this.headers.map((header, index) => {
+      return header.orderModel;
+    });
   }
 }

--- a/src/clr-angular/utils/drag-and-drop/droppable/droppable.ts
+++ b/src/clr-angular/utils/drag-and-drop/droppable/droppable.ts
@@ -34,7 +34,12 @@ export class ClrDroppable<T> implements OnInit, OnDestroy {
     this.droppableEl = this.el.nativeElement;
   }
 
-  private isDraggableMatch: boolean = false;
+  private _isDraggableMatch: boolean = false;
+
+  get isDraggableMatch(): boolean {
+    return this._isDraggableMatch;
+  }
+
   private _isDraggableOver: boolean = false;
 
   set isDraggableOver(value: boolean) {
@@ -154,10 +159,10 @@ export class ClrDroppable<T> implements OnInit, OnDestroy {
 
   private onDragStart(dragStartEvent: DragEventInterface<T>): void {
     // Check draggable and droppable have a matching group key.
-    this.isDraggableMatch = this.checkGroupMatch(dragStartEvent.group);
+    this._isDraggableMatch = this.checkGroupMatch(dragStartEvent.group);
 
     // Subscribe to dragMoved and dragEnded only if draggable and droppable have a matching group key.
-    if (this.isDraggableMatch) {
+    if (this._isDraggableMatch) {
       this.dragStartEmitter.emit(new ClrDragEvent(dragStartEvent));
       this.dragMoveSubscription = this.eventBus.dragMoved.subscribe((dragMoveEvent: DragEventInterface<T>) => {
         this.onDragMove(dragMoveEvent);
@@ -206,7 +211,7 @@ export class ClrDroppable<T> implements OnInit, OnDestroy {
     this.dragEndEmitter.emit(new ClrDragEvent(dragEndEvent));
     this.unsubscribeFrom(this.dragMoveSubscription);
     this.unsubscribeFrom(this.dragEndSubscription);
-    this.isDraggableMatch = false;
+    this._isDraggableMatch = false;
     delete this.clientRect;
   }
 


### PR DESCRIPTION
This PR solves a problem of activating a correct reorder droppable with a proper amount of drop tolerance. In this current implementation, every column header has two `clr-dg-column-reorder-droppable`s on its right and left sides. 

**This PR contains:**
- Partial implementation of two major services: `ColumnOrdersCoordinatorService` and `ColumnOrderModelService`
- Implementation of `ClrDatagridColumnReorderDroppable`

**The next PR will contain:**
- the business logic of dropping and swapping headers
- the animation of columns changing their positions.

Preview: http://gimme-drop-area.surge.sh/datagrids

Signed-off-by: stsogoo <stsogoo@vmware.com>