### PR TITLE
[NG] Datagrid performance degradation with many pages (#3082)

### DIFF
--- a/src/clr-angular/data/datagrid/datagrid-pagination.ts
+++ b/src/clr-angular/data/datagrid/datagrid-pagination.ts
@@ -52,13 +52,7 @@ export class ClrDatagridPagination implements OnDestroy, OnInit {
 
   private defaultSize = true;
 
-  constructor(public page: Page) {}
-
-  /**********
-   * Subscription to the Page service for page changes.
-   * Note: this only emits after the datagrid is initialized/stabalized and the page changes.
-   */
-  ngOnInit() {
+  constructor(public page: Page) {
     /*
      * Default page size is 10.
      * The reason we set it in this constructor and not in the provider itself is because
@@ -67,6 +61,13 @@ export class ClrDatagridPagination implements OnDestroy, OnInit {
     if (this.defaultSize) {
       this.page.size = 10;
     }
+  }
+
+  /**********
+   * Subscription to the Page service for page changes.
+   * Note: this only emits after the datagrid is initialized/stabalized and the page changes.
+   */
+  ngOnInit() {
     this._pageSubscription = this.page.change.subscribe(current => this.currentChanged.emit(current));
   }
 


### PR DESCRIPTION
This code was previously moved from constructor to ngOnInit with this change:

[NG] Datagrid Render Refactor (#2670)
This change addressed following issues:
1. Fixes #1409 - Loading spinner not centered 
2. Fixes #1217 - Footer should not scroll when overflow-x 
3. Fixes #1150 - horizontal scrollbar covers paging info 
4. Fixes #1675 - `clr-dg-row-detail` should expand to full width of parent 
5. Fixes #1631 - row selection checkboxes are in front of a dropdown in the `clr-dg-action-bar` 
6. Fixes #1546 - Dropdowns in actionbar are misaligned

Verified manually that reverting the initialization code does not lead to degradation to any of the above fixes.
Verified manually that none of the dev app demo pages suffers visible degradation (or throws errors) related to the revert.
There is no documented or observed reason not to revert the initialization code.

Signed-off-by: Ivan Donchev <idonchev@vmware.com>