### PR TITLE
[CORE] fix: Removes artifacts from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,6 @@ addons:
     packages:
     - g++-4.8
     - google-chrome-stable
-  artifacts:
-    paths:
-    - "$TRAVIS_BUILD_DIR/reports/"
 cache:
   apt: true
   directories:


### PR DESCRIPTION
This will stop uploading the gemini reference images and gemini failed images to S3/AWS.

After this is merged I can remove the AWS keys from the build settings. 

Signed-off-by: Matt Hippely <mhippely@vmware.com>