### PR TITLE
[ng] add aria-disabled and role separator to dropdown menu

### DIFF
--- a/src/clr-angular/popover/dropdown/dropdown-item.spec.ts
+++ b/src/clr-angular/popover/dropdown/dropdown-item.spec.ts
@@ -38,6 +38,13 @@ export default function(): void {
       expect(this.clarityElement.getAttribute('role')).toBe('menuitem');
     });
 
+    it('sets aria-disabled to true if the FocusableItem is disabled', function(this: Context) {
+      expect(this.clarityElement.getAttribute('aria-disabled')).toBe('false');
+      this.hostComponent.disabled = true;
+      this.detectChanges();
+      expect(this.clarityElement.getAttribute('aria-disabled')).toBe('true');
+    });
+
     it('updates the disabled property of the FocusableItem', function(this: Context) {
       this.hostComponent.disabled = true;
       this.detectChanges();

--- a/src/clr-angular/popover/dropdown/dropdown-item.ts
+++ b/src/clr-angular/popover/dropdown/dropdown-item.ts
@@ -15,6 +15,7 @@ import { RootDropdownService } from './providers/dropdown.service';
   host: {
     '[class.dropdown-item]': 'true',
     '[attr.role]': '"menuitem"',
+    '[attr.aria-disabled]': 'disabled',
   },
   providers: [BASIC_FOCUSABLE_ITEM_PROVIDER],
 })
@@ -33,6 +34,10 @@ export class ClrDropdownItem implements AfterViewInit {
   set disabled(value: boolean | string) {
     // Empty string attribute evaluates to false but should disable the item, so we need to add a special case for it.
     this.focusableItem.disabled = !!value || value === '';
+  }
+
+  get disabled() {
+    return this.focusableItem.disabled;
   }
 
   ngAfterViewInit() {

--- a/src/clr-angular/popover/dropdown/providers/dropdown-focus-handler.service.ts
+++ b/src/clr-angular/popover/dropdown/providers/dropdown-focus-handler.service.ts
@@ -97,6 +97,8 @@ export class DropdownFocusHandler implements FocusableItem {
       this.renderer.setAttribute(el, 'tabindex', '-1');
     } else {
       // The root trigger is the only one outside of the menu, so it needs to its own key listeners.
+      this.renderer.listen(el, 'keydown.arrowup', event => this.ifOpenService.toggleWithEvent(event));
+      this.renderer.listen(el, 'keydown.arrowdown', event => this.ifOpenService.toggleWithEvent(event));
       this.focusService.listenToArrowKeys(el);
     }
   }

--- a/src/clr-angular/popover/dropdown/providers/dropdown-focus-handler.spec.ts
+++ b/src/clr-angular/popover/dropdown/providers/dropdown-focus-handler.spec.ts
@@ -83,6 +83,24 @@ export default function(): void {
         expect(this.trigger.getAttribute('id')).toBe(id);
       });
 
+      it('toggles open when arrow up or down on the trigger', function(this: TestContext) {
+        fakeAsync(function(this: TestContext) {
+          expect(this.ifOpenService.open).toBeFalsy();
+          this.focusHandler.trigger = this.trigger;
+
+          this.focusHandler.trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'arrowup' }));
+          expect(this.ifOpenService.open).toBeTruthy();
+
+          //once open, the up/down arrow keys control the focus on menu items, so we close again for the next test
+          this.ifOpenService.open = false;
+          tick();
+          expect(this.ifOpenService.open).toBeFalsy();
+
+          this.focusHandler.trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'arrowdown' }));
+          expect(this.ifOpenService.open).toBeTruthy();
+        });
+      });
+
       it('listens to arrow keys on the trigger', function(this: TestContext) {
         const spy = spyOn(this.focusService, 'listenToArrowKeys');
         this.focusHandler.trigger = this.trigger;

--- a/src/clr-angular/utils/focus/focus.service.spec.ts
+++ b/src/clr-angular/utils/focus/focus.service.spec.ts
@@ -130,6 +130,12 @@ export default function(): void {
         expect(spy).toHaveBeenCalledWith(target);
       });
 
+      it('does not move focus to another item if current is undefined', function(this: TestContext) {
+        const spy = spyOn(this.focusService, 'moveTo');
+        this.focusService.move(ArrowKeyDirection.DOWN, undefined);
+        expect(spy).not.toHaveBeenCalled();
+      });
+
       it('waits for the next item if it is an Observable', function(this: TestContext) {
         const first = new MockFocusableItem('1');
         const second = new MockFocusableItem('2');

--- a/src/clr-angular/utils/focus/focus.service.ts
+++ b/src/clr-angular/utils/focus/focus.service.ts
@@ -57,19 +57,21 @@ export class FocusService {
    * The second parameter, optional, is here to allow recursion to skip disabled items.
    */
   move(direction: ArrowKeyDirection, current = this.current) {
-    const next = current[direction];
-    if (next) {
-      // Turning the value into an Observable isn't great, but it's the fastest way to avoid code duplication.
-      // If performance ever matters for this, we can refactor using additional private methods.
-      const nextObs = isObservable(next) ? next : of(next);
-      nextObs.subscribe(item => {
-        if (item.disabled) {
-          return this.move(direction, item);
-        } else {
-          this.moveTo(item);
-          return true;
-        }
-      });
+    if (current) {
+      const next = current[direction];
+      if (next) {
+        // Turning the value into an Observable isn't great, but it's the fastest way to avoid code duplication.
+        // If performance ever matters for this, we can refactor using additional private methods.
+        const nextObs = isObservable(next) ? next : of(next);
+        nextObs.subscribe(item => {
+          if (item.disabled) {
+            return this.move(direction, item);
+          } else {
+            this.moveTo(item);
+            return true;
+          }
+        });
+      }
     }
     return false;
   }

--- a/src/dev/src/app/dropdown/dropdown-angular-nested.demo.html
+++ b/src/dev/src/app/dropdown/dropdown-angular-nested.demo.html
@@ -14,7 +14,7 @@
         <clr-dropdown-menu>
             <label class="dropdown-header">Dropdown header</label>
             <a href="javascript://" clrDropdownItem>Action 1</a>
-            <a href="javascript://" class="disabled" clrDropdownItem>Disabled Action</a>
+            <a href="javascript://" class="disabled" clrDropdownItem disabled>Disabled Action</a>
             <div class="dropdown-divider"></div>
             <clr-dropdown>
                 <button clrDropdownTrigger [id]="'sub-menu-1'">Link 1</button>
@@ -42,7 +42,7 @@
         <clr-dropdown-menu *clrIfOpen>
             <label class="dropdown-header">Dropdown header</label>
             <a href="javascript://" clrDropdownItem>Action 1</a>
-            <a href="javascript://" class="disabled" clrDropdownItem>Disabled Action</a>
+            <a href="javascript://" class="disabled" clrDropdownItem disabled>Disabled Action</a>
             <div class="dropdown-divider"></div>
             <clr-dropdown>
                 <button clrDropdownTrigger [id]="'sub-menu-3'">Link 1</button>

--- a/src/dev/src/app/dropdown/dropdown-angular-positioning.demo.html
+++ b/src/dev/src/app/dropdown/dropdown-angular-positioning.demo.html
@@ -17,8 +17,8 @@
                 <label class="dropdown-header">Dropdown header</label>
                 <a href="javascript://" clrDropdownItem>Action 1</a>
                 <a href="javascript://" clrDropdownItem>Action 2</a>
-                <a href="javascript://" class="disabled" clrDropdownItem>Disabled Action</a>
-                <div class="dropdown-divider"></div>
+                <a href="javascript://" class="disabled" clrDropdownItem disabled>Disabled Action</a>
+                <div class="dropdown-divider" role="separator"></div>
                 <a href="javascript://" clrDropdownItem>Link 1</a>
                 <a href="javascript://" clrDropdownItem>Link 2</a>
             </clr-dropdown-menu>
@@ -32,8 +32,8 @@
                 <label class="dropdown-header">Dropdown header</label>
                 <a href="javascript://" clrDropdownItem>Action 1</a>
                 <a href="javascript://" clrDropdownItem>Action 2</a>
-                <a href="javascript://" class="disabled" clrDropdownItem>Disabled Action</a>
-                <div class="dropdown-divider"></div>
+                <a href="javascript://" class="disabled" clrDropdownItem disabled>Disabled Action</a>
+                <div class="dropdown-divider" role="separator"></div>
                 <a href="javascript://" clrDropdownItem>Link 1</a>
                 <a href="javascript://" clrDropdownItem>Link 2</a>
             </clr-dropdown-menu>
@@ -50,8 +50,8 @@
                 <label class="dropdown-header">Dropdown header</label>
                 <a href="javascript://" clrDropdownItem>Action 1</a>
                 <a href="javascript://" clrDropdownItem>Action 2</a>
-                <a href="javascript://" class="disabled" clrDropdownItem>Disabled Action</a>
-                <div class="dropdown-divider"></div>
+                <a href="javascript://" class="disabled" clrDropdownItem disabled>Disabled Action</a>
+                <div class="dropdown-divider" role="separator"></div>
                 <a href="javascript://" clrDropdownItem>Link 1</a>
                 <a href="javascript://" clrDropdownItem>Link 2</a>
             </clr-dropdown-menu>
@@ -65,8 +65,8 @@
                 <label class="dropdown-header">Dropdown header</label>
                 <a href="javascript://" clrDropdownItem>Action 1</a>
                 <a href="javascript://" clrDropdownItem>Action 2</a>
-                <a href="javascript://" class="disabled" clrDropdownItem>Disabled Action</a>
-                <div class="dropdown-divider"></div>
+                <a href="javascript://" class="disabled" clrDropdownItem disabled>Disabled Action</a>
+                <div class="dropdown-divider" role="separator"></div>
                 <a href="javascript://" clrDropdownItem>Link 1</a>
                 <a href="javascript://" clrDropdownItem>Link 2</a>
             </clr-dropdown-menu>

--- a/src/website/src/app/documentation/demos/dropdown/dropdown-angular-close-item-false.ts
+++ b/src/website/src/app/documentation/demos/dropdown/dropdown-angular-close-item-false.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -15,7 +15,7 @@ const HTML_EXAMPLE = `
         <label class="dropdown-header">Dropdown header</label>
         <button type="button" clrDropdownItem>Action 1</button>
         <button type="button" clrDropdownItem>Action 2</button>
-        <div class="dropdown-divider"></div>
+        <div class="dropdown-divider" role="separator"></div>
         <button type="button" clrDropdownItem>Link 1</button>
         <button type="button" clrDropdownItem>Link 2</button>
     </clr-dropdown-menu>

--- a/src/website/src/app/documentation/demos/dropdown/dropdown-angular-positioning.ts
+++ b/src/website/src/app/documentation/demos/dropdown/dropdown-angular-positioning.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -15,7 +15,7 @@ const EXAMPLE = `
         <label class="dropdown-header">Dropdown header</label>
         <button type="button" clrDropdownItem>Action 1</button>
         <button type="button" disabled clrDropdownItem>Disabled Action</button>
-        <div class="dropdown-divider"></div>
+        <div class="dropdown-divider" role="separator"></div>
         <clr-dropdown>
             <button type="button" clrDropdownTrigger>Link 1</button>
             <clr-dropdown-menu>

--- a/src/website/src/app/documentation/demos/dropdown/dropdown-static-buttonlink-toggle.ts
+++ b/src/website/src/app/documentation/demos/dropdown/dropdown-static-buttonlink-toggle.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -16,7 +16,7 @@ const EXAMPLE = `
         <button type="button" class="dropdown-item">Lorem.</button>
         <button type="button" class="dropdown-item">Lorem ipsum.</button>
         <button type="button" class="dropdown-item">Lorem ipsum dolor.</button>
-        <div class="dropdown-divider"></div>
+        <div class="dropdown-divider" role="separator"></div>
         <button type="button" class="dropdown-item">Link</button>
     </div>
 </div>

--- a/src/website/src/app/documentation/demos/dropdown/dropdown-static-default.ts
+++ b/src/website/src/app/documentation/demos/dropdown/dropdown-static-default.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -15,7 +15,7 @@ const HTML_EXAMPLE = `
         <h4 class="dropdown-header">Dropdown header</h4>
         <button type="button" class="dropdown-item active">Action</button>
         <button type="button" class="dropdown-item disabled">Disabled Link</button>
-        <div class="dropdown-divider"></div>
+        <div class="dropdown-divider" role="separator"></div>
         <button type="button" class="dropdown-item">Lorem.</button>
         <div class="dropdown open right-bottom">
             <button class="dropdown-item active expandable">Lorem ipsum.</button>

--- a/src/website/src/app/documentation/demos/dropdown/dropdown-static-fontawesome-toggle.ts
+++ b/src/website/src/app/documentation/demos/dropdown/dropdown-static-fontawesome-toggle.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -16,7 +16,7 @@ const EXAMPLE = `
         <button type="button" class="dropdown-item">Action 1</button>
         <button type="button" class="dropdown-item">Action 2</button>
         <button type="button" class="dropdown-item">Action 3</button>
-        <div class="dropdown-divider"></div>
+        <div class="dropdown-divider" role="separator"></div>
         <button type="button" class="dropdown-item">Link 1</button>
     </div>
 </div>

--- a/src/website/src/app/documentation/demos/dropdown/dropdown-static-icon-toggle.ts
+++ b/src/website/src/app/documentation/demos/dropdown/dropdown-static-icon-toggle.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -16,7 +16,7 @@ const EXAMPLE = `
         <button type="button" class="dropdown-item">Lorem.</button>
         <button type="button" class="dropdown-item">Lorem ipsum.</button>
         <button type="button" class="dropdown-item">Lorem ipsum dolor.</button>
-        <div class="dropdown-divider"></div>
+        <div class="dropdown-divider" role="separator"></div>
         <button type="button" class="dropdown-item">Action 1</button>
     </div>
 </div>

--- a/src/website/src/app/documentation/demos/dropdown/dropdown-static-positioning.ts
+++ b/src/website/src/app/documentation/demos/dropdown/dropdown-static-positioning.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -15,7 +15,7 @@ const EXAMPLE = `
         <h4 class="dropdown-header">Dropdown header</h4>
         <button type="button" class="dropdown-item active">First Action</button>
         <button type="button" class="dropdown-item disabled">Disabled Action</button>
-        <div class="dropdown-divider"></div>
+        <div class="dropdown-divider" role="separator"></div>
         <button type="button" class="dropdown-item">Link 1</button>
         <button type="button" class="dropdown-item">Link 2</button>
     </div>


### PR DESCRIPTION
We already have functionality to skip over disabled items in dropdown when using keyboard navigation. This requires the menu item to have the `disabled` attribute, which the demo code was missing. Angular component documentation already had it so we are good there.

Adding `aria-disabled` allows the disabled item to be announced as such when using screen reader. 

Also adding `role='separator'` to the splitters in the demo / website code. This part happens on the application side so no impact on the component itself.

Signed-off-by: Jeeyun Lim <jeeyun.lim@gmail.com>