### PR TITLE
[DOCS] Fix tab order in Vertical tabs and Sidenav demos (#1923)

### DIFF
--- a/src/dev/src/app/layout/layout-additional-sections.html
+++ b/src/dev/src/app/layout/layout-additional-sections.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -42,11 +42,6 @@
       </ul>
     </nav>
     <div class="content-container">
-      <div class="content-area" style="min-height: 240px">
-        <p>
-          Content Area
-        </p>
-      </div>
       <nav class="sidenav">
         <section class="sidenav-content">
           <section class="nav-group">
@@ -75,6 +70,11 @@
           </section>
         </section>
       </nav>
+      <div class="content-area" style="min-height: 240px">
+        <p>
+          Content Area
+        </p>
+      </div>
       <aside class="example-aside-section">
         Aside
       </aside>

--- a/src/dev/src/app/layout/layout-all.html
+++ b/src/dev/src/app/layout/layout-all.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -60,19 +60,6 @@
       </ul>
     </nav>
     <div class="content-container">
-      <div class="content-area">
-        <p>
-          Content Area
-        </p>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum dignissim eget massa sit amet feugiat.
-          Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat vitae sem at, tincidunt elementum magna. Phasellus
-          tristique posuere dui, ut tempus felis sagittis quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus
-          interdum semper velit eget gravida. Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie
-          cursus, sapien purus volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat
-          purus non, imperdiet ipsum.
-        </p>
-      </div>
       <nav class="sidenav">
         <section class="sidenav-content">
           <section class="nav-group">
@@ -101,6 +88,19 @@
           </section>
         </section>
       </nav>
+      <div class="content-area">
+        <p>
+          Content Area
+        </p>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum dignissim eget massa sit amet feugiat.
+          Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat vitae sem at, tincidunt elementum magna. Phasellus
+          tristique posuere dui, ut tempus felis sagittis quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus
+          interdum semper velit eget gravida. Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie
+          cursus, sapien purus volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat
+          purus non, imperdiet ipsum.
+        </p>
+      </div>
     </div>
   </div>
 </div>

--- a/src/dev/src/app/layout/layout-no-subnav.html
+++ b/src/dev/src/app/layout/layout-no-subnav.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -23,19 +23,6 @@
       </div>
     </header>
     <div class="content-container">
-      <div class="content-area">
-        <p>
-          Content Area
-        </p>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum dignissim eget massa sit amet feugiat.
-          Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat vitae sem at, tincidunt elementum magna. Phasellus
-          tristique posuere dui, ut tempus felis sagittis quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus
-          interdum semper velit eget gravida. Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie
-          cursus, sapien purus volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat
-          purus non, imperdiet ipsum.
-        </p>
-      </div>
       <nav class="sidenav">
         <section class="sidenav-content">
           <section class="nav-group">
@@ -64,6 +51,19 @@
           </section>
         </section>
       </nav>
+      <div class="content-area">
+        <p>
+          Content Area
+        </p>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum dignissim eget massa sit amet feugiat.
+          Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat vitae sem at, tincidunt elementum magna. Phasellus
+          tristique posuere dui, ut tempus felis sagittis quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus
+          interdum semper velit eget gravida. Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie
+          cursus, sapien purus volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat
+          purus non, imperdiet ipsum.
+        </p>
+      </div>
     </div>
   </div>
 </div>

--- a/src/dev/src/app/layout/layout-sidenav-primary.html
+++ b/src/dev/src/app/layout/layout-sidenav-primary.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -25,19 +25,6 @@
       </div>
     </header>
     <div class="content-container">
-      <div class="content-area">
-        <p>
-          Content Area
-        </p>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum dignissim eget massa sit amet feugiat.
-          Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat vitae sem at, tincidunt elementum magna. Phasellus
-          tristique posuere dui, ut tempus felis sagittis quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus
-          interdum semper velit eget gravida. Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie
-          cursus, sapien purus volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat
-          purus non, imperdiet ipsum.
-        </p>
-      </div>
       <nav class="sidenav">
         <section class="sidenav-content">
           <section class="nav-group">
@@ -66,6 +53,19 @@
           </section>
         </section>
       </nav>
+      <div class="content-area">
+        <p>
+          Content Area
+        </p>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum dignissim eget massa sit amet feugiat.
+          Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat vitae sem at, tincidunt elementum magna. Phasellus
+          tristique posuere dui, ut tempus felis sagittis quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus
+          interdum semper velit eget gravida. Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie
+          cursus, sapien purus volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat
+          purus non, imperdiet ipsum.
+        </p>
+      </div>
     </div>
   </div>
 </div>

--- a/src/dev/src/app/layout/layout-subnav-primary.html
+++ b/src/dev/src/app/layout/layout-subnav-primary.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -44,19 +44,6 @@
       </ul>
     </nav>
     <div class="content-container">
-      <div class="content-area">
-        <p>
-          Content Area
-        </p>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum dignissim eget massa sit amet feugiat.
-          Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat vitae sem at, tincidunt elementum magna. Phasellus
-          tristique posuere dui, ut tempus felis sagittis quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus
-          interdum semper velit eget gravida. Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie
-          cursus, sapien purus volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat
-          purus non, imperdiet ipsum.
-        </p>
-      </div>
       <nav class="sidenav">
         <section class="sidenav-content">
           <section class="nav-group">
@@ -85,6 +72,19 @@
           </section>
         </section>
       </nav>
+      <div class="content-area">
+        <p>
+          Content Area
+        </p>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum dignissim eget massa sit amet feugiat.
+          Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat vitae sem at, tincidunt elementum magna. Phasellus
+          tristique posuere dui, ut tempus felis sagittis quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus
+          interdum semper velit eget gravida. Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie
+          cursus, sapien purus volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat
+          purus non, imperdiet ipsum.
+        </p>
+      </div>
     </div>
   </div>
 </div>

--- a/src/dev/src/app/vertical-nav/all-cases/vertical-all-cases.demo.html
+++ b/src/dev/src/app/vertical-nav/all-cases/vertical-all-cases.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -26,24 +26,6 @@
                 </div>
             </header>
             <div class="content-container">
-                <div class="content-area">
-                    <h4>
-                        {{case.title}}
-                    </h4>
-                    <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum
-                        dignissim
-                        eget massa sit amet feugiat. Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat
-                        vitae sem at, tincidunt elementum magna. Phasellus tristique posuere dui, ut tempus felis
-                        sagittis
-                        quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus interdum semper velit eget
-                        gravida.
-                        Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie cursus, sapien
-                        purus
-                        volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat purus
-                        non, imperdiet ipsum.
-                    </p>
-                </div>
                 <clr-vertical-nav [clrVerticalNavCollapsible]="true" [(clrVerticalNavCollapsed)]="collapse">
 
                     <ng-container *ngFor="let item of case.items">
@@ -69,6 +51,24 @@
                     </ng-container>
 
                 </clr-vertical-nav>
+                <div class="content-area">
+                    <h4>
+                        {{case.title}}
+                    </h4>
+                    <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum
+                        dignissim
+                        eget massa sit amet feugiat. Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat
+                        vitae sem at, tincidunt elementum magna. Phasellus tristique posuere dui, ut tempus felis
+                        sagittis
+                        quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus interdum semper velit eget
+                        gravida.
+                        Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie cursus, sapien
+                        purus
+                        volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat purus
+                        non, imperdiet ipsum.
+                    </p>
+                </div>
             </div>
         </div>
     </div>

--- a/src/dev/src/app/vertical-nav/basic/vertical-nav-basic.demo.html
+++ b/src/dev/src/app/vertical-nav/basic/vertical-nav-basic.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -25,6 +25,18 @@
             </div>
         </header>
         <div class="content-container">
+            <clr-vertical-nav>
+
+                <ng-container *ngFor="let item of case.items">
+
+                    <a clrVerticalNavLink href="javascript:void(0)" *ngIf="!item['children']">
+                        <clr-icon [attr.shape]="item.icon" *ngIf="item['icon']" clrVerticalNavIcon></clr-icon>
+                        {{item.label}}
+                    </a>
+
+                </ng-container>
+
+            </clr-vertical-nav>
             <div class="content-area">
                 <h4>
                     {{case.title}}
@@ -39,18 +51,6 @@
                     non, imperdiet ipsum.
                 </p>
             </div>
-            <clr-vertical-nav>
-
-                <ng-container *ngFor="let item of case.items">
-
-                    <a clrVerticalNavLink href="javascript:void(0)" *ngIf="!item['children']">
-                        <clr-icon [attr.shape]="item.icon" *ngIf="item['icon']" clrVerticalNavIcon></clr-icon>
-                        {{item.label}}
-                    </a>
-
-                </ng-container>
-
-            </clr-vertical-nav>
         </div>
     </div>
 </div>

--- a/src/dev/src/app/vertical-nav/collapsible/vertical-nav-collapsible.demo.html
+++ b/src/dev/src/app/vertical-nav/collapsible/vertical-nav-collapsible.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -25,6 +25,19 @@
             </div>
         </header>
         <div class="content-container">
+            <clr-vertical-nav
+                [clrVerticalNavCollapsible]="collapsible"
+                [(clrVerticalNavCollapsed)]="collapse">
+                <ng-container *ngFor="let item of case.items">
+
+                    <a clrVerticalNavLink href="javascript:void(0)" *ngIf="!item['children']">
+                        <clr-icon [attr.shape]="item.icon" *ngIf="item['icon']" clrVerticalNavIcon></clr-icon>
+                        {{item.label}}
+                    </a>
+
+                </ng-container>
+
+            </clr-vertical-nav>
             <div class="content-area">
                 <div>
                     <button class="btn" (click)="toggleCollapsible()">
@@ -47,19 +60,6 @@
                     non, imperdiet ipsum.
                 </p>
             </div>
-            <clr-vertical-nav
-                [clrVerticalNavCollapsible]="collapsible"
-                [(clrVerticalNavCollapsed)]="collapse">
-                <ng-container *ngFor="let item of case.items">
-
-                    <a clrVerticalNavLink href="javascript:void(0)" *ngIf="!item['children']">
-                        <clr-icon [attr.shape]="item.icon" *ngIf="item['icon']" clrVerticalNavIcon></clr-icon>
-                        {{item.label}}
-                    </a>
-
-                </ng-container>
-
-            </clr-vertical-nav>
         </div>
     </div>
 </div>
@@ -86,6 +86,18 @@
             </div>
         </header>
         <div class="content-container">
+            <clr-vertical-nav
+                class="nav-trigger--bottom"
+                [clrVerticalNavCollapsible]="true">
+                <ng-container *ngFor="let item of case.items">
+
+                    <a clrVerticalNavLink href="javascript:void(0)" *ngIf="!item['children']">
+                        <clr-icon [attr.shape]="item.icon" *ngIf="item['icon']" clrVerticalNavIcon></clr-icon>
+                        {{item.label}}
+                    </a>
+
+                </ng-container>
+            </clr-vertical-nav>
             <div class="content-area">
                 <h4>
                     {{case.title}}
@@ -100,18 +112,6 @@
                     non, imperdiet ipsum.
                 </p>
             </div>
-            <clr-vertical-nav
-                class="nav-trigger--bottom"
-                [clrVerticalNavCollapsible]="true">
-                <ng-container *ngFor="let item of case.items">
-
-                    <a clrVerticalNavLink href="javascript:void(0)" *ngIf="!item['children']">
-                        <clr-icon [attr.shape]="item.icon" *ngIf="item['icon']" clrVerticalNavIcon></clr-icon>
-                        {{item.label}}
-                    </a>
-
-                </ng-container>
-            </clr-vertical-nav>
         </div>
     </div>
 </div>

--- a/src/dev/src/app/vertical-nav/direct-icon/vertical-nav-icon.demo.html
+++ b/src/dev/src/app/vertical-nav/direct-icon/vertical-nav-icon.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -25,6 +25,18 @@
             </div>
         </header>
         <div class="content-container">
+            <clr-vertical-nav [clrVerticalNavCollapsible]="true" [(clrVerticalNavCollapsed)]="collapse">
+
+                <ng-container *ngFor="let item of case.items">
+
+                    <a clrVerticalNavLink href="javascript:void(0)" *ngIf="!item['children']">
+                        <clr-icon [attr.shape]="item.icon" *ngIf="item['icon']" clrVerticalNavIcon></clr-icon>
+                        {{item.label}}
+                    </a>
+
+                </ng-container>
+
+            </clr-vertical-nav>
             <div class="content-area">
                 <h4>
                     {{case.title}}
@@ -39,18 +51,6 @@
                     non, imperdiet ipsum.
                 </p>
             </div>
-            <clr-vertical-nav [clrVerticalNavCollapsible]="true" [(clrVerticalNavCollapsed)]="collapse">
-
-                <ng-container *ngFor="let item of case.items">
-
-                    <a clrVerticalNavLink href="javascript:void(0)" *ngIf="!item['children']">
-                        <clr-icon [attr.shape]="item.icon" *ngIf="item['icon']" clrVerticalNavIcon></clr-icon>
-                        {{item.label}}
-                    </a>
-
-                </ng-container>
-
-            </clr-vertical-nav>
         </div>
     </div>
 </div>

--- a/src/dev/src/app/vertical-nav/header-and-divider/vertical-nav-header-and-divider.demo.html
+++ b/src/dev/src/app/vertical-nav/header-and-divider/vertical-nav-header-and-divider.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -25,20 +25,6 @@
             </div>
         </header>
         <div class="content-container">
-            <div class="content-area">
-                <h4>
-                    Headers and Dividers
-                </h4>
-                <p>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum dignissim
-                    eget massa sit amet feugiat. Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat
-                    vitae sem at, tincidunt elementum magna. Phasellus tristique posuere dui, ut tempus felis sagittis
-                    quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus interdum semper velit eget gravida.
-                    Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie cursus, sapien purus
-                    volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat purus
-                    non, imperdiet ipsum.
-                </p>
-            </div>
             <clr-vertical-nav>
 
                 <label class="nav-header">
@@ -67,6 +53,20 @@
                 </a>
 
             </clr-vertical-nav>
+            <div class="content-area">
+                <h4>
+                    Headers and Dividers
+                </h4>
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum dignissim
+                    eget massa sit amet feugiat. Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat
+                    vitae sem at, tincidunt elementum magna. Phasellus tristique posuere dui, ut tempus felis sagittis
+                    quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus interdum semper velit eget gravida.
+                    Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie cursus, sapien purus
+                    volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat purus
+                    non, imperdiet ipsum.
+                </p>
+            </div>
         </div>
     </div>
 </div>

--- a/src/dev/src/app/vertical-nav/highlights/vertical-nav-highlights.demo.html
+++ b/src/dev/src/app/vertical-nav/highlights/vertical-nav-highlights.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -25,20 +25,6 @@
             </div>
         </header>
         <div class="content-container">
-            <div class="content-area">
-                <h4>
-                    {{case.title}}
-                </h4>
-                <p>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum dignissim
-                    eget massa sit amet feugiat. Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat
-                    vitae sem at, tincidunt elementum magna. Phasellus tristique posuere dui, ut tempus felis sagittis
-                    quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus interdum semper velit eget gravida.
-                    Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie cursus, sapien purus
-                    volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat purus
-                    non, imperdiet ipsum.
-                </p>
-            </div>
             <clr-vertical-nav>
 
                 <ng-container *ngFor="let item of case.items">
@@ -69,6 +55,20 @@
                 </ng-container>
 
             </clr-vertical-nav>
+            <div class="content-area">
+                <h4>
+                    {{case.title}}
+                </h4>
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum dignissim
+                    eget massa sit amet feugiat. Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat
+                    vitae sem at, tincidunt elementum magna. Phasellus tristique posuere dui, ut tempus felis sagittis
+                    quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus interdum semper velit eget gravida.
+                    Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie cursus, sapien purus
+                    volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat purus
+                    non, imperdiet ipsum.
+                </p>
+            </div>
         </div>
     </div>
 </div>

--- a/src/dev/src/app/vertical-nav/nested-icon-menus/vertical-nav-nested-icon-menus.demo.html
+++ b/src/dev/src/app/vertical-nav/nested-icon-menus/vertical-nav-nested-icon-menus.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -26,23 +26,6 @@
             </div>
         </header>
         <div class="content-container">
-            <div class="content-area">
-                <div>
-                    <button class="btn gemini-trigger" (click)="collapse = !collapse">Toggle Collapse</button>
-                </div>
-                <h4>
-                    {{case.title}}
-                </h4>
-                <p>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum dignissim
-                    eget massa sit amet feugiat. Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat
-                    vitae sem at, tincidunt elementum magna. Phasellus tristique posuere dui, ut tempus felis sagittis
-                    quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus interdum semper velit eget gravida.
-                    Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie cursus, sapien purus
-                    volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat purus
-                    non, imperdiet ipsum.
-                </p>
-            </div>
             <clr-vertical-nav [clrVerticalNavCollapsible]="true" [(clrVerticalNavCollapsed)]="collapse">
 
                 <ng-container *ngFor="let item of case.items">
@@ -60,6 +43,23 @@
                 </ng-container>
 
             </clr-vertical-nav>
+            <div class="content-area">
+                <div>
+                    <button class="btn gemini-trigger" (click)="collapse = !collapse">Toggle Collapse</button>
+                </div>
+                <h4>
+                    {{case.title}}
+                </h4>
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum dignissim
+                    eget massa sit amet feugiat. Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat
+                    vitae sem at, tincidunt elementum magna. Phasellus tristique posuere dui, ut tempus felis sagittis
+                    quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus interdum semper velit eget gravida.
+                    Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie cursus, sapien purus
+                    volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat purus
+                    non, imperdiet ipsum.
+                </p>
+            </div>
         </div>
     </div>
 </div>
@@ -86,20 +86,6 @@
             </div>
         </header>
         <div class="content-container">
-            <div class="content-area">
-                <h4>
-                    {{case.title}}
-                </h4>
-                <p>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum dignissim
-                    eget massa sit amet feugiat. Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat
-                    vitae sem at, tincidunt elementum magna. Phasellus tristique posuere dui, ut tempus felis sagittis
-                    quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus interdum semper velit eget gravida.
-                    Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie cursus, sapien purus
-                    volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat purus
-                    non, imperdiet ipsum.
-                </p>
-            </div>
             <clr-vertical-nav [clrVerticalNavCollapsible]="true" [(clrVerticalNavCollapsed)]="collapse">
 
                 <ng-container *ngFor="let item of case.items">
@@ -119,6 +105,20 @@
                 </ng-container>
 
             </clr-vertical-nav>
+            <div class="content-area">
+                <h4>
+                    {{case.title}}
+                </h4>
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum dignissim
+                    eget massa sit amet feugiat. Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat
+                    vitae sem at, tincidunt elementum magna. Phasellus tristique posuere dui, ut tempus felis sagittis
+                    quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus interdum semper velit eget gravida.
+                    Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie cursus, sapien purus
+                    volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat purus
+                    non, imperdiet ipsum.
+                </p>
+            </div>
         </div>
     </div>
 </div>

--- a/src/dev/src/app/vertical-nav/nested-menus/vertical-nav-nested-menus.demo.html
+++ b/src/dev/src/app/vertical-nav/nested-menus/vertical-nav-nested-menus.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -26,6 +26,22 @@
             </div>
         </header>
         <div class="content-container nested-menus-text">
+            <clr-vertical-nav [clrVerticalNavCollapsible]="true" [(clrVerticalNavCollapsed)]="collapse">
+
+                <ng-container *ngFor="let item of case.items">
+                    <clr-vertical-nav-group *ngIf="item['children']">
+                        <clr-icon [attr.shape]="item.icon" *ngIf="item['icon']" clrVerticalNavIcon></clr-icon>
+                        {{item.label}}
+
+                        <clr-vertical-nav-group-children *clrIfExpanded>
+                            <a clrVerticalNavLink href="javascript:void(0)" *ngFor="let childItem of item.children">
+                                {{childItem.label}}
+                            </a>
+                        </clr-vertical-nav-group-children>
+                    </clr-vertical-nav-group>
+                </ng-container>
+
+            </clr-vertical-nav>
             <div class="content-area">
                 <div>
                     <button class="btn gemini-trigger" (click)="collapse = !collapse">Toggle Collapse</button>
@@ -43,22 +59,6 @@
                     non, imperdiet ipsum.
                 </p>
             </div>
-            <clr-vertical-nav [clrVerticalNavCollapsible]="true" [(clrVerticalNavCollapsed)]="collapse">
-
-                <ng-container *ngFor="let item of case.items">
-                    <clr-vertical-nav-group *ngIf="item['children']">
-                        <clr-icon [attr.shape]="item.icon" *ngIf="item['icon']" clrVerticalNavIcon></clr-icon>
-                        {{item.label}}
-
-                        <clr-vertical-nav-group-children *clrIfExpanded>
-                            <a clrVerticalNavLink href="javascript:void(0)" *ngFor="let childItem of item.children">
-                                {{childItem.label}}
-                            </a>
-                        </clr-vertical-nav-group-children>
-                    </clr-vertical-nav-group>
-                </ng-container>
-
-            </clr-vertical-nav>
         </div>
     </div>
 </div>
@@ -85,20 +85,6 @@
             </div>
         </header>
         <div class="content-container nested-menus-links">
-            <div class="content-area">
-                <h4>
-                    {{case.title}}
-                </h4>
-                <p>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum dignissim
-                    eget massa sit amet feugiat. Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat
-                    vitae sem at, tincidunt elementum magna. Phasellus tristique posuere dui, ut tempus felis sagittis
-                    quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus interdum semper velit eget gravida.
-                    Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie cursus, sapien purus
-                    volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat purus
-                    non, imperdiet ipsum.
-                </p>
-            </div>
             <clr-vertical-nav [clrVerticalNavCollapsible]="true" [(clrVerticalNavCollapsed)]="collapse">
 
                 <ng-container *ngFor="let item of case.items">
@@ -120,6 +106,20 @@
                 </ng-container>
 
             </clr-vertical-nav>
+            <div class="content-area">
+                <h4>
+                    {{case.title}}
+                </h4>
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum dignissim
+                    eget massa sit amet feugiat. Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat
+                    vitae sem at, tincidunt elementum magna. Phasellus tristique posuere dui, ut tempus felis sagittis
+                    quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus interdum semper velit eget gravida.
+                    Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie cursus, sapien purus
+                    volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat purus
+                    non, imperdiet ipsum.
+                </p>
+            </div>
         </div>
     </div>
 </div>

--- a/src/dev/src/app/vertical-nav/partially-nested-icon-menu/vertical-nav-partial-nested-icon-menus.demo.html
+++ b/src/dev/src/app/vertical-nav/partially-nested-icon-menu/vertical-nav-partial-nested-icon-menus.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -25,23 +25,6 @@
             </div>
         </header>
         <div class="content-container partial-nested-icon-menu">
-            <div class="content-area">
-                <div>
-                    <button class="btn gemini-trigger" (click)="collapse = !collapse">Toggle Collapse</button>
-                </div>
-                <h4>
-                    {{case.title}}
-                </h4>
-                <p>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum dignissim
-                    eget massa sit amet feugiat. Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat
-                    vitae sem at, tincidunt elementum magna. Phasellus tristique posuere dui, ut tempus felis sagittis
-                    quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus interdum semper velit eget gravida.
-                    Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie cursus, sapien purus
-                    volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat purus
-                    non, imperdiet ipsum.
-                </p>
-            </div>
             <clr-vertical-nav [clrVerticalNavCollapsible]="true" [(clrVerticalNavCollapsed)]="collapse">
 
                 <ng-container *ngFor="let item of case.items">
@@ -64,6 +47,23 @@
                 </ng-container>
 
             </clr-vertical-nav>
+            <div class="content-area">
+                <div>
+                    <button class="btn gemini-trigger" (click)="collapse = !collapse">Toggle Collapse</button>
+                </div>
+                <h4>
+                    {{case.title}}
+                </h4>
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum dignissim
+                    eget massa sit amet feugiat. Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat
+                    vitae sem at, tincidunt elementum magna. Phasellus tristique posuere dui, ut tempus felis sagittis
+                    quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus interdum semper velit eget gravida.
+                    Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie cursus, sapien purus
+                    volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat purus
+                    non, imperdiet ipsum.
+                </p>
+            </div>
         </div>
     </div>
 </div>

--- a/src/dev/src/app/vertical-nav/partially-nested-menu/vertical-nav-partial-nested-menus.demo.html
+++ b/src/dev/src/app/vertical-nav/partially-nested-menu/vertical-nav-partial-nested-menus.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -25,23 +25,6 @@
             </div>
         </header>
         <div class="content-container partial-nested-menu">
-            <div class="content-area">
-                <div>
-                    <button class="btn gemini-trigger" (click)="collapse = !collapse">Toggle Collapse</button>
-                </div>
-                <h4>
-                    {{case.title}}
-                </h4>
-                <p>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum dignissim
-                    eget massa sit amet feugiat. Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat
-                    vitae sem at, tincidunt elementum magna. Phasellus tristique posuere dui, ut tempus felis sagittis
-                    quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus interdum semper velit eget gravida.
-                    Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie cursus, sapien purus
-                    volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat purus
-                    non, imperdiet ipsum.
-                </p>
-            </div>
             <clr-vertical-nav [clrVerticalNavCollapsible]="true" [(clrVerticalNavCollapsed)]="collapse">
 
                 <ng-container *ngFor="let item of case.items">
@@ -64,6 +47,23 @@
                 </ng-container>
 
             </clr-vertical-nav>
+            <div class="content-area">
+                <div>
+                    <button class="btn gemini-trigger" (click)="collapse = !collapse">Toggle Collapse</button>
+                </div>
+                <h4>
+                    {{case.title}}
+                </h4>
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum dignissim
+                    eget massa sit amet feugiat. Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat
+                    vitae sem at, tincidunt elementum magna. Phasellus tristique posuere dui, ut tempus felis sagittis
+                    quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus interdum semper velit eget gravida.
+                    Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie cursus, sapien purus
+                    volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat purus
+                    non, imperdiet ipsum.
+                </p>
+            </div>
         </div>
     </div>
 </div>

--- a/src/dev/src/app/vertical-nav/routing/vertical-nav-routing.demo.html
+++ b/src/dev/src/app/vertical-nav/routing/vertical-nav-routing.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -25,51 +25,6 @@
             </div>
         </header>
         <div class="content-container">
-            <div class="content-area">
-                <div class="example-options">
-                    <h6>Options</h6>
-                    <div class="btn-group">
-                        <div class="radio btn">
-                            <input type="radio" name="vertNavRadios" id="rad1" [(ngModel)]="option" value="link">
-                            <label for="rad1">Nav Group Link</label>
-                        </div>
-                        <div class="radio btn">
-                            <input type="radio" name="vertNavRadios" id="rad2" [(ngModel)]="option" value="text">
-                            <label for="rad2">Nav Group Text</label>
-                        </div>
-                        <div class="radio btn">
-                            <input type="radio" name="vertNavRadios" id="rad3" [(ngModel)]="option" value="lazyText">
-                            <label for="rad3">Nav Group Text + Lazy Loading</label>
-                        </div>
-                    </div>
-                </div>
-                <div class="controls">
-                    <h6>Controls</h6>
-                    <button class="btn" (click)="toggleNav()">Toggle Nav</button>
-                    <button class="btn" (click)="toggleGroup()">Toggle Group</button>
-                </div>
-
-                <clr-alert [clrAlertType]="'alert-danger'" [clrAlertClosable]="false" *ngIf="option === 'text'">
-                    <div class="alert-item">
-                        <span class="alert-text">
-                            Lazy Loading + Nav Group parent text (instead of parent links)
-                            will not highlight when a child route is active and the nav group is collapsed.
-                            If you don't have a nav group parent link we recommend that you do not use lazy loading.
-                        </span>
-                    </div>
-                </clr-alert>
-
-                <clr-alert [clrAlertType]="'alert-info'" [clrAlertClosable]="false" *ngIf="option === 'lazyText'">
-                    <div class="alert-item">
-                        <span class="alert-text">
-                            Lazy Loading can work with Nav Group Text but we have to provide a hidden/empty link
-                            which is used to detect the parent route and mark the nav group as active when collapsed.
-                        </span>
-                    </div>
-                </clr-alert>
-
-                <router-outlet></router-outlet>
-            </div>
             <clr-vertical-nav *ngIf="option === 'link'"
                               [clrVerticalNavCollapsible]="true"
                               [clrVerticalNavCollapsed]="navCollapsed"
@@ -214,7 +169,6 @@
                 </clr-vertical-nav>
             </ng-container>
 
-
             <ng-container *ngIf="option === 'lazyText'">
                 <clr-vertical-nav
                     [clrVerticalNavCollapsible]="true"
@@ -286,6 +240,51 @@
 
                 </clr-vertical-nav>
             </ng-container>
+            <div class="content-area">
+                <div class="example-options">
+                    <h6>Options</h6>
+                    <div class="btn-group">
+                        <div class="radio btn">
+                            <input type="radio" name="vertNavRadios" id="rad1" [(ngModel)]="option" value="link">
+                            <label for="rad1">Nav Group Link</label>
+                        </div>
+                        <div class="radio btn">
+                            <input type="radio" name="vertNavRadios" id="rad2" [(ngModel)]="option" value="text">
+                            <label for="rad2">Nav Group Text</label>
+                        </div>
+                        <div class="radio btn">
+                            <input type="radio" name="vertNavRadios" id="rad3" [(ngModel)]="option" value="lazyText">
+                            <label for="rad3">Nav Group Text + Lazy Loading</label>
+                        </div>
+                    </div>
+                </div>
+                <div class="controls">
+                    <h6>Controls</h6>
+                    <button class="btn" (click)="toggleNav()">Toggle Nav</button>
+                    <button class="btn" (click)="toggleGroup()">Toggle Group</button>
+                </div>
+
+                <clr-alert [clrAlertType]="'alert-danger'" [clrAlertClosable]="false" *ngIf="option === 'text'">
+                    <div class="alert-item">
+                        <span class="alert-text">
+                            Lazy Loading + Nav Group parent text (instead of parent links)
+                            will not highlight when a child route is active and the nav group is collapsed.
+                            If you don't have a nav group parent link we recommend that you do not use lazy loading.
+                        </span>
+                    </div>
+                </clr-alert>
+
+                <clr-alert [clrAlertType]="'alert-info'" [clrAlertClosable]="false" *ngIf="option === 'lazyText'">
+                    <div class="alert-item">
+                        <span class="alert-text">
+                            Lazy Loading can work with Nav Group Text but we have to provide a hidden/empty link
+                            which is used to detect the parent route and mark the nav group as active when collapsed.
+                        </span>
+                    </div>
+                </clr-alert>
+
+                <router-outlet></router-outlet>
+            </div>
         </div>
     </div>
 </div>

--- a/src/dev/src/app/vertical-nav/static/vertical-nav-static.demo.html
+++ b/src/dev/src/app/vertical-nav/static/vertical-nav-static.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -26,20 +26,6 @@
             </div>
         </header>
         <div class="content-container">
-            <div class="content-area">
-                <p>
-                    Content Area | {{case.title}}
-                </p>
-                <p>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum dignissim
-                    eget massa sit amet feugiat. Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat
-                    vitae sem at, tincidunt elementum magna. Phasellus tristique posuere dui, ut tempus felis sagittis
-                    quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus interdum semper velit eget gravida.
-                    Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie cursus, sapien purus
-                    volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat purus
-                    non, imperdiet ipsum.
-                </p>
-            </div>
             <div class="clr-vertical-nav"
                  [class.has-nav-groups]="hasNestedChildren(case.items)"
                  [class.has-icons]="case.hasIcons">
@@ -80,6 +66,20 @@
 
                     </ng-container>
                 </div>
+            </div>
+            <div class="content-area">
+                <p>
+                    Content Area | {{case.title}}
+                </p>
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu odio nisi. Vestibulum dignissim
+                    eget massa sit amet feugiat. Quisque auctor mattis quam eu suscipit. Morbi ipsum risus, feugiat
+                    vitae sem at, tincidunt elementum magna. Phasellus tristique posuere dui, ut tempus felis sagittis
+                    quis. Integer iaculis ultrices elit, sed venenatis eros. Vivamus interdum semper velit eget gravida.
+                    Sed finibus eget lacus sed semper. Suspendisse fringilla, tellus in molestie cursus, sapien purus
+                    volutpat lacus, eget venenatis erat est vitae libero. Aliquam et orci hendrerit, consequat purus
+                    non, imperdiet ipsum.
+                </p>
             </div>
         </div>
     </div>

--- a/src/dev/src/app/vertical-nav/unstructured-routes/unstructured-routes.html
+++ b/src/dev/src/app/vertical-nav/unstructured-routes/unstructured-routes.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -25,36 +25,6 @@
             </div>
         </header>
         <div class="content-container">
-            <div class="content-area">
-                <div class="example-options">
-                    <h6>Options</h6>
-                    <div class="btn-group">
-                        <div class="radio btn">
-                            <input type="radio" name="vertNavRadios" id="rad1" [(ngModel)]="option" value="lazy">
-                            <label for="rad1">Lazy Loading</label>
-                        </div>
-                        <div class="radio btn">
-                            <input type="radio" name="vertNavRadios" id="rad2" [(ngModel)]="option" value="no-lazy">
-                            <label for="rad2">No Lazy Loading</label>
-                        </div>
-                    </div>
-                </div>
-                <div class="controls">
-                    <h6>Controls</h6>
-                    <button class="btn" (click)="toggleNav()">Toggle Nav</button>
-                    <button class="btn" (click)="toggleGroup()">Toggle Group</button>
-                </div>
-                <clr-alert [clrAlertType]="'alert-danger'" [clrAlertClosable]="false" *ngIf="option === 'lazy'">
-                    <div class="alert-item">
-                        <span class="alert-text">
-                            Lazy Loading + Unstructured Routes
-                            will not highlight when a child route is active and the nav group is collapsed.
-                            If you don't have structured routes we recommend that you do not use lazy loading.
-                        </span>
-                    </div>
-                </clr-alert>
-                <router-outlet></router-outlet>
-            </div>
             <clr-vertical-nav *ngIf="option === 'lazy'"
                               [clrVerticalNavCollapsible]="true"
                               [clrVerticalNavCollapsed]="navCollapsed"
@@ -131,7 +101,6 @@
 
             </clr-vertical-nav>
 
-
             <clr-vertical-nav *ngIf="option === 'no-lazy'"
                               [clrVerticalNavCollapsible]="true"
                               [clrVerticalNavCollapsed]="navCollapsed"
@@ -204,6 +173,36 @@
                 </a>
 
             </clr-vertical-nav>
+            <div class="content-area">
+                <div class="example-options">
+                    <h6>Options</h6>
+                    <div class="btn-group">
+                        <div class="radio btn">
+                            <input type="radio" name="vertNavRadios" id="rad1" [(ngModel)]="option" value="lazy">
+                            <label for="rad1">Lazy Loading</label>
+                        </div>
+                        <div class="radio btn">
+                            <input type="radio" name="vertNavRadios" id="rad2" [(ngModel)]="option" value="no-lazy">
+                            <label for="rad2">No Lazy Loading</label>
+                        </div>
+                    </div>
+                </div>
+                <div class="controls">
+                    <h6>Controls</h6>
+                    <button class="btn" (click)="toggleNav()">Toggle Nav</button>
+                    <button class="btn" (click)="toggleGroup()">Toggle Group</button>
+                </div>
+                <clr-alert [clrAlertType]="'alert-danger'" [clrAlertClosable]="false" *ngIf="option === 'lazy'">
+                    <div class="alert-item">
+                        <span class="alert-text">
+                            Lazy Loading + Unstructured Routes
+                            will not highlight when a child route is active and the nav group is collapsed.
+                            If you don't have structured routes we recommend that you do not use lazy loading.
+                        </span>
+                    </div>
+                </clr-alert>
+                <router-outlet></router-outlet>
+            </div>
         </div>
     </div>
 </div>

--- a/src/dev/src/app/vertical-nav/without-expanded-directive/without-expanded-directive.html
+++ b/src/dev/src/app/vertical-nav/without-expanded-directive/without-expanded-directive.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -25,27 +25,6 @@
             </div>
         </header>
         <div class="content-container">
-            <div class="content-area">
-                <div class="example-options">
-                    <h6>Options</h6>
-                    <div class="btn-group">
-                        <div class="radio btn">
-                            <input type="radio" name="vertNavRadios" id="rad1" [(ngModel)]="option" value="text">
-                            <label for="rad1">Nav Group Text</label>
-                        </div>
-                        <div class="radio btn">
-                            <input type="radio" name="vertNavRadios" id="rad2" [(ngModel)]="option" value="link">
-                            <label for="rad2">Nav Group Link</label>
-                        </div>
-                    </div>
-                </div>
-                <div class="example-controls">
-                    <h6>Controls</h6>
-                    <button class="btn" (click)="toggleNav()">Toggle Nav</button>
-                    <button class="btn" (click)="toggleGroup()">Toggle Group</button>
-                </div>
-                <router-outlet></router-outlet>
-            </div>
             <clr-vertical-nav *ngIf="option === 'link'"
                               [clrVerticalNavCollapsible]="true"
                               [clrVerticalNavCollapsed]="navCollapsed"
@@ -119,7 +98,6 @@
 
             </clr-vertical-nav>
 
-
             <clr-vertical-nav *ngIf="option === 'text'"
                               [clrVerticalNavCollapsible]="true"
                               [clrVerticalNavCollapsed]="navCollapsed"
@@ -180,6 +158,27 @@
                 </a>
 
             </clr-vertical-nav>
+            <div class="content-area">
+                <div class="example-options">
+                    <h6>Options</h6>
+                    <div class="btn-group">
+                        <div class="radio btn">
+                            <input type="radio" name="vertNavRadios" id="rad1" [(ngModel)]="option" value="text">
+                            <label for="rad1">Nav Group Text</label>
+                        </div>
+                        <div class="radio btn">
+                            <input type="radio" name="vertNavRadios" id="rad2" [(ngModel)]="option" value="link">
+                            <label for="rad2">Nav Group Link</label>
+                        </div>
+                    </div>
+                </div>
+                <div class="example-controls">
+                    <h6>Controls</h6>
+                    <button class="btn" (click)="toggleNav()">Toggle Nav</button>
+                    <button class="btn" (click)="toggleGroup()">Toggle Group</button>
+                </div>
+                <router-outlet></router-outlet>
+            </div>
         </div>
     </div>
 </div>

--- a/src/ks-app/src/app/containers/nav/vertical-nav.component.html
+++ b/src/ks-app/src/app/containers/nav/vertical-nav.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -27,51 +27,6 @@
       </div>
     </header>
     <div class="content-container">
-      <div class="content-area">
-        <div class="example-options">
-          <h6>Options</h6>
-          <div class="btn-group">
-            <div class="radio btn">
-              <input type="radio" name="vertNavRadios" id="rad1" [(ngModel)]="option" value="link">
-              <label for="rad1">Nav Group Link</label>
-            </div>
-            <div class="radio btn">
-              <input type="radio" name="vertNavRadios" id="rad2" [(ngModel)]="option" value="text">
-              <label for="rad2">Nav Group Text</label>
-            </div>
-            <div class="radio btn">
-              <input type="radio" name="vertNavRadios" id="rad3" [(ngModel)]="option" value="lazyText">
-              <label for="rad3">Nav Group Text + Lazy Loading</label>
-            </div>
-          </div>
-        </div>
-        <div class="controls">
-          <h6>Controls</h6>
-          <button class="btn" (click)="toggleNav()">Toggle Nav</button>
-          <button class="btn" (click)="toggleGroup()">Toggle Group</button>
-        </div>
-
-        <clr-alert [clrAlertType]="'alert-danger'" [clrAlertClosable]="false" *ngIf="option === 'text'">
-          <div class="alert-item">
-                        <span class="alert-text">
-                            Lazy Loading + Nav Group parent text (instead of parent links)
-                            will not highlight when a child route is active and the nav group is collapsed.
-                            If you don't have a nav group parent link we recommend that you do not use lazy loading.
-                        </span>
-          </div>
-        </clr-alert>
-
-        <clr-alert [clrAlertType]="'alert-info'" [clrAlertClosable]="false" *ngIf="option === 'lazyText'">
-          <div class="alert-item">
-                        <span class="alert-text">
-                            Lazy Loading can work with Nav Group Text but we have to provide a hidden/empty link
-                            which is used to detect the parent route and mark the nav group as active when collapsed.
-                        </span>
-          </div>
-        </clr-alert>
-
-        <router-outlet></router-outlet>
-      </div>
       <clr-vertical-nav *ngIf="option === 'link'"
                         [clrVerticalNavCollapsible]="true"
                         [clrVerticalNavCollapsed]="navCollapsed"
@@ -216,7 +171,6 @@
         </clr-vertical-nav>
       </ng-container>
 
-
       <ng-container *ngIf="option === 'lazyText'">
         <clr-vertical-nav
           [clrVerticalNavCollapsible]="true"
@@ -288,6 +242,51 @@
 
         </clr-vertical-nav>
       </ng-container>
+      <div class="content-area">
+        <div class="example-options">
+          <h6>Options</h6>
+          <div class="btn-group">
+            <div class="radio btn">
+              <input type="radio" name="vertNavRadios" id="rad1" [(ngModel)]="option" value="link">
+              <label for="rad1">Nav Group Link</label>
+            </div>
+            <div class="radio btn">
+              <input type="radio" name="vertNavRadios" id="rad2" [(ngModel)]="option" value="text">
+              <label for="rad2">Nav Group Text</label>
+            </div>
+            <div class="radio btn">
+              <input type="radio" name="vertNavRadios" id="rad3" [(ngModel)]="option" value="lazyText">
+              <label for="rad3">Nav Group Text + Lazy Loading</label>
+            </div>
+          </div>
+        </div>
+        <div class="controls">
+          <h6>Controls</h6>
+          <button class="btn" (click)="toggleNav()">Toggle Nav</button>
+          <button class="btn" (click)="toggleGroup()">Toggle Group</button>
+        </div>
+
+        <clr-alert [clrAlertType]="'alert-danger'" [clrAlertClosable]="false" *ngIf="option === 'text'">
+          <div class="alert-item">
+                        <span class="alert-text">
+                            Lazy Loading + Nav Group parent text (instead of parent links)
+                            will not highlight when a child route is active and the nav group is collapsed.
+                            If you don't have a nav group parent link we recommend that you do not use lazy loading.
+                        </span>
+          </div>
+        </clr-alert>
+
+        <clr-alert [clrAlertType]="'alert-info'" [clrAlertClosable]="false" *ngIf="option === 'lazyText'">
+          <div class="alert-item">
+                        <span class="alert-text">
+                            Lazy Loading can work with Nav Group Text but we have to provide a hidden/empty link
+                            which is used to detect the parent route and mark the nav group as active when collapsed.
+                        </span>
+          </div>
+        </clr-alert>
+
+        <router-outlet></router-outlet>
+      </div>
     </div>
   </div>
 </div>

--- a/src/website/src/app/documentation/demos/sidenav/sidenav.html
+++ b/src/website/src/app/documentation/demos/sidenav/sidenav.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -12,14 +12,6 @@
             </div>
         </header>
         <div class="content-container">
-            <div class="content-area">
-                <p>
-                    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tempora eligendi quos unde id optio culpa, illo perspiciatis laboriosam explicabo in voluptate incidunt est beatae rerum quisquam accusantium corporis reiciendis delectus!
-                </p>
-                <p>
-                    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Animi nisi ad, minus fuga neque voluptatibus quidem libero ducimus quas ipsa eveniet explicabo voluptates sunt error! Eligendi a, animi consequatur odit.
-                </p>
-            </div>
             <nav class="sidenav">
                 <section class="sidenav-content">
                     <a href="javascript://" class="nav-link active">
@@ -50,6 +42,14 @@
                     </section>
                 </section>
             </nav>
+            <div class="content-area">
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tempora eligendi quos unde id optio culpa, illo perspiciatis laboriosam explicabo in voluptate incidunt est beatae rerum quisquam accusantium corporis reiciendis delectus!
+                </p>
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Animi nisi ad, minus fuga neque voluptatibus quidem libero ducimus quas ipsa eveniet explicabo voluptates sunt error! Eligendi a, animi consequatur odit.
+                </p>
+            </div>
         </div>
     </div>
 </div>

--- a/src/website/src/app/documentation/demos/sidenav/sidenav.ts
+++ b/src/website/src/app/documentation/demos/sidenav/sidenav.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -11,9 +11,6 @@ const EXAMPLE = `
         ...
     </header>
     <div class="content-container">
-        <div class="content-area">
-            ...
-        </div>
         <nav class="sidenav">
             <section class="sidenav-content">
                 <a href="..." class="nav-link active">
@@ -44,6 +41,9 @@ const EXAMPLE = `
                 </section>
             </section>
         </nav>
+        <div class="content-area">
+            ...
+        </div>
     </div>
 </div>
 `;

--- a/src/website/src/app/documentation/demos/vertical-nav/basic-nav-usage/basic-nav-usage.html
+++ b/src/website/src/app/documentation/demos/vertical-nav/basic-nav-usage/basic-nav-usage.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -31,8 +31,6 @@
             </ul>
         </nav>
         <div class="content-container">
-            <div class="content-area">
-            </div>
             <clr-vertical-nav>
                 <a clrVerticalNavLink href="javascript://">Snorlax</a>
                 <a clrVerticalNavLink href="javascript://" class="active">Jigglypuff</a>
@@ -44,6 +42,8 @@
                 <a clrVerticalNavLink href="javascript://">Jolteon</a>
                 <a clrVerticalNavLink href="javascript://">Raichu</a>
             </clr-vertical-nav>
+            <div class="content-area">
+            </div>
         </div>
     </div>
 </div>

--- a/src/website/src/app/documentation/demos/vertical-nav/basic-nav/basic-nav.html
+++ b/src/website/src/app/documentation/demos/vertical-nav/basic-nav/basic-nav.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -15,16 +15,6 @@
             </div>
         </header>
         <div class="content-container">
-            <div class="content-area">
-                <h2>Jiggypuff</h2>
-                <p>
-                    Jigglypuff is a round, pink ball with pointed ears and large, blue eyes. It has rubbery,
-                    balloon-like skin and small, stubby arms and somewhat long feet. On top of its head is a curled tuft
-                    of fur. As seen in Pokémon Stadium, it is filled with air, as a defeated Jigglypuff, deflates until
-                    it is flat. By drawing extra air into its body, it is able to float as demonstrated in Super Smash
-                    Bros.
-                </p>
-            </div>
             <clr-vertical-nav>
                 <a clrVerticalNavLink href="javascript://">Snorlax</a>
                 <a clrVerticalNavLink href="javascript://" class="active">Jigglypuff</a>
@@ -36,6 +26,16 @@
                 <a clrVerticalNavLink href="javascript://">Jolteon</a>
                 <a clrVerticalNavLink href="javascript://">Raichu</a>
             </clr-vertical-nav>
+            <div class="content-area">
+                <h2>Jiggypuff</h2>
+                <p>
+                    Jigglypuff is a round, pink ball with pointed ears and large, blue eyes. It has rubbery,
+                    balloon-like skin and small, stubby arms and somewhat long feet. On top of its head is a curled tuft
+                    of fur. As seen in Pokémon Stadium, it is filled with air, as a defeated Jigglypuff, deflates until
+                    it is flat. By drawing extra air into its body, it is able to float as demonstrated in Super Smash
+                    Bros.
+                </p>
+            </div>
         </div>
     </div>
 </div>

--- a/src/website/src/app/documentation/demos/vertical-nav/routes/basic-structure/basic-structure.html
+++ b/src/website/src/app/documentation/demos/vertical-nav/routes/basic-structure/basic-structure.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -8,7 +8,7 @@
 
 <p>
     Use the <code class="clr-code">clr-vertical-nav</code> component to create the Vertical Nav.
-    Add the <code class="clr-code">clrVerticalNavLink</code> directive on each Nav Link in the Vertical Nav.  Use <code class="clr-code">&lt;div class="nav-divider"&gt;&lt;/div&gt;</code> to add a horizonal divider to separate logical groups.  
+    Add the <code class="clr-code">clrVerticalNavLink</code> directive on each Nav Link in the Vertical Nav.  Use <code class="clr-code">&lt;div class="nav-divider"&gt;&lt;/div&gt;</code> to add a horizonal divider to separate logical groups.
 </p>
 
 <div class="clr-example">
@@ -22,9 +22,6 @@
             </div>
         </header>
         <div class="content-container">
-            <div class="content-area">
-                <router-outlet></router-outlet>
-            </div>
             <clr-vertical-nav>
                 <a clrVerticalNavLink routerLink="./charmander" routerLinkActive="active">Charmander</a>
                 <a clrVerticalNavLink routerLink="./jigglypuff" routerLinkActive="active">Jigglypuff</a>
@@ -34,6 +31,9 @@
                 <div class="nav-divider"></div>
                 <a clrVerticalNavLink routerLink="./credit" routerLinkActive="active">Credit</a>
             </clr-vertical-nav>
+            <div class="content-area">
+                <router-outlet></router-outlet>
+            </div>
         </div>
     </div>
 </div>

--- a/src/website/src/app/documentation/demos/vertical-nav/routes/basic-structure/basic-structure.ts
+++ b/src/website/src/app/documentation/demos/vertical-nav/routes/basic-structure/basic-structure.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -11,9 +11,6 @@ const HTML_EXAMPLE = `
         ...
     </header>
     <div class="content-container">
-        <div class="content-area">
-            <router-outlet></router-outlet>
-        </div>
         <clr-vertical-nav>
             <a clrVerticalNavLink routerLink="./charmander" routerLinkActive="active">Charmander</a>
             <a clrVerticalNavLink routerLink="./jigglypuff" routerLinkActive="active">Jigglypuff</a>
@@ -23,6 +20,9 @@ const HTML_EXAMPLE = `
             <div class="nav-divider"></div>
             <a clrVerticalNavLink routerLink="./credit" routerLinkActive="active">Credit</a>
         </clr-vertical-nav>
+        <div class="content-area">
+            <router-outlet></router-outlet>
+        </div>
     </div>
 </div>
 `;

--- a/src/website/src/app/documentation/demos/vertical-nav/routes/collapsible-nav/collapsible-nav.html
+++ b/src/website/src/app/documentation/demos/vertical-nav/routes/collapsible-nav/collapsible-nav.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -23,9 +23,6 @@
             </div>
         </header>
         <div class="content-container">
-            <div class="content-area">
-                <router-outlet></router-outlet>
-            </div>
             <clr-vertical-nav [clrVerticalNavCollapsible]="collapsible" [(clrVerticalNavCollapsed)]="collapsed">
                 <a clrVerticalNavLink routerLink="./normal" routerLinkActive="active">
                     <clr-icon clrVerticalNavIcon shape="user"></clr-icon>
@@ -52,6 +49,9 @@
                     Credit
                 </a>
             </clr-vertical-nav>
+            <div class="content-area">
+                <router-outlet></router-outlet>
+            </div>
         </div>
     </div>
 </div>
@@ -74,13 +74,6 @@
             </div>
         </header>
         <div class="content-container">
-            <div class="content-area">
-                Normal
-                The Normal type is the most basic type of Pokémon.
-                They are very common and appear from the very first route you visit.
-                Most Normal Pokémon are single type, but there is a large
-                contingent having a second type of Flying.
-            </div>
             <clr-vertical-nav [clrVerticalNavCollapsible]="true" class="nav-trigger--bottom">
                 <a clrVerticalNavLink href="javascript://" class="active">
                     <clr-icon clrVerticalNavIcon shape="user"></clr-icon>
@@ -91,6 +84,13 @@
                     Electric
                 </a>
             </clr-vertical-nav>
+            <div class="content-area">
+                Normal
+                The Normal type is the most basic type of Pokémon.
+                They are very common and appear from the very first route you visit.
+                Most Normal Pokémon are single type, but there is a large
+                contingent having a second type of Flying.
+            </div>
         </div>
     </div>
 </div>

--- a/src/website/src/app/documentation/demos/vertical-nav/routes/icons/icons.html
+++ b/src/website/src/app/documentation/demos/vertical-nav/routes/icons/icons.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -22,9 +22,6 @@
             </div>
         </header>
         <div class="content-container">
-            <div class="content-area">
-                <router-outlet></router-outlet>
-            </div>
             <clr-vertical-nav>
                 <a clrVerticalNavLink routerLink="./normal" routerLinkActive="active">
                     <clr-icon clrVerticalNavIcon shape="user"></clr-icon>
@@ -51,6 +48,9 @@
                     Credit
                 </a>
             </clr-vertical-nav>
+            <div class="content-area">
+                <router-outlet></router-outlet>
+            </div>
         </div>
     </div>
 </div>

--- a/src/website/src/app/documentation/demos/vertical-nav/routes/lazy-loading-nav-groups/lazy-loading-nav-groups.html
+++ b/src/website/src/app/documentation/demos/vertical-nav/routes/lazy-loading-nav-groups/lazy-loading-nav-groups.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -23,9 +23,6 @@
             </div>
         </header>
         <div class="content-container">
-            <div class="content-area">
-                <router-outlet></router-outlet>
-            </div>
             <clr-vertical-nav [clrVerticalNavCollapsible]="demoCollapsible">
                 <clr-vertical-nav-group
                         routerLinkActive="active">
@@ -89,6 +86,9 @@
                     Credit
                 </a>
             </clr-vertical-nav>
+            <div class="content-area">
+                <router-outlet></router-outlet>
+            </div>
         </div>
     </div>
 </div>

--- a/src/website/src/app/documentation/demos/vertical-nav/routes/nav-groups-with-parent-links/nav-groups.html
+++ b/src/website/src/app/documentation/demos/vertical-nav/routes/nav-groups-with-parent-links/nav-groups.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -40,9 +40,6 @@
             </div>
         </header>
         <div class="content-container">
-            <div class="content-area">
-                <router-outlet></router-outlet>
-            </div>
             <clr-vertical-nav [clrVerticalNavCollapsible]="demoCollapsible">
                 <clr-vertical-nav-group
                         routerLinkActive="active">
@@ -115,6 +112,9 @@
                     Credit
                 </a>
             </clr-vertical-nav>
+            <div class="content-area">
+                <router-outlet></router-outlet>
+            </div>
         </div>
     </div>
 </div>

--- a/src/website/src/app/documentation/demos/vertical-nav/routes/nav-groups/nav-groups.html
+++ b/src/website/src/app/documentation/demos/vertical-nav/routes/nav-groups/nav-groups.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -32,9 +32,6 @@
             </div>
         </header>
         <div class="content-container">
-            <div class="content-area">
-                <router-outlet></router-outlet>
-            </div>
             <clr-vertical-nav [clrVerticalNavCollapsible]="demoCollapsible">
                 <clr-vertical-nav-group
                         routerLinkActive="active">
@@ -92,6 +89,9 @@
                     Credit
                 </a>
             </clr-vertical-nav>
+            <div class="content-area">
+                <router-outlet></router-outlet>
+            </div>
         </div>
     </div>
 </div>

--- a/src/website/src/app/documentation/demos/vertical-nav/routes/no-lazy-loading-with-parent-links/no-lazy-loading.html
+++ b/src/website/src/app/documentation/demos/vertical-nav/routes/no-lazy-loading-with-parent-links/no-lazy-loading.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -24,9 +24,6 @@
             </div>
         </header>
         <div class="content-container">
-            <div class="content-area">
-                <router-outlet></router-outlet>
-            </div>
             <clr-vertical-nav [clrVerticalNavCollapsible]="demoCollapsible">
                 <clr-vertical-nav-group
                         routerLinkActive="active">
@@ -99,6 +96,9 @@
                     Credit
                 </a>
             </clr-vertical-nav>
+            <div class="content-area">
+                <router-outlet></router-outlet>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
It was only a matter of element order throughout our documentation and examples.
Probably a legacy "content first" focus strategy since we didn't use "Skip to content" links.
Fixed in dev-app, ks-app and website. Website example snippets updated too.

closes #1923 

Signed-off-by: Ivan Donchev <idonchev@vmware.com>