### PR TITLE
fix license update script to stage changes before commit

### DIFF
--- a/scripts/update-license.js
+++ b/scripts/update-license.js
@@ -30,3 +30,5 @@ files.forEach(file => {
 });
 
 console.log('Updated license headers');
+
+exec(`git add ${files.map(file => path.join(__dirname, '../', file)).join(' ')}`);


### PR DESCRIPTION
The pre-commit changes were not being staged and added to the commit so you'd have to amend your commit with the changes to get license header updates. This will stage the changes before they are committed.