### PR TITLE
fix premature validation appearing until after touched, fixed styling for disabled checkbox/radios

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -663,7 +663,8 @@ export declare class ClrEmphasisModule {
 export declare class ClrForm {
     layoutService: LayoutService;
     constructor(layoutService: LayoutService, markControlService: MarkControlService);
-    markAsDirty(): void;
+    /** @deprecated */ markAsDirty(): void;
+    markAsTouched(): void;
 }
 
 export declare class ClrFormsDeprecatedModule {

--- a/src/clr-angular/deprecations.spec.ts
+++ b/src/clr-angular/deprecations.spec.ts
@@ -4,6 +4,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
+import { ClrForm } from './forms/common/form';
+
 describe('Deprecations', () => {
   // When we deprecate some code, we should write a test to verify it is still in the bundle
   // and keep track of when it was deprecated, and when we plan to remove it.
@@ -13,6 +15,11 @@ describe('Deprecations', () => {
   });
 
   describe('2.0', () => {
+    it('should handle ClrForm.markAsDirty as ClrForm.markAsTouched', () => {
+      spyOn(ClrForm.prototype, 'markAsTouched');
+      ClrForm.prototype.markAsDirty();
+      expect(ClrForm.prototype.markAsTouched).toHaveBeenCalled();
+    });
     it('should replace $clr-default prefixed SASS variables with $clr-global prefixed variables');
     it('should no longer have the $clr-font-weights typography SASS map');
     it('should replace $clr-app-font-color-primary SASS variable with $clr-global-font-color');

--- a/src/clr-angular/forms/common/form.spec.ts
+++ b/src/clr-angular/forms/common/form.spec.ts
@@ -59,11 +59,11 @@ export default function(): void {
       expect(directive.injector.get(MarkControlService)).toBeTruthy();
     });
 
-    it('calls markAsDirty', function() {
+    it('calls markAsTouched', function() {
       const service = directive.injector.get(MarkControlService);
-      spyOn(service, 'markAsDirty');
-      directive.componentInstance.form.markAsDirty();
-      expect(service.markAsDirty).toHaveBeenCalled();
+      spyOn(service, 'markAsTouched');
+      directive.componentInstance.form.markAsTouched();
+      expect(service.markAsTouched).toHaveBeenCalled();
     });
   });
 }

--- a/src/clr-angular/forms/common/form.ts
+++ b/src/clr-angular/forms/common/form.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -21,7 +21,12 @@ import { MarkControlService } from './providers/mark-control.service';
 export class ClrForm {
   constructor(public layoutService: LayoutService, private markControlService: MarkControlService) {}
 
+  /** @deprecated since 2.0 */
   markAsDirty() {
-    this.markControlService.markAsDirty();
+    this.markAsTouched();
+  }
+
+  markAsTouched() {
+    this.markControlService.markAsTouched();
   }
 }

--- a/src/clr-angular/forms/common/if-error/if-error.service.spec.ts
+++ b/src/clr-angular/forms/common/if-error/if-error.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -57,7 +57,7 @@ export default function(): void {
             return function unsubscribe() {};
           },
         },
-        dirty: true,
+        touched: true,
         invalid: true,
       };
       ngControlService.setControl(fakeControl);

--- a/src/clr-angular/forms/common/if-error/if-error.service.ts
+++ b/src/clr-angular/forms/common/if-error/if-error.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -44,7 +44,7 @@ export class IfErrorService implements OnDestroy {
   }
 
   private sendValidity() {
-    if ((this.control.touched || this.control.dirty) && this.control.invalid) {
+    if (this.control.touched && this.control.invalid) {
       this._statusChanges.next(true);
     } else {
       this._statusChanges.next(false);

--- a/src/clr-angular/forms/common/providers/mark-control.service.ts
+++ b/src/clr-angular/forms/common/providers/mark-control.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -9,13 +9,13 @@ import { Subject, Observable } from 'rxjs';
 
 @Injectable()
 export class MarkControlService {
-  private _dirty: Subject<void> = new Subject();
+  private _touched: Subject<void> = new Subject();
 
-  get dirtyChange(): Observable<void> {
-    return this._dirty.asObservable();
+  get touchedChange(): Observable<void> {
+    return this._touched.asObservable();
   }
 
-  markAsDirty() {
-    this._dirty.next();
+  markAsTouched() {
+    this._touched.next();
   }
 }

--- a/src/clr-angular/forms/common/wrapped-control.spec.ts
+++ b/src/clr-angular/forms/common/wrapped-control.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -199,12 +199,12 @@ export default function(): void {
         expect(ControlClassService.prototype.initControlClass).toHaveBeenCalled();
       });
 
-      it('subscribes to requests to mark as dirty', function(this: TestContext) {
+      it('subscribes to requests to mark as touched', function(this: TestContext) {
         setupTest(this, WithControl, TestControl3);
-        expect(this.input.className).not.toContain('ng-dirty');
-        this.markControlService.markAsDirty();
+        expect(this.input.className).not.toContain('ng-touched');
+        this.markControlService.markAsTouched();
         this.fixture.detectChanges();
-        expect(this.input.className).toContain('ng-dirty');
+        expect(this.input.className).toContain('ng-touched');
       });
 
       it('sets the control on ngControlService', function(this: TestContext) {

--- a/src/clr-angular/forms/common/wrapped-control.ts
+++ b/src/clr-angular/forms/common/wrapped-control.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -62,8 +62,8 @@ export class WrappedFormControl<W extends DynamicWrapper> implements OnInit, OnD
     }
     if (this.markControlService) {
       this.subscriptions.push(
-        this.markControlService.dirtyChange.subscribe(() => {
-          this.ngControl.control.markAsDirty();
+        this.markControlService.touchedChange.subscribe(() => {
+          this.ngControl.control.markAsTouched();
           this.ngControl.control.updateValueAndValidity();
         })
       );

--- a/src/clr-angular/forms/styles/_checkbox.clarity.scss
+++ b/src/clr-angular/forms/styles/_checkbox.clarity.scss
@@ -84,6 +84,10 @@
   }
 
   .clr-form-control-disabled .clr-checkbox-wrapper {
+    label {
+      cursor: not-allowed;
+    }
+
     input[type='checkbox'] + label::before,
     input[type='checkbox']:checked + label::before {
       background-color: $clr-forms-checkbox-disabled-background-color;

--- a/src/clr-angular/forms/styles/_radio.clarity.scss
+++ b/src/clr-angular/forms/styles/_radio.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -60,6 +60,12 @@
         background-color: $clr-forms-radio-disabled-background-color; // 'dot' color
         box-shadow: $clr-forms-radio-disabled-shadow; //background-color around the dot
       }
+    }
+  }
+
+  .clr-form-control-disabled .clr-radio-wrapper {
+    label {
+      cursor: not-allowed;
     }
   }
 

--- a/src/clr-angular/forms/tests/container.spec.ts
+++ b/src/clr-angular/forms/tests/container.spec.ts
@@ -152,7 +152,7 @@ function fullSpec(description, testContainer, directives: any | any[], testCompo
 
     it('tracks the validity of the form control', () => {
       expect(container.invalid).toBeFalse();
-      markControlService.markAsDirty();
+      markControlService.markAsTouched();
       fixture.detectChanges();
       expect(container.invalid).toBeTrue();
     });

--- a/src/clr-angular/forms/tests/control.spec.ts
+++ b/src/clr-angular/forms/tests/control.spec.ts
@@ -70,7 +70,7 @@ function fullTest(description, testContainer, testControl, testComponent, contro
     });
 
     it('should have the MarkControlService', () => {
-      expect(markControlService.markAsDirty).toBeTruthy();
+      expect(markControlService.markAsTouched).toBeTruthy();
     });
 
     it('correctly extends WrappedFormControl', () => {

--- a/src/dev/src/app/forms/reset/reset.ts
+++ b/src/dev/src/app/forms/reset/reset.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -18,6 +18,6 @@ export class FormsResetDemo {
   });
 
   validate() {
-    this.form.markAsDirty();
+    this.form.markAsTouched();
   }
 }

--- a/src/dev/src/app/input/input.demo.html
+++ b/src/dev/src/app/input/input.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -17,7 +17,7 @@
 
   <clr-input-container>
     <label>Full example</label>
-    <input type="text" placeholder="Full example" clrInput [(ngModel)]="vertical.three" name="three" required />
+    <input type="text" placeholder="Full example" clrInput [(ngModel)]="vertical.three" name="three" required minlength="8" />
     <clr-control-helper>Helper text</clr-control-helper>
     <clr-control-error>There was an error</clr-control-error>
   </clr-input-container>

--- a/src/dev/src/app/password/password.demo.html
+++ b/src/dev/src/app/password/password.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -22,9 +22,10 @@
 
     <clr-password-container>
       <label>Full example</label>
-      <input placeholder="Full example" clrPassword [(ngModel)]="vertical.three" required name="three" />
+      <input placeholder="Full example" clrPassword [(ngModel)]="vertical.three" required name="three" minlength="8" />
       <clr-control-helper>Helper text</clr-control-helper>
-      <clr-control-error>There was an error</clr-control-error>
+      <clr-control-error *clrIfError="'required'">This is required</clr-control-error>
+      <clr-control-error *clrIfError="'minlength'">Must be at least 8 characters</clr-control-error>
     </clr-password-container>
 
     <clr-password-container>

--- a/src/website/src/app/documentation/demos/forms/forms.demo.html
+++ b/src/website/src/app/documentation/demos/forms/forms.demo.html
@@ -59,7 +59,7 @@
         
         <clr-code-snippet [clrCode]="ngReset" clrLanguage="typescript"></clr-code-snippet>
 
-        <p>Normally, validation errors only appear after the control has been focused on by the user. In cases where you want to force validation errors to show (such as when the user tried to submit a form), you simply need to mark every control as dirty with Angular. To make this easier, we have provided an API <code class="clr-code">ClrForm.markAsDirty()</code> that will force all form controls inside of a form to be dirty, which will display the validation errors.</p>
+        <p>Normally, validation errors only appear after the control has been focused on by the user. In cases where you want to force validation errors to show (such as when the user tried to submit a form), you simply need to mark every control as touched with Angular. You can use the form API to accomplish this, <code class="clr-code">ClrForm.markAsTouched()</code>, which will force all form controls inside of a form to be touched, which will display the validation errors.</p>
         
         <clr-code-snippet [clrCode]="ngValidate" clrLanguage="typescript"></clr-code-snippet>
         

--- a/src/website/src/app/documentation/demos/forms/ng/validate.txt
+++ b/src/website/src/app/documentation/demos/forms/ng/validate.txt
@@ -18,9 +18,9 @@ export class ReactiveFormsDemo {
 
     submit() {
         if (this.exampleForm.invalid) {
-            this.clrForm.markAsDirty();
+            this.clrForm.markAsTouched();
         } else {
-            // ...
+            // Do submit logic
         }
     }
 }

--- a/src/website/src/app/documentation/demos/radio/radio.demo.html
+++ b/src/website/src/app/documentation/demos/radio/radio.demo.html
@@ -114,11 +114,11 @@
         <clr-radio-container>
           <label>Disabled radio example</label>
           <clr-radio-wrapper>
-            <input type="radio" clrCheckbox name="test5" value="option1" [(ngModel)]="exampleThree" disabled />
+            <input type="radio" clrRadio name="test5" value="option1" [(ngModel)]="exampleThree" disabled />
             <label>Option 1</label>
           </clr-radio-wrapper>
           <clr-radio-wrapper>
-            <input type="radio" clrCheckbox name="test5" value="option2" [(ngModel)]="exampleThree" disabled />
+            <input type="radio" clrRadio name="test5" value="option2" [(ngModel)]="exampleThree" disabled />
             <label>Option 2</label>
           </clr-radio-wrapper>
           <clr-control-helper>Helper text</clr-control-helper>


### PR DESCRIPTION
This updates the validation logic to only care about the touched state of a control before it will show validation errors. The reason is we had a dirty state being considered as well, and it would cause validation errors to show too soon. In reality, we only care after the control has been touched (focused and blurred).

This deprecates the `ClrForm.markAsDirty` API in favor of a better named `ClrForm.markAsTouched`.

fixes #3221
fixes #3081