### PR TITLE
datagrid deprecations for row selection and column toggle title/buttons

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -201,6 +201,7 @@ export declare abstract class ClrCommonStrings {
     select?: string;
     selectAll?: string;
     show?: string;
+    showColumns?: string;
     success?: string;
     warning?: string;
 }
@@ -231,7 +232,7 @@ export declare class ClrDatagrid<T = any> implements AfterContentInit, AfterView
     placeholder: ClrDatagridPlaceholder<T>;
     refresh: EventEmitter<ClrDatagridStateInterface<T>>;
     rowActionService: RowActionService;
-    rowSelectionMode: boolean;
+    /** @deprecated */ rowSelectionMode: boolean;
     rows: QueryList<ClrDatagridRow<T>>;
     scrollableColumns: ViewContainerRef;
     selected: T[];

--- a/src/clr-angular/data/datagrid/datagrid-column-toggle-button.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-toggle-button.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -20,6 +20,7 @@ import { DatagridColumnChanges } from './enums/column-changes.enum';
     </button>
   `,
 })
+/** @deprecated since 2.0, remove in 3.0 */
 export class ClrDatagridColumnToggleButton {
   constructor(private columnsService: ColumnsService) {}
 

--- a/src/clr-angular/data/datagrid/datagrid-column-toggle-title.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-toggle-title.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -9,4 +9,5 @@ import { Component } from '@angular/core';
   selector: 'clr-dg-column-toggle-title',
   template: `<ng-content></ng-content>`,
 })
+/** @deprecated since 2.0, remove in 3.0 */
 export class ClrDatagridColumnToggleTitle {}

--- a/src/clr-angular/data/datagrid/datagrid-column-toggle.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-toggle.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -28,7 +28,7 @@ import { DatagridColumnChanges } from './enums/column-changes.enum';
     <div class="column-switch"
          *clrPopoverOld="open; anchor: anchor; anchorPoint: anchorPoint; popoverPoint: popoverPoint">
       <div class="switch-header">
-        <ng-container *ngIf="!customToggleTitle">Show Columns</ng-container>
+        <ng-container *ngIf="!customToggleTitle">{{commonStrings.showColumns}}</ng-container>
         <ng-content select="clr-dg-column-toggle-title"></ng-content>
         <button
           class="btn btn-sm btn-link toggle-switch-close-button"
@@ -52,12 +52,13 @@ import { DatagridColumnChanges } from './enums/column-changes.enum';
       </ul>
       <div class="switch-footer">
         <ng-content select="clr-dg-column-toggle-button"></ng-content>
-        <clr-dg-column-toggle-button *ngIf="!customToggleButton">Select All</clr-dg-column-toggle-button>
+        <clr-dg-column-toggle-button *ngIf="!customToggleButton">{{commonStrings.selectAll}}</clr-dg-column-toggle-button>
       </div>
     </div>
   `,
   host: { '[class.column-switch-wrapper]': 'true', '[class.active]': 'open' },
 })
+/** @deprecated since 2.0, remove in 3.0 */
 export class ClrDatagridColumnToggle {
   /***
    * Popover init

--- a/src/clr-angular/data/datagrid/datagrid.ts
+++ b/src/clr-angular/data/datagrid/datagrid.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -143,6 +143,8 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
   @Output('clrDgSingleSelectedChange') singleSelectedChanged = new EventEmitter<T>(false);
 
   /**
+   * @deprecated since 2.0, remove in 3.0
+   *
    * Selection/Deselection on row click mode
    */
   @Input('clrDgRowSelection')

--- a/src/clr-angular/data/datagrid/providers/selection.ts
+++ b/src/clr-angular/data/datagrid/providers/selection.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -163,6 +163,7 @@ export class Selection<T = any> {
     }
   }
 
+  /** @deprecated since 2.0, remove in 3.0 */
   public rowSelectionMode: boolean = false;
 
   private get _selectable(): boolean {

--- a/src/clr-angular/deprecations.spec.ts
+++ b/src/clr-angular/deprecations.spec.ts
@@ -5,16 +5,26 @@
  */
 
 import { ClrForm } from './forms/common/form';
+import { ClrDatagrid } from './data/datagrid/datagrid';
+import { Selection } from './data/datagrid/providers/selection';
+import { ClrDatagridColumnToggle } from './data/datagrid/datagrid-column-toggle';
+import { ClrDatagridColumnToggleTitle } from './data/datagrid/datagrid-column-toggle-title';
+import { ClrDatagridColumnToggleButton } from './data/datagrid/datagrid-column-toggle-button';
 
 describe('Deprecations', () => {
   // When we deprecate some code, we should write a test to verify it is still in the bundle
   // and keep track of when it was deprecated, and when we plan to remove it.
 
-  describe('1.0', () => {
-    it('should no longer support clr-checkbox in button-groups');
-  });
-
   describe('2.0', () => {
+    it('should deprecate the column toggle title and button components', () => {
+      expect(ClrDatagridColumnToggle).toBeTruthy();
+      expect(ClrDatagridColumnToggleTitle).toBeTruthy();
+      expect(ClrDatagridColumnToggleButton).toBeTruthy();
+    });
+    it('should deprecate but still support clrDgRowSelection', () => {
+      // Can't grab it since its just a setter
+      expect(Object.keys(ClrDatagrid.prototype)).toContain('rowSelectionMode');
+    });
     it('should handle ClrForm.markAsDirty as ClrForm.markAsTouched', () => {
       spyOn(ClrForm.prototype, 'markAsTouched');
       ClrForm.prototype.markAsDirty();

--- a/src/clr-angular/deprecations.spec.ts
+++ b/src/clr-angular/deprecations.spec.ts
@@ -6,7 +6,6 @@
 
 import { ClrForm } from './forms/common/form';
 import { ClrDatagrid } from './data/datagrid/datagrid';
-import { Selection } from './data/datagrid/providers/selection';
 import { ClrDatagridColumnToggle } from './data/datagrid/datagrid-column-toggle';
 import { ClrDatagridColumnToggleTitle } from './data/datagrid/datagrid-column-toggle-title';
 import { ClrDatagridColumnToggleButton } from './data/datagrid/datagrid-column-toggle-button';

--- a/src/clr-angular/emphasis/alert/alerts.spec.ts
+++ b/src/clr-angular/emphasis/alert/alerts.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -270,22 +270,22 @@ class TestComponent {
                [clrAlertClosable]="true"
                [clrAlertClosed]="false"
                [clrAlertAppLevel]="true">
-               <div clr-alert-item class="alert-item">
+               <clr-alert-item>
                    <span class="alert-text">
                    This is the first alert!
                    </span>
-               </div>
+               </clr-alert-item>
            </clr-alert>
            <clr-alert
                [clrAlertType]="'alert-danger'"
                [clrAlertClosable]="true"
                [clrAlertClosed]="false"
                [clrAlertAppLevel]="true">
-               <div clr-alert-item class="alert-item">
+               <clr-alert-item>
                    <span class="alert-text">
                    This is the second alert!
                    </span>
-               </div>
+               </clr-alert-item>
            </clr-alert>
         </clr-alerts>
    `,

--- a/src/clr-angular/utils/i18n/common-strings.interface.ts
+++ b/src/clr-angular/utils/i18n/common-strings.interface.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -85,4 +85,8 @@ export abstract class ClrCommonStrings {
    * Datagrid: pick columns
    */
   pickColumns?: string;
+  /**
+   * Datagrid: show columns
+   */
+  showColumns?: string;
 }

--- a/src/clr-angular/utils/i18n/common-strings.service.ts
+++ b/src/clr-angular/utils/i18n/common-strings.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -29,6 +29,7 @@ export class ClrCommonStringsService implements ClrCommonStrings {
   danger = 'Error';
   rowActions = 'Available actions';
   pickColumns = 'Show or hide columns';
+  showColumns = 'Show Columns';
 }
 
 export function commonStringsFactory(existing?: ClrCommonStrings): ClrCommonStrings {

--- a/src/dev/src/app/drag-and-drop/basic-droppable.demo.html
+++ b/src/dev/src/app/drag-and-drop/basic-droppable.demo.html
@@ -66,11 +66,11 @@
 
 <div class="clr-example" *ngIf="activeDemoVariant==='custom-ghost'">
     <clr-alert [clrAlertType]="'alert-info'">
-        <div clr-alert-item class="alert-item">
+        <clr-alert-item>
                 <span class="alert-text">
                     Dragging a file will show an image icon as a custom ghost.
                 </span>
-        </div>
+        </clr-alert-item>
     </clr-alert>
     <div class="clr-row">
         <div class="clr-col-4 offset-xs-1">
@@ -128,11 +128,11 @@
 
 <div class="clr-example" *ngIf="activeDemoVariant==='drag-handle'">
     <clr-alert [clrAlertType]="'alert-info'">
-        <div clr-alert-item class="alert-item">
+        <clr-alert-item>
                 <span class="alert-text">
                     Drag each file by its icon.
                 </span>
-        </div>
+        </clr-alert-item>
     </clr-alert>
     <div class="clr-row">
         <div class="clr-col-4 offset-xs-1">

--- a/src/dev/src/app/i18n-a11y/common-strings.service.ts
+++ b/src/dev/src/app/i18n-a11y/common-strings.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -32,4 +32,5 @@ export class CommonStringsService implements ClrCommonStrings {
   danger = 'Erreur';
   rowActions = 'Actions disponibles';
   pickColumns = 'Modifier les colonnes';
+  showColumns = 'Afficher les colonnes';
 }

--- a/src/dev/src/app/virtual-scroll/virtual-scroll.demo.ts
+++ b/src/dev/src/app/virtual-scroll/virtual-scroll.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -9,11 +9,11 @@ import { Component } from '@angular/core';
   selector: 'clr-virtual-scroll-demo',
   template: `
         <clr-alert [clrAlertType]="'alert-warning'">
-            <div clr-alert-item class="alert-item">
+            <clr-alert-item>
                 <span class="alert-text">
                     This is a private demo, nothing here is part of Clarity's public API
                 </span>
-            </div>
+            </clr-alert-item>
         </clr-alert>
         
         <h2>Virtual scroll</h2>

--- a/src/ks-app/src/app/containers/drag-and-drop/dnd.component.html
+++ b/src/ks-app/src/app/containers/drag-and-drop/dnd.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -235,11 +235,11 @@
 
 <div class="clr-example" *ngIf="activeDemoVariant==='custom-ghost'">
   <clr-alert [clrAlertType]="'alert-info'">
-    <div clr-alert-item class="alert-item">
+    <clr-alert-item>
                 <span class="alert-text">
                     Dragging a file will show an image icon as a custom ghost.
                 </span>
-    </div>
+    </clr-alert-item>
   </clr-alert>
   <div class="clr-row">
     <div class="clr-col-4 offset-xs-1">
@@ -296,11 +296,11 @@
 
 <div class="clr-example" *ngIf="activeDemoVariant==='drag-handle'">
   <clr-alert [clrAlertType]="'alert-info'">
-    <div clr-alert-item class="alert-item">
+    <clr-alert-item>
                 <span class="alert-text">
                     Drag each file by its icon.
                 </span>
-    </div>
+    </clr-alert-item>
   </clr-alert>
   <div class="clr-row">
     <div class="clr-col-4 offset-xs-1">

--- a/src/website/src/app/documentation/demos/datagrid/hide-show-columns/hide-show-columns.html
+++ b/src/website/src/app/documentation/demos/datagrid/hide-show-columns/hide-show-columns.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -13,12 +13,6 @@
     <code class="clr-code">clr-dg-column</code>. It defaults to showing the column but you can use the hidden property
     to pre-configure it.
 </p>
-
-<h4>Custom Toggle Strings</h4>
-<p>If you need to customize the hide/show toggle component you can override the defaults by adding a <code class="clr-doce">clr-dg-column-toggle</code> component at the beginning of the <code class="clr-code">clr-dg-footer</code> component:
-</p>
-<clr-code-snippet [clrCode]="customToggle"  clrLanguage="html"></clr-code-snippet>
-
 
 <clr-datagrid>
     <clr-dg-column>
@@ -58,10 +52,6 @@
     </clr-dg-row>
 
     <clr-dg-footer>
-        <clr-dg-column-toggle>
-            <clr-dg-column-toggle-title>Kolumne Herauschauen!</clr-dg-column-toggle-title>
-            <clr-dg-column-toggle-button>Alle auswählen!</clr-dg-column-toggle-button>
-        </clr-dg-column-toggle>
         {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
         of {{pagination.totalItems}} users
         <clr-dg-pagination #pagination [clrDgPageSize]="currentPageSize"></clr-dg-pagination>
@@ -69,4 +59,19 @@
 </clr-datagrid>
 
 <clr-code-snippet [clrCode]="example"  clrLanguage="html"></clr-code-snippet>
+
+<h4>Custom Toggle Strings</h4>
+
+<clr-alert [clrAlertType]="'danger'" [clrAlertClosable]="false">
+  <div clr-alert-item class="alert-item">
+        <span class="alert-text">
+          Overriding the column toggle text as described below is deprecated as of 2.0 and will be removed in a future major release.
+          Instead, you should use the <a routerLink="../../internationalization">internationalization documentation</a> to change the language strings.
+        </span>
+  </div>
+</clr-alert>
+
+<p>If you need to customize the hide/show toggle component you can override the defaults by adding a <code class="clr-doce">clr-dg-column-toggle</code> component at the beginning of the <code class="clr-code">clr-dg-footer</code> component:
+</p>
+<clr-code-snippet [clrCode]="customToggle"  clrLanguage="html"></clr-code-snippet>
 

--- a/src/website/src/app/documentation/demos/datagrid/hide-show-columns/hide-show-columns.html
+++ b/src/website/src/app/documentation/demos/datagrid/hide-show-columns/hide-show-columns.html
@@ -63,12 +63,12 @@
 <h4>Custom Toggle Strings</h4>
 
 <clr-alert [clrAlertType]="'danger'" [clrAlertClosable]="false">
-  <div clr-alert-item class="alert-item">
+  <clr-alert-item>
         <span class="alert-text">
           Overriding the column toggle text as described below is deprecated as of 2.0 and will be removed in a future major release.
           Instead, you should use the <a routerLink="../../internationalization">internationalization documentation</a> to change the language strings.
         </span>
-  </div>
+  </clr-alert-item>
 </clr-alert>
 
 <p>If you need to customize the hide/show toggle component you can override the defaults by adding a <code class="clr-doce">clr-dg-column-toggle</code> component at the beginning of the <code class="clr-code">clr-dg-footer</code> component:

--- a/src/website/src/app/documentation/demos/datagrid/hide-show-columns/hide-show-columns.ts
+++ b/src/website/src/app/documentation/demos/datagrid/hide-show-columns/hide-show-columns.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -10,8 +10,8 @@ import { User } from '../inventory/user';
 
 const CUSTOM_TOGGLE = `
 <clr-dg-column-toggle>
-    <clr-dg-column-toggle-title>Kolumne Herauschauen!</clr-dg-column-toggle-title>
-    <clr-dg-column-toggle-button>Alle auswählen!</clr-dg-column-toggle-button>
+    <clr-dg-column-toggle-title>Column Toggle Title</clr-dg-column-toggle-title>
+    <clr-dg-column-toggle-button>Select All Button</clr-dg-column-toggle-button>
 </clr-dg-column-toggle>
 `;
 
@@ -36,11 +36,6 @@ const EXAMPLE = `
     </clr-dg-row>
 
     <clr-dg-footer>
-        <!-- Optional customization of hide/show columns toggle -->
-        <clr-dg-column-toggle>
-            <clr-dg-column-toggle-title>Kolumne Herauschauen!</clr-dg-column-toggle-title>
-            <clr-dg-column-toggle-button>Alle auswählen!</clr-dg-column-toggle-button>
-        </clr-dg-column-toggle>
         {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
         of {{pagination.totalItems}} users
         <clr-dg-pagination #pagination [clrDgPageSize]="currentPageSize"></clr-dg-pagination>

--- a/src/website/src/app/documentation/demos/datagrid/single-selection/single-selection.html
+++ b/src/website/src/app/documentation/demos/datagrid/single-selection/single-selection.html
@@ -54,13 +54,13 @@
 <clr-code-snippet [clrCode]="example" clrLanguage="html"></clr-code-snippet>
 
 <clr-alert [clrAlertType]="'danger'" [clrAlertClosable]="false">
-  <div clr-alert-item class="alert-item">
+  <clr-alert-item>
         <span class="alert-text">
           <code class="clr-code">clrDgRowSelection</code> has been deprecated in 2.0 and will be removed in a future major release.
           It is impossible to support this functionality properly and also comply with accessibility standards for Clarity, and
           we no longer can recommend using this pattern. The workaround is to simply use single selection without row selection.
         </span>
-  </div>
+  </clr-alert-item>
 </clr-alert>
 
 <p>
@@ -72,14 +72,14 @@
 </p>
 
 <clr-alert [clrAlertType]="'warning'" [clrAlertClosable]="false">
-    <div clr-alert-item class="alert-item">
+    <clr-alert-item>
         <span class="alert-text">
             Do not use <code class="clr-code">[clrDgRowSelection]</code> if your row contains any type of clickable
             elements (buttons, links, inputs, expand caret, single-row actions, etc.).
             Doing so would produce invalid HTML in the form of nested buttons,
             which will break in various unpredictable ways depending on the browser.
         </span>
-    </div>
+    </clr-alert-item>
 </clr-alert>
 
 <div class="card card-block">

--- a/src/website/src/app/documentation/demos/datagrid/single-selection/single-selection.html
+++ b/src/website/src/app/documentation/demos/datagrid/single-selection/single-selection.html
@@ -53,6 +53,16 @@
 
 <clr-code-snippet [clrCode]="example" clrLanguage="html"></clr-code-snippet>
 
+<clr-alert [clrAlertType]="'danger'" [clrAlertClosable]="false">
+  <div clr-alert-item class="alert-item">
+        <span class="alert-text">
+          <code class="clr-code">clrDgRowSelection</code> has been deprecated in 2.0 and will be removed in a future major release.
+          It is impossible to support this functionality properly and also comply with accessibility standards for Clarity, and
+          we no longer can recommend using this pattern. The workaround is to simply use single selection without row selection.
+        </span>
+  </div>
+</clr-alert>
+
 <p>
     We also offer an <code class="clr-code">[clrDgRowSelection]</code> input to allow users to
     click anywhere on a row to select it. We however recommend against using this feature unless you have
@@ -61,7 +71,7 @@
     this feature in the future if it continues to hinder accessibility.
 </p>
 
-<clr-alert [clrAlertType]="'danger'" [clrAlertClosable]="false">
+<clr-alert [clrAlertType]="'warning'" [clrAlertClosable]="false">
     <div clr-alert-item class="alert-item">
         <span class="alert-text">
             Do not use <code class="clr-code">[clrDgRowSelection]</code> if your row contains any type of clickable

--- a/src/website/src/app/documentation/demos/i18n/i18n.demo.html
+++ b/src/website/src/app/documentation/demos/i18n/i18n.demo.html
@@ -1,0 +1,75 @@
+<!--
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<clr-doc-wrapper [ng]="ng" [ui]="ui" [title]="title" [newLayout]="newLayout">
+    <article>
+        <h5 class="component-summary" id="summary">Easily translate internal Clarity text into multiple languages.</h5>
+
+        <div id="design-guidelines">
+            <h3 id="layout">Internal language strings</h3>
+
+            <p>Clarity has a short list of text strings that it uses internally for things such as icon alt text or button text. When possible, Clarity avoids
+              using text strings that have to be translated, and rarely changes this list. Any Angular application that needs to support multiple languages
+              can create a different translation and use it for each language.</p>
+
+          <p>
+            In order to improve accessibility of its components, Clarity added a default English title to all icons
+            or non-text interactive elements internal to its components. In order to internationalize them we rely on a
+            <code class="clr-code">ClrCommonStrings</code> service that you can declare for your entire app, which will override
+            our default titles with the ones you provide. Then you just need to include it as a provider in your application.
+          </p>
+
+          <pre><code clr-code-highlight="language-ts" ngNonBindable>
+@Injectable()
+export class MyCommonStringsService implements ClrCommonStrings &#123;
+  open = 'abra';
+&#125;
+</code></pre>
+          <pre><code clr-code-highlight="language-ts" ngNonBindable>
+@NgModule(&#123;
+  imports: [...],
+  declarations: [...],
+  providers: [&#123; provide: ClrCommonStrings, useClass: MyCommonStringsService &#125;]
+&#125;)
+export class AppModule &#123;&#125;
+</code></pre>
+          <p>
+            The list of strings available to configure can be found by simply looking at the declaration of the
+            <code class="clr-code">ClrCommonStrings</code> interface, which is found below.
+          </p>
+          <table class="table">
+            <thead>
+              <tr>
+                <th class="left">Property name</th>
+                <th class="left">Purpose</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let string of strings">
+                <td class="left">{{string.key}}</td>
+                <td class="left">{{string.role}}</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <p>You might also load your strings from an external service, which you would do something like the following service implementation.
+            This would fetch the strings and replace them in the service at runtime, just substitute the server service with your own.</p>
+
+<pre><code clr-code-highlight="language-ts" ngNonBindable>
+@Injectable()
+export class MyCommonStringsService implements ClrCommonStrings &#123;
+  constructor(@Inject(LOCALE_ID) locale: string, server: MyServer) &#123;
+    server.fetchTexts(locale).subscribe(texts =&gt; &#123;
+      // Assign the strings to the correct properties to implement ClrCommonStrings
+      this.open = texts.genericOpenText;
+      ...
+    &#125;);
+  &#125;
+&#125;
+</code></pre>
+        </div>
+    </article>
+</clr-doc-wrapper>

--- a/src/website/src/app/documentation/demos/i18n/i18n.demo.module.ts
+++ b/src/website/src/app/documentation/demos/i18n/i18n.demo.module.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ClarityModule } from '@clr/angular';
+
+import { DocWrapperModule } from '../_doc-wrapper/doc-wrapper.module';
+import { I18nDemo } from './i18n.demo';
+import { RouterModule } from '@angular/router';
+import { UtilsModule } from '../../../utils/utils.module';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ClarityModule,
+    DocWrapperModule,
+    UtilsModule,
+    RouterModule.forChild([{ path: '', component: I18nDemo }]),
+  ],
+  declarations: [I18nDemo],
+  exports: [I18nDemo],
+})
+export class I18nDemoModule {}

--- a/src/website/src/app/documentation/demos/i18n/i18n.demo.ts
+++ b/src/website/src/app/documentation/demos/i18n/i18n.demo.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import { Component } from '@angular/core';
+import { ClarityDocComponent } from '../clarity-doc';
+
+@Component({
+  templateUrl: './i18n.demo.html',
+  host: {
+    '[class.content-area]': 'true',
+    '[class.dox-content-panel]': 'true',
+  },
+})
+export class I18nDemo extends ClarityDocComponent {
+  constructor() {
+    super('internationalization');
+  }
+
+  // List of the string keys and what they mean
+  strings = [
+    { key: 'open', role: 'Open button text' },
+    { key: 'close', role: 'Close button text' },
+    { key: 'show', role: 'Show button text' },
+    { key: 'hide', role: 'Hide button text' },
+    { key: 'expand', role: 'Expandable components: expand caret' },
+    { key: 'collapse', role: 'Expandable components: collapse caret' },
+    { key: 'more', role: 'Overflow menus: ellipsis button' },
+    { key: 'select', role: 'Selectable components: checkbox or radio' },
+    { key: 'selectAll', role: 'Selectable components: checkbox to select all' },
+    { key: 'previous', role: 'Pagination: previous button' },
+    { key: 'next', role: 'Pagination: next button' },
+    { key: 'current', role: 'Pagination: go to current' },
+    { key: 'info', role: 'Alert levels: info' },
+    { key: 'success', role: 'Alert levels: success' },
+    { key: 'warning', role: 'Alert levels: warning' },
+    { key: 'danger', role: 'Alert levels: danger' },
+    { key: 'rowActions', role: 'Datagrid: row actions icon alt text' },
+    { key: 'pickColumns', role: 'Datagrid: show and hide columns icon alt text' },
+    { key: 'showColumns', role: 'Datagrid: show columns title' },
+  ];
+}

--- a/src/website/src/app/documentation/documentation-routing.module.ts
+++ b/src/website/src/app/documentation/documentation-routing.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -148,6 +148,14 @@ const documentationRoutes: Routes = [
         data: {
           bodyClass: 'input',
           browserTitle: 'Inputs',
+        },
+      },
+      {
+        path: 'internationalization',
+        loadChildren: 'src/app/documentation/demos/i18n/i18n.demo.module#I18nDemoModule',
+        data: {
+          bodyClass: 'i18n',
+          browserTitle: 'Internationalization',
         },
       },
       {

--- a/src/website/src/app/icons/icons-get-started/icons-get-started.component.html
+++ b/src/website/src/app/icons/icons-get-started/icons-get-started.component.html
@@ -60,12 +60,12 @@
 </p>
 
 <clr-alert [clrAlertClosable]="false">
-    <div clr-alert-item class="alert-item">
+    <clr-alert-item>
         <span class="alert-text">
             If you load the Clarity Icons in Typescript, make sure you are not loading it through the script tag again. Otherwise you
             will have two different instances of Clarity Icons that override one another.
         </span>
-    </div>
+    </clr-alert-item>
 </clr-alert>
 
 <p>

--- a/src/website/src/settings/componentlist.json
+++ b/src/website/src/settings/componentlist.json
@@ -110,9 +110,8 @@
       "dox": 20
     },
     {
-      "url": "datepicker",
-      "newLayout": true,
-      "text": "Date Picker",
+      "url": "datagrid",
+      "text": "Datagrid",
       "type": "component",
       "ux": 20,
       "ui": 20,
@@ -121,8 +120,9 @@
       "dox": 20
     },
     {
-      "url": "datagrid",
-      "text": "Datagrid",
+      "url": "datepicker",
+      "newLayout": true,
+      "text": "Date Picker",
       "type": "component",
       "ux": 20,
       "ui": 20,
@@ -182,6 +182,16 @@
       "ng": 20,
       "dox": 20,
       "newLayout": true
+    },
+    {
+      "url": "internationalization",
+      "text": "Internationalization",
+      "type": "pattern",
+      "ux": 20,
+      "ui": 20,
+      "core": -1,
+      "ng": 20,
+      "dox": 20
     },
     {
       "url": "labels",


### PR DESCRIPTION
Deprecate the row selection and column toggler overrides. Row selection (#2933) is not accessible and column toggler (#3304) is being brought into line with the other i18n strings in Clarity.

This also adds a new i18n page in docs with how to use strings service.

closes #3304
closes #2933