### PR TITLE
[UI] remove box shadow on disabled buttons

### DIFF
--- a/src/clr-angular/button/_buttons.clarity.scss
+++ b/src/clr-angular/button/_buttons.clarity.scss
@@ -109,6 +109,7 @@
     opacity: 0.4;
     background-color: getSassButtonColor($button-type, disabled-bg-color);
     border-color: getSassButtonColor($button-type, disabled-border-color);
+    box-shadow: none;
   }
 }
 


### PR DESCRIPTION
Remove box shadow on disabled buttons to prevent shadow from showing on active state.

Signed-off-by: Cory Rylan <crylan@vmware.com>