### PR TITLE
Fix tree view flickering from async eventemitter

### DIFF
--- a/src/dev/src/app/tree-view/eager-recursive-tree/eager-recursive-tree.html
+++ b/src/dev/src/app/tree-view/eager-recursive-tree/eager-recursive-tree.html
@@ -36,6 +36,8 @@
   </clr-tree>
 </div>
 
+<pre><code>{{singleRootSelected | json}}</code></pre>
+
 <h4>Multi root, selection</h4>
 <p>
   Selected: {{selectedString(multiRootSelected)}}
@@ -48,3 +50,5 @@
     </clr-tree-node>
   </clr-tree>
 </div>
+
+<pre><code>{{multiRootSelected | json}}</code></pre>

--- a/src/dev/src/app/tree-view/eager-recursive-tree/eager-recursive-tree.ts
+++ b/src/dev/src/app/tree-view/eager-recursive-tree/eager-recursive-tree.ts
@@ -7,13 +7,22 @@ import { Component } from '@angular/core';
 
 import { ClrSelectedState } from '@clr/angular';
 
+interface SelectedMap {
+  [key: string]: ClrSelectedState;
+}
+
+interface TreeNode {
+  name: string;
+  selected?: ClrSelectedState;
+  children?: TreeNode[];
+}
 @Component({
   selector: 'clr-eager-recursive-tree-demo',
   styleUrls: ['../tree-view.demo.scss'],
   templateUrl: './eager-recursive-tree.html',
 })
 export class EagerRecursiveTreeDemo {
-  singleRoot = {
+  singleRoot: TreeNode = {
     name: 'A',
     children: [
       { name: 'AA', children: [{ name: 'AAA' }, { name: 'AAB' }, { name: 'AAC' }] },
@@ -22,7 +31,7 @@ export class EagerRecursiveTreeDemo {
     ],
   };
 
-  multiRoot = [
+  multiRoot: TreeNode[] = [
     {
       name: 'A',
       children: [
@@ -41,12 +50,25 @@ export class EagerRecursiveTreeDemo {
     },
   ];
 
-  singleRootSelected: { [key: string]: ClrSelectedState } = {};
-  multiRootSelected: { [key: string]: ClrSelectedState } = {};
+  private buildDefaultSelected(rootMap: TreeNode | TreeNode[], selectedMap: SelectedMap = {}) {
+    if (!Array.isArray(rootMap)) {
+      rootMap = [rootMap];
+    }
+    rootMap.forEach(node => {
+      selectedMap[node.name] = ClrSelectedState.UNSELECTED;
+      if (node.children) {
+        this.buildDefaultSelected(node.children, selectedMap);
+      }
+    });
+    return selectedMap;
+  }
+
+  singleRootSelected: SelectedMap = this.buildDefaultSelected(this.singleRoot);
+  multiRootSelected: SelectedMap = this.buildDefaultSelected(this.multiRoot);
 
   synchronousChildren = node => node.children;
 
-  selectedString(selectedMap: { [key: string]: ClrSelectedState }) {
+  selectedString(selectedMap: SelectedMap) {
     return Object.keys(selectedMap)
       .filter(key => selectedMap[key] === ClrSelectedState.SELECTED)
       .join(', ');

--- a/src/dev/src/app/tree-view/pre-selection/pre-selection.html
+++ b/src/dev/src/app/tree-view/pre-selection/pre-selection.html
@@ -66,7 +66,9 @@
   </clr-tree-node>
 </div>
 
-<h4>Eager tree, inconsistent pre-selection (Christmas Edition)</h4>
+<!-- THIS IS AN UNSUPPORTED CASE, AND WILL THROW CHOCOLATE ERRORS. RETAINING ONLY FOR TEST CASES. -->
+
+<!-- <h4>Eager tree, inconsistent pre-selection (Christmas Edition)</h4>
 
 <p>
   If different nodes receive inconsistent selection states as their input,
@@ -102,7 +104,7 @@
       Not selected
     </clr-tree-node>
   </clr-tree-node>
-</div>
+</div> -->
 
 <h4>Lazy tree, consistent pre-selection</h4>
 <div class="clr-example">
@@ -185,6 +187,18 @@
           Not selected
         </clr-tree-node>
       </ng-template>
+    </clr-tree-node>
+  </clr-tree>
+</div>
+
+<h4>Larger declarative tree</h4>
+<div class="clr-example">
+  <clr-tree>
+    <clr-tree-node *ngFor="let node of larger">
+      {{node.name}}
+        <clr-tree-node *ngFor="let child of node.children" [(clrSelected)]="child.selected">
+          {{child.name}}
+        </clr-tree-node>
     </clr-tree-node>
   </clr-tree>
 </div>

--- a/src/dev/src/app/tree-view/pre-selection/pre-selection.ts
+++ b/src/dev/src/app/tree-view/pre-selection/pre-selection.ts
@@ -102,4 +102,29 @@ export class PreSelectionDemo {
       },
     },
   };
+
+  larger = [
+    {
+      name: 'Item A',
+      selected: ClrSelectedState.UNSELECTED,
+      children: this.addChildren('A'),
+    },
+    {
+      name: 'Item B',
+      selected: ClrSelectedState.UNSELECTED,
+      children: this.addChildren('B'),
+    },
+    {
+      name: 'Item C',
+      selected: ClrSelectedState.UNSELECTED,
+      children: this.addChildren('C'),
+    },
+  ];
+
+  private addChildren(letter) {
+    return Array.from(Array(50).keys()).map(key => ({
+      name: `Item ${letter}.${key}`,
+      selected: ClrSelectedState.UNSELECTED,
+    }));
+  }
 }


### PR DESCRIPTION
fix(tree) set tree view node event emitter to synchronous and don't output selected changes when setting input on node

A tree view with a number of nodes could be tricked into a state of uncertainty (flickering) by double clicking fast to trigger too many async event loops in the bindings. This stops the event propagation from firing in this specific case, but keeps it in the remainder where it is needed to update other nodes.

fixes #3073

### Release notes

Bugfix for tree view where it could trigger a flickering state by double clicking fast, or in any case where the tree tried to update before the tree had stabilized.