### PR TITLE
[UI] add layout utilities

### DIFF
--- a/src/clr-angular/layout/grid/utilities/_align.clarity.scss
+++ b/src/clr-angular/layout/grid/utilities/_align.clarity.scss
@@ -1,0 +1,27 @@
+// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
+
+.clr-align-baseline {
+  vertical-align: baseline !important;
+}
+
+.clr-align-top {
+  vertical-align: top !important;
+}
+
+.clr-align-middle {
+  vertical-align: middle !important;
+}
+
+.clr-align-bottom {
+  vertical-align: bottom !important;
+}
+
+.clr-align-text-bottom {
+  vertical-align: text-bottom !important;
+}
+
+.clr-align-text-top {
+  vertical-align: text-top !important;
+}

--- a/src/clr-angular/layout/grid/utilities/_clearfix.clarity.scss
+++ b/src/clr-angular/layout/grid/utilities/_clearfix.clarity.scss
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
+
+@mixin clearfix() {
+  &::after {
+    content: '';
+    display: table;
+    clear: both;
+  }
+}
+
+.clr-clearfix {
+  @include clearfix();
+}

--- a/src/clr-angular/layout/grid/utilities/_display.clarity.scss
+++ b/src/clr-angular/layout/grid/utilities/_display.clarity.scss
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
+
+.clr-display-block {
+  display: block !important;
+}
+
+.clr-display-inline-block {
+  display: inline-block !important;
+}
+
+.clr-display-inline {
+  display: inline !important;
+}

--- a/src/clr-angular/layout/grid/utilities/_flex.clarity.scss
+++ b/src/clr-angular/layout/grid/utilities/_flex.clarity.scss
@@ -1,9 +1,8 @@
-// stylelint-disable declaration-no-important
+// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
-// Flex variation
-//
 // Custom styles for additional flex alignment options.
-
 @each $breakpoint in map-keys($clr-grid-breakpoints) {
   @include clr-media-breakpoint-up($breakpoint) {
     $infix: clr-breakpoint-infix($breakpoint, $clr-grid-breakpoints);
@@ -11,12 +10,15 @@
     .clr-flex#{$infix}-row {
       flex-direction: row !important;
     }
+
     .clr-flex#{$infix}-column {
       flex-direction: column !important;
     }
+
     .clr-flex#{$infix}-row-reverse {
       flex-direction: row-reverse !important;
     }
+
     .clr-flex#{$infix}-column-reverse {
       flex-direction: column-reverse !important;
     }
@@ -24,24 +26,31 @@
     .clr-flex#{$infix}-wrap {
       flex-wrap: wrap !important;
     }
+
     .clr-flex#{$infix}-nowrap {
       flex-wrap: nowrap !important;
     }
+
     .clr-flex#{$infix}-wrap-reverse {
       flex-wrap: wrap-reverse !important;
     }
+
     .clr-flex#{$infix}-fill {
       flex: 1 1 auto !important;
     }
+
     .clr-flex#{$infix}-grow-0 {
       flex-grow: 0 !important;
     }
+
     .clr-flex#{$infix}-grow-1 {
       flex-grow: 1 !important;
     }
+
     .clr-flex#{$infix}-shrink-0 {
       flex-shrink: 0 !important;
     }
+
     .clr-flex#{$infix}-shrink-1 {
       flex-shrink: 1 !important;
     }
@@ -49,15 +58,19 @@
     .clr-justify-content#{$infix}-start {
       justify-content: flex-start !important;
     }
+
     .clr-justify-content#{$infix}-end {
       justify-content: flex-end !important;
     }
+
     .clr-justify-content#{$infix}-center {
       justify-content: center !important;
     }
+
     .clr-justify-content#{$infix}-between {
       justify-content: space-between !important;
     }
+
     .clr-justify-content#{$infix}-around {
       justify-content: space-around !important;
     }
@@ -65,15 +78,19 @@
     .clr-align-items#{$infix}-start {
       align-items: flex-start !important;
     }
+
     .clr-align-items#{$infix}-end {
       align-items: flex-end !important;
     }
+
     .clr-align-items#{$infix}-center {
       align-items: center !important;
     }
+
     .clr-align-items#{$infix}-baseline {
       align-items: baseline !important;
     }
+
     .clr-align-items#{$infix}-stretch {
       align-items: stretch !important;
     }
@@ -81,18 +98,23 @@
     .clr-align-content#{$infix}-start {
       align-content: flex-start !important;
     }
+
     .clr-align-content#{$infix}-end {
       align-content: flex-end !important;
     }
+
     .clr-align-content#{$infix}-center {
       align-content: center !important;
     }
+
     .clr-align-content#{$infix}-between {
       align-content: space-between !important;
     }
+
     .clr-align-content#{$infix}-around {
       align-content: space-around !important;
     }
+
     .clr-align-content#{$infix}-stretch {
       align-content: stretch !important;
     }
@@ -100,20 +122,95 @@
     .clr-align-self#{$infix}-auto {
       align-self: auto !important;
     }
+
     .clr-align-self#{$infix}-start {
       align-self: flex-start !important;
     }
+
     .clr-align-self#{$infix}-end {
       align-self: flex-end !important;
     }
+
     .clr-align-self#{$infix}-center {
       align-self: center !important;
     }
+
     .clr-align-self#{$infix}-baseline {
       align-self: baseline !important;
     }
+
     .clr-align-self#{$infix}-stretch {
       align-self: stretch !important;
+    }
+  }
+}
+
+@each $breakpoint in map-keys($clr-grid-breakpoints) {
+  // Flex column reordering
+  @include clr-media-breakpoint-up($breakpoint) {
+    .clr-flex-#{$breakpoint}-first {
+      order: -1;
+    }
+
+    .clr-flex-#{$breakpoint}-last {
+      order: 1;
+    }
+
+    .clr-flex-#{$breakpoint}-unordered {
+      order: 0;
+    }
+  }
+
+  // Alignment for every item
+  @include clr-media-breakpoint-up($breakpoint) {
+    .clr-flex-items-#{$breakpoint}-top {
+      align-items: flex-start;
+    }
+
+    .clr-flex-items-#{$breakpoint}-middle {
+      align-items: center;
+    }
+
+    .clr-flex-items-#{$breakpoint}-bottom {
+      align-items: flex-end;
+    }
+  }
+
+  // Alignment per item
+  @include clr-media-breakpoint-up($breakpoint) {
+    .clr-flex-#{$breakpoint}-top {
+      align-self: flex-start;
+    }
+
+    .clr-flex-#{$breakpoint}-middle {
+      align-self: center;
+    }
+
+    .clr-flex-#{$breakpoint}-bottom {
+      align-self: flex-end;
+    }
+  }
+
+  // Horizontal alignment of item
+  @include clr-media-breakpoint-up($breakpoint) {
+    .clr-flex-items-#{$breakpoint}-left {
+      justify-content: flex-start;
+    }
+
+    .clr-flex-items-#{$breakpoint}-center {
+      justify-content: center;
+    }
+
+    .clr-flex-items-#{$breakpoint}-right {
+      justify-content: flex-end;
+    }
+
+    .clr-flex-items-#{$breakpoint}-around {
+      justify-content: space-around;
+    }
+
+    .clr-flex-items-#{$breakpoint}-between {
+      justify-content: space-between;
     }
   }
 }

--- a/src/clr-angular/layout/grid/utilities/_float.clarity.scss
+++ b/src/clr-angular/layout/grid/utilities/_float.clarity.scss
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
+
+@each $breakpoint in map-keys($clr-grid-breakpoints) {
+  @include clr-media-breakpoint-up($breakpoint) {
+    .clr-float-#{$breakpoint}-left {
+      float: left !important;
+    }
+
+    .clr-float-#{$breakpoint}-right {
+      float: right !important;
+    }
+
+    .clr-float-#{$breakpoint}-none {
+      float: none !important;
+    }
+  }
+}

--- a/src/clr-angular/layout/grid/utilities/_visibility.clarity.scss
+++ b/src/clr-angular/layout/grid/utilities/_visibility.clarity.scss
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
+
+// Responsive visibility utilities
+.clr-invisible {
+  visibility: hidden !important;
+}
+
+@each $bp in map-keys($clr-grid-breakpoints) {
+  .clr-hidden-#{$bp}-up {
+    @include clr-media-breakpoint-up($bp) {
+      display: none !important;
+    }
+  }
+}
+
+// Print utilities
+.clr-visible-print-block {
+  display: none !important;
+
+  @media print {
+    display: block !important;
+  }
+}
+
+.clr-visible-print-inline {
+  display: none !important;
+
+  @media print {
+    display: inline !important;
+  }
+}
+
+.clr-visible-print-inline-block {
+  display: none !important;
+
+  @media print {
+    display: inline-block !important;
+  }
+}
+
+.clr-hidden-print {
+  @media print {
+    display: none !important;
+  }
+}

--- a/src/clr-angular/utils/_components.clarity.scss
+++ b/src/clr-angular/utils/_components.clarity.scss
@@ -8,12 +8,17 @@
 @import '../utils/helpers.clarity';
 @import '../utils/a11y.clarity';
 
-// Grid Dependencies
+// Grid and Layout Utility Dependencies
 @import '../layout/grid/variables/variables.clarity';
 @import '../layout/grid/mixins/breakpoint.clarity';
 @import '../layout/grid/mixins/grid.clarity';
 @import '../layout/grid/mixins/grid-framework.clarity';
+@import '../layout/grid/utilities/align.clarity';
+@import '../layout/grid/utilities/clearfix.clarity';
+@import '../layout/grid/utilities/display.clarity';
 @import '../layout/grid/utilities/flex.clarity';
+@import '../layout/grid/utilities/float.clarity';
+@import '../layout/grid/utilities/visibility.clarity';
 
 //Color
 @import '../color/variables.color';


### PR DESCRIPTION
The layout/responsive utilities were marked and removed from deprecation. Teams still use them even though they are undocumented. This PR adds them back and prefixes them with `clr-` so it is an easier migration to 2.0. In a later PR we can add visual diff tests (gemini I think is being removed so wait for applitools?) and document these APIs as they are useful and it makes sense to be included with Clarity UI.

closes #3403

Signed-off-by: Cory Rylan <crylan@vmware.com>