### PR TITLE
[NG] Datagrid footer responsive layout (#3097)

### DIFF
--- a/src/clr-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clr-angular/data/datagrid/_datagrid.clarity.scss
@@ -2,16 +2,6 @@
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
-@mixin pagination-separator() {
-  content: '';
-  display: inline-block;
-  height: 1rem;
-  width: $clr-rem-1px;
-  background-color: $clr-table-border-color;
-  margin: 0 0.5rem;
-  vertical-align: middle;
-}
-
 @include exports('datagrid.clarity') {
   @include basic-table(
     '.datagrid',
@@ -291,7 +281,7 @@
     .datagrid-row {
       background-color: $clr-thead-bgcolor;
       border-top: none;
-      border-bottom: 2px solid $clr-table-border-color;
+      border-bottom: 1px solid $clr-table-border-color;
 
       .datagrid-row-sticky {
         background-color: $clr-thead-bgcolor;
@@ -626,20 +616,23 @@
     flex: 0 0 auto;
     display: flex;
     flex-flow: row nowrap;
-    justify-content: flex-end;
+    justify-content: space-between;
     align-items: stretch;
-    height: 1.5rem;
     padding: 0 $clr-table-cellpadding;
     // Account for borders
     line-height: calc(1.5rem - #{3 * $clr-default-borderwidth});
     font-size: clr-getTypePropertyValueForDomElement(table_header, font-size);
     background-color: $clr-thead-bgcolor;
     border: $clr-default-borderwidth solid $clr-table-footer-border-top-color;
+    border-top: none;
     border-radius: 0 0 $clr-global-borderradius $clr-global-borderradius;
 
     .pagination {
       display: flex;
       align-items: center;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+      line-height: 1.5rem;
 
       &-size {
         display: block;
@@ -662,25 +655,16 @@
         }
 
         & + .pagination-description {
-          &:before {
-            @include pagination-separator();
-          }
+          margin-left: 1rem;
         }
       }
 
       &-description {
         white-space: nowrap;
-
-        & + .pagination-list {
-          &:before {
-            @include pagination-separator();
-          }
-        }
       }
 
       &-list {
-        margin-right: 0.5rem;
-        height: calc(1.5rem - #{2 * $clr-default-borderwidth});
+        margin-left: 1rem;
         display: flex;
         align-items: center;
       }
@@ -849,11 +833,10 @@
     }
 
     .datagrid-footer {
-      height: 1rem;
       padding: 0 $clr-table-cellpadding;
       line-height: calc(1rem - #{$clr-rem-1px});
-      .pagination-list {
-        height: calc(1rem - #{2 * $clr-default-borderwidth});
+      .pagination {
+        line-height: 1rem;
       }
       .column-switch-wrapper .column-toggle--action {
         margin: 0;

--- a/src/dev/src/app/datagrid/datagrid.demo.html
+++ b/src/dev/src/app/datagrid/datagrid.demo.html
@@ -32,7 +32,7 @@
     <li><a [routerLink]="['./test-cases']">Test Cases</a></li>
     <li><a [routerLink]="['./test-cases-async']">Asynchronous Test Cases</a></li>
     <li><a [routerLink]="['./hide-show']">Hide-show columns demo</a></li>
-    <li><a [routerLink]="['./pinned-columns']">Pinned Columns</a></li>
+    <li><a [routerLink]="['./responsive-footer']">Responsive Footer</a></li>
 </ul>
 
 <router-outlet></router-outlet>

--- a/src/dev/src/app/datagrid/datagrid.demo.module.ts
+++ b/src/dev/src/app/datagrid/datagrid.demo.module.ts
@@ -36,6 +36,7 @@ import { DatagridServerDrivenDemo } from './server-driven/server-driven';
 import { DatagridSmartIteratorDemo } from './smart-iterator/smart-iterator';
 import { DatagridSortingDemo } from './sorting/sorting';
 import { DatagridStringFilteringDemo } from './string-filtering/string-filtering';
+import { DatagridResponsiveFooterDemo } from './responsive-footer/responsive-footer';
 import { DatagridTestCasesAsyncDemo } from './test-cases-async/test-cases-async';
 import { DatagridTestCasesDemo } from './test-cases/test-cases';
 import { ColorFilter } from './utils/color-filter';
@@ -62,6 +63,7 @@ import { ColorFilter } from './utils/color-filter';
     DatagridSmartIteratorDemo,
     DatagridSortingDemo,
     DatagridStringFilteringDemo,
+    DatagridResponsiveFooterDemo,
     DatagridPlaceholderDemo,
     DatagridScrollingDemo,
     DatagridColumnSizingDemo,

--- a/src/dev/src/app/datagrid/datagrid.demo.routing.ts
+++ b/src/dev/src/app/datagrid/datagrid.demo.routing.ts
@@ -29,6 +29,7 @@ import { DatagridSelectionDemo } from './selection/selection';
 import { DatagridServerDrivenDemo } from './server-driven/server-driven';
 import { DatagridSmartIteratorDemo } from './smart-iterator/smart-iterator';
 import { DatagridSortingDemo } from './sorting/sorting';
+import { DatagridResponsiveFooterDemo } from './responsive-footer/responsive-footer';
 import { DatagridStringFilteringDemo } from './string-filtering/string-filtering';
 import { DatagridTestCasesAsyncDemo } from './test-cases-async/test-cases-async';
 import { DatagridTestCasesDemo } from './test-cases/test-cases';
@@ -64,6 +65,7 @@ const ROUTES: Routes = [
       { path: 'test-cases', component: DatagridTestCasesDemo },
       { path: 'test-cases-async', component: DatagridTestCasesAsyncDemo },
       { path: 'hide-show', component: DatagridHideShowDemo },
+      { path: 'responsive-footer', component: DatagridResponsiveFooterDemo },
     ],
   },
 ];

--- a/src/dev/src/app/datagrid/responsive-footer/responsive-footer.html
+++ b/src/dev/src/app/datagrid/responsive-footer/responsive-footer.html
@@ -1,0 +1,90 @@
+<!--
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<h2>Datagrid: Responsive footer demo</h2>
+
+<button class="btn" (click)="static = !static" id="toggle-static">Toggle static footer</button>
+<button class="btn" (click)="compact = !compact" id="toggle-compact">Toggle compact datagrid</button>
+
+<div [style.width.px]="712">
+  <ng-container [ngTemplateOutlet]="grid" [ngTemplateOutletContext]="{static: static, compact: compact}"></ng-container>
+</div>
+
+<div style="width: 400px; display: inline-block;">
+  <ng-container [ngTemplateOutlet]="grid" [ngTemplateOutletContext]="{static: static, compact: compact}"></ng-container>
+</div>
+
+<div style="width: 300px; display: inline-block; margin-left: 0.5rem;">
+  <ng-container [ngTemplateOutlet]="grid" [ngTemplateOutletContext]="{static: static, compact: compact}"></ng-container>
+</div>
+
+<ng-template #grid let-static="static" let-compact="compact">
+  <clr-datagrid [(clrDgSelected)]="selected" [style.max-height.px]="250" [class.datagrid-compact]="compact">
+    <clr-dg-column>
+      <ng-container *clrDgHideableColumn>
+        User ID
+      </ng-container>
+    </clr-dg-column>
+    <clr-dg-column>
+      <!--Name-->
+      <ng-container *clrDgHideableColumn>
+        Name
+      </ng-container>
+    </clr-dg-column>
+    <clr-dg-column>
+      <ng-container *clrDgHideableColumn>
+        Creation date
+      </ng-container>
+    </clr-dg-column>
+    <clr-dg-column>
+      <ng-container *clrDgHideableColumn>
+        Pokemon
+      </ng-container>
+    </clr-dg-column>
+    <clr-dg-column>
+      <ng-container *clrDgHideableColumn>
+        Favorite color
+      </ng-container>
+    </clr-dg-column>
+
+    <clr-dg-placeholder>No users found</clr-dg-placeholder>
+
+    <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
+      <clr-dg-cell>
+        {{user.id}}
+      </clr-dg-cell>
+      <clr-dg-cell>{{user.name}}</clr-dg-cell>
+      <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+      <clr-dg-cell>
+        {{user.pokemon.name}}
+        <clr-signpost>
+          <button
+            type="button"
+            class="signpost-action btn btn-small btn-link"
+            [class.active]="open"
+            clrSignpostTrigger>
+            <clr-icon shape="help-info"></clr-icon>
+          </button>
+          <clr-signpost-content *clrIfOpen [clrPosition]="'top-middle'">
+            The pokemon is strong.
+          </clr-signpost-content>
+        </clr-signpost>
+      </clr-dg-cell>
+      <clr-dg-cell>
+        <span class="color-square" [style.backgroundColor]="user.color"></span>
+      </clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>
+      <ng-container *ngIf="static">A custom static footer</ng-container>
+      <clr-dg-pagination *ngIf="!static" #pagination [clrDgPageSize]="1">
+        <clr-dg-page-size [clrPageSizeOptions]="[1, 3,5]">Users per page</clr-dg-page-size>
+        {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
+        of {{pagination.totalItems}} users
+      </clr-dg-pagination>
+    </clr-dg-footer>
+  </clr-datagrid>
+</ng-template>

--- a/src/dev/src/app/datagrid/responsive-footer/responsive-footer.ts
+++ b/src/dev/src/app/datagrid/responsive-footer/responsive-footer.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component } from '@angular/core';
+
+import { Inventory } from '../inventory/inventory';
+import { User } from '../inventory/user';
+
+@Component({
+  selector: 'clr-datagrid-resp-footer-demo',
+  providers: [Inventory],
+  templateUrl: './responsive-footer.html',
+  styleUrls: ['../datagrid.demo.scss'],
+})
+export class DatagridResponsiveFooterDemo {
+  users: User[];
+  selected: User[] = [];
+  static: boolean = false;
+  compact: boolean = false;
+
+  constructor(inventory: Inventory) {
+    inventory.size = 10;
+    inventory.reset();
+    this.users = inventory.all;
+    this.selected.push(this.users[0]);
+  }
+}


### PR DESCRIPTION
Made datagrid footer wrap to new lines on smaller screens.
Updated margins, removed dividers, as requested in the spec.

closes #2855 
closes #3097 

Signed-off-by: Ivan Donchev <idonchev@vmware.com>