### PR TITLE
[WEBSITE] fix logo paths

### DIFF
--- a/src/website/src/manifest.json
+++ b/src/website/src/manifest.json
@@ -13,37 +13,37 @@
       "type": "image/png"
     },
     {
-      "src": "images/icons/icon-96x96.png",
+      "src": "assets/images/icons/icon-96x96.png",
       "sizes": "96x96",
       "type": "image/png"
     },
     {
-      "src": "images/icons/icon-128x128.png",
+      "src": "assets/images/icons/icon-128x128.png",
       "sizes": "128x128",
       "type": "image/png"
     },
     {
-      "src": "images/icons/icon-144x144.png",
+      "src": "assets/images/icons/icon-144x144.png",
       "sizes": "144x144",
       "type": "image/png"
     },
     {
-      "src": "images/icons/icon-152x152.png",
+      "src": "assets/images/icons/icon-152x152.png",
       "sizes": "152x152",
       "type": "image/png"
     },
     {
-      "src": "images/icons/icon-192x192.png",
+      "src": "assets/images/icons/icon-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "images/icons/icon-384x384.png",
+      "src": "assets/images/icons/icon-384x384.png",
       "sizes": "384x384",
       "type": "image/png"
     },
     {
-      "src": "images/icons/icon-512x512.png",
+      "src": "assets/images/icons/icon-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }


### PR DESCRIPTION
Fixes 404 path issue for logo images with site metadata.

closes #3234

Signed-off-by: Cory Rylan <crylan@vmware.com>