### PR TITLE
feat(schematics) automatically support installing @next

### DIFF
--- a/src/schematics/README.md
+++ b/src/schematics/README.md
@@ -39,7 +39,7 @@ Then when the schematics are parsed, there is a special schematic by the name of
 No matter what you do, you'll need to have a new Angular CLI project for testing. Create a new project with `ng new ngaddtest`. Then `cd ngaddtest` and create a new file called `.npmrc` and put in this line.
 
 ```bash
-registry=http://localhost:4873
+echo "registry=http://localhost:4873" >> .npmrc
 ```
 
 This will ensure that this project runs through your local registry before going to public NPM. I suggest committing this file so later you can always run `git reset --hard` but not lose this file.

--- a/src/schematics/src/add/index.ts
+++ b/src/schematics/src/add/index.ts
@@ -4,6 +4,10 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
+// @TODO REWRITE THIS
+// This is a mess, because it was written early on and could be much better.
+// Also, no real docs existed then or now, so good luck brave soldier.
+
 import { normalize, Path } from '@angular-devkit/core';
 import { chain, Rule, SchematicContext, SchematicsException, Tree } from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
@@ -67,6 +71,18 @@ function updateJsonFile(path: string, callback: (a: any) => any) {
   fs.writeFileSync(path, JSON.stringify(json, null, 2));
 }
 
+// Checks if a version of Angular is compatible with current or next
+function getVersion(ngVersion: string, clrVersion: string) {
+  const diff = 6; // Number disparity between Angular and Clarity, this works as long as we stay in sync with versioning
+  const version1 = ngVersion.split('.');
+
+  if (Number(version1[0]) - diff > 0) {
+    return 'next';
+  } else {
+    return clrVersion;
+  }
+}
+
 // Handles adding a module to the NgModule
 function addDeclarationToNgModule(
   options: ComponentOptions,
@@ -121,22 +137,24 @@ export default function(options: ComponentOptions): Rule {
 
     // Add Clarity packages to package.json, if not found
     updateJsonFile('package.json', json => {
+      const version = getVersion(json.dependencies['@angular/core'], corePackage.version);
+
       const packages = Object.keys(json.dependencies);
       if (!packages.includes('@clr/angular')) {
-        json.dependencies['@clr/angular'] = `^${corePackage.version}`;
+        json.dependencies['@clr/angular'] = `${version}`;
       }
       if (!packages.includes('@clr/ui')) {
-        json.dependencies['@clr/ui'] = `^${corePackage.version}`;
+        json.dependencies['@clr/ui'] = `${version}`;
       }
       if (!packages.includes('@clr/icons')) {
-        json.dependencies['@clr/icons'] = `^${corePackage.version}`;
+        json.dependencies['@clr/icons'] = `${version}`;
       }
       if (!packages.includes('@webcomponents/custom-elements')) {
         json.dependencies['@webcomponents/custom-elements'] = '^1.0.0';
       }
     });
 
-    // Add Clarity assets to .angular-cli.json, if not found
+    // Add Clarity assets to .angular.json, if not found
     updateJsonFile(configFile, json => {
       const projects = Object.keys(json.projects);
       const project = projects.find(key => {


### PR DESCRIPTION
This will setup the Clarity @next version when trying to use a n+1 version of Angular support.

### Release Notes

Updated `ng add @clr/angular` to detect if you are using a version of Angular that is ahead of our latest version (such as beta releases) and automatically install our beta/rc version as well to avoid mismatches.