### PR TITLE
[NG][WEB] Adding aria-label to datagrid-pagination

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -225,15 +225,20 @@ export declare abstract class ClrCommonStrings {
     close?: string;
     collapse?: string;
     current?: string;
+    currentPage?: string;
     danger?: string;
     expand?: string;
+    firstPage?: string;
     hide?: string;
     info?: string;
+    lastPage?: string;
     more?: string;
     next?: string;
+    nextPage?: string;
     open?: string;
     pickColumns?: string;
     previous?: string;
+    previousPage?: string;
     rowActions?: string;
     select?: string;
     selectAll?: string;
@@ -241,6 +246,7 @@ export declare abstract class ClrCommonStrings {
     showColumns?: string;
     sortColumn?: string;
     success?: string;
+    totalPages?: string;
     warning?: string;
 }
 
@@ -403,6 +409,7 @@ export declare class ClrDatagridModule {
 
 export declare class ClrDatagridPagination implements OnDestroy, OnInit {
     _pageSizeComponent: ClrDatagridPageSize;
+    commonStrings: ClrCommonStrings;
     currentChanged: EventEmitter<number>;
     currentPage: number;
     currentPageInputRef: ElementRef;
@@ -413,7 +420,7 @@ export declare class ClrDatagridPagination implements OnDestroy, OnInit {
     page: Page;
     pageSize: number;
     totalItems: number;
-    constructor(page: Page);
+    constructor(page: Page, commonStrings: ClrCommonStrings);
     next(): void;
     ngOnDestroy(): void;
     ngOnInit(): void;

--- a/src/clr-angular/data/datagrid/datagrid-pagination.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-pagination.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -9,16 +9,19 @@ import { ClrDatagridPagination } from './datagrid-pagination';
 import { TestContext } from './helpers.spec';
 import { Page } from './providers/page';
 import { StateDebouncer } from './providers/state-debouncer.provider';
+import { ClrCommonStringsService } from '../../utils/i18n/common-strings.service';
 
 export default function(): void {
   describe('ClrDatagridPagination component', function() {
     describe('Typescript API', function() {
       let pageService: Page;
       let component: ClrDatagridPagination;
+      let commonStrings: ClrCommonStringsService;
 
       beforeEach(function() {
         pageService = new Page(new StateDebouncer());
-        component = new ClrDatagridPagination(pageService);
+        commonStrings = new ClrCommonStringsService();
+        component = new ClrDatagridPagination(pageService, commonStrings);
         component.ngOnInit(); // For the subscription that will get destroyed.
       });
 
@@ -307,6 +310,38 @@ export default function(): void {
         );
 
         expect(invalidButton).toBeUndefined();
+      });
+    });
+
+    describe('Accessibility', function() {
+      // Until we can properly type "this"
+      let context: TestContext<ClrDatagridPagination, FullTest>;
+      let commonStrings: ClrCommonStringsService;
+
+      beforeEach(function() {
+        context = this.create(ClrDatagridPagination, FullTest, [Page, StateDebouncer]);
+        commonStrings = new ClrCommonStringsService();
+
+        context.testComponent.size = 10;
+        context.testComponent.total = 100;
+        context.testComponent.current = 10;
+        context.detectChanges();
+      });
+
+      it('expect buttons to have the correct aria-label from ClrCommonStringsService', function() {
+        const firstPage = context.clarityElement.querySelector('.pagination-first');
+        const lastPage = context.clarityElement.querySelector('.pagination-last');
+        const previousPage = context.clarityElement.querySelector('.pagination-previous');
+        const nextPage = context.clarityElement.querySelector('.pagination-next');
+        const currentPage = context.clarityElement.querySelector('.pagination-current');
+        const totalPages = context.clarityElement.querySelector('.pagination-list span');
+
+        expect(firstPage.attributes['aria-label'].value).toBe(commonStrings.firstPage);
+        expect(lastPage.attributes['aria-label'].value).toBe(commonStrings.lastPage);
+        expect(previousPage.attributes['aria-label'].value).toBe(commonStrings.previousPage);
+        expect(nextPage.attributes['aria-label'].value).toBe(commonStrings.nextPage);
+        expect(currentPage.attributes['aria-label'].value).toBe(commonStrings.currentPage);
+        expect(totalPages.attributes['aria-label'].value).toBe(commonStrings.totalPages);
       });
     });
   });

--- a/src/clr-angular/data/datagrid/datagrid-pagination.ts
+++ b/src/clr-angular/data/datagrid/datagrid-pagination.ts
@@ -17,6 +17,7 @@ import {
 import { Subscription } from 'rxjs';
 import { Page } from './providers/page';
 import { ClrDatagridPageSize } from './datagrid-page-size';
+import { ClrCommonStrings } from '../../utils/i18n/common-strings.interface';
 
 @Component({
   selector: 'clr-dg-pagination',
@@ -28,18 +29,51 @@ import { ClrDatagridPageSize } from './datagrid-page-size';
       <ng-content></ng-content>
     </div>
     <div class="pagination-list" *ngIf="page.last > 1">
-      <button type="button" class="pagination-first" [disabled]="page.current <= 1" (click)="page.current = 1">
+      <button
+        type="button" 
+        class="pagination-first" 
+        [disabled]="page.current <= 1" 
+        (click)="page.current = 1"
+        [attr.aria-label]="commonStrings.firstPage"
+        >
         <clr-icon shape="step-forward-2 down"></clr-icon>
       </button>
-      <button type="button" class="pagination-previous" [disabled]="page.current <= 1" (click)="page.current = page.current - 1">
+      <button 
+        type="button"
+        class="pagination-previous" 
+        [disabled]="page.current <= 1" 
+        (click)="page.current = page.current - 1"
+        [attr.aria-label]="commonStrings.previousPage"
+        >
         <clr-icon shape="angle left"></clr-icon>
       </button>
-      <input #currentPageInput type="text" class="pagination-current" [size]="page.last.toString().length" [value]="page.current"
-             (keydown.enter)="updateCurrentPage($event)" (blur)="updateCurrentPage($event)"/>&nbsp;/&nbsp;<span>{{page.last}}</span>
-      <button type="button" class="pagination-next" [disabled]="page.current >= page.last" (click)="page.current = page.current + 1">
+      <input 
+        #currentPageInput 
+        type="text" 
+        class="pagination-current" 
+        [size]="page.last.toString().length" 
+        [value]="page.current"
+        (keydown.enter)="updateCurrentPage($event)" 
+        (blur)="updateCurrentPage($event)"
+        [attr.aria-label]="commonStrings.currentPage"
+        />
+        &nbsp;/&nbsp;<span [attr.aria-label]="commonStrings.totalPages">{{page.last}}</span>
+      <button 
+        type="button"
+        class="pagination-next" 
+        [disabled]="page.current >= page.last" 
+        (click)="page.current = page.current + 1"
+        [attr.aria-label]="commonStrings.nextPage"
+        >
         <clr-icon shape="angle right"></clr-icon>
       </button>
-      <button type="button" class="pagination-last" [disabled]="page.current >= page.last" (click)="page.current = page.last">
+      <button 
+        type="button" 
+        class="pagination-last" 
+        [disabled]="page.current >= page.last" 
+        (click)="page.current = page.last"
+        [attr.aria-label]="commonStrings.lastPage"
+        >
         <clr-icon shape="step-forward-2 up"></clr-icon>
       </button>
     </div>
@@ -52,7 +86,7 @@ export class ClrDatagridPagination implements OnDestroy, OnInit {
   @ViewChild('currentPageInput', { static: false })
   currentPageInputRef: ElementRef;
 
-  constructor(public page: Page) {
+  constructor(public page: Page, public commonStrings: ClrCommonStrings) {
     this.page.activated = true;
   }
 

--- a/src/clr-angular/utils/i18n/common-strings.interface.ts
+++ b/src/clr-angular/utils/i18n/common-strings.interface.ts
@@ -93,4 +93,28 @@ export abstract class ClrCommonStrings {
    * Datagrid: sort of columns
    */
   sortColumn?: string;
+  /**
+   * Datagrid: first page
+   */
+  firstPage?: string;
+  /**
+   * Datagrid: last page
+   */
+  lastPage?: string;
+  /**
+   * Datagrid: next page
+   */
+  nextPage?: string;
+  /**
+   * Datagrid: previous page
+   */
+  previousPage?: string;
+  /**
+   * Datagrid: previous page
+   */
+  currentPage?: string;
+  /**
+   * Datagird: total pages
+   */
+  totalPages?: string;
 }

--- a/src/clr-angular/utils/i18n/common-strings.service.ts
+++ b/src/clr-angular/utils/i18n/common-strings.service.ts
@@ -31,6 +31,12 @@ export class ClrCommonStringsService implements ClrCommonStrings {
   pickColumns = 'Show or hide columns';
   showColumns = 'Show Columns';
   sortColumn = 'Sort Column';
+  firstPage = 'First Page';
+  lastPage = 'Last Page';
+  nextPage = 'Next Page';
+  previousPage = 'Previous Page';
+  currentPage = 'Current Page';
+  totalPages = 'Total Pages';
 }
 
 export function commonStringsFactory(existing?: ClrCommonStrings): ClrCommonStrings {

--- a/src/dev/src/app/i18n-a11y/common-strings.service.ts
+++ b/src/dev/src/app/i18n-a11y/common-strings.service.ts
@@ -33,4 +33,11 @@ export class CommonStringsService implements ClrCommonStrings {
   rowActions = 'Actions disponibles';
   pickColumns = 'Modifier les colonnes';
   showColumns = 'Afficher les colonnes';
+  sortColumn = 'Colonne de tri';
+  firstPage = 'Première page';
+  lastPage = 'Dernière page';
+  nextPage = 'Page suivante';
+  previousPage = 'Page précédente';
+  currentPage = 'Page actuelle';
+  totalPages = 'Pages totales';
 }

--- a/src/website/src/app/documentation/demos/i18n/i18n.demo.ts
+++ b/src/website/src/app/documentation/demos/i18n/i18n.demo.ts
@@ -40,5 +40,11 @@ export class I18nDemo extends ClarityDocComponent {
     { key: 'pickColumns', role: 'Datagrid: show and hide columns icon alt text' },
     { key: 'showColumns', role: 'Datagrid: show columns title' },
     { key: 'sortColumn', role: 'Datagrid: sort columns title' },
+    { key: 'firstPage', role: 'Datagrid: pagination first page button text' },
+    { key: 'lastPage', role: 'Datagrid: pagination last page button text' },
+    { key: 'nextPage', role: 'Datagrid: pagination next page button text' },
+    { key: 'previousPage', role: 'Datagrid: pagination previous page button text' },
+    { key: 'currentPage', role: 'Datagrid: pagination current page button text' },
+    { key: 'totalPages', role: 'Datagrid: pagination total pages button text' },
   ];
 }


### PR DESCRIPTION
Adding `aria-label` to the buttons located inside `datagrid-pagination` component

  * Adding `[attr.aria-label]` to buttons to display proper action 
  * Update the documentation for `CommonStringsService`
  * Adding translated examples for `i18n` demo in French
  * Adding Unittest for the new `aria-label` attributes

The correct way of changing the value of the `[attr.aria-label]` is by extending and overwriting the `CommonStringsService`  [Internationalization  Documentation](https://clarity.design/documentation/internationalization)

Close #3189 