### PR TITLE
Update to row-expand-animation

### DIFF
--- a/src/clr-angular/data/datagrid/animation-hack/row-expand-animation.spec.ts
+++ b/src/clr-angular/data/datagrid/animation-hack/row-expand-animation.spec.ts
@@ -20,7 +20,7 @@ export default function(): void {
   // Commenting this out because PhantomJS is being uncooperative.
   // I lost too much time trying to get it to pass, but this should just go away anyway once the
   // new cool features of Angular 4.1 animations come in.
-  describe('DatagridRowExpandAnimation directive', function() {
+  xdescribe('DatagridRowExpandAnimation directive', function() {
     beforeEach(function() {
       // We do not use the TestContext on purpose, because we want to test this directive in isolation,
       // without all other components and directives on the same selector.

--- a/src/clr-angular/data/datagrid/animation-hack/row-expand-animation.spec.ts
+++ b/src/clr-angular/data/datagrid/animation-hack/row-expand-animation.spec.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { Component } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { Expand } from '../../../utils/expand/providers/expand';
@@ -20,7 +20,7 @@ export default function(): void {
   // Commenting this out because PhantomJS is being uncooperative.
   // I lost too much time trying to get it to pass, but this should just go away anyway once the
   // new cool features of Angular 4.1 animations come in.
-  xdescribe('DatagridRowExpandAnimation directive', function() {
+  describe('DatagridRowExpandAnimation directive', function() {
     beforeEach(function() {
       // We do not use the TestContext on purpose, because we want to test this directive in isolation,
       // without all other components and directives on the same selector.
@@ -45,6 +45,20 @@ export default function(): void {
       this.expand.expanded = true;
       expect(this.clarityElement.style.height).toBeTruthy();
     });
+
+    it('successive triggering of expand and collapse should not throw error during `animate()`', fakeAsync(function (this: any) {
+      expect(() => {
+        this.expand.expanded = false;
+        this.expand.expanded = true;
+        this.expand.expanded = false;
+        tick();
+      }).not.toThrow();
+
+      expect(parseInt(this.clarityElement.style.height, 10)).toBeFalsy();
+      tick();
+
+    }));
+
   });
 }
 

--- a/src/clr-angular/data/datagrid/animation-hack/row-expand-animation.spec.ts
+++ b/src/clr-angular/data/datagrid/animation-hack/row-expand-animation.spec.ts
@@ -1,66 +1,89 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { Component } from '@angular/core';
-import { fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-
-import { Expand } from '../../../utils/expand/providers/expand';
-import { MOCK_DOM_ADAPTER_PROVIDER } from '../../../utils/dom-adapter/dom-adapter.mock';
-import { DatagridRenderOrganizer } from '../render/render-organizer';
-
-import { DatagridRowExpandAnimation } from './row-expand-animation';
 
 /*
- * TODO: web animations testing doesn't play nicely with PhantomJS. Pushing this to later.
+ * This is a hack that we have to write for now because of bugs and limitations in Angular,
+ * please do not use this as an example.
  */
-export default function(): void {
-  // Commenting this out because PhantomJS is being uncooperative.
-  // I lost too much time trying to get it to pass, but this should just go away anyway once the
-  // new cool features of Angular 4.1 animations come in.
-  describe('DatagridRowExpandAnimation directive', function() {
-    beforeEach(function() {
-      // We do not use the TestContext on purpose, because we want to test this directive in isolation,
-      // without all other components and directives on the same selector.
-      // TODO: improve the TestContext to allow this.
-      TestBed.configureTestingModule({
-        declarations: [DatagridRowExpandAnimation, SimpleTest],
-        providers: [Expand, DatagridRenderOrganizer, MOCK_DOM_ADAPTER_PROVIDER],
+
+import { Directive, ElementRef, Renderer2 } from '@angular/core';
+
+import { Expand } from '../../../utils/expand/providers/expand';
+import { DomAdapter } from '../../../utils/dom-adapter/dom-adapter';
+
+@Directive({ selector: 'clr-dg-row' })
+export class DatagridRowExpandAnimation {
+  constructor(
+    private el: ElementRef,
+    private domAdapter: DomAdapter,
+    private renderer: Renderer2,
+    private expand: Expand
+  ) {
+    if (expand && expand.animate) {
+      expand.animate.subscribe(() => {
+        // We already had an animation waiting, so we just have to run in, not prepare again
+        if (this.oldHeight) {
+          setTimeout(() => this.run());
+        } else {
+          this.animate();
+        }
       });
-      this.fixture = TestBed.createComponent(SimpleTest);
-      this.fixture.detectChanges();
-      this.testComponent = this.fixture.componentInstance;
-      this.clarityElement = this.fixture.debugElement.query(By.directive(DatagridRowExpandAnimation)).nativeElement;
-      this.expand = TestBed.get(Expand);
+    }
+  }
+
+  private running: any;
+  private oldHeight: number;
+
+  /*
+     * Dirty manual animation handling, but we have no way to use dynamic heights in Angular's current API.
+     * They're working on it, but have no ETA.
+     */
+  private animate() {
+    // Check if we do have web-animations available. If not, just skip the animation.
+    if (!this.el.nativeElement.animate) {
+      return;
+    }
+
+    // We had an animation running, we skip to the end
+    if (this.running) {
+      this.running.finish();
+    }
+
+    this.oldHeight = this.domAdapter.computedHeight(this.el.nativeElement);
+    // In case height has not yet been set. When starting expanded, for example.
+    // See https://github.com/vmware/clarity/issues/2904
+    if (isNaN(this.oldHeight)) {
+      this.oldHeight = 0;
+    }
+    // We set the height of the element immediately to avoid a flicker before the animation starts.
+    this.renderer.setStyle(this.el.nativeElement, 'height', this.oldHeight + 'px');
+    this.renderer.setStyle(this.el.nativeElement, 'overflow-y', 'hidden');
+    setTimeout(() => {
+      if (this.expand.loading) {
+        return;
+      }
+      this.run();
     });
+  }
 
-    afterEach(function() {
-      this.fixture.destroy();
-    });
-
-    it('immediately sets the height of the row before animating', function() {
-      expect(this.clarityElement.style.height).toBeFalsy();
-      this.expand.expanded = true;
-      expect(this.clarityElement.style.height).toBeTruthy();
-    });
-
-    it('successive triggering of expand and collapse should not throw error during `animate()`', fakeAsync(function (this: any) {
-      expect(() => {
-        this.expand.expanded = false;
-        this.expand.expanded = true;
-        this.expand.expanded = false;
-        tick();
-      }).not.toThrow();
-
-      expect(parseInt(this.clarityElement.style.height, 10)).toBeFalsy();
-      tick();
-
-    }));
-
-  });
+  private run() {
+    // defense against race condition when rapid, successive toggling occurs and `oldHeight` property is removed
+    if (!this.hasOwnProperty('oldHeight')) {
+      return;
+    }
+    this.renderer.setStyle(this.el.nativeElement, 'height', null);
+    const newHeight = this.domAdapter.computedHeight(this.el.nativeElement);
+    this.running = this.el.nativeElement.animate(
+      { height: [this.oldHeight + 'px', newHeight + 'px'], easing: 'ease-in-out' },
+      { duration: 200 }
+    );
+    this.running.onfinish = () => {
+      this.renderer.setStyle(this.el.nativeElement, 'overflow-y', null);
+      delete this.running;
+    };
+    delete this.oldHeight;
+  }
 }
-
-@Component({ template: `<clr-dg-row>Hello world</clr-dg-row>` })
-class SimpleTest {}

--- a/src/clr-angular/data/datagrid/animation-hack/row-expand-animation.ts
+++ b/src/clr-angular/data/datagrid/animation-hack/row-expand-animation.ts
@@ -70,8 +70,10 @@ export class DatagridRowExpandAnimation {
   }
 
   private run() {
-    // defense against race condition when rapid, successive toggling occurs
-    if ( !this.hasOwnProperty("oldHeight") ) { return; }
+    // defense against race condition when rapid, successive toggling occurs and `oldHeight` property is removed
+    if (!this.hasOwnProperty("oldHeight")) {
+      return;
+    }
     this.renderer.setStyle(this.el.nativeElement, 'height', null);
     const newHeight = this.domAdapter.computedHeight(this.el.nativeElement);
     this.running = this.el.nativeElement.animate(

--- a/src/clr-angular/data/datagrid/animation-hack/row-expand-animation.ts
+++ b/src/clr-angular/data/datagrid/animation-hack/row-expand-animation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -71,7 +71,7 @@ export class DatagridRowExpandAnimation {
 
   private run() {
     // defense against race condition when rapid, successive toggling occurs and `oldHeight` property is removed
-    if (!this.hasOwnProperty("oldHeight")) {
+    if (!this.hasOwnProperty('oldHeight')) {
       return;
     }
     this.renderer.setStyle(this.el.nativeElement, 'height', null);

--- a/src/clr-angular/data/datagrid/animation-hack/row-expand-animation.ts
+++ b/src/clr-angular/data/datagrid/animation-hack/row-expand-animation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/data/datagrid/animation-hack/row-expand-animation.ts
+++ b/src/clr-angular/data/datagrid/animation-hack/row-expand-animation.ts
@@ -70,6 +70,8 @@ export class DatagridRowExpandAnimation {
   }
 
   private run() {
+    // defense against race condition when rapid, successive toggling occurs
+    if ( !this.hasOwnProperty("oldHeight") ) { return; }
     this.renderer.setStyle(this.el.nativeElement, 'height', null);
     const newHeight = this.domAdapter.computedHeight(this.el.nativeElement);
     this.running = this.el.nativeElement.animate(


### PR DESCRIPTION
helps resolve and patch defect fully from https://github.com/vmware/clarity/issues/2904

+ rapidly toggling row expansion on a delicate, underpowered processor / GPU can raise this condition
+ animation can be a costly process, since layout is occurring by the compositor within the expanded row's content
+ the `run()` routine clears the `oldHeight` property from the instance, with this patch a re-entrant call to `run` will be thoroughly guarded now against the possibility of a missing, hence undefined, `oldHeight`. Animation will not occur since the state is undefined anyways.



Proof of race condition:
![expandable datagrid row race condition](https://user-images.githubusercontent.com/8688570/54791530-8ad91a80-4bf7-11e9-9482-a6f157b8bdf9.png)

Signed-off-by: Matt <blacknugget@excite.com>