### PR TITLE
fix(forms): remove deprecated from .clr-input elements.

### DIFF
--- a/src/clr-angular/forms/styles/_mixins.forms.scss
+++ b/src/clr-angular/forms/styles/_mixins.forms.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -69,9 +69,7 @@
 }
 
 @mixin form-fields-appearance($border-bottom-color) {
-  // @TODO: this !important is here because we have deprecated styles that are overriding our themeable color styles.
-  // Remove when deprecated forms are removed.
-  color: $clr-forms-text-color !important;
+  color: $clr-forms-text-color;
   display: inline-block;
   border-bottom: $clr-default-borderwidth solid $border-bottom-color;
 }


### PR DESCRIPTION

This removes an important css overrid that was needed for deprecated forms. 
 
Signed-off-by: Matt Hippely <mhippely@vmware.com>