### PR TITLE
change datagrid cell to gridcell role

### DIFF
--- a/src/clr-angular/data/datagrid/datagrid-cell.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-cell.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -38,7 +38,7 @@ export default function(): void {
     });
 
     it('adds a11y roles to the cell', function() {
-      expect(context.clarityElement.attributes.role.value).toBe('cell');
+      expect(context.clarityElement.attributes.role.value).toBe('gridcell');
     });
   });
 }

--- a/src/clr-angular/data/datagrid/datagrid-cell.ts
+++ b/src/clr-angular/data/datagrid/datagrid-cell.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -17,7 +17,7 @@ import { WrappedCell } from './wrapped-cell';
   host: {
     '[class.datagrid-cell]': 'true',
     '[class.datagrid-signpost-trigger]': 'signpost.length > 0',
-    role: 'cell',
+    role: 'gridcell',
   },
 })
 export class ClrDatagridCell implements OnInit {

--- a/src/clr-angular/data/datagrid/datagrid-row.html
+++ b/src/clr-angular/data/datagrid/datagrid-row.html
@@ -25,12 +25,12 @@
     <div class="datagrid-row-scrollable" [ngClass]="{'is-replaced': replaced && expanded}">
       <div class="datagrid-scrolling-cells">
         <div *ngIf="selection.selectionType === SELECTION_TYPE.Multi"
-             class="datagrid-select datagrid-fixed-column datagrid-cell">
+             class="datagrid-select datagrid-fixed-column datagrid-cell" role="gridcell">
           <input clrCheckbox type="checkbox" [ngModel]="selected" (ngModelChange)="toggle($event)" [id]="checkboxId"
                  [attr.aria-label]="commonStrings.select">
         </div>
         <div *ngIf="selection.selectionType === SELECTION_TYPE.Single"
-             class="datagrid-select datagrid-fixed-column datagrid-cell">
+             class="datagrid-select datagrid-fixed-column datagrid-cell" role="gridcell">
             <!-- TODO: it would be better if in addition to the generic "Select" label, we could add aria-labelledby
             to label the radio by the first cell in the row (typically an id or name).
             It's pretty easy to label it with the whole row since we already have an id for it, but in most
@@ -40,11 +40,11 @@
                    [attr.aria-label]="commonStrings.select">
         </div>
         <div *ngIf="rowActionService.hasActionableRow"
-             class="datagrid-row-actions datagrid-fixed-column datagrid-cell">
+             class="datagrid-row-actions datagrid-fixed-column datagrid-cell" role="gridcell">
           <ng-content select="clr-dg-action-overflow"></ng-content>
         </div>
         <div *ngIf="globalExpandable.hasExpandableRow"
-             class="datagrid-expandable-caret datagrid-fixed-column datagrid-cell">
+             class="datagrid-expandable-caret datagrid-fixed-column datagrid-cell" role="gridcell">
           <ng-container *ngIf="expand.expandable">
             <button (click)="toggleExpand()" *ngIf="!expand.loading" type="button" class="datagrid-expandable-caret-button">
               <clr-icon shape="caret"

--- a/src/clr-angular/data/datagrid/datagrid.html
+++ b/src/clr-angular/data/datagrid/datagrid.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->


### PR DESCRIPTION
This is the basic fix, but I'm still not getting it to read the column headers when reading a cell with VoiceOver. I also cannot get it to work in _any_ `role="grid"` component (ours or found anywhere on the web), unless it is an actual table element.