### PR TITLE
[NG] Fix pagination init lifecycle

### DIFF
--- a/src/clr-angular/data/datagrid/all.spec.ts
+++ b/src/clr-angular/data/datagrid/all.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -31,6 +31,7 @@ import DatagridItemsTrackBySpecs from './datagrid-items-trackby.spec';
 import DatagridItemsSpecs from './datagrid-items.spec';
 import DatagridPageSizeSpecs from './datagrid-page-size.spec';
 import DatagridPaginationSpecs from './datagrid-pagination.spec';
+import DatagridPaginationIntegrationSpecs from './datagrid-pagination.integration.spec';
 import DatagridPlaceholderSpecs from './datagrid-placeholder.spec';
 import DatagridRowDetailSpecs from './datagrid-row-detail.spec';
 import DatagridRowSpecs from './datagrid-row.spec';
@@ -85,6 +86,7 @@ describe('Datagrid', function() {
     DatagridRowDetailSpecs();
     DatagridPageSizeSpecs();
     DatagridPaginationSpecs();
+    DatagridPaginationIntegrationSpecs();
     DatagridFooterSpecs();
     DatagridPlaceholderSpecs();
     DatagridSpecs();

--- a/src/clr-angular/data/datagrid/datagrid-pagination.integration.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-pagination.integration.spec.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component, Directive } from '@angular/core';
+import { spec, TestContext } from '../../utils/testing/helpers.spec';
+import { ClrDatagridModule } from './datagrid.module';
+import { ClrDatagridPagination } from './datagrid-pagination';
+import { Page } from './providers/page';
+
+@Component({
+  template: `
+    <clr-datagrid>
+      <clr-dg-column>Column</clr-dg-column>
+      
+      <clr-dg-row *clrDgItems="let item of items" instantiationCounter>
+        <clr-dg-cell>{{item}}</clr-dg-cell>
+      </clr-dg-row>
+
+      <clr-dg-footer>
+        <clr-dg-pagination [clrDgPageSize]="20"></clr-dg-pagination>
+      </clr-dg-footer>
+    </clr-datagrid>
+    `,
+})
+class IntegrationTest {
+  items = Array(100).fill(0);
+}
+
+/**
+ * We cannot spy on constructors in Typescript, so this tricks allows us to count the number
+ * of rows instantiated during a test.
+ */
+@Directive({
+  selector: '[instantiationCounter]',
+})
+class InstantiationCounter {
+  static total = 0;
+
+  constructor() {
+    InstantiationCounter.total++;
+  }
+}
+
+export default function(): void {
+  describe('ClrDatagridPagination component integration', function() {
+    type Context = TestContext<ClrDatagridPagination, IntegrationTest>;
+
+    spec(ClrDatagridPagination, IntegrationTest, ClrDatagridModule, { declarations: [InstantiationCounter] }, false);
+
+    it('sets the page size a single time on initialization', function(this: Context) {
+      const spy = spyOnProperty(Page.prototype, 'size', 'set').and.callThrough();
+      this.init();
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(20);
+    });
+
+    it('only instantiates rows that need to be displayed', function(this: Context) {
+      InstantiationCounter.total = 0;
+      this.init();
+      expect(InstantiationCounter.total).toBe(20);
+    });
+  });
+}

--- a/src/clr-angular/data/datagrid/datagrid-pagination.ts
+++ b/src/clr-angular/data/datagrid/datagrid-pagination.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -50,9 +50,9 @@ export class ClrDatagridPagination implements OnDestroy, OnInit {
   @ContentChild(ClrDatagridPageSize) _pageSizeComponent: ClrDatagridPageSize;
   @ViewChild('currentPageInput') currentPageInputRef: ElementRef;
 
-  private defaultSize = true;
-
-  constructor(public page: Page) {}
+  constructor(public page: Page) {
+    this.page.activated = true;
+  }
 
   /**********
    * Subscription to the Page service for page changes.
@@ -61,10 +61,10 @@ export class ClrDatagridPagination implements OnDestroy, OnInit {
   ngOnInit() {
     /*
      * Default page size is 10.
-     * The reason we set it in this constructor and not in the provider itself is because
-     * we don't want pagination (page size 0) if this component isn't present in the datagrid.
+     * The reason we set it here and not in the provider itself is because
+     * we don't want pagination if this component isn't present in the datagrid.
      */
-    if (this.defaultSize) {
+    if (!this.page.size) {
       this.page.size = 10;
     }
     this._pageSubscription = this.page.change.subscribe(current => this.currentChanged.emit(current));
@@ -92,7 +92,6 @@ export class ClrDatagridPagination implements OnDestroy, OnInit {
   @Input('clrDgPageSize')
   public set pageSize(size: number) {
     if (typeof size === 'number') {
-      this.defaultSize = false;
       this.page.size = size;
     }
   }

--- a/src/clr-angular/data/datagrid/providers/items.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/items.spec.ts
@@ -143,6 +143,19 @@ export default function(): void {
       expect(nbChanges).toBe(6);
     });
 
+    it('does not emit items changes until the page size is available', function() {
+      let nbChanges = 0;
+      this.itemsInstance.change.subscribe((items: number[]) => {
+        nbChanges++;
+      });
+      this.pageInstance.activated = true;
+      expect(nbChanges).toEqual(0);
+      setSmartItems(this.itemsInstance);
+      expect(nbChanges).toEqual(0);
+      this.pageInstance.size = 3;
+      expect(nbChanges).toEqual(1);
+    });
+
     describe('manual refresh', function() {
       beforeEach(function() {
         this.users = [{ name: 'hello' }, { name: 'world' }];

--- a/src/clr-angular/data/datagrid/providers/items.ts
+++ b/src/clr-angular/data/datagrid/providers/items.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -178,7 +178,8 @@ export class Items<T = any> {
    * Extracts the current page from the sorted list
    */
   private _changePage() {
-    if (this.uninitialized) {
+    // If we know we have pagination but the page size hasn't been set yet, we wait for it.
+    if (this.uninitialized || (this._page.activated && this._page.size === 0)) {
       return;
     }
     if (this._page.size > 0) {

--- a/src/clr-angular/data/datagrid/providers/page.ts
+++ b/src/clr-angular/data/datagrid/providers/page.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -11,6 +11,8 @@ import { StateDebouncer } from './state-debouncer.provider';
 @Injectable()
 export class Page {
   constructor(private stateDebouncer: StateDebouncer) {}
+
+  public activated = false;
 
   /**
    * Page size, a value of 0 means no pagination


### PR DESCRIPTION
Because of a lifecycle quirk, we would instantiate as many ClrDatagridRow components
as we would have in the entire dataset. They wouldn't go throught their full Angular
lifecycle, but they would be instantiated nonetheless.
This commit fixes this by making the Items provider wait for the page size to be
available before emitting any changes.

Fixes #3082.