### PR TITLE
Fix sitemap to prevent 404 errors on website

### DIFF
--- a/src/website/src/sitemap.xml
+++ b/src/website/src/sitemap.xml
@@ -209,15 +209,19 @@
         <changefreq>daily</changefreq>
     </url>
     <url>
+      <loc>https://clarity.design/documentation/password</loc>
+      <changefreq>daily</changefreq>
+    </url>
+    <url>
         <loc>https://clarity.design/documentation/progress</loc>
         <changefreq>daily</changefreq>
     </url>
     <url>
-        <loc>https://clarity.design/documentation/radios</loc>
+        <loc>https://clarity.design/documentation/radio</loc>
         <changefreq>daily</changefreq>
     </url>
     <url>
-        <loc>https://clarity.design/documentation/select-boxes</loc>
+        <loc>https://clarity.design/documentation/select</loc>
         <changefreq>daily</changefreq>
     </url>
     <url>


### PR DESCRIPTION
Missing/wrong URLs lead to 404 on browser refresh or direct link

Signed-off-by: Ivan Donchev <idonchev@vmware.com>