### PR TITLE
Improved icon typings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ src/clr-angular/package.json
 
 # IDE - VSCode
 .vscode/*
-# !.vscode/settings.json
+!.vscode/settings.json
 # !.vscode/tasks.json
 # !.vscode/launch.json
 # !.vscode/extensions.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "./node_modules/typescript/lib"
+}

--- a/src/clr-icons/shapes/all-shapes.ts
+++ b/src/clr-icons/shapes/all-shapes.ts
@@ -1,43 +1,49 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { ChartShapes } from './chart-shapes';
-import { CommerceShapes } from './commerce-shapes';
-import { CoreShapes } from './core-shapes';
-import { EssentialShapes } from './essential-shapes';
-import { MediaShapes } from './media-shapes';
-import { SocialShapes } from './social-shapes';
-import { TechnologyShapes } from './technology-shapes';
-import { TextEditShapes } from './text-edit-shapes';
-import { TravelShapes } from './travel-shapes';
+import { ChartShapes, ChartShape } from './chart-shapes';
+import { CommerceShapes, CommerceShape } from './commerce-shapes';
+import { CoreShapes, CoreShape } from './core-shapes';
+import { EssentialShapes, EssentialShape } from './essential-shapes';
+import { MediaShapes, MediaShape } from './media-shapes';
+import { SocialShapes, SocialShape } from './social-shapes';
+import { TechnologyShapes, TechnologyShape } from './technology-shapes';
+import { TextEditShapes, TextEditShape } from './text-edit-shapes';
+import { TravelShapes, TravelShape } from './travel-shapes';
+import safeWindowAdd from '../utils/safe-window-add';
 
-const allShapesSets = [
-  CoreShapes,
-  CommerceShapes,
-  EssentialShapes,
-  MediaShapes,
-  SocialShapes,
-  TechnologyShapes,
-  TravelShapes,
-  ChartShapes,
-  TextEditShapes,
-];
+/**
+ * Valid shapes.
+ */
+export type AllShape =
+  | ChartShape
+  | CommerceShape
+  | CoreShape
+  | EssentialShape
+  | MediaShape
+  | SocialShape
+  | TechnologyShape
+  | TextEditShape
+  | TravelShape;
 
-const allShapes: any = {};
+/**
+ * AllShapes valid type.
+ */
+type AllShapesType = { [shape in AllShape]: string };
 
-for (const set of allShapesSets) {
-  for (const shape in set) {
-    if (set.hasOwnProperty(shape)) {
-      allShapes[shape] = set[shape];
-    }
-  }
-}
+export const AllShapes: AllShapesType = {
+  ...CoreShapes,
+  ...CommerceShapes,
+  ...EssentialShapes,
+  ...MediaShapes,
+  ...SocialShapes,
+  ...TechnologyShapes,
+  ...TravelShapes,
+  ...ChartShapes,
+  ...TextEditShapes,
+};
 
-if (typeof window !== 'undefined' && window.hasOwnProperty('ClarityIcons')) {
-  window.ClarityIcons.add(allShapes);
-}
-
-export { allShapes as AllShapes };
+safeWindowAdd(AllShapes);

--- a/src/clr-icons/shapes/chart-shapes.ts
+++ b/src/clr-icons/shapes/chart-shapes.ts
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { descriptorConfig } from '../utils/descriptor-config';
 import { clrIconSVG } from '../utils/svg-tag-generator';
+import safeWindowAdd from '../utils/safe-window-add';
 
 /* tslint:disable:variable-name */
 export const ClrShapeAxisChart = clrIconSVG(`
@@ -222,24 +222,28 @@ export const ClrShapeBellCurve = clrIconSVG(
   `<path d="M33,29H3A1,1,0,1,1,3,27H33A1,1,0,1,1,33,29Z" class="clr-i-outline clr-i-outline-path-1" /><path d="M33,25h-.62a8.11,8.11,0,0,1-8-6.67C23.62,14.44,21.89,7.94,18,7.94s-5.69,6.51-6.38,10.39a8.11,8.11,0,0,1-8,6.65H3a1,1,0,1,1,0-2h.6A6.11,6.11,0,0,0,9.6,18c1.41-7.88,4.3-12,8.35-12s6.93,4.16,8.33,12a6.11,6.11,0,0,0,6,5H33a1,1,0,0,1,0,2Z" class="clr-i-outline clr-i-outline-path-2" />`
 );
 
-export const ChartShapes: any = {
+export const ChartShapes = {
   'axis-chart': ClrShapeAxisChart,
   'bar-chart': ClrShapeBarChart,
+  'bell-curve': ClrShapeBellCurve,
+  'box-plot': ClrShapeBoxPlot,
   'bubble-chart': ClrShapeBubbleChart,
   'cloud-chart': ClrShapeCloudChart,
   'curve-chart': ClrShapeCurveChart,
   'grid-chart': ClrShapeGridChart,
+  'heat-map': ClrShapeHeatMap,
   'line-chart': ClrShapeLineChart,
   'pie-chart': ClrShapePieChart,
-  'tick-chart': ClrShapeTickChart,
   'scatter-plot': ClrShapeScatterPlot,
-  'box-plot': ClrShapeBoxPlot,
-  'heat-map': ClrShapeHeatMap,
-  'bell-curve': ClrShapeBellCurve,
+  'tick-chart': ClrShapeTickChart,
+  /** Alias for: line-chart */ get analytics(): string {
+    return this['line-chart'];
+  },
 };
 
-Object.defineProperty(ChartShapes, 'analytics', descriptorConfig(ChartShapes['line-chart']));
+/**
+ * Valid shapes.
+ */
+export type ChartShape = keyof typeof ChartShapes;
 
-if (typeof window !== 'undefined' && window.hasOwnProperty('ClarityIcons')) {
-  window.ClarityIcons.add(ChartShapes);
-}
+safeWindowAdd(ChartShapes);

--- a/src/clr-icons/shapes/commerce-shapes.ts
+++ b/src/clr-icons/shapes/commerce-shapes.ts
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { descriptorConfig } from '../utils/descriptor-config';
 import { clrIconSVG } from '../utils/svg-tag-generator';
+import safeWindowAdd from '../utils/safe-window-add';
 
 /* tslint:disable:variable-name */
 export const ClrShapeCalculator = clrIconSVG(
@@ -165,31 +165,35 @@ export const ClrShapeRuble = clrIconSVG(
   `<path d="M20.57,20A8.23,8.23,0,0,0,29,12a8.23,8.23,0,0,0-8.43-8H12a1,1,0,0,0-1,1V18H9a1,1,0,0,0,0,2h2v2H9a1,1,0,0,0,0,2h2v7a1,1,0,0,0,2,0V24h9a1,1,0,0,0,0-2H13V20ZM13,6h7.57A6.24,6.24,0,0,1,27,12a6.23,6.23,0,0,1-6.43,6H13Z" class="clr-i-outline clr-i-outline-path-1" /><path d="M20.75,9.25H15v8.81h5.79a4.66,4.66,0,0,0,4.86-4.4A4.65,4.65,0,0,0,20.75,9.25Z" class="clr-i-solid clr-i-solid-path-1" /><path d="M18,2A16,16,0,1,0,34,18,16,16,0,0,0,18,2Zm2.75,18.56H15V22h8.29a1,1,0,0,1,0,2H15v5a1.25,1.25,0,0,1-2.5,0V24H11.25a1,1,0,0,1,0-2h1.21V20.56H11.25a1.25,1.25,0,0,1,0-2.5h1.21V8a1.25,1.25,0,0,1,1.25-1.25h7a7.14,7.14,0,0,1,7.36,6.9A7.15,7.15,0,0,1,20.75,20.56Z" class="clr-i-solid clr-i-solid-path-2" />`
 );
 
-export const CommerceShapes: any = {
+export const CommerceShapes = {
+  bank: ClrShapeBank,
+  bitcoin: ClrShapeBitcoin,
   calculator: ClrShapeCalculator,
+  'coin-bag': ClrShapeCoinBag,
+  'credit-card': ClrShapeCreditCard,
+  'dollar-bill': ClrShapeDollarBill,
+  dollar: ClrShapeDollar,
+  'e-check': ClrShapeECheck,
+  euro: ClrShapeEuro,
+  peso: ClrShapePeso,
   'piggy-bank': ClrShapePiggyBank,
+  pound: ClrShapePound,
+  ruble: ClrShapeRuble,
+  rupee: ClrShapeRupee,
   'shopping-bag': ClrShapeShoppingBag,
   'shopping-cart': ClrShapeShoppingCart,
-  wallet: ClrShapeWallet,
   store: ClrShapeStore,
-  euro: ClrShapeEuro,
-  dollar: ClrShapeDollar,
-  peso: ClrShapePeso,
-  'credit-card': ClrShapeCreditCard,
-  bank: ClrShapeBank,
-  'dollar-bill': ClrShapeDollarBill,
-  'e-check': ClrShapeECheck,
-  pound: ClrShapePound,
-  rupee: ClrShapeRupee,
+  wallet: ClrShapeWallet,
   won: ClrShapeWon,
   yen: ClrShapeYen,
-  bitcoin: ClrShapeBitcoin,
-  ruble: ClrShapeRuble,
-  'coin-bag': ClrShapeCoinBag,
+  /** Alias for: piggy-bank */ get savings(): string {
+    return this['piggy-bank'];
+  },
 };
 
-Object.defineProperty(CommerceShapes, 'savings', descriptorConfig(CommerceShapes['piggy-bank']));
+/**
+ * Valid shapes.
+ */
+export type CommerceShape = keyof typeof CommerceShapes;
 
-if (typeof window !== 'undefined' && window.hasOwnProperty('ClarityIcons')) {
-  window.ClarityIcons.add(CommerceShapes);
-}
+safeWindowAdd(CommerceShapes);

--- a/src/clr-icons/shapes/core-shapes.ts
+++ b/src/clr-icons/shapes/core-shapes.ts
@@ -1,9 +1,8 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { descriptorConfig } from '../utils/descriptor-config';
 import { clrIconSVG } from '../utils/svg-tag-generator';
 
 /* tslint:disable:variable-name */
@@ -304,54 +303,84 @@ export const ClrShapeStepForward2 = clrIconSVG(
   `<path d="M7.08,6.52a1.68,1.68,0,0,0,0,2.4L16.51,18,7.12,27.08a1.7,1.7,0,0,0,2.36,2.44h0L21.4,18,9.48,6.47A1.69,1.69,0,0,0,7.08,6.52Z" class="clr-i-outline clr-i-outline-path-1" /><path d="M26.49,5a1.7,1.7,0,0,0-1.7,1.7V29.3a1.7,1.7,0,0,0,3.4,0V6.7A1.7,1.7,0,0,0,26.49,5Z" class="clr-i-outline clr-i-outline-path-2" />`
 );
 
-export const CoreShapes: any = {
-  'unknown-status': ClrShapeUnknownStatus,
-  home: ClrShapeHome,
-  cog: ClrShapeCog,
-  check: ClrShapeCheck,
-  times: ClrShapeTimes,
-  'exclamation-triangle': ClrShapeExclamationTriangle,
-  'exclamation-circle': ClrShapeExclamationCircle,
-  'check-circle': ClrShapeCheckCircle,
-  'info-circle': ClrShapeInfoCircle,
-  'info-standard': ClrShapeInfoStandard,
-  'success-standard': ClrShapeSuccessStandard,
-  'error-standard': ClrShapeErrorStandard,
-  'warning-standard': ClrShapeWarningStandard,
-  'help-info': ClrShapeHelpInfo,
-  bars: ClrShapeBars,
-  user: ClrShapeUser,
+export const CoreShapes = {
+  'angle-double': ClrShapeAngleDouble,
   angle: ClrShapeAngle,
-  folder: ClrShapeFolder,
-  'folder-open': ClrShapeFolderOpen,
+  bars: ClrShapeBars,
   bell: ClrShapeBell,
-  image: ClrShapeImage,
+  calendar: ClrShapeCalendar,
+  'check-circle': ClrShapeCheckCircle,
+  check: ClrShapeCheck,
   cloud: ClrShapeCloud,
+  cog: ClrShapeCog,
   'ellipsis-horizontal': ClrShapeEllipsisHorizontal,
   'ellipsis-vertical': ClrShapeEllipsisVertical,
-  'filter-grid': ClrShapeFilterGrid,
-  'filter-grid-circle': ClrShapeFilterGridCircle,
-  'vm-bug': ClrShapeVmBug,
-  search: ClrShapeSearch,
-  'view-columns': ClrShapeViewColumns,
-  'angle-double': ClrShapeAngleDouble,
-  calendar: ClrShapeCalendar,
+  'error-standard': ClrShapeErrorStandard,
   event: ClrShapeEvent,
-  eye: ClrShapeEye,
+  'exclamation-circle': ClrShapeExclamationCircle,
+  'exclamation-triangle': ClrShapeExclamationTriangle,
   'eye-hide': ClrShapeEyeHide,
+  eye: ClrShapeEye,
+  'filter-grid-circle': ClrShapeFilterGridCircle,
+  'filter-grid': ClrShapeFilterGrid,
+  'folder-open': ClrShapeFolderOpen,
+  folder: ClrShapeFolder,
+  'help-info': ClrShapeHelpInfo,
+  home: ClrShapeHome,
+  image: ClrShapeImage,
+  'info-circle': ClrShapeInfoCircle,
+  'info-standard': ClrShapeInfoStandard,
+  search: ClrShapeSearch,
   'step-forward-2': ClrShapeStepForward2,
+  'success-standard': ClrShapeSuccessStandard,
+  times: ClrShapeTimes,
+  'unknown-status': ClrShapeUnknownStatus,
+  user: ClrShapeUser,
+  'view-columns': ClrShapeViewColumns,
+  'vm-bug': ClrShapeVmBug,
+  'warning-standard': ClrShapeWarningStandard,
+  /** Alias for: angle */ get caret(): string {
+    return this['angle'];
+  },
+  /** Alias for: angle-double */ get collapse(): string {
+    return this['angle-double'];
+  },
+  /** Alias for: bars */ get menu(): string {
+    return this['bars'];
+  },
+  /** Alias for: bell */ get notification(): string {
+    return this['bell'];
+  },
+  /** Alias for: check */ get success(): string {
+    return this['check'];
+  },
+  /** Alias for: cog */ get settings(): string {
+    return this['cog'];
+  },
+  /** Alias for: exclamation-circle */ get error(): string {
+    return this['exclamation-circle'];
+  },
+  /** Alias for: exclamation-triangle */ get warning(): string {
+    return this['exclamation-triangle'];
+  },
+  /** Alias for: folder */ get directory(): string {
+    return this['folder'];
+  },
+  /** Alias for: home */ get house(): string {
+    return this['home'];
+  },
+  /** Alias for: info-circle */ get info(): string {
+    return this['info-circle'];
+  },
+  /** Alias for: times */ get close(): string {
+    return this['times'];
+  },
+  /** Alias for: user */ get avatar(): string {
+    return this['user'];
+  },
 };
 
-Object.defineProperty(CoreShapes, 'house', descriptorConfig(CoreShapes.home));
-Object.defineProperty(CoreShapes, 'settings', descriptorConfig(CoreShapes.cog));
-Object.defineProperty(CoreShapes, 'success', descriptorConfig(CoreShapes.check));
-Object.defineProperty(CoreShapes, 'close', descriptorConfig(CoreShapes.times));
-Object.defineProperty(CoreShapes, 'warning', descriptorConfig(CoreShapes['exclamation-triangle']));
-Object.defineProperty(CoreShapes, 'error', descriptorConfig(CoreShapes['exclamation-circle']));
-Object.defineProperty(CoreShapes, 'info', descriptorConfig(CoreShapes['info-circle']));
-Object.defineProperty(CoreShapes, 'menu', descriptorConfig(CoreShapes.bars));
-Object.defineProperty(CoreShapes, 'avatar', descriptorConfig(CoreShapes.user));
-Object.defineProperty(CoreShapes, 'caret', descriptorConfig(CoreShapes.angle));
-Object.defineProperty(CoreShapes, 'directory', descriptorConfig(CoreShapes.folder));
-Object.defineProperty(CoreShapes, 'notification', descriptorConfig(CoreShapes.bell));
-Object.defineProperty(CoreShapes, 'collapse', descriptorConfig(CoreShapes['angle-double']));
+/**
+ * Valid shapes.
+ */
+export type CoreShape = keyof typeof CoreShapes;

--- a/src/clr-icons/shapes/essential-shapes.ts
+++ b/src/clr-icons/shapes/essential-shapes.ts
@@ -1,16 +1,10 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { descriptorConfig } from '../utils/descriptor-config';
 import { clrIconSVG } from '../utils/svg-tag-generator';
-
-interface Window {
-  ClarityIcons: any;
-}
-
-declare var window: Window;
+import safeWindowAdd from '../utils/safe-window-add';
 
 /* tslint:disable:variable-name */
 export const ClrShapeAddText = clrIconSVG(`<path class="clr-i-outline clr-i-outline-path-1" d="M31,21H13a1,1,0,0,0,0,2H31a1,1,0,0,0,0-2Z"/>
@@ -902,150 +896,183 @@ export const ClrShapeDotCircle = clrIconSVG(
   `<path d="M18,11a7,7,0,1,1-7,7,7,7,0,0,1,7-7" class="clr-i-outline clr-i-outline-path-1" /><path d="M18,34A16,16,0,1,1,34,18,16,16,0,0,1,18,34ZM18,4A14,14,0,1,0,32,18,14,14,0,0,0,18,4Z" class="clr-i-outline clr-i-outline-path-2" />`
 );
 
-export const EssentialShapes: any = {
+export const EssentialShapes = {
+  'accessibility-1': ClrShapeAccessibility1,
+  'accessibility-2': ClrShapeAccessibility2,
   'add-text': ClrShapeAddText,
+  'alarm-clock': ClrShapeAlarmClock,
   'alarm-off': ClrShapeAlarmOff,
-  pinboard: ClrShapePinboard,
-  new: ClrShapeNew,
+  arrow: ClrShapeArrow,
+  asterisk: ClrShapeAsterisk,
+  balance: ClrShapeBalance,
+  ban: ClrShapeBan,
+  bolt: ClrShapeBolt,
+  book: ClrShapeBook,
+  briefcase: ClrShapeBriefcase,
   'bubble-exclamation': ClrShapeBubbleExclamation,
-  'grid-view': ClrShapeGridView,
+  bug: ClrShapeBug,
+  bullseye: ClrShapeBullseye,
+  'child-arrow': ClrShapeChildArrow,
+  'circle-arrow': ClrShapeCircleArrow,
+  circle: ClrShapeCircle,
+  clipboard: ClrShapeClipboard,
+  clock: ClrShapeClock,
+  clone: ClrShapeClone,
+  'collapse-card': ClrShapeCollapseCard,
+  'color-picker': ClrShapeColorPicker,
+  'copy-to-clipboard': ClrShapeCopyToClipboard,
+  copy: ClrShapeCopy,
+  crosshairs: ClrShapeCrosshairs,
   'cursor-arrow': ClrShapeCursorArrow,
-  'cursor-hand': ClrShapeCursorHand,
   'cursor-hand-click': ClrShapeCursorHandClick,
   'cursor-hand-grab': ClrShapeCursorHandGrab,
   'cursor-hand-open': ClrShapeCursorHandOpen,
+  'cursor-hand': ClrShapeCursorHand,
   'cursor-move': ClrShapeCursorMove,
-  resize: ClrShapeResize,
-  objects: ClrShapeObjects,
-  book: ClrShapeBook,
-  asterisk: ClrShapeAsterisk,
-  bug: ClrShapeBug,
-  scissors: ClrShapeScissors,
-  thermometer: ClrShapeThermometer,
-  pencil: ClrShapePencil,
-  note: ClrShapeNote,
-  refresh: ClrShapeRefresh,
-  sync: ClrShapeSync,
-  'view-list': ClrShapeViewList,
-  'view-cards': ClrShapeViewCards,
-  'tree-view': ClrShapeTreeView,
-  lightbulb: ClrShapeLightbulb,
+  details: ClrShapeDetails,
+  'dot-circle': ClrShapeDotCircle,
   download: ClrShapeDownload,
-  upload: ClrShapeUpload,
-  lock: ClrShapeLock,
-  unlock: ClrShapeUnlock,
-  users: ClrShapeUsers,
-  'pop-out': ClrShapePopOut,
-  filter: ClrShapeFilter,
-  pin: ClrShapePin,
+  'drag-handle-corner': ClrShapeDragHandleCorner,
+  'drag-handle': ClrShapeDragHandle,
+  eraser: ClrShapeEraser,
+  'expand-card': ClrShapeExpandCard,
+  'file-group': ClrShapeFileGroup,
+  'file-settings': ClrShapeFileSettings,
+  'file-zip': ClrShapeFileZip,
   file: ClrShapeFile,
-  plus: ClrShapePlus,
-  minus: ClrShapeMinus,
-  'minus-circle': ClrShapeMinusCircle,
-  'plus-circle': ClrShapePlusCircle,
-  ban: ClrShapeBan,
-  'times-circle': ClrShapeTimesCircle,
-  trash: ClrShapeTrash,
-  circle: ClrShapeCircle,
-  tag: ClrShapeTag,
-  tags: ClrShapeTags,
-  history: ClrShapeHistory,
-  clock: ClrShapeClock,
-  'alarm-clock': ClrShapeAlarmClock,
-  arrow: ClrShapeArrow,
-  'circle-arrow': ClrShapeCircleArrow,
-  'child-arrow': ClrShapeChildArrow,
-  copy: ClrShapeCopy,
+  'filter-2': ClrShapeFilter2,
+  'filter-off': ClrShapeFilterOff,
+  filter: ClrShapeFilter,
+  firewall: ClrShapeFirewall,
+  fish: ClrShapeFish,
+  flame: ClrShapeFlame,
+  form: ClrShapeForm,
+  fuel: ClrShapeFuel,
+  'grid-view': ClrShapeGridView,
   help: ClrShapeHelp,
+  history: ClrShapeHistory,
+  hourglass: ClrShapeHourglass,
+  'id-badge': ClrShapeIdBadge,
+  key: ClrShapeKey,
+  landscape: ClrShapeLandscape,
+  library: ClrShapeLibrary,
+  lightbulb: ClrShapeLightbulb,
+  list: ClrShapeList,
+  lock: ClrShapeLock,
   login: ClrShapeLogin,
   logout: ClrShapeLogout,
+  'minus-circle': ClrShapeMinusCircle,
+  minus: ClrShapeMinus,
+  moon: ClrShapeMoon,
+  new: ClrShapeNew,
+  'no-access': ClrShapeNoAccess,
+  note: ClrShapeNote,
+  objects: ClrShapeObjects,
+  organization: ClrShapeOrganization,
+  paperclip: ClrShapePaperclip,
+  paste: ClrShapePaste,
+  pencil: ClrShapePencil,
+  pin: ClrShapePin,
+  pinboard: ClrShapePinboard,
+  'plus-circle': ClrShapePlusCircle,
+  plus: ClrShapePlus,
+  'pop-out': ClrShapePopOut,
+  portrait: ClrShapePortrait,
   printer: ClrShapePrinter,
-  world: ClrShapeWorld,
-  slider: ClrShapeSlider,
-  clipboard: ClrShapeClipboard,
-  firewall: ClrShapeFirewall,
-  list: ClrShapeList,
+  recycle: ClrShapeRecycle,
   redo: ClrShapeRedo,
-  undo: ClrShapeUndo,
+  refresh: ClrShapeRefresh,
+  repeat: ClrShapeRepeat,
+  resize: ClrShapeResize,
+  scissors: ClrShapeScissors,
   scroll: ClrShapeScroll,
-  'file-settings': ClrShapeFileSettings,
-  'two-way-arrows': ClrShapeTwoWayArrows,
+  shrink: ClrShapeShrink,
+  slider: ClrShapeSlider,
+  snowflake: ClrShapeSnowflake,
+  'sort-by': ClrShapeSortBy,
+  sun: ClrShapeSun,
   switch: ClrShapeSwitch,
+  sync: ClrShapeSync,
+  table: ClrShapeTable,
+  tag: ClrShapeTag,
+  tags: ClrShapeTags,
+  target: ClrShapeTarget,
+  thermometer: ClrShapeThermometer,
+  'times-circle': ClrShapeTimesCircle,
   tools: ClrShapeTools,
+  trash: ClrShapeTrash,
+  'tree-view': ClrShapeTreeView,
+  tree: ClrShapeTree,
+  'two-way-arrows': ClrShapeTwoWayArrows,
+  undo: ClrShapeUndo,
+  unlock: ClrShapeUnlock,
+  upload: ClrShapeUpload,
+  users: ClrShapeUsers,
+  'view-cards': ClrShapeViewCards,
+  'view-list': ClrShapeViewList,
+  volume: ClrShapeVolume,
+  wand: ClrShapeWand,
   'window-close': ClrShapeWindowClose,
   'window-max': ClrShapeWindowMax,
   'window-min': ClrShapeWindowMin,
   'window-restore': ClrShapeWindowRestore,
+  world: ClrShapeWorld,
+  wrench: ClrShapeWrench,
   'zoom-in': ClrShapeZoomIn,
   'zoom-out': ClrShapeZoomOut,
-  key: ClrShapeKey,
-  library: ClrShapeLibrary,
-  bolt: ClrShapeBolt,
-  wrench: ClrShapeWrench,
-  bullseye: ClrShapeBullseye,
-  target: ClrShapeTarget,
-  flame: ClrShapeFlame,
-  hourglass: ClrShapeHourglass,
-  'no-access': ClrShapeNoAccess,
-  organization: ClrShapeOrganization,
-  balance: ClrShapeBalance,
-  'id-badge': ClrShapeIdBadge,
-  repeat: ClrShapeRepeat,
-  'file-group': ClrShapeFileGroup,
-  paperclip: ClrShapePaperclip,
-  shrink: ClrShapeShrink,
-  'accessibility-1': ClrShapeAccessibility1,
-  'accessibility-2': ClrShapeAccessibility2,
-  'sort-by': ClrShapeSortBy,
-  'collapse-card': ClrShapeCollapseCard,
-  'expand-card': ClrShapeExpandCard,
-  briefcase: ClrShapeBriefcase,
-  'color-picker': ClrShapeColorPicker,
-  'copy-to-clipboard': ClrShapeCopyToClipboard,
-  'filter-2': ClrShapeFilter2,
-  'drag-handle': ClrShapeDragHandle,
-  moon: ClrShapeMoon,
-  sun: ClrShapeSun,
-  wand: ClrShapeWand,
-  clone: ClrShapeClone,
-  details: ClrShapeDetails,
-  'drag-handle-corner': ClrShapeDragHandleCorner,
-  eraser: ClrShapeEraser,
-  landscape: ClrShapeLandscape,
-  paste: ClrShapePaste,
-  portrait: ClrShapePortrait,
-  'file-zip': ClrShapeFileZip,
-  'filter-off': ClrShapeFilterOff,
-  recycle: ClrShapeRecycle,
-  tree: ClrShapeTree,
-  fish: ClrShapeFish,
-  form: ClrShapeForm,
-  fuel: ClrShapeFuel,
-  snowflake: ClrShapeSnowflake,
-  table: ClrShapeTable,
-  'dot-circle': ClrShapeDotCircle,
-  volume: ClrShapeVolume,
-  crosshairs: ClrShapeCrosshairs,
+  /** Alias for: ban */ get cancel(): string {
+    return this['ban'];
+  },
+  /** Alias for: bolt */ get lightning(): string {
+    return this['bolt'];
+  },
+  /** Alias for: bubble-exclamation */ get alert(): string {
+    return this['bubble-exclamation'];
+  },
+  /** Alias for: file */ get document(): string {
+    return this['file'];
+  },
+  /** Alias for: login */ get 'sign-in'(): string {
+    return this['login'];
+  },
+  /** Alias for: logout */ get 'sign-out'(): string {
+    return this['logout'];
+  },
+  /** Alias for: note */ get 'note-edit'(): string {
+    return this['note'];
+  },
+  /** Alias for: organization */ get 'flow-chart'(): string {
+    return this['organization'];
+  },
+  /** Alias for: paperclip */ get attachment(): string {
+    return this['paperclip'];
+  },
+  /** Alias for: pencil */ get edit(): string {
+    return this['pencil'];
+  },
+  /** Alias for: pinboard */ get pinned(): string {
+    return this['pinboard'];
+  },
+  /** Alias for: plus */ get add(): string {
+    return this['plus'];
+  },
+  /** Alias for: resize */ get 'resize-up'(): string {
+    return this['resize'];
+  },
+  /** Alias for: shrink */ get 'resize-down'(): string {
+    return this['shrink'];
+  },
+  /** Alias for: times-circle */ get remove(): string {
+    return this['times-circle'];
+  },
+  /** Alias for: users */ get group(): string {
+    return this['users'];
+  },
 };
 
-Object.defineProperty(EssentialShapes, 'edit', descriptorConfig(EssentialShapes.pencil));
-Object.defineProperty(EssentialShapes, 'note-edit', descriptorConfig(EssentialShapes.note));
-Object.defineProperty(EssentialShapes, 'group', descriptorConfig(EssentialShapes.users));
-Object.defineProperty(EssentialShapes, 'document', descriptorConfig(EssentialShapes.file));
-Object.defineProperty(EssentialShapes, 'add', descriptorConfig(EssentialShapes.plus));
-Object.defineProperty(EssentialShapes, 'cancel', descriptorConfig(EssentialShapes.ban));
-Object.defineProperty(EssentialShapes, 'remove', descriptorConfig(EssentialShapes['times-circle']));
-Object.defineProperty(EssentialShapes, 'sign-in', descriptorConfig(EssentialShapes.login));
-Object.defineProperty(EssentialShapes, 'sign-out', descriptorConfig(EssentialShapes.logout));
-Object.defineProperty(EssentialShapes, 'lightning', descriptorConfig(EssentialShapes.bolt));
-Object.defineProperty(EssentialShapes, 'flow-chart', descriptorConfig(EssentialShapes.organization));
-Object.defineProperty(EssentialShapes, 'alert', descriptorConfig(EssentialShapes['bubble-exclamation']));
-Object.defineProperty(EssentialShapes, 'pinned', descriptorConfig(EssentialShapes.pinboard));
-Object.defineProperty(EssentialShapes, 'attachment', descriptorConfig(EssentialShapes.paperclip));
-Object.defineProperty(EssentialShapes, 'attachment', descriptorConfig(EssentialShapes.paperclip));
-Object.defineProperty(EssentialShapes, 'resize-down', descriptorConfig(EssentialShapes.shrink));
-Object.defineProperty(EssentialShapes, 'resize-up', descriptorConfig(EssentialShapes.resize));
+/**
+ * Valid shapes.
+ */
+export type EssentialShape = keyof typeof EssentialShapes;
 
-if (typeof window !== 'undefined' && window.hasOwnProperty('ClarityIcons')) {
-  window.ClarityIcons.add(EssentialShapes);
-}
+safeWindowAdd(EssentialShapes);

--- a/src/clr-icons/shapes/media-shapes.ts
+++ b/src/clr-icons/shapes/media-shapes.ts
@@ -4,11 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { clrIconSVG } from '../utils/svg-tag-generator';
-
-interface Window {
-  ClarityIcons: any;
-}
-declare var window: Window;
+import safeWindowAdd from '../utils/safe-window-add';
 
 /* tslint:disable:variable-name */
 export const ClrShapePlay = clrIconSVG(
@@ -139,31 +135,34 @@ export const ClrShapeMicrophoneMute = clrIconSVG(`<path d="M30,17h-2c0,1.8-0.5,3
 		c-5.4,0.2-9.8-4.1-10-9.4c0-0.2,0-0.4,0-0.6H6c0.1,6.2,4.8,11.4,11,12v3h-3c-0.6,0-1,0.4-1,1s0.4,1,1,1h8c0.6,0,1-0.4,1-1
 		s-0.4-1-1-1h-3v-3C21.2,28.8,23.4,28,25.2,26.6z" class="clr-i-solid clr-i-solid-path-3" />`);
 
-export const MediaShapes: any = {
-  play: ClrShapePlay,
-  pause: ClrShapePause,
-  'step-forward': ClrShapeStepForward,
-  stop: ClrShapeStop,
-  power: ClrShapePower,
-  rewind: ClrShapeRewind,
+export const MediaShapes = {
+  'camera': ClrShapeCamera,
   'fast-forward': ClrShapeFastForward,
-  camera: ClrShapeCamera,
-  'video-camera': ClrShapeVideoCamera,
-  shuffle: ClrShapeShuffle,
-  'volume-up': ClrShapeVolumeUp,
-  'volume-down': ClrShapeVolumeDown,
-  'volume-mute': ClrShapeVolumeMute,
-  headphones: ClrShapeHeadphones,
   'film-strip': ClrShapeFilmStrip,
-  'music-note': ClrShapeMusicNote,
+  'headphones': ClrShapeHeadphones,
   'image-gallery': ClrShapeImageGallery,
+  'microphone-mute': ClrShapeMicrophoneMute,
+  'microphone': ClrShapeMicrophone,
+  'music-note': ClrShapeMusicNote,
+  'pause': ClrShapePause,
+  'play': ClrShapePlay,
+  'power': ClrShapePower,
   'replay-all': ClrShapeReplayAll,
   'replay-one': ClrShapeReplayOne,
+  'rewind': ClrShapeRewind,
+  'shuffle': ClrShapeShuffle,
+  'step-forward': ClrShapeStepForward,
+  'stop': ClrShapeStop,
+  'video-camera': ClrShapeVideoCamera,
   'video-gallery': ClrShapeVideoGallery,
-  microphone: ClrShapeMicrophone,
-  'microphone-mute': ClrShapeMicrophoneMute,
+  'volume-down': ClrShapeVolumeDown,
+  'volume-mute': ClrShapeVolumeMute,
+  'volume-up': ClrShapeVolumeUp,
 };
 
-if (typeof window !== 'undefined' && window.hasOwnProperty('ClarityIcons')) {
-  window.ClarityIcons.add(MediaShapes);
-}
+/**
+ * Valid shapes.
+ */
+export type MediaShape = keyof typeof MediaShapes;
+
+safeWindowAdd(MediaShapes);

--- a/src/clr-icons/shapes/social-shapes.ts
+++ b/src/clr-icons/shapes/social-shapes.ts
@@ -1,17 +1,13 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { descriptorConfig } from '../utils/descriptor-config';
 import { clrIconSVG } from '../utils/svg-tag-generator';
+import safeWindowAdd from '../utils/safe-window-add';
 
 // TODO: deprecate these imported shapes in 0.12
 // TODO: remove these imported shapes in 0.13
-interface Window {
-  ClarityIcons: any;
-}
-declare var window: Window;
 
 import { ClrShapeCalendar, ClrShapeEvent } from './core-shapes';
 
@@ -156,33 +152,41 @@ export const ClrShapeThumbsDown = clrIconSVG(
             <path d="M9,23a1,1,0,0,0,1-1V6A1,1,0,0,0,9,5H2V23Z" class="clr-i-solid clr-i-solid-path-2" />`
 );
 
-export const SocialShapes: any = {
+export const SocialShapes = {
+  bookmark: ClrShapeBookmark,
+  calendar: ClrShapeCalendar,
+  'chat-bubble': ClrShapeChatBubble,
+  envelope: ClrShapeEnvelope,
+  event: ClrShapeEvent,
+  flag: ClrShapeFlag,
+  'half-star': ClrShapeHalfStar,
+  'happy-face': ClrShapeHappyFace,
+  'heart-broken': ClrShapeHeartBroken,
+  heart: ClrShapeHeart,
+  inbox: ClrShapeInbox,
+  'neutral-face': ClrShapeNeutralFace,
+  picture: ClrShapePicture,
+  'sad-face': ClrShapeSadFace,
   share: ClrShapeShare,
   star: ClrShapeStar,
-  'half-star': ClrShapeHalfStar,
-  bookmark: ClrShapeBookmark,
-  envelope: ClrShapeEnvelope,
-  calendar: ClrShapeCalendar,
-  event: ClrShapeEvent,
-  tasks: ClrShapeTasks,
-  flag: ClrShapeFlag,
-  inbox: ClrShapeInbox,
-  heart: ClrShapeHeart,
-  'heart-broken': ClrShapeHeartBroken,
   'talk-bubbles': ClrShapeTalkBubbles,
-  'chat-bubble': ClrShapeChatBubble,
-  picture: ClrShapePicture,
-  'happy-face': ClrShapeHappyFace,
-  'neutral-face': ClrShapeNeutralFace,
-  'sad-face': ClrShapeSadFace,
-  'thumbs-up': ClrShapeThumbsUp,
+  tasks: ClrShapeTasks,
   'thumbs-down': ClrShapeThumbsDown,
+  'thumbs-up': ClrShapeThumbsUp,
+  /** Alias for: calendar */ get date(): string {
+    return this['calendar'];
+  },
+  /** Alias for: envelope */ get email(): string {
+    return this['envelope'];
+  },
+  /** Alias for: star */ get favorite(): string {
+    return this['star'];
+  },
 };
 
-Object.defineProperty(SocialShapes, 'favorite', descriptorConfig(SocialShapes.star));
-Object.defineProperty(SocialShapes, 'email', descriptorConfig(SocialShapes.envelope));
-Object.defineProperty(SocialShapes, 'date', descriptorConfig(SocialShapes.calendar));
+/**
+ * Valid shapes.
+ */
+export type SocialShape = keyof typeof SocialShapes;
 
-if (typeof window !== 'undefined' && window.hasOwnProperty('ClarityIcons')) {
-  window.ClarityIcons.add(SocialShapes);
-}
+safeWindowAdd(SocialShapes);

--- a/src/clr-icons/shapes/technology-shapes.ts
+++ b/src/clr-icons/shapes/technology-shapes.ts
@@ -1,16 +1,10 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { descriptorConfig } from '../utils/descriptor-config';
 import { clrIconSVG } from '../utils/svg-tag-generator';
-
-interface Window {
-  ClarityIcons: any;
-}
-
-declare var window: Window;
+import safeWindowAdd from '../utils/safe-window-add';
 
 /* tslint:disable:variable-name */
 export const ClrShapeRulerPencil = clrIconSVG(
@@ -74,7 +68,7 @@ export const ClrShapeBlock = clrIconSVG(
             <path d="M26.87,1.26l-5.72,9.91a1.28,1.28,0,0,0,1.1,1.92H33.7a1.28,1.28,0,0,0,1.1-1.92L29.08,1.26A1.28,1.28,0,0,0,26.87,1.26Z" class="clr-i-outline--alerted clr-i-outline-path-2--alerted clr-i-alert" />
             <path d="M30,13.5V26.36L19,31.44V16.64l8.08-3.73a7.57,7.57,0,0,1-2-1.27L18,14.9,7.39,10,18,5.1l4.61,2.13A7.12,7.12,0,0,1,22.5,6a8,8,0,0,1,.07-1L18.42,3.09a1,1,0,0,0-.84,0l-13,6A1,1,0,0,0,4,10V27a1,1,0,0,0,.58.91l13,6a1,1,0,0,0,.84,0l13-6A1,1,0,0,0,32,27V13.22A7.37,7.37,0,0,1,30,13.5ZM17,31.44,6,26.36V11.56l11,5.08Z" class="clr-i-outline--badged clr-i-outline-path-1--badged" />
             <circle cx="30" cy="6" r="5" class="clr-i-outline--badged clr-i-outline-path-2--badged clr-i-badge" />
-            
+
             <path d="M31.42,9.09l-13-6a1,1,0,0,0-.84,0l-13,6A1,1,0,0,0,4,10V27a1,1,0,0,0,.58.91l13,6a1,1,0,0,0,.84,0l13-6A1,1,0,0,0,32,27V10A1,1,0,0,0,31.42,9.09ZM18,14.9,7.39,10,18,5.1,28.61,10ZM30,26.36,19,31.44V16.64l11-5.08Z" class="clr-i-solid clr-i-solid-path-1" />
             <path d="M30,15.38v11L19,31.44V16.64l2.79-1.29a3.68,3.68,0,0,1-2.25-1.16L18,14.9,7.39,10,18,5.1l3,1.39,1-1.75L18.42,3.09a1,1,0,0,0-.84,0l-13,6A1,1,0,0,0,4,10V27a1,1,0,0,0,.58.91l13,6a1,1,0,0,0,.84,0l13-6A1,1,0,0,0,32,27V15.38Z" class="clr-i-solid--alerted clr-i-solid-path-1--alerted" />
             <path d="M26.85,1.12,21.13,11a1.27,1.27,0,0,0,1.1,1.91H33.68A1.27,1.27,0,0,0,34.78,11L29.06,1.12A1.28,1.28,0,0,0,26.85,1.12Z" class="clr-i-solid--alerted clr-i-solid-path-2--alerted clr-i-alert" />
@@ -1163,104 +1157,122 @@ export const ClrShapeHostGroup = clrIconSVG(
 <path class="clr-i-solid clr-i-solid-path-3" d="M24.08,20 L22.08,20 L22.08,2 L11.08,2 L11.08,0 L23.08,0 C23.6322847,0 24.08,0.44771525 24.08,1 L24.08,20 Z" />`
 );
 
-export const TechnologyShapes: any = {
-  'ruler-pencil': ClrShapeRulerPencil,
-  'phone-handset': ClrShapePhoneHandset,
-  'no-wifi': ClrShapeNoWifi,
-  install: ClrShapeInstall,
-  uninstall: ClrShapeUninstall,
-  layers: ClrShapeLayers,
-  block: ClrShapeBlock,
-  'blocks-group': ClrShapeBlocksGroup,
-  bundle: ClrShapeBundle,
-  wifi: ClrShapeWifi,
-  'rack-server': ClrShapeRackServer,
-  'hard-disk': ClrShapeHardDisk,
+export const TechnologyShapes = {
+  administrator: ClrShapeAdministrator,
+  application: ClrShapeApplication,
+  applications: ClrShapeApplications,
+  archive: ClrShapeArchive,
+  'assign-user': ClrShapeAssignUser,
+  atom: ClrShapeAtom,
   'backup-restore': ClrShapeBackupRestore,
   backup: ClrShapeBackup,
-  devices: ClrShapeDevices,
-  keyboard: ClrShapeKeyboard,
-  mouse: ClrShapeMouse,
-  dashboard: ClrShapeDashboard,
-  host: ClrShapeHost,
-  storage: ClrShapeStorage,
-  cluster: ClrShapeCluster,
-  applications: ClrShapeApplications,
-  building: ClrShapeBuilding,
-  cpu: ClrShapeCPU,
-  memory: ClrShapeMemory,
-  'data-cluster': ClrShapeDataCluster,
-  'resource-pool': ClrShapeResourcePool,
-  shield: ClrShapeShield,
-  'shield-check': ClrShapeShieldCheck,
-  'shield-x': ClrShapeShieldX,
-  import: ClrShapeImport,
-  export: ClrShapeExport,
-  'upload-cloud': ClrShapeUploadCloud,
-  'download-cloud': ClrShapeDownloadCloud,
-  plugin: ClrShapePlugin,
-  floppy: ClrShapeFloppy,
-  computer: ClrShapeComputer,
-  display: ClrShapeDisplay,
-  terminal: ClrShapeTerminal,
-  code: ClrShapeCode,
-  application: ClrShapeApplication,
+  'bar-code': ClrShapeBarCode,
   battery: ClrShapeBattery,
-  mobile: ClrShapeMobile,
-  tablet: ClrShapeTablet,
-  'network-globe': ClrShapeNetworkGlobe,
-  'network-settings': ClrShapeNetworkSettings,
-  'network-switch': ClrShapeNetworkSwitch,
-  router: ClrShapeRouter,
-  vm: ClrShapeVM,
-  'vmw-app': ClrShapeVMWApp,
+  block: ClrShapeBlock,
+  'blocks-group': ClrShapeBlocksGroup,
+  'bluetooth-off': ClrShapeBluetoothOff,
+  bluetooth: ClrShapeBluetooth,
+  building: ClrShapeBuilding,
+  bundle: ClrShapeBundle,
+  capacitor: ClrShapeCapacitor,
+  'cd-dvd': ClrShapeCdDvd,
   certificate: ClrShapeCertificate,
-  archive: ClrShapeArchive,
-  unarchive: ClrShapeUnarchive,
-  connect: ClrShapeConnect,
-  disconnect: ClrShapeDisconnect,
-  link: ClrShapeLink,
-  unlink: ClrShapeUnlink,
   'cloud-network': ClrShapeCloudNetwork,
   'cloud-scale': ClrShapeCloudScale,
   'cloud-traffic': ClrShapeCloudTraffic,
-  deploy: ClrShapeDeploy,
-  helix: ClrShapeHelix,
-  flask: ClrShapeFlask,
-  administrator: ClrShapeAdministrator,
-  'hard-drive': ClrShapeHardDrive,
-  'hard-drive-disks': ClrShapeHardDriveDisks,
-  nvme: ClrShapeNVMe,
-  ssd: ClrShapeSSD,
-  bluetooth: ClrShapeBluetooth,
-  'bluetooth-off': ClrShapeBluetoothOff,
-  'process-on-vm': ClrShapeProcessOnVM,
-  'assign-user': ClrShapeAssignUser,
-  atom: ClrShapeAtom,
-  'bar-code': ClrShapeBarCode,
-  'cd-dvd': ClrShapeCdDvd,
-  container: ClrShapeContainer,
+  cluster: ClrShapeCluster,
+  code: ClrShapeCode,
+  computer: ClrShapeComputer,
+  connect: ClrShapeConnect,
   'container-volume': ClrShapeContainerVolume,
+  container: ClrShapeContainer,
+  cpu: ClrShapeCPU,
+  dashboard: ClrShapeDashboard,
+  'data-cluster': ClrShapeDataCluster,
+  deploy: ClrShapeDeploy,
+  devices: ClrShapeDevices,
+  disconnect: ClrShapeDisconnect,
+  display: ClrShapeDisplay,
+  'download-cloud': ClrShapeDownloadCloud,
+  export: ClrShapeExport,
   'file-share': ClrShapeFileShare,
-  'qr-code': ClrShapeQrCode,
-  usb: ClrShapeUsb,
-  radar: ClrShapeRadar,
-  capacitor: ClrShapeCapacitor,
-  squid: ClrShapeSquid,
-  inductor: ClrShapeInductor,
-  resistor: ClrShapeResistor,
+  flask: ClrShapeFlask,
+  floppy: ClrShapeFloppy,
+  'hard-disk': ClrShapeHardDisk,
+  'hard-drive-disks': ClrShapeHardDriveDisks,
+  'hard-drive': ClrShapeHardDrive,
+  helix: ClrShapeHelix,
   'host-group': ClrShapeHostGroup,
+  host: ClrShapeHost,
+  import: ClrShapeImport,
+  inductor: ClrShapeInductor,
+  install: ClrShapeInstall,
+  keyboard: ClrShapeKeyboard,
+  layers: ClrShapeLayers,
+  link: ClrShapeLink,
+  memory: ClrShapeMemory,
+  mobile: ClrShapeMobile,
+  mouse: ClrShapeMouse,
+  'network-globe': ClrShapeNetworkGlobe,
+  'network-settings': ClrShapeNetworkSettings,
+  'network-switch': ClrShapeNetworkSwitch,
+  'no-wifi': ClrShapeNoWifi,
+  nvme: ClrShapeNVMe,
+  'phone-handset': ClrShapePhoneHandset,
+  plugin: ClrShapePlugin,
+  'process-on-vm': ClrShapeProcessOnVM,
+  'qr-code': ClrShapeQrCode,
+  'rack-server': ClrShapeRackServer,
+  radar: ClrShapeRadar,
+  resistor: ClrShapeResistor,
+  'resource-pool': ClrShapeResourcePool,
+  router: ClrShapeRouter,
+  'ruler-pencil': ClrShapeRulerPencil,
+  'shield-check': ClrShapeShieldCheck,
+  'shield-x': ClrShapeShieldX,
+  shield: ClrShapeShield,
+  squid: ClrShapeSquid,
+  ssd: ClrShapeSSD,
+  storage: ClrShapeStorage,
+  tablet: ClrShapeTablet,
+  terminal: ClrShapeTerminal,
+  unarchive: ClrShapeUnarchive,
+  uninstall: ClrShapeUninstall,
+  unlink: ClrShapeUnlink,
+  'upload-cloud': ClrShapeUploadCloud,
+  usb: ClrShapeUsb,
+  vm: ClrShapeVM,
+  'vmw-app': ClrShapeVMWApp,
+  wifi: ClrShapeWifi,
+  /** Alias for: certificate */ get license(): string {
+    return this['certificate'];
+  },
+  /** Alias for: helix */ get dna(): string {
+    return this['helix'];
+  },
+  /** Alias for: host */ get server(): string {
+    return this['host'];
+  },
+  /** Alias for: mobile */ get 'mobile-phone'(): string {
+    return this['mobile'];
+  },
+  /** Alias for: no-wifi */ get disconnected(): string {
+    return this['no-wifi'];
+  },
+  /** Alias for: phone-handset */ get receiver(): string {
+    return this['phone-handset'];
+  },
+  /** Alias for: ruler-pencil */ get design(): string {
+    return this['ruler-pencil'];
+  },
+  /** Alias for: terminal */ get command(): string {
+    return this['terminal'];
+  },
 };
 
-Object.defineProperty(TechnologyShapes, 'server', descriptorConfig(TechnologyShapes.host));
-Object.defineProperty(TechnologyShapes, 'command', descriptorConfig(TechnologyShapes.terminal));
-Object.defineProperty(TechnologyShapes, 'mobile-phone', descriptorConfig(TechnologyShapes.mobile));
-Object.defineProperty(TechnologyShapes, 'license', descriptorConfig(TechnologyShapes.certificate));
-Object.defineProperty(TechnologyShapes, 'disconnected', descriptorConfig(TechnologyShapes['no-wifi']));
-Object.defineProperty(TechnologyShapes, 'receiver', descriptorConfig(TechnologyShapes['phone-handset']));
-Object.defineProperty(TechnologyShapes, 'design', descriptorConfig(TechnologyShapes['ruler-pencil']));
-Object.defineProperty(TechnologyShapes, 'dna', descriptorConfig(TechnologyShapes.helix));
+/**
+ * Valid shapes.
+ */
+export type TechnologyShape = keyof typeof TechnologyShapes;
 
-if (typeof window !== 'undefined' && window.hasOwnProperty('ClarityIcons')) {
-  window.ClarityIcons.add(TechnologyShapes);
-}
+safeWindowAdd(TechnologyShapes);

--- a/src/clr-icons/shapes/text-edit-shapes.ts
+++ b/src/clr-icons/shapes/text-edit-shapes.ts
@@ -5,6 +5,7 @@
  */
 
 import { clrIconSVG } from '../utils/svg-tag-generator';
+import safeWindowAdd from '../utils/safe-window-add';
 
 /* tslint:disable:variable-name */
 export const ClrShapeBold = clrIconSVG(
@@ -74,30 +75,33 @@ export const ClrShapeLanguage = clrIconSVG(`<path d="M30,3H14v5h2V5h14c0.6,0,1,0
 		c-1.2,0.6-2.6,0.9-4,1l-0.1-2c0.7,0,1.4-0.1,2.1-0.3c-0.9-0.9-1.5-2-1.8-3.2h2.1c0.3,0.9,0.9,1.6,1.6,2.2c1.1-0.9,1.8-2.2,1.9-3.7
 		h-6V8h3V6h2v2h3.3l0.1,1c0.1,2.1-0.7,4.2-2.2,5.7C27.1,14.9,27.7,15,28.3,15z" class="clr-i-solid clr-i-solid-path-2" />`);
 
-export const TextEditShapes: any = {
-  bold: ClrShapeBold,
-  'bullet-list': ClrShapeBulletList,
-  'checkbox-list': ClrShapeCheckboxList,
-  'number-list': ClrShapeNumberList,
-  'font-size': ClrShapeFontSize,
-  italic: ClrShapeItalic,
-  'justify-text': ClrShapeJustifyText,
-  'center-text': ClrShapeCenterText,
-  'align-left-text': ClrShapeAlignLeftText,
-  'align-right-text': ClrShapeAlignRightText,
-  'paint-roller': ClrShapePaintRoller,
-  'block-quote': ClrShapeBlockQuote,
-  text: ClrShapeText,
-  underline: ClrShapeUnderline,
-  'align-center': ClrShapeAlignCenter,
-  'align-left': ClrShapeAlignLeft,
-  'align-right': ClrShapeAlignRight,
+export const TextEditShapes = {
   'align-bottom': ClrShapeAlignBottom,
+  'align-center': ClrShapeAlignCenter,
+  'align-left-text': ClrShapeAlignLeftText,
+  'align-left': ClrShapeAlignLeft,
   'align-middle': ClrShapeAlignMiddle,
+  'align-right-text': ClrShapeAlignRightText,
+  'align-right': ClrShapeAlignRight,
   'align-top': ClrShapeAlignTop,
-  language: ClrShapeLanguage,
+  'block-quote': ClrShapeBlockQuote,
+  'bold': ClrShapeBold,
+  'bullet-list': ClrShapeBulletList,
+  'center-text': ClrShapeCenterText,
+  'checkbox-list': ClrShapeCheckboxList,
+  'font-size': ClrShapeFontSize,
+  'italic': ClrShapeItalic,
+  'justify-text': ClrShapeJustifyText,
+  'language': ClrShapeLanguage,
+  'number-list': ClrShapeNumberList,
+  'paint-roller': ClrShapePaintRoller,
+  'text': ClrShapeText,
+  'underline': ClrShapeUnderline,
 };
 
-if (typeof window !== 'undefined' && window.hasOwnProperty('ClarityIcons')) {
-  window.ClarityIcons.add(TextEditShapes);
-}
+/**
+ * Valid shapes.
+ */
+export type TextEditShape = keyof typeof TextEditShapes;
+
+safeWindowAdd(TextEditShapes);

--- a/src/clr-icons/shapes/travel-shapes.ts
+++ b/src/clr-icons/shapes/travel-shapes.ts
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { descriptorConfig } from '../utils/descriptor-config';
 import { clrIconSVG } from '../utils/svg-tag-generator';
+import safeWindowAdd from '../utils/safe-window-add';
 
 /* tslint:disable:variable-name */
 export const ClrShapeTruck = clrIconSVG(
@@ -97,24 +97,30 @@ export const ClrShapeTrailer = clrIconSVG(`<path d="M15,19.2c-3.2,0-5.8,2.6-5.8,
 		c0,0,0,0,0,0c2.1,0,3.8-1.7,3.8-3.9V11h5c0.6,0,1-0.4,1-1S33.6,9,33,9z M26,13H4v-2h22V13z" class="clr-i-outline clr-i-outline-path-3" /><path d="M33,9H2v13.1c0,0,0,0,0,0C2,24.3,3.7,26,5.9,26H7v-2H5.9c-1,0-1.8-0.8-1.9-1.9V15h22v7.1c0,1-0.8,1.8-1.9,1.9H23v2h1.1
 	c0,0,0,0,0,0c2.1,0,3.8-1.7,3.8-3.9V11h5c0.6,0,1-0.4,1-1S33.6,9,33,9z" class="clr-i-solid clr-i-solid-path-1" /><path d="M15,19.2c-3.2,0-5.8,2.6-5.8,5.8s2.6,5.8,5.8,5.8s5.8-2.6,5.8-5.8l0,0C20.8,21.8,18.2,19.2,15,19.2z M16,26h-2v-2h2V26z" class="clr-i-solid clr-i-solid-path-2" />`);
 
-export const TravelShapes: any = {
-  truck: ClrShapeTruck,
+export const TravelShapes = {
   airplane: ClrShapeAirplane,
-  car: ClrShapeCar,
-  map: ClrShapeMap,
-  compass: ClrShapeCompass,
-  'map-marker': ClrShapeMapMarker,
   bicycle: ClrShapeBicycle,
   boat: ClrShapeBoat,
   campervan: ClrShapeCampervan,
+  car: ClrShapeCar,
   caravan: ClrShapeCaravan,
+  compass: ClrShapeCompass,
   ferry: ClrShapeFerry,
+  'map-marker': ClrShapeMapMarker,
+  map: ClrShapeMap,
   trailer: ClrShapeTrailer,
+  truck: ClrShapeTruck,
+  /** Alias for: airplane */ get plane(): string {
+    return this['airplane'];
+  },
+  /** Alias for: car */ get auto(): string {
+    return this['car'];
+  },
 };
 
-Object.defineProperty(TravelShapes, 'plane', descriptorConfig(TravelShapes.airplane));
-Object.defineProperty(TravelShapes, 'auto', descriptorConfig(TravelShapes.car));
+/**
+ * Valid shapes.
+ */
+export type TravelShape = keyof typeof TravelShapes;
 
-if (typeof window !== 'undefined' && window.hasOwnProperty('ClarityIcons')) {
-  window.ClarityIcons.add(TravelShapes);
-}
+safeWindowAdd(TravelShapes);

--- a/src/clr-icons/utils/safe-window-add.ts
+++ b/src/clr-icons/utils/safe-window-add.ts
@@ -1,0 +1,24 @@
+import { ClarityIconsApi } from '../clr-icons-api';
+
+/**
+ * Shapes object interface.
+ */
+interface Shapes {
+  [shapeName: string]: string;
+}
+
+/**
+ * Safely adds icon shapes to the window ClarityIcons instance.
+ * @param shapes Object with shapes.
+ */
+export const safeWindowAdd = (shapes: Shapes) => {
+  if (
+    typeof window !== 'undefined' &&
+    window.ClarityIcons !== undefined &&
+    window.ClarityIcons instanceof ClarityIconsApi
+  ) {
+    window.ClarityIcons.add(shapes);
+  }
+};
+
+export default safeWindowAdd;


### PR DESCRIPTION
- Improved icon typings to have infered keys. This can be used to check icons in compile time.
- Added VSCode setting to use local TypeScript.
- Removed settings.json from .gitignore.
- Added utility to add icons to the global ClarityIcons namespace.
- Consistent property naming for icon shapes.