### PR TITLE
[DOCS] Update datepicker internationaization example

### DIFF
--- a/src/website/src/app/documentation/demos/datepicker/demos/datepicker-internationalization.demo.html
+++ b/src/website/src/app/documentation/demos/datepicker/demos/datepicker-internationalization.demo.html
@@ -53,6 +53,13 @@
     building your Angular CLI application.
 </p>
 <p>
+    Changing the locale requires its data to be registered first.
+    <clr-code-snippet [clrCode]="registerLocaleExample"></clr-code-snippet>
+    Afterwards you can simply provide the locale in any Module or Component by the 
+    <code class="clr-code">LOCALE_ID</code> token.
+    <clr-code-snippet [clrCode]="provideLocaleExample"></clr-code-snippet>
+</p>
+<p>
     For more information on setting the locale
     parameter and loading the locale data, please read the Angular
     <a href="https://angular.io/guide/i18n" target="_blank">internationalization</a>

--- a/src/website/src/app/documentation/demos/datepicker/demos/datepicker-internationalization.demo.ts
+++ b/src/website/src/app/documentation/demos/datepicker/demos/datepicker-internationalization.demo.ts
@@ -5,8 +5,24 @@
  */
 import { Component } from '@angular/core';
 
+const PROVIDE_LOCALE_EXAMPLE = `
+providers: [
+    {provide: LOCALE_ID, useValue: 'fr'}
+]
+`;
+
+const REGISTER_LOCALE_EXAMPLE = `
+import { registerLocaleData } from '@angular/common';
+import localeFr from '@angular/common/locales/fr';
+
+registerLocaleData(localeFr);
+`;
+
 @Component({
   selector: 'clr-datepicker-internationalization-demo',
   templateUrl: './datepicker-internationalization.demo.html',
 })
-export class DatepickerInternationalizationDemo {}
+export class DatepickerInternationalizationDemo {
+  registerLocaleExample = REGISTER_LOCALE_EXAMPLE;
+  provideLocaleExample = PROVIDE_LOCALE_EXAMPLE; 
+}

--- a/src/website/src/app/documentation/demos/datepicker/demos/datepicker-internationalization.demo.ts
+++ b/src/website/src/app/documentation/demos/datepicker/demos/datepicker-internationalization.demo.ts
@@ -24,5 +24,5 @@ registerLocaleData(localeFr);
 })
 export class DatepickerInternationalizationDemo {
   registerLocaleExample = REGISTER_LOCALE_EXAMPLE;
-  provideLocaleExample = PROVIDE_LOCALE_EXAMPLE; 
+  provideLocaleExample = PROVIDE_LOCALE_EXAMPLE;
 }


### PR DESCRIPTION
## Summary
Updated the datepicker internationalization example in the documentation.

* What is the change?
Added codesnippets to show how to register the data of a locale and how to use  `LOCALE_ID ` to change the date format of the DatePicker

* What is a use case for this change?
Prevent errors while changing the locale 

