### PR TITLE
[NG] Enable tab content to scale to tabs container (#3279)

### DIFF
--- a/src/clr-angular/layout/tabs/_tabs.clarity.scss
+++ b/src/clr-angular/layout/tabs/_tabs.clarity.scss
@@ -28,6 +28,10 @@ button.nav-link {
   }
 }
 
+.tab-content {
+  display: inline;
+}
+
 .tabs-vertical {
   display: flex;
 

--- a/src/clr-angular/layout/tabs/tab-content.ts
+++ b/src/clr-angular/layout/tabs/tab-content.ts
@@ -13,7 +13,7 @@ let nbTabContentComponents: number = 0;
   selector: 'clr-tab-content',
   template: `
     <ng-template #tabContentProjectedRef>
-      <section [id]="tabContentId" role="tabpanel" [class.active]="active"
+      <section [id]="tabContentId" role="tabpanel" class="tab-content" [class.active]="active"
                [hidden]="!active"
                [attr.aria-labelledby]="ariaLabelledBy"
                [attr.aria-expanded]="active"

--- a/src/clr-angular/layout/tabs/tabs.spec.ts
+++ b/src/clr-angular/layout/tabs/tabs.spec.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { Component, Type, ViewChild } from '@angular/core';
+import { Component, ElementRef, Type, ViewChild } from '@angular/core';
 
 import { addHelpers, TestContext } from '../../data/datagrid/helpers.spec';
 
@@ -133,6 +133,24 @@ class NestedTabsTest {
 })
 class NoClrIfActiveTest {
   @ViewChild(ClrTabs) tabsInstance: ClrTabs;
+}
+
+@Component({
+  template: `
+    <div style="height: 456px">
+        <clr-tabs>
+            <clr-tab>
+                <button clrTabLink>Tab1</button>
+                <clr-tab-content *clrIfActive>
+                    <p #content style="height: 100%">Content1</p>
+                </clr-tab-content>
+            </clr-tab>
+        </clr-tabs>
+    </div>
+   `,
+})
+class ScalingTestComponent {
+  @ViewChild('content') content: ElementRef;
 }
 
 describe('Tabs', () => {
@@ -299,8 +317,27 @@ describe('Tabs', () => {
     });
 
     it('has only one of the elements visible', () => {
-      expect(window.getComputedStyle(contents[0]).display).toBe('block');
+      expect(window.getComputedStyle(contents[0]).display).not.toBe('none');
       expect(window.getComputedStyle(contents[1]).display).toBe('none');
+    });
+  });
+
+  describe('Content scale', () => {
+    let context: TestContext<ClrTabs, ScalingTestComponent>;
+    let component: ScalingTestComponent;
+
+    beforeEach(function() {
+      context = this.create(ClrTabs, ScalingTestComponent);
+      component = context.testComponent;
+      context.fixture.detectChanges();
+    });
+
+    afterEach(() => {
+      context.fixture.destroy();
+    });
+
+    it('should scale to tabs parent height', () => {
+      expect(component.content.nativeElement.offsetHeight).toBe(456);
     });
   });
 });

--- a/src/clr-angular/layout/tabs/tabs.ts
+++ b/src/clr-angular/layout/tabs/tabs.ts
@@ -71,7 +71,13 @@ export class ClrTabs implements AfterContentInit, OnDestroy {
 
   @Input('clrLayout')
   set layout(layout: TabsLayout) {
-    if (Object.values(TabsLayout).includes(layout)) {
+    if (
+      Object.keys(TabsLayout)
+        .map(key => {
+          return TabsLayout[key];
+        })
+        .indexOf(layout) >= 0
+    ) {
       this.tabsService.layout = layout;
     }
   }


### PR DESCRIPTION
The introduction of block-level section element had introduced the
need to explicitly manage the container height. Reverting it to
inline will allow direct visibility between the tab content and tabs
parent container.

Signed-off-by: Ivan Donchev <idonchev@vmware.com>