### PR TITLE
[WEB] Backport the Internationalization documentation to V1

### DIFF
--- a/src/website/src/app/documentation/demos/i18n/i18n.demo.html
+++ b/src/website/src/app/documentation/demos/i18n/i18n.demo.html
@@ -1,0 +1,75 @@
+<!--
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<clr-doc-wrapper [ng]="ng" [ui]="ui" [title]="title" [newLayout]="newLayout">
+    <article>
+        <h5 class="component-summary" id="summary">Easily translate internal Clarity text into multiple languages.</h5>
+        <div >
+            <h3 id="design-guidelines">Internal language strings</h3>
+
+            <p>Clarity has a short list of text strings that it uses internally for things such as icon alt text or button text. When possible, Clarity avoids
+              using text strings that have to be translated, and rarely changes this list. Any Angular application that needs to support multiple languages
+              can create a different translation and use it for each language.</p>
+
+          <p>
+            In order to improve accessibility of its components, Clarity added a default English title to all icons
+            or non-text interactive elements internal to its components. In order to internationalize them we rely on a
+            <code class="clr-code">ClrCommonStrings</code> service that you can declare for your entire app, which will override
+            our default titles with the ones you provide. Then you just need to include it as a provider in your application.
+          </p>
+        <h3 id="examples">Examples</h3>
+
+          <pre><code clr-code-highlight="language-ts" ngNonBindable>
+@Injectable()
+export class MyCommonStringsService implements ClrCommonStrings &#123;
+  open = 'abra';
+&#125;
+</code></pre>
+          <pre><code clr-code-highlight="language-ts" ngNonBindable>
+@NgModule(&#123;
+  imports: [...],
+  declarations: [...],
+  providers: [&#123; provide: ClrCommonStrings, useClass: MyCommonStringsService &#125;]
+&#125;)
+export class AppModule &#123;&#125;
+</code></pre>
+          <p>
+            The list of strings available to configure can be found by simply looking at the declaration of the
+            <code class="clr-code">ClrCommonStrings</code> interface, which is found below.
+          </p>
+          <table class="table">
+            <thead>
+              <tr>
+                <th class="left">Property name</th>
+                <th class="left">Purpose</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let string of strings">
+                <td class="left">{{string.key}}</td>
+                <td class="left">{{string.role}}</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <p>You might also load your strings from an external service, which you would do something like the following service implementation.
+            This would fetch the strings and replace them in the service at runtime, just substitute the server service with your own.</p>
+
+<pre><code clr-code-highlight="language-ts" ngNonBindable>
+@Injectable()
+export class MyCommonStringsService implements ClrCommonStrings &#123;
+  constructor(@Inject(LOCALE_ID) locale: string, server: MyServer) &#123;
+    server.fetchTexts(locale).subscribe(texts =&gt; &#123;
+      // Assign the strings to the correct properties to implement ClrCommonStrings
+      this.open = texts.genericOpenText;
+      ...
+    &#125;);
+  &#125;
+&#125;
+</code></pre>
+        </div>
+    </article>
+</clr-doc-wrapper>

--- a/src/website/src/app/documentation/demos/i18n/i18n.demo.module.ts
+++ b/src/website/src/app/documentation/demos/i18n/i18n.demo.module.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ClarityModule } from '@clr/angular';
+
+import { DocWrapperModule } from '../_doc-wrapper/doc-wrapper.module';
+import { I18nDemo } from './i18n.demo';
+import { RouterModule } from '@angular/router';
+import { UtilsModule } from '../../../utils/utils.module';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ClarityModule,
+    DocWrapperModule,
+    UtilsModule,
+    RouterModule.forChild([{ path: '', component: I18nDemo }]),
+  ],
+  declarations: [I18nDemo],
+  exports: [I18nDemo],
+})
+export class I18nDemoModule {}

--- a/src/website/src/app/documentation/demos/i18n/i18n.demo.ts
+++ b/src/website/src/app/documentation/demos/i18n/i18n.demo.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import { Component } from '@angular/core';
+import { ClarityDocComponent } from '../clarity-doc';
+
+@Component({
+  templateUrl: './i18n.demo.html',
+  host: {
+    '[class.content-area]': 'true',
+    '[class.dox-content-panel]': 'true',
+  },
+})
+export class I18nDemo extends ClarityDocComponent {
+  newLayout = true;
+  constructor() {
+    super('internationalization');
+  }
+
+  // List of the string keys and what they mean
+  strings = [
+    { key: 'open', role: 'Open button text' },
+    { key: 'close', role: 'Close button text' },
+    { key: 'show', role: 'Show button text' },
+    { key: 'hide', role: 'Hide button text' },
+    { key: 'expand', role: 'Expandable components: expand caret' },
+    { key: 'collapse', role: 'Expandable components: collapse caret' },
+    { key: 'more', role: 'Overflow menus: ellipsis button' },
+    { key: 'select', role: 'Selectable components: checkbox or radio' },
+    { key: 'selectAll', role: 'Selectable components: checkbox to select all' },
+    { key: 'previous', role: 'Pagination: previous button' },
+    { key: 'next', role: 'Pagination: next button' },
+    { key: 'current', role: 'Pagination: go to current' },
+    { key: 'info', role: 'Alert levels: info' },
+    { key: 'success', role: 'Alert levels: success' },
+    { key: 'warning', role: 'Alert levels: warning' },
+    { key: 'danger', role: 'Alert levels: danger' },
+    { key: 'rowActions', role: 'Datagrid: row actions icon alt text' },
+    { key: 'pickColumns', role: 'Datagrid: show and hide columns icon alt text' },
+    { key: 'showColumns', role: 'Datagrid: show columns title' },
+    { key: 'sortColumn', role: 'Datagrid: sort columns title' },
+    { key: 'firstPage', role: 'Datagrid: pagination first page button text' },
+    { key: 'lastPage', role: 'Datagrid: pagination last page button text' },
+    { key: 'nextPage', role: 'Datagrid: pagination next page button text' },
+    { key: 'previousPage', role: 'Datagrid: pagination previous page button text' },
+    { key: 'currentPage', role: 'Datagrid: pagination current page button text' },
+    { key: 'totalPages', role: 'Datagrid: pagination total pages button text' },
+    { key: 'minValue', role: 'Datagrid: minimum value (numeric filters)' },
+    { key: 'maxValue', role: 'Datagrid: maximum value (numeric filters' },
+  ];
+}

--- a/src/website/src/app/documentation/documentation-routing.module.ts
+++ b/src/website/src/app/documentation/documentation-routing.module.ts
@@ -151,6 +151,14 @@ const documentationRoutes: Routes = [
         },
       },
       {
+        path: 'internationalization',
+        loadChildren: 'src/app/documentation/demos/i18n/i18n.demo.module#I18nDemoModule',
+        data: {
+          bodyClass: 'i18n',
+          browserTitle: 'Internationalization',
+        },
+      },
+      {
         path: 'labels',
         loadChildren: 'src/app/documentation/demos/labels/labels.demo.module#LabelsDemoModule',
         data: {

--- a/src/website/src/settings/componentlist.json
+++ b/src/website/src/settings/componentlist.json
@@ -184,6 +184,16 @@
       "newLayout": true
     },
     {
+      "url": "internationalization",
+      "text": "Internationalization",
+      "type": "pattern",
+      "ux": 20,
+      "ui": 20,
+      "core": -1,
+      "ng": 20,
+      "dox": 20
+    },
+    {
       "url": "labels",
       "text": "Labels",
       "type": "component",


### PR DESCRIPTION
Backporting the Internationalization documentation from v2 to v1 under Patterns.

![Screen Shot 2019-06-11 at 8 27 17 PM](https://user-images.githubusercontent.com/204564/59293184-57061200-8c87-11e9-9cee-7dd5bbde115b.png)
