### PR TITLE
[ng] clear focus on focused items inside dropdown container on focusout

### DIFF
--- a/src/clr-angular/popover/dropdown/providers/dropdown-focus-handler.service.ts
+++ b/src/clr-angular/popover/dropdown/providers/dropdown-focus-handler.service.ts
@@ -16,6 +16,7 @@ import { FocusService } from '../../../utils/focus/focus.service';
 import { FocusableItem } from '../../../utils/focus/focusable-item/focusable-item';
 import { linkParent, linkVertical } from '../../../utils/focus/focusable-item/linkers';
 import { wrapObservable } from '../../../utils/focus/wrap-observable';
+import { take } from 'rxjs/operators';
 
 @Injectable()
 export class DropdownFocusHandler implements FocusableItem {
@@ -112,7 +113,10 @@ export class DropdownFocusHandler implements FocusableItem {
       // For dropdowns, the menu shouldn't actually be in the tab order. We manually focus it when opening.
       this.renderer.setAttribute(el, 'tabindex', '-1');
       // When the user moves focus outside of the menu, we close the dropdown
-      this.renderer.listen(el, 'focusout', event => {
+      this.renderer.listen(el, 'blur', event => {
+        // we clear out any existing focus on the items
+        this.children.pipe(take(1)).subscribe(items => items.forEach(item => item.blur()));
+
         // focusout + relatedTarget because a simple blur event would trigger
         // when the user clicks an item inside of the menu, closing the dropdown.
         if (event.relatedTarget && isPlatformBrowser(this.platformId)) {

--- a/src/clr-angular/popover/dropdown/providers/dropdown-focus-handler.spec.ts
+++ b/src/clr-angular/popover/dropdown/providers/dropdown-focus-handler.spec.ts
@@ -141,6 +141,19 @@ export default function(): void {
         expect(this.ifOpenService.open).toBeFalsy();
       });
 
+      it('blurs the focused items when container is focused and blurred', function(this: TestContext) {
+        this.focusHandler.container = this.container;
+        this.focusHandler.addChildren(this.children);
+        this.ifOpenService.open = true;
+
+        const spyBlur = spyOn(this.children[0], 'blur');
+        this.container.focus();
+        expect(spyBlur).not.toHaveBeenCalled();
+
+        this.container.blur();
+        expect(spyBlur).toHaveBeenCalled();
+      });
+
       it('puts focus back on the trigger when the dropdown becomes closed', function(this: TestContext) {
         this.focusHandler.trigger = this.trigger;
         this.focusHandler.container = this.container;
@@ -253,7 +266,7 @@ export default function(): void {
         expect(this.trigger.getAttribute('tabindex')).toBe('-1');
       });
 
-      it('toggles the .clr-focus class on the trigger when focused an blurred', function(this: TestContext) {
+      it('toggles the .clr-focus class on the trigger when focused and blurred', function(this: TestContext) {
         this.focusHandler.trigger = this.trigger;
         expect(this.trigger.classList).not.toContain('clr-focus');
         this.focusHandler.focus();


### PR DESCRIPTION
There was a small bug for the dropdown where the item that was focused retains the focus when you close the dropdown. This was happening only on dropdowns whose items weren't being destroyed (i.e. not using `*clrIfOpen`). This is a fix for that.

Signed-off-by: Jeeyun Lim <jeeyun.lim@gmail.com>