### PR TITLE
[NG] Stop caching children for lazy recursive trees

### DIFF
--- a/src/clr-angular/data/tree-view/models/recursive-tree-node.model.spec.ts
+++ b/src/clr-angular/data/tree-view/models/recursive-tree-node.model.spec.ts
@@ -41,6 +41,19 @@ export default function(): void {
       expect(nbFetch).toBe(1);
     });
 
+    it('offers a clearChildren() method that forces the children to be fetched again next time', function() {
+      let nbFetch = 0;
+      const root = new RecursiveTreeNodeModel('A', null, node => {
+        nbFetch++;
+        return synchronousChildren(node);
+      });
+      root.fetchChildren();
+      expect(nbFetch).toBe(1);
+      root.clearChildren();
+      root.fetchChildren();
+      expect(nbFetch).toBe(2);
+    });
+
     it('declares itself as parent for created children', function() {
       const root = new RecursiveTreeNodeModel('A', null, synchronousChildren);
       expect(root.children.map(c => c.parent)).toEqual([root, root]);

--- a/src/clr-angular/data/tree-view/models/recursive-tree-node.model.ts
+++ b/src/clr-angular/data/tree-view/models/recursive-tree-node.model.ts
@@ -28,6 +28,12 @@ export class RecursiveTreeNodeModel<T> extends TreeNodeModel<T> {
 
   private childrenFetched = false;
 
+  clearChildren() {
+    this._children.forEach(child => child.destroy());
+    delete this._children;
+    this.childrenFetched = false;
+  }
+
   fetchChildren() {
     if (this.childrenFetched) {
       return;

--- a/src/clr-angular/data/tree-view/recursive-children.ts
+++ b/src/clr-angular/data/tree-view/recursive-children.ts
@@ -29,13 +29,13 @@ import { RecursiveTreeNodeModel } from './models/recursive-tree-node.model';
  */
 export class RecursiveChildren<T> {
   constructor(public featuresService: TreeFeaturesService<T>, @Optional() private expandService: Expand) {
-    if (expandService && featuresService.recursion) {
+    if (expandService) {
       this.subscription = this.expandService.expandChange.subscribe(value => {
-        if (value && this.parent) {
-          // Once again, I'm sure we can find a way to avoid this casting by typing every component in a way that
-          // lets us use the more specific model classes depending on the use of *clrRecursiveForOf or not.
-          // But it would take time, which we don't have right now.
-          (<RecursiveTreeNodeModel<T>>this.parent).fetchChildren();
+        if (!value && this.parent && !this.featuresService.eager && this.featuresService.recursion) {
+          // In the case of lazy-loading recursive trees, we clear the children on collapse.
+          // This is better in case they change between two user interaction, and that way
+          // the app itself can decide whether to cache them or not.
+          (<RecursiveTreeNodeModel<T>>this.parent).clearChildren();
         }
       });
     }


### PR DESCRIPTION
We used to fetch children for lazy recursive trees only once, but we closed their selection Observable when we shouldn't. Rather than avoid closing the Observables when we reuse models, I decided to stop caching children altogether, letting the app decide whether they want to cache or not and do it on their side. It's less intrusive and more flexible.

Fixes #3209.