### PR TITLE
fix(datagrid): adds sort button icon to datagrid-column

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -295,10 +295,8 @@ export declare class ClrDatagridCell implements OnInit, OnDestroy {
 export declare class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<T, DatagridStringFilterImpl<T>> implements OnDestroy, OnInit {
     readonly _view: any;
     readonly ariaSort: "none" | "ascending" | "descending";
-    readonly asc: boolean;
     columnId: string;
     customFilter: boolean;
-    readonly desc: boolean;
     field: string;
     filterValue: string;
     filterValueChange: EventEmitter<{}>;
@@ -306,6 +304,7 @@ export declare class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<
     hideable: DatagridHideableColumnModel;
     projectedFilter: any;
     sortBy: ClrDatagridComparatorInterface<T> | string;
+    sortIcon: any;
     sortOrder: ClrDatagridSortOrder;
     sortOrderChange: EventEmitter<ClrDatagridSortOrder>;
     readonly sortable: boolean;

--- a/src/clr-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clr-angular/data/datagrid/_datagrid.clarity.scss
@@ -349,34 +349,6 @@
         margin-left: auto;
       }
 
-      &.asc,
-      &.desc {
-        font-weight: 600;
-
-        .datagrid-column-flex::after {
-          content: '';
-          display: flex;
-          flex: 0 0 auto;
-          vertical-align: middle;
-          width: $clr-datagrid-icon-size;
-          height: $clr-datagrid-icon-size;
-          margin-left: 0.25rem;
-          background-repeat: no-repeat;
-          background-size: contain;
-        }
-      }
-
-      &.asc {
-        .datagrid-column-flex::after {
-          background-image: generateUpArrowIcon($clr-color-action-600);
-        }
-      }
-      &.desc {
-        .datagrid-column-flex::after {
-          background-image: generateDownArrowIcon($clr-color-action-600);
-        }
-      }
-
       .datagrid-filter-toggle {
         @include clr-no-styles-button();
         cursor: pointer;
@@ -452,11 +424,21 @@
         text-align: left;
         flex: 1 1 auto;
         align-self: flex-start;
+        display: flex;
       }
 
-      button.datagrid-column-title:hover {
-        text-decoration: underline;
-        cursor: pointer;
+      button.datagrid-column-title {
+        &:hover {
+          text-decoration: underline;
+          cursor: pointer;
+        }
+        .sort-icon {
+          color: $clr-color-action-600;
+          margin-left: auto; // pushes icon to rhs b/c of parents display: flex
+          width: $clr-datagrid-icon-size;
+          height: $clr-datagrid-icon-size;
+          vertical-align: middle;
+        }
       }
 
       .datagrid-column-separator {

--- a/src/clr-angular/data/datagrid/datagrid-column.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column.spec.ts
@@ -110,22 +110,27 @@ export default function(): void {
         expect(component.sortOrder).toBe(ClrDatagridSortOrder.DESC);
       });
 
-      it('knows if the column is currently sorted in ascending order', function() {
+      it('knows when the column has an ascending sortIcon', function() {
         component.sortBy = comparator;
-        expect(component.asc).toBe(false);
+        expect(component.sortIcon).toBeUndefined();
         component.sort();
-        expect(component.asc).toBe(true);
-        component.sort();
-        expect(component.asc).toBe(false);
+        expect(component.sortIcon).toBe('arrow');
       });
 
-      it('knows if the column is currently sorted in descending order', function() {
+      it('knows when the column has a descending sortIcon', function() {
         component.sortBy = comparator;
-        expect(component.desc).toBe(false);
+        expect(component.sortIcon).toBeUndefined();
         component.sort();
-        expect(component.desc).toBe(false);
         component.sort();
-        expect(component.desc).toBe(true);
+        expect(component.sortIcon).toBe('arrow down');
+      });
+
+      it('sets the column sortIcon to null when sort is cleared', function() {
+        component.sortBy = comparator;
+        expect(component.sortIcon).toBe(undefined);
+        component.sort();
+        sortService.clear();
+        expect(component.sortIcon).toBeNull();
       });
 
       it('offers a shortcut to sort based on a property name', function() {
@@ -333,21 +338,15 @@ export default function(): void {
         expect(context.clarityDirective.sortOrder).toBe(ClrDatagridSortOrder.DESC);
       });
 
-      it('adds the .asc class to the host when sorted in ascending order', function() {
+      it('adds and removes an icon for sorting', function() {
         context.clarityDirective.sortBy = new TestComparator();
         context.clarityDirective.sort();
         context.detectChanges();
-        expect(context.clarityElement.classList.contains('asc')).toBeTruthy();
-        expect(context.clarityElement.classList.contains('desc')).toBeFalsy();
-      });
-
-      it('adds the .desc class to the host when sorted in descending order', function() {
-        context.clarityDirective.sortBy = new TestComparator();
-        context.clarityDirective.sort();
-        context.clarityDirective.sort();
+        expect(context.clarityElement.querySelector('.sort-icon')).not.toBeNull();
+        const sortService = context.fixture.debugElement.query(By.directive(ClrDatagridColumn)).injector.get(Sort);
+        sortService.clear();
         context.detectChanges();
-        expect(context.clarityElement.classList.contains('asc')).toBeFalsy();
-        expect(context.clarityElement.classList.contains('desc')).toBeTruthy();
+        expect(context.clarityElement.querySelector('.sort-icon')).toBeNull();
       });
 
       it('adds a11y roles to the column', function() {

--- a/src/clr-angular/data/datagrid/datagrid-column.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column.spec.ts
@@ -338,11 +338,18 @@ export default function(): void {
         expect(context.clarityDirective.sortOrder).toBe(ClrDatagridSortOrder.DESC);
       });
 
-      it('adds and removes an icon for sorting', function() {
+      it('adds and removes the correct icon when sorting', function() {
         context.clarityDirective.sortBy = new TestComparator();
         context.clarityDirective.sort();
         context.detectChanges();
-        expect(context.clarityElement.querySelector('.sort-icon')).not.toBeNull();
+
+        const arrowIcon = context.clarityElement.querySelector('.sort-icon');
+        expect(arrowIcon.getAttribute('shape')).toEqual('arrow');
+
+        context.clarityDirective.sort();
+        context.detectChanges();
+        expect(arrowIcon.getAttribute('shape')).toEqual('arrow down');
+
         const sortService = context.fixture.debugElement.query(By.directive(ClrDatagridColumn)).injector.get(Sort);
         sortService.clear();
         context.detectChanges();

--- a/src/clr-angular/data/datagrid/datagrid-column.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column.ts
@@ -7,7 +7,6 @@ import {
   Component,
   ContentChild,
   EventEmitter,
-  HostBinding,
   Injector,
   Input,
   OnDestroy,
@@ -35,30 +34,34 @@ let nbCount: number = 0;
 @Component({
   selector: 'clr-dg-column',
   template: `
-        <div class="datagrid-column-flex">
-            <!-- I'm really not happy with that select since it's not very scalable -->
-            <ng-content select="clr-dg-filter, clr-dg-string-filter"></ng-content>
+      <div class="datagrid-column-flex">
+          <!-- I'm really not happy with that select since it's not very scalable -->
+          <ng-content select="clr-dg-filter, clr-dg-string-filter"></ng-content>
 
-            <clr-dg-string-filter
-                    *ngIf="field && !customFilter"
-                    [clrDgStringFilter]="registered"
-                    [(clrFilterValue)]="filterValue"></clr-dg-string-filter>
+          <clr-dg-string-filter
+                  *ngIf="field && !customFilter"
+                  [clrDgStringFilter]="registered"
+                  [(clrFilterValue)]="filterValue"></clr-dg-string-filter>
 
-            <ng-template #columnTitle>
-                <ng-content></ng-content>
-            </ng-template>
+          <ng-template #columnTitle>
+              <ng-content></ng-content>
+          </ng-template>
 
-            <button class="datagrid-column-title" *ngIf="sortable" (click)="sort()" type="button">
-                <ng-container *ngTemplateOutlet="columnTitle"></ng-container>
-            </button>
+          <button class="datagrid-column-title" *ngIf="sortable" (click)="sort()" type="button">
+              <ng-container *ngTemplateOutlet="columnTitle"></ng-container>
+              <clr-icon
+                      *ngIf="sortIcon"
+                      [attr.shape]="sortIcon"
+                      class="sort-icon"></clr-icon>
+          </button>
 
-            <span class="datagrid-column-title" *ngIf="!sortable">
+          <span class="datagrid-column-title" *ngIf="!sortable">
                <ng-container *ngTemplateOutlet="columnTitle"></ng-container>
             </span>
 
-            <clr-dg-column-separator></clr-dg-column-separator>
-        </div>
-    `,
+          <clr-dg-column-separator></clr-dg-column-separator>
+      </div>
+  `,
   host: {
     '[class.datagrid-column]': 'true',
     '[class.datagrid-column--hidden]': 'hidden',
@@ -75,6 +78,8 @@ export class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<T, Datag
       if (this.sortOrder !== ClrDatagridSortOrder.UNSORTED && sort.comparator !== this._sortBy) {
         this._sortOrder = ClrDatagridSortOrder.UNSORTED;
         this.sortOrderChange.emit(this._sortOrder);
+        // removes the sortIcon when column becomes unsorted
+        this.sortIcon = null;
       }
       // deprecated: to be removed - START
       if (this.sorted && sort.comparator !== this._sortBy) {
@@ -269,6 +274,8 @@ export class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<T, Datag
 
     // setting the private variable to not retrigger the setter logic
     this._sortOrder = this._sort.reverse ? ClrDatagridSortOrder.DESC : ClrDatagridSortOrder.ASC;
+    // Sets the correct icon for current sort order
+    this.sortIcon = this._sortOrder === ClrDatagridSortOrder.DESC ? 'arrow down' : 'arrow';
     this.sortOrderChange.emit(this._sortOrder);
 
     // deprecated: to be removed - START
@@ -277,33 +284,7 @@ export class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<T, Datag
     // deprecated: to be removed - END
   }
 
-  /**
-   * Indicates if the column is currently sorted in ascending order
-   */
-  @HostBinding('class.asc')
-  public get asc() {
-    // deprecated: if condition to be removed - START
-    if (typeof this.sortOrder === 'undefined') {
-      return this.sorted && !this._sort.reverse;
-    } else {
-      return this.sortOrder === ClrDatagridSortOrder.ASC;
-    }
-    // deprecated: if condition to be removed - END
-  }
-
-  /**
-   * Indicates if the column is currently sorted in descending order
-   */
-  @HostBinding('class.desc')
-  public get desc() {
-    // deprecated: if condition to be removed - START
-    if (typeof this.sortOrder === 'undefined') {
-      return this.sorted && this._sort.reverse;
-    } else {
-      return this.sortOrder === ClrDatagridSortOrder.DESC;
-    }
-    // deprecated: if condition to be removed - END
-  }
+  public sortIcon;
 
   /**
    * A custom filter for this column that can be provided in the projected content

--- a/src/clr-angular/image/_icons.clarity.scss
+++ b/src/clr-angular/image/_icons.clarity.scss
@@ -62,20 +62,6 @@ $svg_data: 'data:image/svg+xml;charset=utf8';
   @return url('#{$svg_data},#{$caret-icon}');
 }
 
-@function generateDownArrowIcon($fillColor: $clr-color-action-600) {
-  $down-arrow-icon: '%3Csvg%20version%3D%221.1%22%20id%3D%22Layer_1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20x%3D%220px%22%20y%3D%220px%22%0A%09%20viewBox%3D%220%200%2016%2016%22%20style%3D%22enable-background%3Anew%200%200%2016%2016%3B%22%20xml%3Aspace%3D%22preserve%22%3E%0A%3Cstyle%20type%3D%22text%2Fcss%22%3E%0A%09.st0%7Bfill%3A%23' +
-    str-slice($fillColor + '', 2) +
-    '%3B%7D%0A%3C%2Fstyle%3E%0A%3Ctitle%3Eicon%20artboards%20patch%202%20strokecenter%3C%2Ftitle%3E%0A%3Cpath%20class%3D%22st0%22%20d%3D%22M8.5%2C13c-0.1%2C0.1-0.3%2C0-0.4-0.1L4.6%2C9.4c-0.2-0.2-0.2-0.5%2C0-0.7s0.5-0.2%2C0.7%2C0l3.1%2C3.1l3.1-3.2%0A%09c0.2-0.2%2C0.5-0.2%2C0.7%2C0s0.2%2C0.5%2C0%2C0.7C12.2%2C9.3%2C8.6%2C12.9%2C8.5%2C13z%22%2F%3E%0A%3Crect%20x%3D%228%22%20y%3D%223%22%20class%3D%22st0%22%20width%3D%221%22%20height%3D%229.3%22%2F%3E%0A%3C%2Fsvg%3E';
-  @return url('#{$svg_data},#{$down-arrow-icon}');
-}
-
-@function generateUpArrowIcon($fillColor: $clr-color-action-600) {
-  $up-arrow-icon: '%3Csvg%20id%3D%22Layer_1%22%20data-name%3D%22Layer%201%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2016%2016%22%3E%3Cdefs%3E%3Cstyle%3E.cls-1%7Bfill%3A%23' +
-    str-slice($fillColor + '', 2) +
-    '%3B%7D%3C%2Fstyle%3E%3C%2Fdefs%3E%3Ctitle%3Eicon%20artboards%20patch%202%20strokecenter%3C%2Ftitle%3E%3Cpath%20class%3D%22cls-1%22%20d%3D%22M8.5%2C3a0.5%2C0.5%2C0%2C0%2C0-.35.15l-3.5%2C3.5a0.5%2C0.5%2C0%2C0%2C0%2C.71.71L8.5%2C4.21l3.15%2C3.15a0.5%2C0.5%2C0%2C0%2C0%2C.71-0.71l-3.5-3.5A0.5%2C0.5%2C0%2C0%2C0%2C8.5%2C3Z%22%2F%3E%3Crect%20class%3D%22cls-1%22%20x%3D%228%22%20y%3D%224%22%20width%3D%221%22%20height%3D%2210%22%2F%3E%3C%2Fsvg%3E';
-  @return url('#{$svg_data},#{$up-arrow-icon}');
-}
-
 @function generateLeftCaretIcon($fillColor: $clr-color-neutral-600) {
   $left-caret-icon: '%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20viewBox%3D%220%200%2016%2016%22%3E%3Cdefs%3E%3Cstyle%3E.cls-3%7Bfill%3A%23' +
     str-slice($fillColor + '', 2) +


### PR DESCRIPTION
- Removes the svg from scss
- adds a clr-icon that can toggle between both sorting states
- removes the clr-icon when unsorted

Signed-off-by: Matt Hippely <mhippely@vmware.com>