### PR TITLE
adding a column service to datagrid to track widths

### DIFF
--- a/src/clr-angular/data/datagrid/datagrid-column-separator.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-separator.ts
@@ -61,6 +61,7 @@ export class ClrDatagridColumnSeparator {
 
   private redFlagTracker(resizeTrackerEl: HTMLElement) {
     let isWithinMaxResizeRange: boolean;
+    // @TODO(JEREMY) Review this, it will always be true because above is always null
     if (isWithinMaxResizeRange !== this.columnResizerService.isWithinMaxResizeRange) {
       isWithinMaxResizeRange = this.columnResizerService.isWithinMaxResizeRange;
       if (!isWithinMaxResizeRange) {

--- a/src/clr-angular/data/datagrid/datagrid-footer.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-footer.spec.ts
@@ -12,10 +12,11 @@ import { FiltersProvider } from './providers/filters';
 import { HideableColumnService } from './providers/hideable-column.service';
 import { Items } from './providers/items';
 import { Page } from './providers/page';
-import { Selection, SelectionType } from './providers/selection';
+import { Selection } from './providers/selection';
 import { Sort } from './providers/sort';
 import { StateDebouncer } from './providers/state-debouncer.provider';
 import { TableSizeService } from './providers/table-size.service';
+import { SelectionType } from './enums/selection-type';
 
 const PROVIDERS_NEEDED = [
   Selection,

--- a/src/clr-angular/data/datagrid/datagrid-footer.ts
+++ b/src/clr-angular/data/datagrid/datagrid-footer.ts
@@ -8,7 +8,8 @@ import { Subscription } from 'rxjs';
 
 import { ClrDatagridColumnToggle } from './datagrid-column-toggle';
 import { HideableColumnService } from './providers/hideable-column.service';
-import { Selection, SelectionType } from './providers/selection';
+import { Selection } from './providers/selection';
+import { SelectionType } from './enums/selection-type';
 
 @Component({
   selector: 'clr-dg-footer',

--- a/src/clr-angular/data/datagrid/datagrid-row-detail.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-row-detail.spec.ts
@@ -9,36 +9,19 @@ import { Expand } from '../../utils/expand/providers/expand';
 
 import { DatagridHideableColumnModel } from './datagrid-hideable-column.model';
 import { ClrDatagridRowDetail } from './datagrid-row-detail';
-import { TestContext } from './helpers.spec';
-import { FiltersProvider } from './providers/filters';
+import { DATAGRID_SPEC_PROVIDERS, TestContext } from './helpers.spec';
 import { ExpandableRowsCount } from './providers/global-expandable-rows';
 import { HideableColumnService } from './providers/hideable-column.service';
-import { Items } from './providers/items';
-import { Page } from './providers/page';
 import { RowActionService } from './providers/row-action-service';
-import { Selection, SelectionType } from './providers/selection';
-import { Sort } from './providers/sort';
-import { StateDebouncer } from './providers/state-debouncer.provider';
-import { DatagridRenderOrganizer } from './render/render-organizer';
+import { Selection } from './providers/selection';
+import { SelectionType } from './enums/selection-type';
 
 export default function(): void {
   describe('ClrDatagridRowDetail component', function() {
     let context: TestContext<ClrDatagridRowDetail<void>, FullTest>;
 
     beforeEach(function() {
-      context = this.create(ClrDatagridRowDetail, FullTest, [
-        Selection,
-        Items,
-        FiltersProvider,
-        Sort,
-        Page,
-        RowActionService,
-        Expand,
-        DatagridRenderOrganizer,
-        HideableColumnService,
-        StateDebouncer,
-        ExpandableRowsCount,
-      ]);
+      context = this.create(ClrDatagridRowDetail, FullTest, DATAGRID_SPEC_PROVIDERS);
     });
 
     it('projects content', function() {
@@ -108,19 +91,7 @@ export default function(): void {
     let hideableColumnService: HideableColumnService;
 
     beforeEach(function() {
-      context = this.create(ClrDatagridRowDetail, HiddenTest, [
-        Selection,
-        Items,
-        FiltersProvider,
-        Sort,
-        Page,
-        RowActionService,
-        Expand,
-        DatagridRenderOrganizer,
-        HideableColumnService,
-        StateDebouncer,
-        ExpandableRowsCount,
-      ]);
+      context = this.create(ClrDatagridRowDetail, HiddenTest, DATAGRID_SPEC_PROVIDERS);
       hideableColumnService = context.getClarityProvider(HideableColumnService);
     });
 

--- a/src/clr-angular/data/datagrid/datagrid-row-detail.ts
+++ b/src/clr-angular/data/datagrid/datagrid-row-detail.ts
@@ -13,7 +13,8 @@ import { DatagridHideableColumnModel } from './datagrid-hideable-column.model';
 import { ExpandableRowsCount } from './providers/global-expandable-rows';
 import { HideableColumnService } from './providers/hideable-column.service';
 import { RowActionService } from './providers/row-action-service';
-import { Selection, SelectionType } from './providers/selection';
+import { Selection } from './providers/selection';
+import { SelectionType } from './enums/selection-type';
 
 /**
  * Generic bland container serving various purposes for Datagrid.

--- a/src/clr-angular/data/datagrid/datagrid-row.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-row.spec.ts
@@ -9,42 +9,18 @@ import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 
 import { Expand } from '../../utils/expand/providers/expand';
 import { LoadingListener } from '../../utils/loading/loading-listener';
-
-import { DatagridWillyWonka } from './chocolate/datagrid-willy-wonka';
 import { DatagridHideableColumnModel } from './datagrid-hideable-column.model';
 import { ClrDatagridRow } from './datagrid-row';
 import { DatagridDisplayMode } from './enums/display-mode.enum';
-import { TestContext } from './helpers.spec';
+import { DATAGRID_SPEC_PROVIDERS, TestContext } from './helpers.spec';
 import { MockDisplayModeService } from './providers/display-mode.mock';
 import { DisplayModeService } from './providers/display-mode.service';
-import { FiltersProvider } from './providers/filters';
 import { ExpandableRowsCount } from './providers/global-expandable-rows';
 import { HideableColumnService } from './providers/hideable-column.service';
 import { Items } from './providers/items';
-import { Page } from './providers/page';
-import { RowActionService } from './providers/row-action-service';
-import { Selection, SelectionType } from './providers/selection';
-import { Sort } from './providers/sort';
-import { StateDebouncer } from './providers/state-debouncer.provider';
-import { DomAdapter } from '../../utils/dom-adapter/dom-adapter';
+import { Selection } from './providers/selection';
 import { DatagridRenderOrganizer } from './render/render-organizer';
-
-const PROVIDERS = [
-  Selection,
-  Items,
-  FiltersProvider,
-  Sort,
-  Page,
-  RowActionService,
-  ExpandableRowsCount,
-  DatagridRenderOrganizer,
-  DomAdapter,
-  HideableColumnService,
-  DatagridWillyWonka,
-  StateDebouncer,
-  { provide: DisplayModeService, useClass: MockDisplayModeService },
-  Expand,
-];
+import { SelectionType } from './enums/selection-type';
 
 type Item = { id: number };
 
@@ -56,7 +32,7 @@ export default function(): void {
       let renderer: DatagridRenderOrganizer;
 
       beforeEach(function() {
-        context = this.create(ClrDatagridRow, FullTest, PROVIDERS);
+        context = this.create(ClrDatagridRow, FullTest, DATAGRID_SPEC_PROVIDERS);
         renderer = context.getClarityProvider(DatagridRenderOrganizer);
         context.detectChanges();
         renderer.resize();
@@ -97,7 +73,7 @@ export default function(): void {
       let displayMode: MockDisplayModeService;
 
       beforeEach(function() {
-        context = this.create(ClrDatagridRow, ProjectionTest, PROVIDERS);
+        context = this.create(ClrDatagridRow, ProjectionTest, DATAGRID_SPEC_PROVIDERS);
         displayMode = <MockDisplayModeService>context.getClarityProvider(DisplayModeService);
       });
 
@@ -119,7 +95,7 @@ export default function(): void {
       let selectionProvider: Selection;
 
       beforeEach(function() {
-        context = this.create(ClrDatagridRow, FullTest, PROVIDERS);
+        context = this.create(ClrDatagridRow, FullTest, DATAGRID_SPEC_PROVIDERS);
         selectionProvider = TestBed.get(Selection);
         TestBed.get(Items).all = [{ id: 1 }, { id: 2 }];
       });
@@ -288,7 +264,7 @@ export default function(): void {
       let expand: Expand;
 
       beforeEach(function() {
-        context = this.create(ClrDatagridRow, ExpandTest, PROVIDERS);
+        context = this.create(ClrDatagridRow, ExpandTest, DATAGRID_SPEC_PROVIDERS);
         context.detectChanges();
         expand = context.getClarityProvider(Expand);
       });
@@ -439,7 +415,7 @@ export default function(): void {
       let hideableColumnService: HideableColumnService;
 
       beforeEach(function() {
-        context = this.create(ClrDatagridRow, HideShowTest, PROVIDERS);
+        context = this.create(ClrDatagridRow, HideShowTest, DATAGRID_SPEC_PROVIDERS);
         hideableColumnService = context.getClarityProvider(HideableColumnService);
       });
 

--- a/src/clr-angular/data/datagrid/datagrid-row.ts
+++ b/src/clr-angular/data/datagrid/datagrid-row.ts
@@ -32,9 +32,10 @@ import { DisplayModeService } from './providers/display-mode.service';
 import { ExpandableRowsCount } from './providers/global-expandable-rows';
 import { HideableColumnService } from './providers/hideable-column.service';
 import { RowActionService } from './providers/row-action-service';
-import { Selection, SelectionType } from './providers/selection';
+import { Selection } from './providers/selection';
 import { WrappedRow } from './wrapped-row';
 import { ClrCommonStrings } from '../../utils/i18n/common-strings.interface';
+import { SelectionType } from './enums/selection-type';
 
 let nbRow: number = 0;
 
@@ -166,6 +167,9 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
       const columnList = this.hideableColumnService.getColumns();
       if (cellList.length === columnList.length) {
         this.updateCellsForColumns(columnList);
+        this.dgCells.forEach(cell => {
+          this._scrollableCells.insert(cell._view);
+        });
       }
     });
 

--- a/src/clr-angular/data/datagrid/datagrid.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid.spec.ts
@@ -11,12 +11,11 @@ import { DatagridPropertyStringFilter } from './built-in/filters/datagrid-proper
 import { DatagridStringFilterImpl } from './built-in/filters/datagrid-string-filter-impl';
 import { ClrDatagrid } from './datagrid';
 import { DatagridDisplayMode } from './enums/display-mode.enum';
-import { TestContext } from './helpers.spec';
+import { DATAGRID_SPEC_PROVIDERS, TestContext } from './helpers.spec';
 import { ClrDatagridComparatorInterface } from './interfaces/comparator.interface';
 import { ClrDatagridFilterInterface } from './interfaces/filter.interface';
 import { ClrDatagridStateInterface } from './interfaces/state.interface';
 import { ClrDatagridStringFilterInterface } from './interfaces/string-filter.interface';
-import { ColumnToggleButtonsService } from './providers/column-toggle-buttons.service';
 import { MockDisplayModeService } from './providers/display-mode.mock';
 import { DisplayModeService } from './providers/display-mode.service';
 import { FiltersProvider } from './providers/filters';
@@ -25,12 +24,10 @@ import { HideableColumnService } from './providers/hideable-column.service';
 import { Items } from './providers/items';
 import { Page } from './providers/page';
 import { RowActionService } from './providers/row-action-service';
-import { Selection, SelectionType } from './providers/selection';
+import { Selection } from './providers/selection';
 import { Sort } from './providers/sort';
-import { StateDebouncer } from './providers/state-debouncer.provider';
-import { StateProvider } from './providers/state.provider';
-import { TableSizeService } from './providers/table-size.service';
 import { DatagridRenderOrganizer } from './render/render-organizer';
+import { SelectionType } from './enums/selection-type';
 
 @Component({
   template: `
@@ -365,23 +362,6 @@ class ProjectionTest {
 class ExpandedReplacedCellsTest {
   items = [1, 2, 3];
 }
-
-const PROVIDERS = [
-  { provide: DisplayModeService, useClass: MockDisplayModeService },
-  Selection,
-  Sort,
-  FiltersProvider,
-  Page,
-  Items,
-  DatagridRenderOrganizer,
-  RowActionService,
-  ExpandableRowsCount,
-  HideableColumnService,
-  StateDebouncer,
-  StateProvider,
-  ColumnToggleButtonsService,
-  TableSizeService,
-];
 
 export default function(): void {
   describe('ClrDatagrid component', function() {
@@ -847,7 +827,7 @@ export default function(): void {
       let displayModeService: MockDisplayModeService;
 
       beforeEach(function() {
-        context = this.createWithOverride(ClrDatagrid, ProjectionTest, [], [], PROVIDERS);
+        context = this.createWithOverride(ClrDatagrid, ProjectionTest, [], [], DATAGRID_SPEC_PROVIDERS);
         displayModeService = <MockDisplayModeService>context.getClarityProvider(DisplayModeService);
       });
 

--- a/src/clr-angular/data/datagrid/datagrid.ts
+++ b/src/clr-angular/data/datagrid/datagrid.ts
@@ -35,13 +35,15 @@ import { HideableColumnService } from './providers/hideable-column.service';
 import { Items } from './providers/items';
 import { Page } from './providers/page';
 import { RowActionService } from './providers/row-action-service';
-import { Selection, SelectionType } from './providers/selection';
+import { Selection } from './providers/selection';
 import { Sort } from './providers/sort';
 import { StateDebouncer } from './providers/state-debouncer.provider';
 import { StateProvider } from './providers/state.provider';
 import { TableSizeService } from './providers/table-size.service';
 import { DatagridRenderOrganizer } from './render/render-organizer';
 import { ClrCommonStrings } from '../../utils/i18n/common-strings.interface';
+import { SelectionType } from './enums/selection-type';
+import { ColumnsService } from './providers/columns.service';
 
 @Component({
   selector: 'clr-datagrid',
@@ -60,6 +62,7 @@ import { ClrCommonStrings } from '../../utils/i18n/common-strings.interface';
     StateProvider,
     ColumnToggleButtonsService,
     TableSizeService,
+    ColumnsService,
     DisplayModeService,
   ],
   host: { '[class.datagrid-host]': 'true' },

--- a/src/clr-angular/data/datagrid/enums/column-changes.enum.ts
+++ b/src/clr-angular/data/datagrid/enums/column-changes.enum.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+export enum DatagridColumnChanges {
+  WIDTH,
+}

--- a/src/clr-angular/data/datagrid/enums/selection-type.ts
+++ b/src/clr-angular/data/datagrid/enums/selection-type.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+export enum SelectionType {
+  None,
+  Single,
+  Multi,
+}

--- a/src/clr-angular/data/datagrid/helpers.spec.ts
+++ b/src/clr-angular/data/datagrid/helpers.spec.ts
@@ -13,6 +13,47 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { ClarityModule } from '../../clr-angular.module';
+import { DisplayModeService } from './providers/display-mode.service';
+import { MockDisplayModeService } from './providers/display-mode.mock';
+import { Selection } from './providers/selection';
+import { Sort } from './providers/sort';
+import { FiltersProvider } from './providers/filters';
+import { Page } from './providers/page';
+import { ColumnsService } from './providers/columns.service';
+import { Items } from './providers/items';
+import { DatagridRenderOrganizer } from './render/render-organizer';
+import { RowActionService } from './providers/row-action-service';
+import { ExpandableRowsCount } from './providers/global-expandable-rows';
+import { HideableColumnService } from './providers/hideable-column.service';
+import { StateDebouncer } from './providers/state-debouncer.provider';
+import { StateProvider } from './providers/state.provider';
+import { ColumnToggleButtonsService } from './providers/column-toggle-buttons.service';
+import { TableSizeService } from './providers/table-size.service';
+import { Expand } from '../../utils/expand/providers/expand';
+import { DatagridWillyWonka } from './chocolate/datagrid-willy-wonka';
+import { DomAdapter } from '../../utils/dom-adapter/dom-adapter';
+
+// Reusable list of providers used in a number of tests
+export const DATAGRID_SPEC_PROVIDERS = [
+  { provide: DisplayModeService, useClass: MockDisplayModeService },
+  Selection,
+  Sort,
+  FiltersProvider,
+  DatagridWillyWonka,
+  DomAdapter,
+  Expand,
+  Page,
+  ColumnsService,
+  Items,
+  DatagridRenderOrganizer,
+  RowActionService,
+  ExpandableRowsCount,
+  HideableColumnService,
+  StateDebouncer,
+  StateProvider,
+  ColumnToggleButtonsService,
+  TableSizeService,
+];
 
 export class TestContext<D, C> {
   fixture: ComponentFixture<C>;

--- a/src/clr-angular/data/datagrid/interfaces/column-state.interface.ts
+++ b/src/clr-angular/data/datagrid/interfaces/column-state.interface.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import { DatagridColumnChanges } from '../enums/column-changes.enum';
+
+export interface DatagridColumnState {
+  changes?: DatagridColumnChanges[]; // This is an array of change types to update
+  width?: number; // This is the width calculated for the column
+  strictWidth?: number; // This is the strict width if defined in styles/css
+}

--- a/src/clr-angular/data/datagrid/providers/columns.service.ts
+++ b/src/clr-angular/data/datagrid/providers/columns.service.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import { Injectable, OnDestroy } from '@angular/core';
+import { BehaviorSubject, Subscription } from 'rxjs';
+import { DatagridColumnState } from '../interfaces/column-state.interface';
+import { DatagridRenderStep } from '../enums/render-step.enum';
+import { DatagridRenderOrganizer } from '../render/render-organizer';
+
+@Injectable()
+export class ColumnsService implements OnDestroy {
+  subscriptions: Subscription[] = [];
+  columns: BehaviorSubject<DatagridColumnState>[] = [];
+
+  constructor(private organizer: DatagridRenderOrganizer) {
+    this.subscriptions.push(
+      this.organizer.filterRenderSteps(DatagridRenderStep.CLEAR_WIDTHS).subscribe(() => this.reset())
+    );
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.forEach(sub => sub.unsubscribe());
+  }
+
+  private reset() {
+    this.columns.forEach((column, index) => {
+      this.emitStateChange(index, { width: 0 });
+    });
+  }
+
+  // Helper method to emit a change to a column only when there is an actual diff to process for that column
+  emitStateChange(columnIndex: number, diff: Partial<DatagridColumnState>) {
+    if (!this.columns[columnIndex]) {
+      return;
+    }
+    const current = this.columns[columnIndex].value;
+    const hasChange = Object.keys(diff).filter(key => diff[key] !== current[key]);
+
+    if (hasChange) {
+      this.columns[columnIndex].next({ ...current, ...diff });
+    }
+  }
+}

--- a/src/clr-angular/data/datagrid/providers/selection.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/selection.spec.ts
@@ -12,9 +12,10 @@ import { ClrDatagridFilterInterface } from '../interfaces/filter.interface';
 import { FiltersProvider } from './filters';
 import { Items } from './items';
 import { Page } from './page';
-import { Selection, SelectionType } from './selection';
+import { Selection } from './selection';
 import { Sort } from './sort';
 import { StateDebouncer } from './state-debouncer.provider';
+import { SelectionType } from '../enums/selection-type';
 
 const numberSort = (a: number, b: number) => a - b;
 

--- a/src/clr-angular/data/datagrid/providers/selection.ts
+++ b/src/clr-angular/data/datagrid/providers/selection.ts
@@ -4,20 +4,13 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { Injectable, TrackByFunction } from '@angular/core';
-import { Observable } from 'rxjs';
-import { Subject } from 'rxjs';
-import { Subscription } from 'rxjs';
+import { Observable, Subject, Subscription } from 'rxjs';
 
 import { FiltersProvider } from './filters';
 import { Items } from './items';
+import { SelectionType } from '../enums/selection-type';
 
 let nbSelection: number = 0;
-
-export enum SelectionType {
-  None,
-  Single,
-  Multi,
-}
 
 @Injectable()
 export class Selection<T = any> {

--- a/src/clr-angular/data/datagrid/render/cell-renderer.spec.ts
+++ b/src/clr-angular/data/datagrid/render/cell-renderer.spec.ts
@@ -13,33 +13,42 @@ import { DatagridCellRenderer } from './cell-renderer';
 import { STRICT_WIDTH_CLASS } from './constants';
 import { DatagridRenderOrganizer } from './render-organizer';
 import { MOCK_ORGANIZER_PROVIDER, MockDatagridRenderOrganizer } from './render-organizer.mock';
+import { BehaviorSubject } from 'rxjs';
+import { DatagridColumnState } from '../interfaces/column-state.interface';
+import { DatagridColumnChanges } from '../enums/column-changes.enum';
+
+@Component({ template: `<clr-dg-cell>Hello world</clr-dg-cell>` })
+class SimpleTest {}
 
 export default function(): void {
   describe('DatagridCellRenderer directive', function() {
     let context: TestContext<DatagridCellRenderer, SimpleTest>;
     let organizer: MockDatagridRenderOrganizer;
+    let stateSub: BehaviorSubject<DatagridColumnState>;
 
     beforeEach(function() {
       context = this.create(DatagridCellRenderer, SimpleTest, [MOCK_ORGANIZER_PROVIDER, HideableColumnService]);
       organizer = <MockDatagridRenderOrganizer>context.getClarityProvider(DatagridRenderOrganizer);
+      stateSub = new BehaviorSubject<DatagridColumnState>({});
+      context.clarityDirective.columnState = stateSub;
     });
 
     it('sets proper width and class for strict width cells', function() {
-      context.clarityDirective.setWidth(true, 42);
+      stateSub.next({ changes: [DatagridColumnChanges.WIDTH], width: 42, strictWidth: 42 });
       expect(context.clarityElement.style.width).toBe('42px');
       expect(context.clarityElement.classList).toContain(STRICT_WIDTH_CLASS);
     });
 
     it('makes the cell non-flexible if and only if the width is strict', function() {
-      context.clarityDirective.setWidth(true, 42);
+      stateSub.next({ changes: [DatagridColumnChanges.WIDTH], width: 42, strictWidth: 42 });
       expect(context.clarityElement.style.width).toBe('42px');
       expect(context.clarityElement.classList).toContain(STRICT_WIDTH_CLASS);
-      context.clarityDirective.setWidth(false, 42);
+      stateSub.next({ changes: [DatagridColumnChanges.WIDTH], width: 42, strictWidth: 0 });
       expect(context.clarityElement.classList).not.toContain(STRICT_WIDTH_CLASS);
     });
 
     it('resets the cell to default width when notified', function() {
-      context.clarityDirective.setWidth(true, 42);
+      stateSub.next({ changes: [DatagridColumnChanges.WIDTH], width: 42, strictWidth: 42 });
       expect(context.clarityElement.style.width).toBe('42px');
       expect(context.clarityElement.classList).toContain(STRICT_WIDTH_CLASS);
       organizer.updateRenderStep.next(DatagridRenderStep.CLEAR_WIDTHS);
@@ -48,6 +57,3 @@ export default function(): void {
     });
   });
 }
-
-@Component({ template: `<clr-dg-cell>Hello world</clr-dg-cell>` })
-class SimpleTest {}

--- a/src/clr-angular/data/datagrid/render/cell-renderer.ts
+++ b/src/clr-angular/data/datagrid/render/cell-renderer.ts
@@ -4,15 +4,27 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { Directive, ElementRef, OnDestroy, Renderer2 } from '@angular/core';
-import { Subscription } from 'rxjs';
+import { BehaviorSubject, Subscription } from 'rxjs';
 
 import { DatagridRenderStep } from '../enums/render-step.enum';
 
 import { STRICT_WIDTH_CLASS } from './constants';
 import { DatagridRenderOrganizer } from './render-organizer';
+import { DatagridColumnState } from '../interfaces/column-state.interface';
+import { DatagridColumnChanges } from '../enums/column-changes.enum';
 
 @Directive({ selector: 'clr-dg-cell' })
 export class DatagridCellRenderer implements OnDestroy {
+  private stateSubscription: Subscription;
+
+  // @TODO(JEREMY) Work out how to dedupe some of this code between header and cell renderers
+  set columnState(columnState: BehaviorSubject<DatagridColumnState>) {
+    if (this.stateSubscription) {
+      this.stateSubscription.unsubscribe();
+    }
+    this.stateSubscription = columnState.subscribe(state => this.stateChanges(state));
+  }
+
   constructor(private el: ElementRef, private renderer: Renderer2, organizer: DatagridRenderOrganizer) {
     this.subscriptions.push(
       organizer.filterRenderSteps(DatagridRenderStep.CLEAR_WIDTHS).subscribe(() => this.clearWidth())
@@ -22,6 +34,23 @@ export class DatagridCellRenderer implements OnDestroy {
   private subscriptions: Subscription[] = [];
   ngOnDestroy() {
     this.subscriptions.forEach(sub => sub.unsubscribe());
+    if (this.stateSubscription) {
+      this.stateSubscription.unsubscribe();
+    }
+  }
+
+  private stateChanges(state: DatagridColumnState) {
+    if (state.changes && state.changes.length) {
+      state.changes.forEach(change => {
+        switch (change) {
+          case DatagridColumnChanges.WIDTH:
+            this.setWidth(state);
+            break;
+          default:
+            break;
+        }
+      });
+    }
   }
 
   private clearWidth() {
@@ -29,12 +58,12 @@ export class DatagridCellRenderer implements OnDestroy {
     this.renderer.setStyle(this.el.nativeElement, 'width', null);
   }
 
-  public setWidth(strict: boolean, value: number) {
-    if (strict) {
+  private setWidth(state: DatagridColumnState) {
+    if (state.strictWidth) {
       this.renderer.addClass(this.el.nativeElement, STRICT_WIDTH_CLASS);
     } else {
       this.renderer.removeClass(this.el.nativeElement, STRICT_WIDTH_CLASS);
     }
-    this.renderer.setStyle(this.el.nativeElement, 'width', value + 'px');
+    this.renderer.setStyle(this.el.nativeElement, 'width', state.width + 'px');
   }
 }

--- a/src/clr-angular/data/datagrid/render/constants.ts
+++ b/src/clr-angular/data/datagrid/render/constants.ts
@@ -4,6 +4,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
+// @TODO The top two are not used now, which is probably a performance drag that was broken along the way.
+// There was a previous pattern to hide everything to do computation then display, for Firefox, needs revisiting.
 export const NO_LAYOUT_CLASS = 'datagrid-no-layout';
 export const COMPUTE_WIDTH_CLASS = 'datagrid-computing-columns-width';
 export const STRICT_WIDTH_CLASS = 'datagrid-fixed-width';

--- a/src/clr-angular/data/datagrid/render/header-renderer.ts
+++ b/src/clr-angular/data/datagrid/render/header-renderer.ts
@@ -4,16 +4,27 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { Directive, ElementRef, EventEmitter, OnDestroy, Output, Renderer2 } from '@angular/core';
-import { Subscription } from 'rxjs';
+import { BehaviorSubject, Subscription } from 'rxjs';
 
 import { DomAdapter } from '../../../utils/dom-adapter/dom-adapter';
 import { DatagridRenderStep } from '../enums/render-step.enum';
 import { ColumnResizerService } from '../providers/column-resizer.service';
 import { STRICT_WIDTH_CLASS } from './constants';
 import { DatagridRenderOrganizer } from './render-organizer';
+import { DatagridColumnState } from '../interfaces/column-state.interface';
+import { DatagridColumnChanges } from '../enums/column-changes.enum';
 
 @Directive({ selector: 'clr-dg-column', providers: [ColumnResizerService] })
 export class DatagridHeaderRenderer implements OnDestroy {
+  private stateSubscription: Subscription;
+
+  set columnState(columnState: BehaviorSubject<DatagridColumnState>) {
+    if (this.stateSubscription) {
+      this.stateSubscription.unsubscribe();
+    }
+    this.stateSubscription = columnState.subscribe(state => this.stateChanges(state));
+  }
+
   constructor(
     private el: ElementRef,
     private renderer: Renderer2,
@@ -36,12 +47,30 @@ export class DatagridHeaderRenderer implements OnDestroy {
   /**
    * Indicates if the column has a strict width, so it doesn't shrink or expand based on the content.
    */
-  public strictWidth: number;
   private widthSet: boolean = false;
+  private autoSet: boolean = false;
 
   private subscriptions: Subscription[] = [];
+
   ngOnDestroy() {
     this.subscriptions.forEach(sub => sub.unsubscribe());
+    if (this.stateSubscription) {
+      this.stateSubscription.unsubscribe();
+    }
+  }
+
+  private stateChanges(state: DatagridColumnState) {
+    if (state.changes && state.changes.length) {
+      state.changes.forEach(change => {
+        switch (change) {
+          case DatagridColumnChanges.WIDTH:
+            this.setWidth(state);
+            break;
+          default:
+            break;
+        }
+      });
+    }
   }
 
   private clearWidth() {
@@ -49,37 +78,52 @@ export class DatagridHeaderRenderer implements OnDestroy {
     if (this.widthSet && !this.columnResizerService.resizedBy) {
       this.renderer.setStyle(this.el.nativeElement, 'width', null);
     }
-  }
-
-  private detectStrictWidth() {
-    if (this.columnResizerService.resizedBy) {
-      this.strictWidth = this.columnResizerService.widthAfterResize;
-    } else {
-      this.strictWidth = this.domAdapter.userDefinedWidth(this.el.nativeElement);
+    if (this.autoSet) {
+      this.renderer.removeClass(this.el.nativeElement, STRICT_WIDTH_CLASS);
     }
   }
 
-  public computeWidth(): number {
-    let width: number = this.strictWidth;
+  private detectStrictWidth(): number {
+    if (this.columnResizerService.resizedBy) {
+      return this.columnResizerService.widthAfterResize;
+    } else if (this.autoSet) {
+      return 0;
+    } else {
+      return this.domAdapter.userDefinedWidth(this.el.nativeElement);
+    }
+  }
+
+  private computeWidth(strictWidth: number): number {
+    let width: number = strictWidth;
     if (!width) {
       width = this.domAdapter.scrollWidth(this.el.nativeElement);
     }
     return width;
   }
 
-  public setWidth(width: number) {
-    if (this.strictWidth) {
+  public getColumnWidthState(): Partial<DatagridColumnState> {
+    const strictWidth = this.detectStrictWidth();
+    return {
+      width: this.computeWidth(strictWidth),
+      strictWidth: strictWidth,
+    };
+  }
+
+  private setWidth(state: DatagridColumnState) {
+    if (state.strictWidth) {
       if (this.columnResizerService.resizedBy) {
-        this.resizeEmitter.emit(width);
-        this.renderer.setStyle(this.el.nativeElement, 'width', width + 'px');
+        this.resizeEmitter.emit(state.width);
+        this.renderer.setStyle(this.el.nativeElement, 'width', state.width + 'px');
         this.widthSet = false;
       }
       // Don't set width if there is a user-defined one. Just add the strict width class.
       this.renderer.addClass(this.el.nativeElement, STRICT_WIDTH_CLASS);
-      return;
+      this.autoSet = false;
+    } else {
+      this.renderer.removeClass(this.el.nativeElement, STRICT_WIDTH_CLASS);
+      this.renderer.setStyle(this.el.nativeElement, 'width', state.width + 'px');
+      this.widthSet = true;
+      this.autoSet = true;
     }
-    this.renderer.removeClass(this.el.nativeElement, STRICT_WIDTH_CLASS);
-    this.renderer.setStyle(this.el.nativeElement, 'width', width + 'px');
-    this.widthSet = true;
   }
 }

--- a/src/clr-angular/data/datagrid/render/render-organizer.spec.ts
+++ b/src/clr-angular/data/datagrid/render/render-organizer.spec.ts
@@ -51,12 +51,6 @@ export default function(): void {
       ]);
     });
 
-    it('clears the widths when when resizing', function(this: UserContext) {
-      this.organizer.widths = [{ px: 1, strict: false }, { px: 2, strict: true }];
-      this.organizer.resize();
-      expect(this.organizer.widths).toEqual([]);
-    });
-
     it('provides a filtering utility that targets one step', function(this: UserContext) {
       let currentStep: DatagridRenderStep = null;
       this.organizer.filterRenderSteps(DatagridRenderStep.ALIGN_COLUMNS).subscribe(step => (currentStep = step));

--- a/src/clr-angular/data/datagrid/render/render-organizer.ts
+++ b/src/clr-angular/data/datagrid/render/render-organizer.ts
@@ -23,10 +23,7 @@ export class DatagridRenderOrganizer {
 
   private alreadySized = false;
 
-  public widths: { px: number; strict: boolean }[] = [];
-
   public resize() {
-    this.widths.length = 0;
     this._renderStep.next(DatagridRenderStep.CALCULATE_MODE_ON);
     if (this.alreadySized) {
       this._renderStep.next(DatagridRenderStep.CLEAR_WIDTHS);

--- a/src/dev/src/app/datagrid/hide-show-columns/hide-show.html
+++ b/src/dev/src/app/datagrid/hide-show-columns/hide-show.html
@@ -12,11 +12,11 @@
 <button class="btn btn-outline-primary" (click)="conditionalSignpost = !conditionalSignpost">
     Toggle Signposts
 </button>
-<button class="btn btn-outline-primary" (click)="toggleDate()">
-    Toggle Date
+<button class="btn btn-outline-primary" (click)="shortFormat = !shortFormat">
+    Toggle Date Type
 </button>
 <clr-datagrid>
-    <clr-dg-column *ngIf="showId">
+    <clr-dg-column *ngIf="showId" [style.width.px]="100">
         <ng-container *clrDgHideableColumn>
             User ID
         </ng-container>
@@ -27,7 +27,7 @@
             Name
         </ng-container>
     </clr-dg-column>
-    <clr-dg-column *ngIf="showDate">
+    <clr-dg-column [style.width.px]="150">
         <ng-container *clrDgHideableColumn>
             Creation date
         </ng-container>
@@ -55,7 +55,8 @@
             </clr-signpost>
         </clr-dg-cell>
         <clr-dg-cell>{{user.name}}</clr-dg-cell>
-        <clr-dg-cell *ngIf="showDate">{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell *ngIf="shortFormat">{{user.creation | date:'shortDate'}}</clr-dg-cell>
+        <clr-dg-cell *ngIf="!shortFormat">{{user.creation | date:'fullDate'}}</clr-dg-cell>
         <clr-dg-cell>
             {{user.pokemon.name}}
             <clr-signpost>

--- a/src/dev/src/app/datagrid/hide-show-columns/hide-show.ts
+++ b/src/dev/src/app/datagrid/hide-show-columns/hide-show.ts
@@ -18,7 +18,7 @@ import { User } from '../inventory/user';
 export class DatagridHideShowDemo {
   users: User[];
   showId = true;
-  showDate = true;
+  shortFormat = true;
   conditionalSignpost = true;
   currentPageSize = 1;
 
@@ -30,9 +30,5 @@ export class DatagridHideShowDemo {
 
   toggleId() {
     this.showId = !this.showId;
-  }
-
-  toggleDate() {
-    this.showDate = !this.showDate;
   }
 }


### PR DESCRIPTION
This will eventually be used to store several other stateful properties of columns, such as hidden and ordering information. For now, it is to give us a starting implementation point to store column states in a way that is consolidated and easily cached.

Internally, this lifts the state of the width calculations out of the render organizer into a centralized column service. This array of behaviorsubjects get passed into the column cells based on their index, and each cell subscribes to column changes. This privatizes some of the connection between the main/header and row/cell renderers. More work is to be done here, this is just a first pass at the basic architecture.

I also moved the SelectionType enum to its own file, since that is our pattern.

**Internal change - no release notes necessary**