### PR TITLE
[NG] remove duplicate aria behavior with alerts

### DIFF
--- a/src/clr-angular/emphasis/alert/alert.html
+++ b/src/clr-angular/emphasis/alert/alert.html
@@ -11,8 +11,7 @@
     [class.alert-hidden]="isHidden"
     [class.alert-sm]="isSmall"
     [class.alert-app-level]="isAppLevel"
-    role="alert"
-    aria-live="assertive">
+    role="alert">
     <div class="alert-items">
         <ng-content></ng-content>
     </div>

--- a/src/clr-angular/emphasis/alert/alert.spec.ts
+++ b/src/clr-angular/emphasis/alert/alert.spec.ts
@@ -121,9 +121,10 @@ export default function(): void {
       expect(myAlert.getAttribute('role')).toBe('alert');
     });
 
-    it('Has an ARIA-live value of assertive', () => {
+    it('should not have an aria-live when using role alert', () => {
+      // https://www.w3.org/TR/wai-aria-1.1/#alert
       const myAlert: HTMLElement = compiled.querySelector('.alert');
-      expect(myAlert.getAttribute('aria-live')).toBe('assertive');
+      expect(myAlert.getAttribute('aria-live')).toBe(null);
     });
 
     it('shows and hides the alert based on the clrAlertClosed input', () => {


### PR DESCRIPTION
Removed unnecessary `aria-live` attribute when using `role="alert"`.

closes #3195

Signed-off-by: Cory Rylan <crylan@vmware.com>