### PR TITLE
[NG] a11y improvements for control errors

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -231,6 +231,10 @@ export declare abstract class ClrCommonStrings {
 }
 
 export declare class ClrControlError {
+    describedByAttr: string;
+    constructor(controlIdService: ControlIdService);
+    ngOnDestroy(): void;
+    ngOnInit(): void;
 }
 
 export declare class ClrControlHelper {

--- a/src/clr-angular/forms/common/error.spec.ts
+++ b/src/clr-angular/forms/common/error.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -8,16 +8,23 @@ import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { ClrControlError } from './error';
+import { ControlIdService } from './providers/control-id.service';
 
 @Component({ template: `<clr-control-error>Test error</clr-control-error>` })
 class SimpleTest {}
+
+@Component({ template: `<clr-control-error aria-describedby="hello"></clr-control-error>` })
+class ExplicitAriaTest {}
 
 export default function(): void {
   describe('ClrControlError', () => {
     let fixture;
 
     beforeEach(function() {
-      TestBed.configureTestingModule({ declarations: [ClrControlError, SimpleTest] });
+      TestBed.configureTestingModule({
+        declarations: [ClrControlError, SimpleTest, ExplicitAriaTest],
+        providers: [ControlIdService],
+      });
       fixture = TestBed.createComponent(SimpleTest);
       fixture.detectChanges();
     });
@@ -30,6 +37,28 @@ export default function(): void {
       expect(
         fixture.debugElement.query(By.directive(ClrControlError)).nativeElement.classList.contains('clr-subtext')
       ).toBeTrue();
+    });
+
+    it('adds the aria-live to host so screen reader can announce error message', function() {
+      expect(
+        fixture.debugElement.query(By.directive(ClrControlError)).nativeElement.hasAttribute('aria-live')
+      ).toBeTrue();
+    });
+
+    it('sets the the aria-describedby given so screen reader can associate error to input', function() {
+      const controlIdService = fixture.debugElement.injector.get(ControlIdService);
+      const message = fixture.nativeElement.querySelector('clr-control-error');
+      expect(message.getAttribute('aria-describedby')).toBe(controlIdService.id);
+      controlIdService.id = 'test';
+      fixture.detectChanges();
+      expect(message.getAttribute('aria-describedby')).toBe('test');
+    });
+
+    it('leaves the for aria-describedby untouched if it exists', function() {
+      const explicitFixture = TestBed.createComponent(ExplicitAriaTest);
+      explicitFixture.detectChanges();
+      const message = explicitFixture.nativeElement.querySelector('clr-control-error');
+      expect(message.getAttribute('aria-describedby')).toBe('hello');
     });
   });
 }

--- a/src/clr-angular/forms/common/error.ts
+++ b/src/clr-angular/forms/common/error.ts
@@ -1,16 +1,39 @@
 /**
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component } from '@angular/core';
+import { Component, Optional, HostBinding, Input } from '@angular/core';
+import { ControlIdService } from './providers/control-id.service';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'clr-control-error',
   template: `
     <ng-content></ng-content>
     `,
-  host: { '[class.clr-subtext]': 'true' },
+  host: {
+    '[class.clr-subtext]': 'true',
+    '[attr.aria-live]': '"polite"',
+  },
 })
-export class ClrControlError {}
+export class ClrControlError {
+  @Input('aria-describedby')
+  @HostBinding('attr.aria-describedby')
+  describedByAttr: string = null;
+
+  private subscriptions: Subscription[] = [];
+
+  constructor(@Optional() private controlIdService: ControlIdService) {}
+
+  ngOnInit() {
+    if (this.controlIdService && !this.describedByAttr) {
+      this.subscriptions.push(this.controlIdService.idChange.subscribe(id => (this.describedByAttr = id)));
+    }
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.forEach(sub => sub.unsubscribe());
+  }
+}


### PR DESCRIPTION
Minor adjustments for `clr-control-error` to make it more accessible to screen readers.

closes #3289 

Signed-off-by: Cory Rylan <crylan@vmware.com>