### PR TITLE
[NG] Disable checkboxes in tree view

### DIFF
--- a/src/clr-angular/data/tree-view/_tree-view.clarity.scss
+++ b/src/clr-angular/data/tree-view/_tree-view.clarity.scss
@@ -175,4 +175,20 @@
       margin-left: 0.125rem;
     }
   }
+
+  .clr-treenode-checkbox.disabled {
+    pointer-events: none;
+    opacity: $clr-forms-disabled-opacity;
+  }
+
+  // NOTE: The pointer-events are disabled here to disable click event on the input element lying under
+  // the label element. This is because, input click/change event happening on the DOM,
+  // makes it hard for persisting the indeterminate state on the input by setting 'checked' state
+  // of input to true and it clashes with the '_model.selected.value'. The DOM property bindings of the
+  // input element are messed up for programmatically persisting the indeterminate state
+  .clr-treenode-checkbox {
+    input[type='checkbox'] {
+      pointer-events: none;
+    }
+  }
 }

--- a/src/clr-angular/data/tree-view/models/tree-node.model.spec.ts
+++ b/src/clr-angular/data/tree-view/models/tree-node.model.spec.ts
@@ -16,7 +16,7 @@ class TestModel extends TreeNodeModel<string> {
     this.parent = parent;
   }
 
-  children: TestModel[];
+  children: TestModel[] = [];
   parent: TestModel | null;
 }
 
@@ -131,6 +131,121 @@ export default function(): void {
       root.selected.subscribe({ complete: () => (complete = true) });
       root.destroy();
       expect(complete).toBeTrue();
+    });
+
+    describe('with disabled nodes', function() {
+      it('offers a disabled BehaviorSubject', function() {
+        expect(root.disabled instanceof BehaviorSubject).toBeTrue();
+      });
+
+      it('allows to set the disabled state of a node without propagating', function() {
+        child.setDisabled(true, false, false);
+        expect(child.disabled.value).toBe(true);
+        [root, ...child.children].forEach(n => expect(n.disabled.value).toBe(false));
+      });
+
+      it('emits disabled changes only when it actually changes', function() {
+        let nbChanges = 0;
+        child.disabled.subscribe(_ => nbChanges++);
+        // BehaviorSubject sends us the first state on subscription
+        expect(nbChanges).toBe(1);
+        child.setDisabled(false, false, false);
+        expect(nbChanges).toBe(1);
+        child.setDisabled(true, false, false);
+        expect(nbChanges).toBe(2);
+      });
+
+      it('can propagate the disabled state to parents', function() {
+        // Disabling all children of a node will make it disabled
+        child.children.forEach(c => c.setDisabled(true, true, false));
+        expect(child.disabled.value).toBe(true);
+        // Once the parent is disabled, a child cannot be enabled
+        child.children[0].setDisabled(false, false, false);
+        expect(child.children[1].disabled.value).toBe(true);
+      });
+
+      it('can propagate the disabled state to children', function() {
+        // Disabling a parent disables all the children down the tree
+        root.setDisabled(true, false, true);
+        [...root.children, ...child.children].forEach(n => expect(n.disabled.value).toBe(true));
+        // Enabling a parent enables all the children down the tree
+        root.setDisabled(false, false, true);
+        [...root.children, ...child.children].forEach(n => expect(n.disabled.value).toBe(false));
+        // In the case of dynamically changing parent/children, the local condition should be given
+        // higher priority than the parent policy.
+        child.setDisabled(true, false, true);
+        [...child.children].forEach(n => expect(n.disabled.value).toBe(true));
+        // local condition
+        child.children[1].isDisabledInputSetToTrue = true;
+        child.setDisabled(false, false, true);
+        expect(child.children[0].disabled.value).toBe(false);
+        expect(child.children[1].disabled.value).toBe(true);
+      });
+
+      it('completes the disabled Observable on destroy', function() {
+        let complete = false;
+        root.disabled.subscribe({ complete: () => (complete = true) });
+        root.destroy();
+        expect(complete).toBeTrue();
+      });
+
+      describe('Selection', function() {
+        it('does not toggle the selection of disabled nodes and only toggles the enabled nodes', function() {
+          root.children[1].setDisabled(true, false, false);
+          expect(root.children[0].selected.value).toBe(ClrSelectedState.UNSELECTED);
+          expect(root.children[1].selected.value).toBe(ClrSelectedState.UNSELECTED);
+          root.toggleSelection(true);
+          expect(root.children[0].selected.value).toBe(ClrSelectedState.SELECTED);
+          expect(root.children[1].selected.value).toBe(ClrSelectedState.UNSELECTED);
+        });
+
+        describe('Indeterminate parent', function() {
+          beforeEach(function() {
+            // Unselected and disabeld child
+            expect(root.children[1].selected.value).toBe(ClrSelectedState.UNSELECTED);
+            root.children[1].setDisabled(true, false, false);
+            root.toggleSelection(true);
+          });
+
+          it('selecting a parent with some nodes that are unselected and also disabled, results in indeterminate state of the parent', function() {
+            expect(root.children[0].selected.value).toBe(ClrSelectedState.SELECTED);
+            expect(root.children[1].selected.value).toBe(ClrSelectedState.UNSELECTED);
+            expect(root.selected.value).toBe(ClrSelectedState.INDETERMINATE);
+          });
+
+          it('selects only the nodes that are unselected and also enabled when indeterminate parent is clicked', function() {
+            root.children[0].setSelected(ClrSelectedState.UNSELECTED, false, false);
+            root.toggleSelection(true);
+            expect(root.children[0].selected.value).toBe(ClrSelectedState.SELECTED);
+            expect(root.children[1].selected.value).toBe(ClrSelectedState.UNSELECTED);
+          });
+
+          it('toggling persists the indeterminate state when some of the nodes are disabled and also unselected', function() {
+            root.toggleSelection(true);
+            expect(root.selected.value).toBe(ClrSelectedState.INDETERMINATE);
+          });
+
+          it('toggling the indeterminate state of a parent with enabled children that are already selected, does not unselect them', function() {
+            root.toggleSelection(true);
+            // remains same
+            expect(root.children[0].selected.value).toBe(ClrSelectedState.SELECTED);
+            expect(root.children[1].selected.value).toBe(ClrSelectedState.UNSELECTED);
+          });
+
+          it('toggling indeterminate state with child nodes that are disabled and selected results in selected state', function() {
+            // Enable the node that is disabled in before each above
+            root.children[1].setDisabled(false, false, false);
+            // Selected and disabled child
+            root.children[1].setSelected(ClrSelectedState.SELECTED, false, false);
+            root.children[1].setDisabled(true, false, false);
+
+            expect(root.selected.value).toBe(ClrSelectedState.INDETERMINATE);
+            root.toggleSelection(true);
+
+            expect(root.selected.value).toBe(ClrSelectedState.SELECTED);
+          });
+        });
+      });
     });
   });
 }

--- a/src/clr-angular/data/tree-view/models/tree-node.model.ts
+++ b/src/clr-angular/data/tree-view/models/tree-node.model.ts
@@ -9,6 +9,9 @@ import { BehaviorSubject } from 'rxjs';
 
 export abstract class TreeNodeModel<T> {
   selected = new BehaviorSubject<ClrSelectedState>(ClrSelectedState.UNSELECTED);
+  disabled = new BehaviorSubject<boolean>(false);
+  // A local condition which is given higher priority than the parent node's 'isSelectionDisabled' policy
+  isDisabledInputSetToTrue: boolean = false;
   model: T | null;
   /*
    * Ideally, I would like to use a polymorphic this type here to ensure homogeneity of the tree, something like:
@@ -30,6 +33,7 @@ export abstract class TreeNodeModel<T> {
   destroy() {
     // Just to be safe
     this.selected.complete();
+    this.disabled.complete();
   }
 
   // Propagate by default when eager, don't propagate in the lazy-loaded tree.
@@ -37,12 +41,36 @@ export abstract class TreeNodeModel<T> {
     if (state === this.selected.value) {
       return;
     }
-    this.selected.next(state);
-    if (propagateDown && state !== ClrSelectedState.INDETERMINATE && this.children) {
-      this.children.forEach(child => child.setSelected(state, false, true));
+    if (propagateDown && state !== ClrSelectedState.INDETERMINATE && this.children.length > 0) {
+      this.children.filter(child => !child.disabled.value).forEach(child => child.setSelected(state, false, true));
+      // If there are any children, then we have to always calculate the selection state from the children after they are set.
+      // This is because, the state sent by parent is not always the state set on children because of the possibility of any
+      // disabled descended nodes persisting their selection states.
+      this._updateSelectionFromChildren();
+    } else {
+      this.selected.next(state);
     }
     if (propagateUp && this.parent) {
       this.parent._updateSelectionFromChildren();
+    }
+  }
+
+  setDisabled(value: boolean, propagateUp: boolean, propagateDown: boolean) {
+    if (this.disabled.value === value) {
+      return;
+    }
+    // If selection of the parent is disabled, then this node also has to be disabled
+    const disabledValue = this.parent && this.parent.disabled.value ? true : value;
+    this.disabled.next(disabledValue);
+    // Don't change the disableSelection state of the children for which the clrDisableSelection is set to true
+    if (propagateDown) {
+      this.children
+        .filter(child => !child.isDisabledInputSetToTrue)
+        .forEach(child => child.setDisabled(this.disabled.value, false, true));
+    }
+    // Parent has to disable itself when all the children are disabled
+    if (propagateUp && this.disabled.value && this.parent) {
+      this.parent._updateDisabledStateFromChildren();
     }
   }
 
@@ -53,6 +81,12 @@ export abstract class TreeNodeModel<T> {
     // NOTE: we always propagate selection up in this method because it is only called when the user takes an action.
     // It should never be called from lifecycle hooks or app-provided inputs.
     this.setSelected(newState, true, propagate);
+  }
+
+  toggleClickHandler(propagate: boolean, event: Event) {
+    // NOTE: To prevent click event on the input element when label is clicked
+    event.preventDefault();
+    this.toggleSelection(propagate);
   }
 
   private computeSelectionStateFromChildren() {
@@ -97,6 +131,23 @@ export abstract class TreeNodeModel<T> {
     this.selected.next(newState);
     if (this.parent) {
       this.parent._updateSelectionFromChildren();
+    }
+  }
+
+  private get areAllChildrenDisabled(): boolean {
+    return !this.children.find(child => !child.disabled.value);
+  }
+
+  /*
+  * Internal, but needs to be called by other nodes
+  */
+  _updateDisabledStateFromChildren() {
+    if (!this.areAllChildrenDisabled) {
+      return;
+    }
+    this.disabled.next(true);
+    if (this.parent) {
+      this.parent._updateDisabledStateFromChildren();
     }
   }
 }

--- a/src/clr-angular/data/tree-view/tree-node.html
+++ b/src/clr-angular/data/tree-view/tree-node.html
@@ -20,12 +20,18 @@
   <div class="clr-treenode-spinner-container" *ngIf="expandService.loading || _model.loading">
         <span class="clr-treenode-spinner spinner"></span>
   </div>
-  <div class="clr-checkbox-wrapper clr-treenode-checkbox" *ngIf="featuresService.selectable">
+  <div class="clr-checkbox-wrapper clr-treenode-checkbox" *ngIf="featuresService.selectable"
+    [ngClass]="{'disabled': _model.disabled.value}">
     <input type="checkbox" id="{{nodeId}}-check" class="clr-checkbox" [attr.aria-labelledby]="nodeId"
            [checked]="_model.selected.value === STATES.SELECTED"
-           [indeterminate]="_model.selected.value === STATES.INDETERMINATE"
-           (change)="_model.toggleSelection(featuresService.eager)">
-    <label for="{{nodeId}}-check" class="clr-control-label"></label>
+           [indeterminate]="_model.selected.value === STATES.INDETERMINATE">
+    <!-- NOTE: The toggle selection handler is here instead of change on input above because, input change event happening
+      on the DOM makes it hard for persisting the Indeterminate state on input by setting the 'checked' state 
+      of the input to true even when it's false on the '_model.selected.value'. The DOM property bindings of the
+      input element are messed up for programmatically persisting the indeterminate state -->
+    <label for="{{nodeId}}-check" class="clr-control-label" 
+      (click)="_model.toggleClickHandler(featuresService.eager, $event)">
+    </label>
   </div>
   <div class="clr-treenode-content" [id]="nodeId">
     <ng-content></ng-content>

--- a/src/clr-angular/data/tree-view/tree-node.ts
+++ b/src/clr-angular/data/tree-view/tree-node.ts
@@ -77,6 +77,20 @@ export class ClrTreeNode<T> implements OnInit, OnDestroy {
     return !!this.expandService.expandable || this._model.children.length > 0;
   }
 
+  @Input('clrDisabled')
+  get disabled(): boolean {
+    return this._model.disabled.value;
+  }
+  set disabled(value: boolean) {
+    if (value === null || typeof value === 'undefined') {
+      value = true;
+    }
+    if (typeof value === 'boolean') {
+      this._model.isDisabledInputSetToTrue = value;
+      this._model.setDisabled(value, this.featuresService.eager, this.featuresService.eager);
+    }
+  }
+
   @Input('clrSelected')
   get selected(): ClrSelectedState | boolean {
     return this._model.selected.value;
@@ -100,6 +114,8 @@ export class ClrTreeNode<T> implements OnInit, OnDestroy {
   }
 
   @Output('clrSelectedChange') selectedChange = new EventEmitter<ClrSelectedState>(false);
+
+  @Output('clrDisabledChange') disabledChange = new EventEmitter<boolean>(false);
 
   @HostBinding('attr.role')
   get treeNodeRole(): string {
@@ -144,6 +160,7 @@ export class ClrTreeNode<T> implements OnInit, OnDestroy {
       this._model.selected.pipe(filter(() => !this.skipEmitChange)).subscribe(value => this.selectedChange.emit(value))
     );
     this.subscriptions.push(this.expandService.expandChange.subscribe(value => this.expandedChange.emit(value)));
+    this.subscriptions.push(this._model.disabled.subscribe(value => this.disabledChange.emit(value)));
   }
 
   ngOnDestroy() {

--- a/src/clr-angular/forms/styles/_checkbox.clarity.scss
+++ b/src/clr-angular/forms/styles/_checkbox.clarity.scss
@@ -83,7 +83,8 @@
     border-color: $clr-forms-invalid-color;
   }
 
-  .clr-form-control-disabled .clr-checkbox-wrapper {
+  .clr-form-control-disabled .clr-checkbox-wrapper,
+  .clr-treenode-checkbox.disabled {
     input[type='checkbox'] + label::before,
     input[type='checkbox']:checked + label::before {
       background-color: $clr-forms-checkbox-disabled-background-color;

--- a/src/dev/src/app/tree-view/eager-declarative-tree/eager-declarative-tree.html
+++ b/src/dev/src/app/tree-view/eager-declarative-tree/eager-declarative-tree.html
@@ -54,6 +54,52 @@
   </clr-tree-node>
 </div>
 
+<h4>Selection with Disabled nodes</h4>
+<button class="btn" [ngClass]="{'btn-success-outline': isNodeAdisabled, 'btn-danger-outline': !isNodeAdisabled}"
+  (click)="toggleNode('A')">{{ isNodeAdisabled ? "Enable" : "Disable" }} node A</button>
+
+<button class="btn" [ngClass]="{'btn-success-outline': isNodeA1disabled, 'btn-danger-outline': !isNodeA1disabled}"
+  (click)="toggleNode('A-1')">{{ isNodeA1disabled ? "Enable" : "Disable" }} node A-1</button>
+
+<button class="btn" [ngClass]="{'btn-success-outline': isNodeA2disabled, 'btn-danger-outline': !isNodeA2disabled}"
+  (click)="toggleNode('A-2')">{{ isNodeA2disabled ? "Enable" : "Disable" }} node A-2</button>
+
+<button class="btn" [ngClass]="{'btn-success-outline': isNodeA3disabled, 'btn-danger-outline': !isNodeA3disabled}"
+  (click)="toggleNode('A-3')">{{ isNodeA3disabled ? "Enable" : "Disable" }} node A-3</button>
+
+<button class="btn" [ngClass]="{'btn-success-outline': isNodeA23disabled, 'btn-danger-outline': !isNodeA23disabled}"
+  (click)="toggleNode('A-2.3')">{{ isNodeA23disabled ? "Enable" : "Disable" }} node A-2.3</button>
+
+<div class="clr-example">
+  <clr-tree-node [clrSelected]="false" [clrDisabled]="isNodeAdisabled">
+    A
+    <clr-tree-node [clrDisabled]="isNodeA1disabled">
+      A-1
+    </clr-tree-node>
+    <clr-tree-node [clrDisabled]="isNodeA2disabled">
+      A-2
+      <clr-tree-node>
+        A-2.1
+      </clr-tree-node>
+      <clr-tree-node>
+        A-2.2
+      </clr-tree-node>
+      <clr-tree-node [clrDisabled]="isNodeA23disabled">
+        A-2.3
+        <clr-tree-node>
+          A-2.3.1
+        </clr-tree-node>
+        <clr-tree-node>
+          A-2.3.2
+        </clr-tree-node>
+      </clr-tree-node>
+    </clr-tree-node>
+    <clr-tree-node [clrDisabled]="isNodeA3disabled">
+      A-3
+    </clr-tree-node>
+  </clr-tree-node>
+</div>
+
 <h4>Pre-expanded node, <code class="clr-code">ng-container</code> syntax</h4>
 <div id="expanded-node" class="clr-example">
   <clr-tree-node [clrSelected]="false">

--- a/src/dev/src/app/tree-view/eager-declarative-tree/eager-declarative-tree.ts
+++ b/src/dev/src/app/tree-view/eager-declarative-tree/eager-declarative-tree.ts
@@ -13,4 +13,25 @@ import { Component } from '@angular/core';
 export class EagerDeclarativeTreeDemo {
   expanded1 = true;
   expanded2 = true;
+  isNodeAdisabled: boolean = true;
+
+  isNodeA1disabled: boolean = false;
+  isNodeA2disabled: boolean = false;
+  isNodeA3disabled: boolean = false;
+
+  isNodeA23disabled: boolean = false;
+
+  toggleNode(name) {
+    if (name === 'A-1') {
+      this.isNodeA1disabled = !this.isNodeA1disabled;
+    } else if (name === 'A-2') {
+      this.isNodeA2disabled = !this.isNodeA2disabled;
+    } else if (name === 'A-3') {
+      this.isNodeA3disabled = !this.isNodeA3disabled;
+    } else if (name === 'A-2.3') {
+      this.isNodeA23disabled = !this.isNodeA23disabled;
+    } else if (name === 'A') {
+      this.isNodeAdisabled = !this.isNodeAdisabled;
+    }
+  }
 }


### PR DESCRIPTION
Add the ability to dynamically disable selection of tree node checkboxes.

closes the issue: https://github.com/vmware/clarity/issues/1458

Signed-off-by: Prudhvi Simhadri <prudhvi.af121@gmail.com>