### PR TITLE
[NG] Focus management utilities

### DIFF
--- a/src/clr-angular/popover/dropdown/_menu-mixins.clarity.scss
+++ b/src/clr-angular/popover/dropdown/_menu-mixins.clarity.scss
@@ -43,7 +43,7 @@
   text-transform: none;
 
   &:hover,
-  &.focus {
+  &.clr-focus {
     background-color: $clr-dropdown-bg-hover-color;
     color: $clr-dropdown-item-text-color;
     text-decoration: none;
@@ -73,7 +73,7 @@
     }
 
     &:active,
-    &.focus {
+    &.clr-focus {
       background: none;
       box-shadow: none;
     }

--- a/src/clr-angular/popover/dropdown/_menu-mixins.clarity.scss
+++ b/src/clr-angular/popover/dropdown/_menu-mixins.clarity.scss
@@ -43,7 +43,7 @@
   text-transform: none;
 
   &:hover,
-  &:focus {
+  &.focus {
     background-color: $clr-dropdown-bg-hover-color;
     color: $clr-dropdown-item-text-color;
     text-decoration: none;
@@ -73,7 +73,7 @@
     }
 
     &:active,
-    &:focus {
+    &.focus {
       background: none;
       box-shadow: none;
     }

--- a/src/clr-angular/popover/dropdown/all.spec.ts
+++ b/src/clr-angular/popover/dropdown/all.spec.ts
@@ -7,12 +7,21 @@ import { addHelpers } from '../../data/datagrid/helpers.spec';
 
 import DropdownMenuSpecs from './dropdown-menu.spec';
 import DropdownSpecs from './dropdown.spec';
+import DropdownItemSpecs from './dropdown-item.spec';
+import DropdownTriggerSpecs from './dropdown-trigger.spec';
+import DropdownFocusHandlerSpecs from './providers/dropdown-focus-handler.spec';
 
 describe('Dropdown', function() {
   addHelpers();
 
+  describe('Providers', function() {
+    DropdownFocusHandlerSpecs();
+  });
+
   describe('Components', function() {
     DropdownSpecs();
     DropdownMenuSpecs();
+    DropdownItemSpecs();
+    DropdownTriggerSpecs();
   });
 });

--- a/src/clr-angular/popover/dropdown/dropdown-item.spec.ts
+++ b/src/clr-angular/popover/dropdown/dropdown-item.spec.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component } from '@angular/core';
+
+import { spec, TestContext } from '../../utils/testing/helpers.spec';
+import { FocusableItem } from '../../utils/focus/focusable-item/focusable-item';
+import { ClrDropdownItem } from './dropdown-item';
+import { ClrDropdown } from './dropdown';
+import { ROOT_DROPDOWN_PROVIDER } from './providers/dropdown.service';
+
+@Component({
+  template: `
+    <button clrDropdownItem [disabled]="disabled">Hello world</button>
+  `,
+})
+class SimpleTest {
+  disabled: boolean;
+}
+
+export default function(): void {
+  describe('DropdownItem directive', function() {
+    /*
+     * Most tests for this directive are apparently jammed in the main dropdown.spec.ts,
+     * but moving them isn't relevant to this commit.
+     */
+
+    type Context = TestContext<ClrDropdownItem, SimpleTest>;
+    spec(ClrDropdownItem, SimpleTest, null, {
+      // Dummy dropdown provider, I don't even need a single property or method on it at the moment.
+      providers: [{ provide: ClrDropdown, useValue: {} }, ROOT_DROPDOWN_PROVIDER],
+    });
+
+    it('adds the menuitem role to the host', function(this: Context) {
+      expect(this.clarityElement.getAttribute('role')).toBe('menuitem');
+    });
+
+    it('updates the disabled property of the FocusableItem', function(this: Context) {
+      this.hostComponent.disabled = true;
+      this.detectChanges();
+      expect(this.getClarityProvider(FocusableItem).disabled).toBe(true);
+      this.hostComponent.disabled = false;
+      this.detectChanges();
+      expect(this.getClarityProvider(FocusableItem).disabled).toBe(false);
+    });
+  });
+}

--- a/src/clr-angular/popover/dropdown/dropdown-item.ts
+++ b/src/clr-angular/popover/dropdown/dropdown-item.ts
@@ -3,19 +3,35 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { AfterViewInit, Directive, ElementRef, Renderer2 } from '@angular/core';
+import { AfterViewInit, Directive, ElementRef, Input, Renderer2 } from '@angular/core';
 
 import { ClrDropdown } from './dropdown';
+import { BASIC_FOCUSABLE_ITEM_PROVIDER } from '../../utils/focus/focusable-item/basic-focusable-item.service';
+import { FocusableItem } from '../../utils/focus/focusable-item/focusable-item';
 import { RootDropdownService } from './providers/dropdown.service';
 
-@Directive({ selector: '[clrDropdownItem]', host: { '[class.dropdown-item]': 'true' } })
+@Directive({
+  selector: '[clrDropdownItem]',
+  host: {
+    '[class.dropdown-item]': 'true',
+    '[attr.role]': '"menuitem"',
+  },
+  providers: [BASIC_FOCUSABLE_ITEM_PROVIDER],
+})
 export class ClrDropdownItem implements AfterViewInit {
   constructor(
     private dropdown: ClrDropdown,
-    private el: ElementRef,
+    private el: ElementRef<HTMLElement>,
     private _dropdownService: RootDropdownService,
-    private renderer: Renderer2
+    private renderer: Renderer2,
+    private focusableItem: FocusableItem
   ) {}
+
+  @Input()
+  set disabled(value: boolean | string) {
+    // Empty string attribute evaluates to false but should disable the item, so we need to add a special case for it.
+    this.focusableItem.disabled = !!value || value === '';
+  }
 
   ngAfterViewInit() {
     this.renderer.listen(this.el.nativeElement, 'click', () => this.onDropdownItemClick());

--- a/src/clr-angular/popover/dropdown/dropdown-trigger.spec.ts
+++ b/src/clr-angular/popover/dropdown/dropdown-trigger.spec.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component } from '@angular/core';
+import { IfOpenService } from '../../utils/conditional/if-open.service';
+import { FocusService } from '../../utils/focus/focus.service';
+
+import { spec, TestContext } from '../../utils/testing/helpers.spec';
+import { ClrDropdownTrigger } from './dropdown-trigger';
+import { ClrDropdown } from './dropdown';
+import { DROPDOWN_FOCUS_HANDLER_PROVIDER, DropdownFocusHandler } from './providers/dropdown-focus-handler.service';
+
+@Component({
+  template: `
+    <button clrDropdownTrigger>Hello world</button>
+  `,
+  // These services are declared here because they need the renderer
+  providers: [FocusService, DROPDOWN_FOCUS_HANDLER_PROVIDER],
+})
+class SimpleTest {}
+
+export default function(): void {
+  describe('DropdownTrigger directive', function() {
+    /*
+     * Most tests for this directive are apparently jammed in the main dropdown.spec.ts,
+     * but moving them isn't relevant to this commit.
+     */
+
+    type Context = TestContext<ClrDropdownTrigger, SimpleTest>;
+    spec(ClrDropdownTrigger, SimpleTest, null, { providers: [{ provide: ClrDropdown, useValue: {} }, IfOpenService] });
+
+    it('adds the aria-haspopup attribute to the host', function(this: Context) {
+      expect(this.clarityElement.getAttribute('aria-haspopup')).toBe('menu');
+    });
+
+    it('adds the aria-expanded attribute to the host', function(this: Context) {
+      const ifOpenService = this.getProvider(IfOpenService);
+      ifOpenService.open = false;
+      this.detectChanges();
+      expect(this.clarityElement.getAttribute('aria-expanded')).toBe('false');
+      ifOpenService.open = true;
+      this.detectChanges();
+      expect(this.clarityElement.getAttribute('aria-expanded')).toBe('true');
+    });
+
+    it('declares itself to the DropdownFocusHandler', function(this: Context) {
+      expect(this.getClarityProvider(DropdownFocusHandler).trigger).toBe(this.clarityElement);
+    });
+  });
+}

--- a/src/clr-angular/popover/dropdown/dropdown-trigger.ts
+++ b/src/clr-angular/popover/dropdown/dropdown-trigger.ts
@@ -3,11 +3,12 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { Directive, HostListener } from '@angular/core';
+import { Directive, ElementRef, HostListener } from '@angular/core';
 
 import { IfOpenService } from '../../utils/conditional/if-open.service';
 
 import { ClrDropdown } from './dropdown';
+import { DropdownFocusHandler } from './providers/dropdown-focus-handler.service';
 
 @Directive({
   // We support both selectors for legacy reasons
@@ -17,16 +18,24 @@ import { ClrDropdown } from './dropdown';
     '[class.dropdown-item]': '!isRootLevelToggle',
     '[class.expandable]': '!isRootLevelToggle',
     '[class.active]': 'active',
+    '[attr.aria-haspopup]': '"menu"',
+    '[attr.aria-expanded]': 'ifOpenService.open',
   },
 })
 export class ClrDropdownTrigger {
   public isRootLevelToggle: boolean = true;
 
-  constructor(dropdown: ClrDropdown, private ifOpenService: IfOpenService) {
+  constructor(
+    dropdown: ClrDropdown,
+    private ifOpenService: IfOpenService,
+    el: ElementRef<HTMLElement>,
+    focusHandler: DropdownFocusHandler
+  ) {
     // if the containing dropdown has a parent, then this is not the root level one
     if (dropdown.parent) {
       this.isRootLevelToggle = false;
     }
+    focusHandler.trigger = el.nativeElement;
   }
 
   get active(): boolean {

--- a/src/clr-angular/popover/dropdown/dropdown.spec.ts
+++ b/src/clr-angular/popover/dropdown/dropdown.spec.ts
@@ -8,9 +8,12 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { IfOpenService } from '../../utils/conditional/if-open.service';
+import { FocusService } from '../../utils/focus/focus.service';
+import { FocusableItem } from '../../utils/focus/focusable-item/focusable-item';
 
 import { ClrDropdown } from './dropdown';
 import { ClrDropdownModule } from './dropdown.module';
+import { DropdownFocusHandler } from './providers/dropdown-focus-handler.service';
 
 export default function(): void {
   describe('Dropdown', () => {
@@ -197,6 +200,18 @@ export default function(): void {
 
       // Make sure the dropdown correctly closed, otherwise our expect() in the subscription might not have run.
       expect(ifOpenService.open).toBe(false);
+    });
+
+    it('declares a FocusService provider', () => {
+      const focusService = fixture.debugElement.query(By.directive(ClrDropdown)).injector.get(FocusService, null);
+      expect(focusService).not.toBeNull();
+    });
+
+    it('declares a DropdownFocusHandler provider', () => {
+      const injector = fixture.debugElement.query(By.directive(ClrDropdown)).injector;
+      const focusHandler = injector.get(DropdownFocusHandler, null);
+      expect(focusHandler).not.toBeNull();
+      expect(injector.get(FocusableItem, null)).toBe(focusHandler);
     });
   });
 }

--- a/src/clr-angular/popover/dropdown/dropdown.ts
+++ b/src/clr-angular/popover/dropdown/dropdown.ts
@@ -8,6 +8,8 @@ import { Subscription } from 'rxjs';
 
 import { IfOpenService } from '../../utils/conditional/if-open.service';
 import { POPOVER_HOST_ANCHOR } from '../common/popover-host-anchor.token';
+import { DROPDOWN_FOCUS_HANDLER_PROVIDER } from './providers/dropdown-focus-handler.service';
+import { FOCUS_SERVICE_PROVIDER } from '../../utils/focus/focus.service';
 
 import { ROOT_DROPDOWN_PROVIDER, RootDropdownService } from './providers/dropdown.service';
 
@@ -19,7 +21,13 @@ import { ROOT_DROPDOWN_PROVIDER, RootDropdownService } from './providers/dropdow
     // FIXME: remove this as soon as we stop supporting this old <div class="dropdown-menu"> syntax
     '[class.open]': 'ifOpenService.open',
   },
-  providers: [IfOpenService, ROOT_DROPDOWN_PROVIDER, { provide: POPOVER_HOST_ANCHOR, useExisting: ElementRef }],
+  providers: [
+    IfOpenService,
+    ROOT_DROPDOWN_PROVIDER,
+    { provide: POPOVER_HOST_ANCHOR, useExisting: ElementRef },
+    FOCUS_SERVICE_PROVIDER,
+    DROPDOWN_FOCUS_HANDLER_PROVIDER,
+  ],
 })
 export class ClrDropdown implements OnDestroy {
   private subscriptions: Subscription[] = [];

--- a/src/clr-angular/popover/dropdown/providers/dropdown-focus-handler.service.ts
+++ b/src/clr-angular/popover/dropdown/providers/dropdown-focus-handler.service.ts
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { isPlatformBrowser } from '@angular/common';
+import { Inject, Injectable, Optional, PLATFORM_ID, Renderer2, SkipSelf } from '@angular/core';
+import { Observable, of, ReplaySubject } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { IfOpenService } from '../../../utils/conditional/if-open.service';
+import { customFocusableItemProvider } from '../../../utils/focus/focusable-item/custom-focusable-item-provider';
+import { UNIQUE_ID } from '../../../utils/id-generator/id-generator.service';
+import { Direction } from '../../../utils/focus/direction.enum';
+import { FocusService } from '../../../utils/focus/focus.service';
+import { FocusableItem } from '../../../utils/focus/focusable-item/focusable-item';
+import { linkParent, linkVertical } from '../../../utils/focus/focusable-item/linkers';
+import { wrapObservable } from '../../../utils/focus/wrap-observable';
+
+@Injectable()
+export class DropdownFocusHandler implements FocusableItem {
+  constructor(
+    @Inject(UNIQUE_ID) public id: string,
+    private renderer: Renderer2,
+    @SkipSelf()
+    @Optional()
+    private parent: DropdownFocusHandler,
+    private ifOpenService: IfOpenService,
+    private focusService: FocusService,
+    @Inject(PLATFORM_ID) private platformId: Object
+  ) {
+    this.resetChildren();
+    this.moveToFirstItemWhenOpen();
+    if (!this.parent) {
+      this.handleRootFocus();
+    }
+  }
+
+  /**
+   * If the dropdown was opened by clicking on the trigger, we automatically move to the first item
+   */
+  moveToFirstItemWhenOpen() {
+    this.ifOpenService.openChange.subscribe(open => {
+      if (open && this.ifOpenService.originalEvent) {
+        this.focusService.moveTo(this);
+        if (this.parent) {
+          this.focusService.move(Direction.RIGHT);
+        } else {
+          this.focusService.move(Direction.DOWN);
+        }
+      }
+    });
+  }
+
+  private focusBackOnTrigger = false;
+
+  /**
+   * Focus on the menu when it opens, and focus back on the root trigger when the whole dropdown becomes closed
+   */
+  handleRootFocus() {
+    this.ifOpenService.openChange.subscribe(open => {
+      if (open) {
+        // Even if we properly waited for ngAfterViewInit, the container still wouldn't be attached to the DOM.
+        // So setTimeout is the only way to wait for the container to be ready to focus it.
+        setTimeout(() => {
+          if (this.container && isPlatformBrowser(this.platformId)) {
+            this.container.focus();
+          }
+        });
+      }
+      if (!open) {
+        // We reset the state of the focus service both on initialization and when closing.
+        this.focusService.reset(this);
+        // But we only actively focus the trigger when closing, not on initialization.
+        if (this.focusBackOnTrigger) {
+          this.focus();
+        }
+      }
+      this.focusBackOnTrigger = open;
+    });
+  }
+
+  private _trigger: HTMLElement;
+  get trigger() {
+    return this._trigger;
+  }
+  set trigger(el: HTMLElement) {
+    this._trigger = el;
+    this.renderer.setAttribute(el, 'id', this.id);
+    if (this.parent) {
+      // The root trigger needs to be in the tab flow, but nested ones are removed like any other dropdown item.
+      this.renderer.setAttribute(el, 'tabindex', '-1');
+    } else {
+      // The root trigger is the only one outside of the menu, so it needs to its own key listeners.
+      this.focusService.listenToArrowKeys(el);
+    }
+  }
+
+  private _container: HTMLElement;
+  get container() {
+    return this._container;
+  }
+  set container(el: HTMLElement) {
+    this._container = el;
+    if (!this.parent) {
+      // The root container is the only one we register to the focus service, others do not need focus
+      this.focusService.registerContainer(el);
+      // For dropdowns, the menu shouldn't actually be in the tab order. We manually focus it when opening.
+      this.renderer.setAttribute(el, 'tabindex', '-1');
+      // When the user moves focus outside of the menu, we close the dropdown
+      this.renderer.listen(el, 'focusout', event => {
+        // focusout + relatedTarget because a simple blur event would trigger
+        // when the user clicks an item inside of the menu, closing the dropdown.
+        if (event.relatedTarget && isPlatformBrowser(this.platformId)) {
+          if (el.contains(event.relatedTarget) || event.relatedTarget === this.trigger) {
+            return;
+          }
+        }
+        // We let the user move focus to where the want, we don't force the focus back on the trigger
+        this.focusBackOnTrigger = false;
+        this.ifOpenService.open = false;
+      });
+    }
+  }
+
+  focus() {
+    if (this.trigger) {
+      if (this.parent) {
+        this.renderer.addClass(this.trigger, 'focus');
+      } else if (isPlatformBrowser(this.platformId)) {
+        this.trigger.focus();
+      }
+    }
+  }
+  blur() {
+    if (this.trigger) {
+      if (this.parent) {
+        this.renderer.removeClass(this.trigger, 'focus');
+      } else if (isPlatformBrowser(this.platformId)) {
+        this.trigger.blur();
+      }
+    }
+  }
+
+  activate() {
+    if (isPlatformBrowser(this.platformId)) {
+      this.trigger.click();
+    }
+  }
+
+  private children: ReplaySubject<FocusableItem[]>;
+  right?: Observable<FocusableItem>;
+  down?: Observable<FocusableItem>;
+  up?: Observable<FocusableItem>;
+
+  private openAndGetChildren() {
+    return wrapObservable(this.children, () => (this.ifOpenService.open = true));
+  }
+  private closeAndGetThis() {
+    return wrapObservable(of(this), () => (this.ifOpenService.open = false));
+  }
+
+  resetChildren() {
+    this.children = new ReplaySubject<FocusableItem[]>(1);
+    if (this.parent) {
+      this.right = this.openAndGetChildren().pipe(map(all => all[0]));
+    } else {
+      this.down = this.openAndGetChildren().pipe(map(all => all[0]));
+      this.up = this.openAndGetChildren().pipe(map(all => all[all.length - 1]));
+    }
+  }
+
+  addChildren(children: FocusableItem[]) {
+    linkVertical(children);
+    if (this.parent) {
+      linkParent(children, this.closeAndGetThis(), Direction.LEFT);
+    }
+    this.children.next(children);
+  }
+}
+
+export const DROPDOWN_FOCUS_HANDLER_PROVIDER = customFocusableItemProvider(DropdownFocusHandler);

--- a/src/clr-angular/popover/dropdown/providers/dropdown-focus-handler.service.ts
+++ b/src/clr-angular/popover/dropdown/providers/dropdown-focus-handler.service.ts
@@ -11,7 +11,7 @@ import { map } from 'rxjs/operators';
 import { IfOpenService } from '../../../utils/conditional/if-open.service';
 import { customFocusableItemProvider } from '../../../utils/focus/focusable-item/custom-focusable-item-provider';
 import { UNIQUE_ID } from '../../../utils/id-generator/id-generator.service';
-import { Direction } from '../../../utils/focus/direction.enum';
+import { ArrowKeyDirection } from '../../../utils/focus/arrow-key-direction.enum';
 import { FocusService } from '../../../utils/focus/focus.service';
 import { FocusableItem } from '../../../utils/focus/focusable-item/focusable-item';
 import { linkParent, linkVertical } from '../../../utils/focus/focusable-item/linkers';
@@ -44,9 +44,9 @@ export class DropdownFocusHandler implements FocusableItem {
       if (open && this.ifOpenService.originalEvent) {
         this.focusService.moveTo(this);
         if (this.parent) {
-          this.focusService.move(Direction.RIGHT);
+          this.focusService.move(ArrowKeyDirection.RIGHT);
         } else {
-          this.focusService.move(Direction.DOWN);
+          this.focusService.move(ArrowKeyDirection.DOWN);
         }
       }
     });
@@ -126,7 +126,7 @@ export class DropdownFocusHandler implements FocusableItem {
   focus() {
     if (this.trigger) {
       if (this.parent) {
-        this.renderer.addClass(this.trigger, 'focus');
+        this.renderer.addClass(this.trigger, 'clr-focus');
       } else if (isPlatformBrowser(this.platformId)) {
         this.trigger.focus();
       }
@@ -135,7 +135,7 @@ export class DropdownFocusHandler implements FocusableItem {
   blur() {
     if (this.trigger) {
       if (this.parent) {
-        this.renderer.removeClass(this.trigger, 'focus');
+        this.renderer.removeClass(this.trigger, 'clr-focus');
       } else if (isPlatformBrowser(this.platformId)) {
         this.trigger.blur();
       }
@@ -173,7 +173,7 @@ export class DropdownFocusHandler implements FocusableItem {
   addChildren(children: FocusableItem[]) {
     linkVertical(children);
     if (this.parent) {
-      linkParent(children, this.closeAndGetThis(), Direction.LEFT);
+      linkParent(children, this.closeAndGetThis(), ArrowKeyDirection.LEFT);
     }
     this.children.next(children);
   }

--- a/src/clr-angular/popover/dropdown/providers/dropdown-focus-handler.spec.ts
+++ b/src/clr-angular/popover/dropdown/providers/dropdown-focus-handler.spec.ts
@@ -1,0 +1,325 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component } from '@angular/core';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { isObservable, Observable } from 'rxjs';
+import { IfOpenService } from '../../../utils/conditional/if-open.service';
+import { Direction } from '../../../utils/focus/direction.enum';
+import { FOCUS_SERVICE_PROVIDER, FocusService } from '../../../utils/focus/focus.service';
+import { FocusableItem } from '../../../utils/focus/focusable-item/focusable-item';
+import { MockFocusableItem } from '../../../utils/focus/focusable-item/focusable-item.mock';
+import * as linkers from '../../../utils/focus/focusable-item/linkers';
+import { UNIQUE_ID } from '../../../utils/id-generator/id-generator.service';
+import { DROPDOWN_FOCUS_HANDLER_PROVIDER, DropdownFocusHandler } from './dropdown-focus-handler.service';
+import any = jasmine.any;
+
+@Component({
+  selector: 'simple-host',
+  template: '',
+  providers: [IfOpenService, FOCUS_SERVICE_PROVIDER, DROPDOWN_FOCUS_HANDLER_PROVIDER],
+})
+class SimpleHost {}
+
+@Component({
+  template: '<simple-host></simple-host>',
+  providers: [IfOpenService, FOCUS_SERVICE_PROVIDER, DROPDOWN_FOCUS_HANDLER_PROVIDER],
+})
+class NestedHost {}
+
+interface TestContext {
+  fixture: ComponentFixture<SimpleHost | NestedHost>;
+  ifOpenService: IfOpenService;
+  focusService: FocusService;
+  focusHandler: DropdownFocusHandler;
+  trigger: HTMLElement;
+  container: HTMLElement;
+  outside: HTMLElement;
+  children: FocusableItem[];
+}
+
+export default function(): void {
+  describe('DropdownFocusHandler', function() {
+    describe('basic dropdown', function() {
+      beforeEach(function(this: TestContext) {
+        TestBed.configureTestingModule({ declarations: [SimpleHost] });
+        this.fixture = TestBed.createComponent(SimpleHost);
+        this.ifOpenService = this.fixture.debugElement.injector.get(IfOpenService);
+        this.focusService = this.fixture.debugElement.injector.get(FocusService);
+        this.focusHandler = this.fixture.debugElement.injector.get(DropdownFocusHandler, null);
+        this.trigger = document.createElement('button');
+        this.container = document.createElement('div');
+        this.outside = document.createElement('button');
+        // We need the elements in the DOM to be able to focus them
+        document.body.append(this.trigger, this.container, this.outside);
+        this.children = new Array(3).fill(0).map((_, i) => new MockFocusableItem(`${i}`));
+      });
+
+      afterEach(function(this: TestContext) {
+        document.body.removeChild(this.trigger);
+        document.body.removeChild(this.container);
+        document.body.removeChild(this.outside);
+      });
+
+      it('declares a UNIQUE_ID provider', function(this: TestContext) {
+        expect(this.fixture.debugElement.injector.get(UNIQUE_ID, 'not_found')).not.toBe('not_found');
+      });
+
+      it('declares a DropdownFocusHandler provider', function(this: TestContext) {
+        expect(this.focusHandler).not.toBeNull();
+      });
+
+      it('aliases the DropdownFocusHandler as a FocusableItem', function(this: TestContext) {
+        expect(this.fixture.debugElement.injector.get(FocusableItem, null)).toBe(this.focusHandler);
+      });
+
+      it('sets the id of the trigger to the unique generated id', function(this: TestContext) {
+        const id = this.fixture.debugElement.injector.get(UNIQUE_ID, 'not_found');
+        this.focusHandler.trigger = this.trigger;
+        expect(this.trigger.getAttribute('id')).toBe(id);
+      });
+
+      it('listens to arrow keys on the trigger', function(this: TestContext) {
+        const spy = spyOn(this.focusService, 'listenToArrowKeys');
+        this.focusHandler.trigger = this.trigger;
+        expect(spy).toHaveBeenCalledWith(this.trigger);
+      });
+
+      it('proxies focus() and blur() to the trigger', function(this: TestContext) {
+        this.focusHandler.trigger = this.trigger;
+        expect(document.activeElement).not.toBe(this.trigger);
+        this.focusHandler.focus();
+        expect(document.activeElement).toBe(this.trigger);
+        this.focusHandler.blur();
+        expect(document.activeElement).not.toBe(this.trigger);
+      });
+
+      it('clicks on the trigger when activated', function(this: TestContext) {
+        let clicks = 0;
+        this.trigger.addEventListener('click', () => clicks++);
+        this.focusHandler.trigger = this.trigger;
+        expect(clicks).toBe(0);
+        this.focusHandler.activate();
+        expect(clicks).toBe(1);
+        this.focusHandler.activate();
+        expect(clicks).toBe(2);
+      });
+
+      it('registers the container to the FocusService', function(this: TestContext) {
+        const spy = spyOn(this.focusService, 'registerContainer');
+        this.focusHandler.container = this.container;
+        expect(spy).toHaveBeenCalledWith(this.container);
+      });
+
+      it('sets a tabindex of -1 on the container', function(this: TestContext) {
+        this.focusHandler.container = this.container;
+        expect(this.container.getAttribute('tabindex')).toBe('-1');
+      });
+
+      it(
+        'focuses on the container when the dropdown becomes open',
+        fakeAsync(function(this: TestContext) {
+          this.focusHandler.container = this.container;
+          expect(document.activeElement).not.toBe(this.container);
+          this.ifOpenService.open = true;
+          // This specific focusing action is asynchronous so we have to tick
+          tick();
+          expect(document.activeElement).toBe(this.container);
+        })
+      );
+
+      it('closes the dropdown when the container is blurred', function(this: TestContext) {
+        this.focusHandler.container = this.container;
+        this.ifOpenService.open = true;
+        this.container.focus();
+        expect(this.ifOpenService.open).toBeTruthy();
+        this.container.blur();
+        expect(this.ifOpenService.open).toBeFalsy();
+      });
+
+      it('puts focus back on the trigger when the dropdown becomes closed', function(this: TestContext) {
+        this.focusHandler.trigger = this.trigger;
+        this.focusHandler.container = this.container;
+        expect(document.activeElement).not.toBe(this.trigger);
+        this.ifOpenService.open = true;
+        this.ifOpenService.open = false;
+        expect(document.activeElement).toBe(this.trigger);
+      });
+
+      it(
+        'does not prevent moving focus to a different part of the page',
+        fakeAsync(function(this: TestContext) {
+          this.focusHandler.trigger = this.trigger;
+          this.focusHandler.container = this.container;
+          this.ifOpenService.open = true;
+          tick();
+          this.outside.focus();
+          expect(document.activeElement).toBe(this.outside);
+        })
+      );
+
+      it('links received children vertically', function(this: TestContext) {
+        const spy = spyOn(linkers, 'linkVertical');
+        this.focusHandler.addChildren(this.children);
+        expect(spy).toHaveBeenCalledWith(this.children);
+      });
+
+      it('points down to the first child', function(this: TestContext) {
+        let down: FocusableItem;
+        this.focusHandler.down.subscribe(child => (down = child));
+        this.focusHandler.addChildren(this.children);
+        expect(down).toBe(this.children[0]);
+      });
+
+      it('points up to the last child', function(this: TestContext) {
+        let up: FocusableItem;
+        this.focusHandler.up.subscribe(child => (up = child));
+        this.focusHandler.addChildren(this.children);
+        expect(up).toBe(this.children[this.children.length - 1]);
+      });
+
+      it('does not point left or right', function(this: TestContext) {
+        this.focusHandler.addChildren(this.children);
+        expect((<FocusableItem>this.focusHandler).left).toBeUndefined();
+        expect((<FocusableItem>this.focusHandler).right).toBeUndefined();
+      });
+
+      it('points correctly even if children have been added early', function(this: TestContext) {
+        let down: FocusableItem;
+        this.focusHandler.addChildren(this.children);
+        this.focusHandler.down.subscribe(child => (down = child));
+        expect(down).toBe(this.children[0]);
+      });
+
+      it('properly resets children', function(this: TestContext) {
+        this.focusHandler.addChildren(this.children);
+        this.focusHandler.resetChildren();
+        this.focusHandler.down.subscribe(() => fail('Expected no pointer down.'));
+        this.focusHandler.up.subscribe(() => fail('Expected no pointer up.'));
+      });
+
+      it('opens the dropdown when trying to go down or up', function(this: TestContext) {
+        expect(this.ifOpenService.open).toBeFalsy();
+        this.focusHandler.down.subscribe(() => null);
+        expect(this.ifOpenService.open).toBeTruthy();
+        this.ifOpenService.open = false;
+        this.focusHandler.up.subscribe(() => null);
+        expect(this.ifOpenService.open).toBeTruthy();
+      });
+
+      it('moves to the first child when opened with a click', function(this: TestContext) {
+        this.focusHandler.addChildren(this.children);
+        const moveTo = spyOn(this.focusService, 'moveTo');
+        const move = spyOn(this.focusService, 'move');
+        this.ifOpenService.toggleWithEvent({});
+        // First we move to the clicked item, which is the trigger,
+        expect(moveTo).toHaveBeenCalledWith(this.focusHandler);
+        // then we move down to the first item,
+        expect(move).toHaveBeenCalledWith(Direction.DOWN);
+        // but maybe that's too detailed for this unit test? It's just the easiest way to test it right now.
+      });
+    });
+
+    describe('nested dropdown', function() {
+      beforeEach(function(this: TestContext) {
+        TestBed.configureTestingModule({ declarations: [SimpleHost, NestedHost] });
+        this.fixture = TestBed.createComponent(NestedHost);
+        const nestedInjector = this.fixture.debugElement.query(By.directive(SimpleHost)).injector;
+        this.ifOpenService = nestedInjector.get(IfOpenService);
+        this.focusService = nestedInjector.get(FocusService);
+        this.focusHandler = nestedInjector.get(DropdownFocusHandler, null);
+        this.trigger = document.createElement('button');
+        this.container = document.createElement('div');
+        // We need the elements in the DOM to be able to focus them
+        document.body.append(this.trigger, this.container);
+        this.children = new Array(3).fill(0).map((_, i) => new MockFocusableItem(`${i}`));
+      });
+
+      afterEach(function(this: TestContext) {
+        document.body.removeChild(this.trigger);
+        document.body.removeChild(this.container);
+      });
+
+      it('sets a tabindex of -1 on the trigger', function(this: TestContext) {
+        this.focusHandler.trigger = this.trigger;
+        expect(this.trigger.getAttribute('tabindex')).toBe('-1');
+      });
+
+      it('toggles the .focus class on the trigger when focused an blurred', function(this: TestContext) {
+        this.focusHandler.trigger = this.trigger;
+        expect(this.trigger.classList).not.toContain('focus');
+        this.focusHandler.focus();
+        expect(this.trigger.classList).toContain('focus');
+        this.focusHandler.blur();
+        expect(this.trigger.classList).not.toContain('focus');
+      });
+
+      it('does not register the container to the FocusService', function(this: TestContext) {
+        const spy = spyOn(this.focusService, 'registerContainer');
+        this.focusHandler.container = this.container;
+        expect(spy).not.toHaveBeenCalled();
+      });
+
+      it(
+        'does not focus on the container when the dropdown becomes open',
+        fakeAsync(function(this: TestContext) {
+          this.focusHandler.container = this.container;
+          this.ifOpenService.open = true;
+          // This specific focusing action is asynchronous so we have to tick
+          tick();
+          expect(document.activeElement).not.toBe(this.container);
+        })
+      );
+
+      it('does not focus on the trigger when the dropdown becomes closed', function(this: TestContext) {
+        this.focusHandler.trigger = this.trigger;
+        this.focusHandler.container = this.container;
+        this.ifOpenService.open = true;
+        this.ifOpenService.open = false;
+        expect(document.activeElement).not.toBe(this.trigger);
+      });
+
+      it('points right to the first child', function(this: TestContext) {
+        let right: FocusableItem;
+        this.focusHandler.right.subscribe(child => (right = child));
+        this.focusHandler.addChildren(this.children);
+        expect(right).toBe(this.children[0]);
+      });
+
+      it('does not point up, down or left', function(this: TestContext) {
+        this.focusHandler.addChildren(this.children);
+        expect((<FocusableItem>this.focusHandler).up).toBeUndefined();
+        expect((<FocusableItem>this.focusHandler).down).toBeUndefined();
+        expect((<FocusableItem>this.focusHandler).left).toBeUndefined();
+      });
+
+      it('links received children back to the trigger', function(this: TestContext) {
+        const spy = spyOn(linkers, 'linkParent');
+        this.focusHandler.addChildren(this.children);
+        expect(spy).toHaveBeenCalledWith(this.children, any(Observable), Direction.LEFT);
+      });
+
+      it('closes the dropdown when trying to go back to the trigger', function(this: TestContext) {
+        this.focusHandler.addChildren(this.children);
+        this.ifOpenService.open = true;
+        const back = this.children[0].left;
+        expect(isObservable(back)).toBeTruthy();
+        (<Observable<FocusableItem>>back).subscribe(() => null);
+        expect(this.ifOpenService.open).toBeFalsy();
+      });
+
+      it('moves to the first child when opened with a click', function(this: TestContext) {
+        this.focusHandler.addChildren(this.children);
+        const moveTo = spyOn(this.focusService, 'moveTo');
+        const move = spyOn(this.focusService, 'move');
+        this.ifOpenService.toggleWithEvent({});
+        expect(moveTo).toHaveBeenCalledWith(this.focusHandler);
+        expect(move).toHaveBeenCalledWith(Direction.RIGHT);
+      });
+    });
+  });
+}

--- a/src/clr-angular/popover/dropdown/providers/dropdown-focus-handler.spec.ts
+++ b/src/clr-angular/popover/dropdown/providers/dropdown-focus-handler.spec.ts
@@ -9,7 +9,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { By } from '@angular/platform-browser';
 import { isObservable, Observable } from 'rxjs';
 import { IfOpenService } from '../../../utils/conditional/if-open.service';
-import { Direction } from '../../../utils/focus/direction.enum';
+import { ArrowKeyDirection } from '../../../utils/focus/arrow-key-direction.enum';
 import { FOCUS_SERVICE_PROVIDER, FocusService } from '../../../utils/focus/focus.service';
 import { FocusableItem } from '../../../utils/focus/focusable-item/focusable-item';
 import { MockFocusableItem } from '../../../utils/focus/focusable-item/focusable-item.mock';
@@ -219,7 +219,7 @@ export default function(): void {
         // First we move to the clicked item, which is the trigger,
         expect(moveTo).toHaveBeenCalledWith(this.focusHandler);
         // then we move down to the first item,
-        expect(move).toHaveBeenCalledWith(Direction.DOWN);
+        expect(move).toHaveBeenCalledWith(ArrowKeyDirection.DOWN);
         // but maybe that's too detailed for this unit test? It's just the easiest way to test it right now.
       });
     });
@@ -249,13 +249,13 @@ export default function(): void {
         expect(this.trigger.getAttribute('tabindex')).toBe('-1');
       });
 
-      it('toggles the .focus class on the trigger when focused an blurred', function(this: TestContext) {
+      it('toggles the .clr-focus class on the trigger when focused an blurred', function(this: TestContext) {
         this.focusHandler.trigger = this.trigger;
-        expect(this.trigger.classList).not.toContain('focus');
+        expect(this.trigger.classList).not.toContain('clr-focus');
         this.focusHandler.focus();
-        expect(this.trigger.classList).toContain('focus');
+        expect(this.trigger.classList).toContain('clr-focus');
         this.focusHandler.blur();
-        expect(this.trigger.classList).not.toContain('focus');
+        expect(this.trigger.classList).not.toContain('clr-focus');
       });
 
       it('does not register the container to the FocusService', function(this: TestContext) {
@@ -300,7 +300,7 @@ export default function(): void {
       it('links received children back to the trigger', function(this: TestContext) {
         const spy = spyOn(linkers, 'linkParent');
         this.focusHandler.addChildren(this.children);
-        expect(spy).toHaveBeenCalledWith(this.children, any(Observable), Direction.LEFT);
+        expect(spy).toHaveBeenCalledWith(this.children, any(Observable), ArrowKeyDirection.LEFT);
       });
 
       it('closes the dropdown when trying to go back to the trigger', function(this: TestContext) {
@@ -318,7 +318,7 @@ export default function(): void {
         const move = spyOn(this.focusService, 'move');
         this.ifOpenService.toggleWithEvent({});
         expect(moveTo).toHaveBeenCalledWith(this.focusHandler);
-        expect(move).toHaveBeenCalledWith(Direction.RIGHT);
+        expect(move).toHaveBeenCalledWith(ArrowKeyDirection.RIGHT);
       });
     });
   });

--- a/src/clr-angular/utils/focus/all.spec.ts
+++ b/src/clr-angular/utils/focus/all.spec.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import FocusServiceSpec from './focus.service.spec';
+import WrapObservable from './wrap-observable.spec';
+import BasicFocusableItemSpec from './focusable-item/basic-focusable-item.spec';
+import LinkersSpec from './focusable-item/linkers.spec';
+
+describe('Focus management', function() {
+  FocusServiceSpec();
+  WrapObservable();
+  BasicFocusableItemSpec();
+  LinkersSpec();
+});

--- a/src/clr-angular/utils/focus/arrow-key-direction.enum.ts
+++ b/src/clr-angular/utils/focus/arrow-key-direction.enum.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-export enum Direction {
+export enum ArrowKeyDirection {
   UP = 'up',
   DOWN = 'down',
   LEFT = 'left',

--- a/src/clr-angular/utils/focus/direction.enum.ts
+++ b/src/clr-angular/utils/focus/direction.enum.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+export enum Direction {
+  UP = 'up',
+  DOWN = 'down',
+  LEFT = 'left',
+  RIGHT = 'right',
+}

--- a/src/clr-angular/utils/focus/focus.service.spec.ts
+++ b/src/clr-angular/utils/focus/focus.service.spec.ts
@@ -8,7 +8,7 @@ import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { Subject } from 'rxjs';
-import { Direction } from './direction.enum';
+import { ArrowKeyDirection } from './arrow-key-direction.enum';
 import { FOCUS_SERVICE_PROVIDER, FocusService } from './focus.service';
 import { FocusableItem } from './focusable-item/focusable-item';
 import { MockFocusableItem } from './focusable-item/focusable-item.mock';
@@ -105,7 +105,7 @@ export default function(): void {
       it('can move in all directions', function(this: TestContext) {
         const spy = spyOn(this.focusService, 'moveTo');
         const current = new MockFocusableItem('center');
-        for (const direction of Object.values(Direction)) {
+        for (const direction of Object.values(ArrowKeyDirection)) {
           const target = new MockFocusableItem(direction);
           current[direction] = target;
           this.focusService.reset(current);
@@ -126,7 +126,7 @@ export default function(): void {
         nopeAgain.down = target;
         const spy = spyOn(this.focusService, 'moveTo');
         this.focusService.reset(current);
-        this.focusService.move(Direction.DOWN);
+        this.focusService.move(ArrowKeyDirection.DOWN);
         expect(spy).toHaveBeenCalledWith(target);
       });
 
@@ -137,7 +137,7 @@ export default function(): void {
         first.down = delayed;
         const spy = spyOn(this.focusService, 'moveTo');
         this.focusService.reset(first);
-        this.focusService.move(Direction.DOWN);
+        this.focusService.move(ArrowKeyDirection.DOWN);
         expect(spy).not.toHaveBeenCalled();
         delayed.next(second);
         expect(spy).toHaveBeenCalledWith(second);
@@ -148,13 +148,13 @@ export default function(): void {
         const el = document.createElement('div');
         this.focusService.listenToArrowKeys(el);
         el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
-        expect(spy).toHaveBeenCalledWith(Direction.UP);
+        expect(spy).toHaveBeenCalledWith(ArrowKeyDirection.UP);
         el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
-        expect(spy).toHaveBeenCalledWith(Direction.DOWN);
+        expect(spy).toHaveBeenCalledWith(ArrowKeyDirection.DOWN);
         el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }));
-        expect(spy).toHaveBeenCalledWith(Direction.LEFT);
+        expect(spy).toHaveBeenCalledWith(ArrowKeyDirection.LEFT);
         el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
-        expect(spy).toHaveBeenCalledWith(Direction.RIGHT);
+        expect(spy).toHaveBeenCalledWith(ArrowKeyDirection.RIGHT);
       });
 
       it('makes a given container focusable', function(this: TestContext) {

--- a/src/clr-angular/utils/focus/focus.service.spec.ts
+++ b/src/clr-angular/utils/focus/focus.service.spec.ts
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Observable, Subject } from 'rxjs';
+import { Direction } from './direction.enum';
+import { FOCUS_SERVICE_PROVIDER, FocusService } from './focus.service';
+import { FocusableItem } from './focusable-item/focusable-item';
+
+@Component({
+  selector: 'simple-host',
+  template: '',
+  providers: [FOCUS_SERVICE_PROVIDER],
+})
+class SimpleHost {}
+
+@Component({
+  template: '<simple-host></simple-host>',
+  providers: [FOCUS_SERVICE_PROVIDER],
+})
+class NestedHost {}
+
+interface TestContext {
+  focusService: FocusService;
+}
+
+class MockFocusableItem implements FocusableItem {
+  constructor(public id: string) {}
+
+  disabled = false;
+
+  focus() {}
+  blur() {}
+  activate() {}
+
+  up?: FocusableItem | Observable<FocusableItem>;
+  down?: FocusableItem | Observable<FocusableItem>;
+  left?: FocusableItem | Observable<FocusableItem>;
+  right?: FocusableItem | Observable<FocusableItem>;
+}
+
+export default function(): void {
+  describe('Focus service', function() {
+    describe('FOCUS_SERVICE_PROVIDER', function() {
+      it('declares itself as a FocusService provider', function() {
+        TestBed.configureTestingModule({ declarations: [SimpleHost] });
+        const fixture = TestBed.createComponent(SimpleHost);
+        expect(fixture.debugElement.injector.get(FocusService, null)).not.toBeNull();
+      });
+
+      it('creates a single instance for nested components declaring it as a provider', function() {
+        TestBed.configureTestingModule({ declarations: [SimpleHost, NestedHost] });
+        const fixture = TestBed.createComponent(NestedHost);
+        const parentService = fixture.debugElement.injector.get(FocusService, null);
+        const childService = fixture.debugElement.query(By.directive(SimpleHost)).injector.get(FocusService, null);
+        expect(childService).toBe(parentService);
+      });
+    });
+
+    describe('API', function() {
+      beforeEach(function(this: TestContext) {
+        // Because the service uses Angular's Renderer2, we need to use TestBed for this spec.
+        TestBed.configureTestingModule({ declarations: [SimpleHost] });
+        const fixture = TestBed.createComponent(SimpleHost);
+        this.focusService = fixture.debugElement.injector.get(FocusService, null);
+      });
+
+      function setupContainer(context: TestContext) {
+        const container = document.createElement('div');
+        context.focusService.registerContainer(container);
+        return container;
+      }
+
+      it('can be reset to a specific currently focused item', function(this: TestContext) {
+        const item = new MockFocusableItem('');
+        this.focusService.reset(item);
+        expect(this.focusService.current).toBe(item);
+      });
+
+      it('can activate the currently focused item', function(this: TestContext) {
+        const item = new MockFocusableItem('');
+        const spy = spyOn(item, 'activate');
+        this.focusService.reset(item);
+        this.focusService.activateCurrent();
+        expect(spy).toHaveBeenCalled();
+      });
+
+      it('updates aria-activedescendant on the container when focusing a new item', function(this: TestContext) {
+        const container = setupContainer(this);
+        const item = new MockFocusableItem('hello');
+        this.focusService.moveTo(item);
+        expect(container.getAttribute('aria-activedescendant')).toBe('hello');
+        expect(this.focusService.current).toBe(item);
+      });
+
+      it('calls the focus() method of the new focused item', function(this: TestContext) {
+        setupContainer(this);
+        const item = new MockFocusableItem('');
+        const spy = spyOn(item, 'focus');
+        this.focusService.moveTo(item);
+        expect(spy).toHaveBeenCalled();
+      });
+
+      it('calls the blur() method of the previously focused item', function(this: TestContext) {
+        setupContainer(this);
+        const first = new MockFocusableItem('1');
+        const second = new MockFocusableItem('2');
+        this.focusService.reset(first);
+        const spy = spyOn(first, 'blur');
+        this.focusService.moveTo(second);
+        expect(spy).toHaveBeenCalled();
+      });
+
+      it('can move in all directions', function(this: TestContext) {
+        const spy = spyOn(this.focusService, 'moveTo');
+        const current = new MockFocusableItem('center');
+        for (const direction of Object.values(Direction)) {
+          const target = new MockFocusableItem(direction);
+          current[direction] = target;
+          this.focusService.reset(current);
+          this.focusService.move(direction);
+          expect(spy).toHaveBeenCalledWith(target);
+        }
+      });
+
+      it('skips disabled items', function(this: TestContext) {
+        const current = new MockFocusableItem('1');
+        const nope = new MockFocusableItem('2');
+        nope.disabled = true;
+        const nopeAgain = new MockFocusableItem('3');
+        nopeAgain.disabled = true;
+        const target = new MockFocusableItem('4');
+        current.down = nope;
+        nope.down = nopeAgain;
+        nopeAgain.down = target;
+        const spy = spyOn(this.focusService, 'moveTo');
+        this.focusService.reset(current);
+        this.focusService.move(Direction.DOWN);
+        expect(spy).toHaveBeenCalledWith(target);
+      });
+
+      it('waits for the next item if it is an Observable', function(this: TestContext) {
+        const first = new MockFocusableItem('1');
+        const second = new MockFocusableItem('2');
+        const delayed = new Subject<FocusableItem>();
+        first.down = delayed;
+        const spy = spyOn(this.focusService, 'moveTo');
+        this.focusService.reset(first);
+        this.focusService.move(Direction.DOWN);
+        expect(spy).not.toHaveBeenCalled();
+        delayed.next(second);
+        expect(spy).toHaveBeenCalledWith(second);
+      });
+
+      it('can listen to arrow keys on an element', function(this: TestContext) {
+        const spy = spyOn(this.focusService, 'move');
+        const el = document.createElement('div');
+        this.focusService.listenToArrowKeys(el);
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+        expect(spy).toHaveBeenCalledWith(Direction.UP);
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+        expect(spy).toHaveBeenCalledWith(Direction.DOWN);
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }));
+        expect(spy).toHaveBeenCalledWith(Direction.LEFT);
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+        expect(spy).toHaveBeenCalledWith(Direction.RIGHT);
+      });
+
+      it('makes a given container focusable', function(this: TestContext) {
+        const container = setupContainer(this);
+        expect(container.getAttribute('tabindex')).toBe('0');
+      });
+
+      it('moves when arrow keys are pressed on the container', function(this: TestContext) {
+        const spy = spyOn(this.focusService, 'listenToArrowKeys');
+        const container = setupContainer(this);
+        expect(spy).toHaveBeenCalledWith(container);
+      });
+
+      it('activates the current item when pressing Enter on the container', function(this: TestContext) {
+        const spy = spyOn(this.focusService, 'activateCurrent');
+        const container = setupContainer(this);
+        container.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+        expect(spy).toHaveBeenCalled();
+      });
+
+      it('activates the current item when pressing Space on the container', function(this: TestContext) {
+        const spy = spyOn(this.focusService, 'activateCurrent');
+        const container = setupContainer(this);
+        container.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
+        expect(spy).toHaveBeenCalled();
+      });
+    });
+  });
+}

--- a/src/clr-angular/utils/focus/focus.service.spec.ts
+++ b/src/clr-angular/utils/focus/focus.service.spec.ts
@@ -7,10 +7,11 @@
 import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { Observable, Subject } from 'rxjs';
+import { Subject } from 'rxjs';
 import { Direction } from './direction.enum';
 import { FOCUS_SERVICE_PROVIDER, FocusService } from './focus.service';
 import { FocusableItem } from './focusable-item/focusable-item';
+import { MockFocusableItem } from './focusable-item/focusable-item.mock';
 
 @Component({
   selector: 'simple-host',
@@ -27,21 +28,6 @@ class NestedHost {}
 
 interface TestContext {
   focusService: FocusService;
-}
-
-class MockFocusableItem implements FocusableItem {
-  constructor(public id: string) {}
-
-  disabled = false;
-
-  focus() {}
-  blur() {}
-  activate() {}
-
-  up?: FocusableItem | Observable<FocusableItem>;
-  down?: FocusableItem | Observable<FocusableItem>;
-  left?: FocusableItem | Observable<FocusableItem>;
-  right?: FocusableItem | Observable<FocusableItem>;
 }
 
 export default function(): void {

--- a/src/clr-angular/utils/focus/focus.service.ts
+++ b/src/clr-angular/utils/focus/focus.service.ts
@@ -7,7 +7,7 @@
 import { Injectable, Optional, Renderer2, SkipSelf } from '@angular/core';
 import { isObservable, of } from 'rxjs';
 
-import { Direction } from './direction.enum';
+import { ArrowKeyDirection } from './arrow-key-direction.enum';
 import { FocusableItem } from './focusable-item/focusable-item';
 
 @Injectable()
@@ -28,10 +28,10 @@ export class FocusService {
   listenToArrowKeys(el: HTMLElement) {
     // The following listeners return false when there was an action to take for the key pressed,
     // in order to prevent the default behavior of that key.
-    this.renderer.listen(el, 'keydown.arrowup', () => !this.move(Direction.UP));
-    this.renderer.listen(el, 'keydown.arrowdown', () => !this.move(Direction.DOWN));
-    this.renderer.listen(el, 'keydown.arrowleft', () => !this.move(Direction.LEFT));
-    this.renderer.listen(el, 'keydown.arrowright', () => !this.move(Direction.RIGHT));
+    this.renderer.listen(el, 'keydown.arrowup', () => !this.move(ArrowKeyDirection.UP));
+    this.renderer.listen(el, 'keydown.arrowdown', () => !this.move(ArrowKeyDirection.DOWN));
+    this.renderer.listen(el, 'keydown.arrowleft', () => !this.move(ArrowKeyDirection.LEFT));
+    this.renderer.listen(el, 'keydown.arrowright', () => !this.move(ArrowKeyDirection.RIGHT));
   }
 
   registerContainer(el: HTMLElement) {
@@ -56,7 +56,7 @@ export class FocusService {
   /**
    * The second parameter, optional, is here to allow recursion to skip disabled items.
    */
-  move(direction: Direction, current = this.current) {
+  move(direction: ArrowKeyDirection, current = this.current) {
     const next = current[direction];
     if (next) {
       // Turning the value into an Observable isn't great, but it's the fastest way to avoid code duplication.

--- a/src/clr-angular/utils/focus/focus.service.ts
+++ b/src/clr-angular/utils/focus/focus.service.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Injectable, Optional, Renderer2, SkipSelf } from '@angular/core';
+import { isObservable, of } from 'rxjs';
+
+import { Direction } from './direction.enum';
+import { FocusableItem } from './focusable-item/focusable-item';
+
+@Injectable()
+export class FocusService {
+  constructor(private renderer: Renderer2) {}
+
+  private container: HTMLElement;
+
+  private _current: FocusableItem;
+  public get current() {
+    return this._current;
+  }
+
+  reset(first: FocusableItem) {
+    this._current = first;
+  }
+
+  listenToArrowKeys(el: HTMLElement) {
+    // The following listeners return false when there was an action to take for the key pressed,
+    // in order to prevent the default behavior of that key.
+    this.renderer.listen(el, 'keydown.arrowup', () => !this.move(Direction.UP));
+    this.renderer.listen(el, 'keydown.arrowdown', () => !this.move(Direction.DOWN));
+    this.renderer.listen(el, 'keydown.arrowleft', () => !this.move(Direction.LEFT));
+    this.renderer.listen(el, 'keydown.arrowright', () => !this.move(Direction.RIGHT));
+  }
+
+  registerContainer(el: HTMLElement) {
+    this.container = el;
+    this.renderer.setAttribute(el, 'tabindex', '0');
+    this.listenToArrowKeys(el);
+    // The following listeners return false when there was an action to take for the key pressed,
+    // in order to prevent the default behavior of that key.
+    this.renderer.listen(el, 'keydown.space', () => !this.activateCurrent());
+    this.renderer.listen(el, 'keydown.enter', () => !this.activateCurrent());
+  }
+
+  moveTo(item: FocusableItem) {
+    this.renderer.setAttribute(this.container, 'aria-activedescendant', item.id);
+    if (this.current) {
+      this.current.blur();
+    }
+    item.focus();
+    this._current = item;
+  }
+
+  /**
+   * The second parameter, optional, is here to allow recursion to skip disabled items.
+   */
+  move(direction: Direction, current = this.current) {
+    const next = current[direction];
+    if (next) {
+      // Turning the value into an Observable isn't great, but it's the fastest way to avoid code duplication.
+      // If performance ever matters for this, we can refactor using additional private methods.
+      const nextObs = isObservable(next) ? next : of(next);
+      nextObs.subscribe(item => {
+        if (item.disabled) {
+          return this.move(direction, item);
+        } else {
+          this.moveTo(item);
+          return true;
+        }
+      });
+    }
+    return false;
+  }
+
+  activateCurrent() {
+    if (this.current && this.current.activate) {
+      this.current.activate();
+      return true;
+    }
+    return false;
+  }
+}
+
+export function clrFocusServiceFactory(existing: FocusService, renderer: Renderer2) {
+  return existing || new FocusService(renderer);
+}
+
+export const FOCUS_SERVICE_PROVIDER = {
+  provide: FocusService,
+  useFactory: clrFocusServiceFactory,
+  deps: [[new Optional(), new SkipSelf(), FocusService], Renderer2],
+};

--- a/src/clr-angular/utils/focus/focusable-item/basic-focusable-item.service.ts
+++ b/src/clr-angular/utils/focus/focusable-item/basic-focusable-item.service.ts
@@ -21,7 +21,7 @@ export class BasicFocusableItem implements FocusableItem {
     renderer.setAttribute(el.nativeElement, 'tabindex', '-1');
   }
 
-  disabled: boolean;
+  disabled = false;
 
   focus() {
     this.renderer.addClass(this.el.nativeElement, 'focus');

--- a/src/clr-angular/utils/focus/focusable-item/basic-focusable-item.service.ts
+++ b/src/clr-angular/utils/focus/focusable-item/basic-focusable-item.service.ts
@@ -24,10 +24,10 @@ export class BasicFocusableItem implements FocusableItem {
   disabled = false;
 
   focus() {
-    this.renderer.addClass(this.el.nativeElement, 'focus');
+    this.renderer.addClass(this.el.nativeElement, 'clr-focus');
   }
   blur() {
-    this.renderer.removeClass(this.el.nativeElement, 'focus');
+    this.renderer.removeClass(this.el.nativeElement, 'clr-focus');
   }
 
   activate() {

--- a/src/clr-angular/utils/focus/focusable-item/basic-focusable-item.service.ts
+++ b/src/clr-angular/utils/focus/focusable-item/basic-focusable-item.service.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { isPlatformBrowser } from '@angular/common';
+import { ElementRef, Inject, Injectable, PLATFORM_ID, Renderer2 } from '@angular/core';
+import { UNIQUE_ID, UNIQUE_ID_PROVIDER } from '../../id-generator/id-generator.service';
+import { FocusableItem } from './focusable-item';
+
+@Injectable()
+export class BasicFocusableItem implements FocusableItem {
+  constructor(
+    @Inject(UNIQUE_ID) public id: string,
+    private el: ElementRef<HTMLElement>,
+    private renderer: Renderer2,
+    @Inject(PLATFORM_ID) private platformId: Object
+  ) {
+    renderer.setAttribute(el.nativeElement, 'id', id);
+    renderer.setAttribute(el.nativeElement, 'tabindex', '-1');
+  }
+
+  disabled: boolean;
+
+  focus() {
+    this.renderer.addClass(this.el.nativeElement, 'focus');
+  }
+  blur() {
+    this.renderer.removeClass(this.el.nativeElement, 'focus');
+  }
+
+  activate() {
+    if (isPlatformBrowser(this.platformId)) {
+      this.el.nativeElement.click();
+    }
+  }
+}
+
+export const BASIC_FOCUSABLE_ITEM_PROVIDER = [
+  UNIQUE_ID_PROVIDER,
+  {
+    provide: FocusableItem,
+    useClass: BasicFocusableItem,
+  },
+];

--- a/src/clr-angular/utils/focus/focusable-item/basic-focusable-item.spec.ts
+++ b/src/clr-angular/utils/focus/focusable-item/basic-focusable-item.spec.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { UNIQUE_ID } from '../../id-generator/id-generator.service';
+import { BASIC_FOCUSABLE_ITEM_PROVIDER, BasicFocusableItem } from './basic-focusable-item.service';
+import { FocusableItem } from './focusable-item';
+
+@Component({
+  template: '',
+  providers: [BASIC_FOCUSABLE_ITEM_PROVIDER],
+})
+class SimpleHost {}
+
+interface TestContext {
+  el: HTMLElement;
+  item: BasicFocusableItem;
+  id: string;
+}
+
+export default function(): void {
+  describe('Basic focusable item', function() {
+    beforeEach(function(this: TestContext) {
+      // Because the "service" uses ElementRef and Renderer (it's not really a service),
+      // we need to use Angular's testing tools to run this spec.
+      TestBed.configureTestingModule({ declarations: [SimpleHost] });
+      const fixture = TestBed.createComponent(SimpleHost);
+      this.el = fixture.debugElement.nativeElement;
+      this.item = fixture.debugElement.injector.get(FocusableItem, null);
+      this.id = fixture.debugElement.injector.get(UNIQUE_ID, 'not_found');
+    });
+
+    it('declares a UNIQUE_ID provider', function(this: TestContext) {
+      expect(this.id).not.toBe('not_found');
+    });
+
+    it('declares itself as a FocusableItem provider', function(this: TestContext) {
+      expect(this.item).toBeTruthy();
+    });
+
+    it('sets the id attribute of the host', function(this: TestContext) {
+      expect(this.el.getAttribute('id')).toBe(this.id);
+    });
+
+    it('removes the host from tab order', function(this: TestContext) {
+      expect(this.el.getAttribute('tabindex')).toBe('-1');
+    });
+
+    it('adds the .focus class to the host when focused', function(this: TestContext) {
+      this.item.focus();
+      expect(this.el.classList).toContain('focus');
+    });
+
+    it('removes the .focus class from the host when not focused', function(this: TestContext) {
+      this.item.focus();
+      this.item.blur();
+      expect(this.el.classList).not.toContain('focus');
+    });
+
+    it('triggers a click on the host when activated', function(this: TestContext) {
+      let clicks = 0;
+      this.el.addEventListener('click', () => clicks++);
+      expect(clicks).toBe(0);
+      this.item.activate();
+      expect(clicks).toBe(1);
+      this.item.activate();
+      expect(clicks).toBe(2);
+    });
+  });
+}

--- a/src/clr-angular/utils/focus/focusable-item/basic-focusable-item.spec.ts
+++ b/src/clr-angular/utils/focus/focusable-item/basic-focusable-item.spec.ts
@@ -50,15 +50,15 @@ export default function(): void {
       expect(this.el.getAttribute('tabindex')).toBe('-1');
     });
 
-    it('adds the .focus class to the host when focused', function(this: TestContext) {
+    it('adds the .clr-focus class to the host when focused', function(this: TestContext) {
       this.item.focus();
-      expect(this.el.classList).toContain('focus');
+      expect(this.el.classList).toContain('clr-focus');
     });
 
-    it('removes the .focus class from the host when not focused', function(this: TestContext) {
+    it('removes the .clr-focus class from the host when not focused', function(this: TestContext) {
       this.item.focus();
       this.item.blur();
-      expect(this.el.classList).not.toContain('focus');
+      expect(this.el.classList).not.toContain('clr-focus');
     });
 
     it('triggers a click on the host when activated', function(this: TestContext) {

--- a/src/clr-angular/utils/focus/focusable-item/custom-focusable-item-provider.ts
+++ b/src/clr-angular/utils/focus/focusable-item/custom-focusable-item-provider.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Type } from '@angular/core';
+import { UNIQUE_ID_PROVIDER } from '../../id-generator/id-generator.service';
+import { FocusableItem } from './focusable-item';
+
+export function customFocusableItemProvider<T>(implementation: Type<T>) {
+  return [
+    UNIQUE_ID_PROVIDER,
+    implementation,
+    {
+      provide: FocusableItem,
+      useExisting: implementation,
+    },
+  ];
+}

--- a/src/clr-angular/utils/focus/focusable-item/focusable-item.mock.ts
+++ b/src/clr-angular/utils/focus/focusable-item/focusable-item.mock.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Observable } from 'rxjs';
+import { FocusableItem } from './focusable-item';
+
+export class MockFocusableItem implements FocusableItem {
+  constructor(public id: string) {}
+
+  disabled = false;
+
+  focus() {}
+  blur() {}
+  activate() {}
+
+  up?: FocusableItem | Observable<FocusableItem>;
+  down?: FocusableItem | Observable<FocusableItem>;
+  left?: FocusableItem | Observable<FocusableItem>;
+  right?: FocusableItem | Observable<FocusableItem>;
+}

--- a/src/clr-angular/utils/focus/focusable-item/focusable-item.ts
+++ b/src/clr-angular/utils/focus/focusable-item/focusable-item.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Observable } from 'rxjs';
+
+export abstract class FocusableItem {
+  id: string;
+  disabled?: boolean;
+
+  abstract focus(): void;
+  abstract blur(): void;
+  abstract activate?(): void;
+
+  up?: FocusableItem | Observable<FocusableItem>;
+  down?: FocusableItem | Observable<FocusableItem>;
+  left?: FocusableItem | Observable<FocusableItem>;
+  right?: FocusableItem | Observable<FocusableItem>;
+}

--- a/src/clr-angular/utils/focus/focusable-item/linkers.spec.ts
+++ b/src/clr-angular/utils/focus/focusable-item/linkers.spec.ts
@@ -6,14 +6,8 @@
 
 import { Direction } from '../direction.enum';
 import { FocusableItem } from './focusable-item';
+import { MockFocusableItem } from './focusable-item.mock';
 import { linkParent, linkVertical } from './linkers';
-
-class MockFocusableItem implements FocusableItem {
-  constructor(public id: string) {}
-
-  focus() {}
-  blur() {}
-}
 
 export default function(): void {
   describe('linkParent()', function() {

--- a/src/clr-angular/utils/focus/focusable-item/linkers.spec.ts
+++ b/src/clr-angular/utils/focus/focusable-item/linkers.spec.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Direction } from '../direction.enum';
+import { FocusableItem } from './focusable-item';
+import { linkParent, linkVertical } from './linkers';
+
+class MockFocusableItem implements FocusableItem {
+  constructor(public id: string) {}
+
+  focus() {}
+  blur() {}
+}
+
+export default function(): void {
+  describe('linkParent()', function() {
+    it('links the list of items to the parent according to the given direction', function() {
+      const parent = new MockFocusableItem('parent');
+      const children: FocusableItem[] = new Array(5).fill(0).map((_, i) => new MockFocusableItem(`${i}`));
+      linkParent(children, parent, Direction.RIGHT);
+      for (const child of children) {
+        expect(child.right).toBe(parent);
+      }
+    });
+  });
+
+  describe('linkVertical()', function() {
+    type TestContext = {
+      first: FocusableItem;
+      second: FocusableItem;
+      third: FocusableItem;
+    };
+
+    beforeEach(function(this: TestContext) {
+      this.first = new MockFocusableItem('0');
+      this.second = new MockFocusableItem('1');
+      this.third = new MockFocusableItem('2');
+    });
+
+    it('links the items vertically both ways', function(this: TestContext) {
+      linkVertical([this.first, this.second, this.third]);
+      expect(this.second.up).toBe(this.first);
+      expect(this.second.down).toBe(this.third);
+    });
+
+    it('loops by default', function(this: TestContext) {
+      linkVertical([this.first, this.second, this.third]);
+      expect(this.first.up).toBe(this.third);
+      expect(this.third.down).toBe(this.first);
+    });
+
+    it('offer the option to not loop', function(this: TestContext) {
+      linkVertical([this.first, this.second, this.third], false);
+      expect(this.first.up).toBeUndefined();
+      expect(this.third.down).toBeUndefined();
+    });
+  });
+}

--- a/src/clr-angular/utils/focus/focusable-item/linkers.spec.ts
+++ b/src/clr-angular/utils/focus/focusable-item/linkers.spec.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Direction } from '../direction.enum';
+import { ArrowKeyDirection } from '../arrow-key-direction.enum';
 import { FocusableItem } from './focusable-item';
 import { MockFocusableItem } from './focusable-item.mock';
 import { linkParent, linkVertical } from './linkers';
@@ -14,7 +14,7 @@ export default function(): void {
     it('links the list of items to the parent according to the given direction', function() {
       const parent = new MockFocusableItem('parent');
       const children: FocusableItem[] = new Array(5).fill(0).map((_, i) => new MockFocusableItem(`${i}`));
-      linkParent(children, parent, Direction.RIGHT);
+      linkParent(children, parent, ArrowKeyDirection.RIGHT);
       for (const child of children) {
         expect(child.right).toBe(parent);
       }

--- a/src/clr-angular/utils/focus/focusable-item/linkers.ts
+++ b/src/clr-angular/utils/focus/focusable-item/linkers.ts
@@ -5,7 +5,7 @@
  */
 
 import { Observable } from 'rxjs';
-import { Direction } from '../direction.enum';
+import { ArrowKeyDirection } from '../arrow-key-direction.enum';
 import { FocusableItem } from './focusable-item';
 
 /**
@@ -14,7 +14,7 @@ import { FocusableItem } from './focusable-item';
 export function linkParent(
   items: FocusableItem[],
   parent: FocusableItem | Observable<FocusableItem>,
-  direction: Direction
+  direction: ArrowKeyDirection
 ) {
   items.forEach(item => (item[direction] = parent));
 }

--- a/src/clr-angular/utils/focus/focusable-item/linkers.ts
+++ b/src/clr-angular/utils/focus/focusable-item/linkers.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Observable } from 'rxjs';
+import { Direction } from '../direction.enum';
+import { FocusableItem } from './focusable-item';
+
+/**
+ * Links a set of focusable items to a parent along one direction
+ */
+export function linkParent(
+  items: FocusableItem[],
+  parent: FocusableItem | Observable<FocusableItem>,
+  direction: Direction
+) {
+  items.forEach(item => (item[direction] = parent));
+}
+
+/**
+ * Double-links a set of focusable items vertically, possibly looping
+ */
+export function linkVertical(items: FocusableItem[], loop = true) {
+  items.forEach((item, index) => {
+    if (index > 0) {
+      item.up = items[index - 1];
+    }
+    if (index < items.length - 1) {
+      item.down = items[index + 1];
+    }
+  });
+  if (loop && items.length > 1) {
+    items[0].up = items[items.length - 1];
+    items[items.length - 1].down = items[0];
+  }
+}
+
+// Right now I only need the two linkers above, but we can easily add more linkers. A couple examples:
+// export function linkHorizontal(items: FocusableItem[], loop = true);
+// export function linkTable(items: FocusableItem[][]);

--- a/src/clr-angular/utils/focus/wrap-observable.spec.ts
+++ b/src/clr-angular/utils/focus/wrap-observable.spec.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Observable, Subject } from 'rxjs';
+import { wrapObservable } from './wrap-observable';
+
+interface TestContext {
+  original: Subject<string>;
+  wrapped: Observable<string>;
+  log: string[];
+}
+
+export default function(): void {
+  describe('wrapObservable()', function() {
+    beforeEach(function(this: TestContext) {
+      this.log = [];
+      this.original = new Subject<string>();
+      this.wrapped = wrapObservable(
+        this.original,
+        () => this.log.push('Subscribed'),
+        () => this.log.push('Unsubscribed')
+      );
+    });
+
+    afterEach(function(this: TestContext) {
+      this.original.complete();
+    });
+
+    it('executes the onSubscribe function on subscription', function(this: TestContext) {
+      expect(this.log).toEqual([]);
+      this.wrapped.subscribe(value => this.log.push(value));
+      expect(this.log).toEqual(['Subscribed']);
+    });
+
+    it('executes the onUnsubscribe function on unsubscription', function(this: TestContext) {
+      expect(this.log).toEqual([]);
+      const subscription = this.wrapped.subscribe(value => this.log.push(value));
+      this.log.length = 0;
+      subscription.unsubscribe();
+      expect(this.log).toEqual(['Unsubscribed']);
+    });
+
+    it('emits the same values as the original observable', function(this: TestContext) {
+      this.wrapped.subscribe(value => this.log.push(value));
+      this.log.length = 0;
+      this.original.next('Hello');
+      expect(this.log).toEqual(['Hello']);
+      this.original.next('World');
+      expect(this.log).toEqual(['Hello', 'World']);
+    });
+  });
+}

--- a/src/clr-angular/utils/focus/wrap-observable.ts
+++ b/src/clr-angular/utils/focus/wrap-observable.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Observable, Observer } from 'rxjs';
+
+export function wrapObservable<T>(
+  observable: Observable<T>,
+  onSubscribe?: (observer: Observer<T>) => void,
+  onUnsubscribe?: (observer: Observer<T>) => void
+): Observable<T> {
+  return Observable.create((observer: Observer<T>) => {
+    onSubscribe(observer);
+    const subscription = observable.subscribe(observer);
+    return () => {
+      subscription.unsubscribe();
+      if (onUnsubscribe) {
+        onUnsubscribe(observer);
+      }
+    };
+  });
+}

--- a/src/clr-angular/utils/testing/helpers.spec.ts
+++ b/src/clr-angular/utils/testing/helpers.spec.ts
@@ -48,7 +48,8 @@ export class TestContext<C, H> {
     return TestBed.get(token, notFoundValue);
   }
 
-  getClarityProvider<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T): T {
+  // The Function type here is just to tell Typescript to be nice with abstract classes. Weird.
+  getClarityProvider<T>(token: Type<T> | InjectionToken<T> | Function, notFoundValue?: T): T {
     return this.clarityDebugElement.injector.get(token, notFoundValue);
   }
 


### PR DESCRIPTION
Given the complexity and particular constraints of each of our components, writing a "just slap this in" focus management directive turned out to be impractical. Instead, I had to expose smaller pieces that you combine together with a bit more integration on the component side, but hopefully reducing code duplication enough to be valuable.

Here is the architecture of these new focus management utilities:
- Based on Chris' preference, we will be using `aria-activedescendant` rather than actual focus management.
- All focusable objects we are going to work with should implement the `FocusableItem` interface.
- These focusable objects have optional pointers in all directions to indicate what the next object in that direction is.
- A singleton FocusService per focus-managed component will work with this "graph" of focusable items and navigate it according to the keys pressed by the user.
- In order to help build the graph of focusable items, reusable linkers are provided. I only implemented 2 so far, but added a comment noting that we can easily add more in the future.
- A typical focusable item for our components will simply toggle the `.focus` CSS class on itself when focused. Once again, this is because we use `aria-activedescendant` so the item isn't actually focused, it just needs to look focused.

**************

The second commit uses the common focus management utilities to enable keyboard navigation of dropdowns.

The biggest hurdle here is that inside of a dropdown menu, the focusable items can be either a dropdown item or the trigger of a nested dropdown. But because we can't query deeply as that would break multiple levels of nesting, our `@ContentChildren` query only has access to the top-level children. This means we have to work with the nested dropdowns themselves, not their trigger. To get this to work, I introduce a custom FocusableItem implementation for each dropdown which "proxies" focus behavior to its trigger, and bridges keyboard navigation by pointing to its children.

Note that this relies on the fact that `@ContentChildren` doesn't have to query for components or directives, it can query directly for providers. So any component or directive declaring said provider will be part of the resulting `QueryList`.

I wish I could have spent a bit more time trying to extract more reusable pieces from the custom DropdownFocusHandler implementation, since the Combobox will share most of it expect the nesting management. But it's a bit too entangled right now and I am under a pretty hard time constraint, so I'm sorry to let @jeeyun handle the extraction for when she'll implement this for combobox.

This implementation uses a pattern you might not have faced yet with Observables: observables that execute an action when any observer subscribes to them (in this case opening/closing the dropdown). This lets us avoid adding a bunch of observables in the FocusService to try and subscribe to them from every focusable item, which would end up in nice spaghetti code. Instead, when the focus service tries to go down, we can simply intercept that with our on-subscribe pattern, open the dropdown, and then go down.

There were a lot of edge cases to test, I hope I my specs are comprehensive enough.

Here is a live demo of this implementation: http://clarity-accessible-dropdown.surge.sh/