### PR TITLE
Icons a11y and docs

### DIFF
--- a/src/clr-icons/clr-icons-element.ts
+++ b/src/clr-icons/clr-icons-element.ts
@@ -63,6 +63,11 @@ ClarityIconElement.prototype.connectedCallback = function() {
   // So we could check whether the attribute values really changed or not.
   // If not, we don't need to execute the same codes again.
 
+  // We want to hide the custom element from screen readers but allow the svg/img content to still be read inline
+  // Adding role=none allows the screen reader to skip the custom element as if it were a div or span.
+  // https://www.scottohara.me/blog/2018/05/05/hidden-vs-none.html
+  this.setAttribute('role', 'none');
+
   if (this.hasAttribute('size')) {
     const sizeAttrValue = this.getAttribute('size');
 
@@ -125,7 +130,7 @@ ClarityIconElement.prototype.attributeChangedCallback = function(
     this._setIconSize(newValue);
   }
 
-  // Note: the size attribute is irrelavent from the shape template;
+  // Note: the size attribute is irrelevant from the shape template;
   // That's why the size checking placed before detecting changes in shape and title attributes.
   // This means even if the shape is not found, the injected shape will have the user-given size.
 
@@ -173,10 +178,13 @@ ClarityIconElement.prototype.disconnectedCallback = function() {
 
 ClarityIconElement.prototype._setAriaLabelledBy = function() {
   const existingAriaLabelledBy: string = this.getAttribute('aria-labelledby');
+  const svgElement: SVGElement = this.querySelector('svg');
+  const elementToSet = svgElement ? svgElement : this;
+
   if (!existingAriaLabelledBy) {
-    this.setAttribute('aria-labelledby', this.clrIconUniqId);
+    elementToSet.setAttribute('aria-labelledby', this.clrIconUniqId);
   } else if (existingAriaLabelledBy && existingAriaLabelledBy.indexOf(this.clrIconUniqId) < 0) {
-    this.setAttribute('aria-labelledby', existingAriaLabelledBy + ' ' + this.clrIconUniqId);
+    elementToSet.setAttribute('aria-labelledby', existingAriaLabelledBy + ' ' + this.clrIconUniqId);
   }
 };
 

--- a/src/clr-icons/clr-icons.spec.ts
+++ b/src/clr-icons/clr-icons.spec.ts
@@ -378,21 +378,12 @@ describe('ClarityIcons', () => {
     itIgnore(['ie'], 'should inject a custom title into the template if title attribute is present', () => {
       const clarityIcon = document.createElement('clr-icon') as ClarityIconElement;
       const customTitle = 'my-custom-title';
-
-      const timeStart = performance.now();
       clarityIcon.setAttribute('shape', 'angle');
-      const settingShapeAttr = performance.now() - timeStart;
-
       clarityIcon.setAttribute('title', customTitle);
-      const settingTitleAttr = performance.now() - timeStart;
 
-      console.log('Icon shape attr setting took: ' + settingShapeAttr);
-      console.log('Icon title attr setting took: ' + settingTitleAttr);
-
-      const clrIconUniqId = clarityIcon.clrIconUniqId;
-      const testShape = giveAngleShapeTitle(clrIconUniqId, customTitle);
-
-      expect(removeWhitespace(clarityIcon.innerHTML)).toBe(removeWhitespace(testShape));
+      expect(removeWhitespace(clarityIcon.innerHTML)).toContain(
+        `<span class="is-off-screen" id="${clarityIcon.clrIconUniqId}">${customTitle}</span>`
+      );
     });
 
     itIgnore(['ie'], "should inject custom title if given and template doesn't contain title tag", () => {
@@ -402,26 +393,23 @@ describe('ClarityIcons', () => {
       ClarityIcons.add({ 'test-shape': shapeBeforeTitleAttrChange });
 
       const clarityIcon = document.createElement('clr-icon') as ClarityIconElement;
-
       clarityIcon.setAttribute('shape', 'test-shape');
       clarityIcon.setAttribute('title', customTitle);
 
       const clrIconUniqId = clarityIcon.clrIconUniqId;
-      const shapeAfterTitleAttrChange = `<svg><g></g></svg><span class="is-off-screen" id="${clrIconUniqId}">${customTitle}</span>`;
+      const shapeAfterTitleAttrChange = `<svg aria-labelledby="${clrIconUniqId}"><g></g></svg><span class="is-off-screen" id="${clrIconUniqId}">${customTitle}</span>`;
       expect(removeWhitespace(clarityIcon.innerHTML)).toBe(removeWhitespace(shapeAfterTitleAttrChange));
     });
 
     itIgnore(['ie'], "should inject a custom title if it's is specified before the shape attribute specified", () => {
       const clarityIcon = document.createElement('clr-icon') as ClarityIconElement;
       const customTitle = 'my-custom-title';
-
       clarityIcon.setAttribute('title', customTitle);
       clarityIcon.setAttribute('shape', 'angle');
 
-      const clrIconUniqId = clarityIcon.clrIconUniqId;
-      const testShape = giveAngleShapeTitle(clrIconUniqId, customTitle);
-
-      expect(removeWhitespace(clarityIcon.innerHTML)).toBe(removeWhitespace(testShape));
+      expect(removeWhitespace(clarityIcon.innerHTML)).toContain(
+        `<span class="is-off-screen" id="${clarityIcon.clrIconUniqId}">${customTitle}</span>`
+      );
     });
 
     it('should update existing title if custom title is specified', () => {
@@ -485,22 +473,17 @@ describe('ClarityIcons', () => {
       const testShape = `<svg><title>test-shape</title><g></g></svg>`;
       ClarityIcons.add({ 'test-shape': testShape });
 
-      const testShapeAfterShapeAttrChange = `<svg><title>test-shape</title><g></g></svg><span class="is-off-screen" id="${clrIconUniqId}">${customTitle}</span>`;
+      const testShapeAfterShapeAttrChange = `<svg aria-labelledby="${clrIconUniqId}"><title>test-shape</title><g></g></svg><span class="is-off-screen" id="${clrIconUniqId}">${customTitle}</span>`;
 
       clarityIcon.setAttribute('shape', 'test-shape');
       expect(removeWhitespace(clarityIcon.innerHTML)).toBe(removeWhitespace(testShapeAfterShapeAttrChange));
     });
 
-    it('should add aria-labelledby attribute if title attribute is present', () => {
+    it('should add aria-labelledby attribute to the svg if title attribute is present', () => {
       const clarityIcon = document.createElement('clr-icon') as ClarityIconElement;
-
-      const customTitle = 'my-custom-title';
-
       clarityIcon.setAttribute('shape', 'angle');
-      clarityIcon.setAttribute('title', customTitle);
-
-      const clrIconUniqId = clarityIcon.clrIconUniqId;
-      expect(clarityIcon.getAttribute('aria-labelledby')).toBe(clrIconUniqId);
+      clarityIcon.setAttribute('title', 'my-custom-title');
+      expect(clarityIcon.querySelector('svg').getAttribute('aria-labelledby')).toBe(clarityIcon.clrIconUniqId);
     });
 
     itIgnore(['ie'], 'should inject error shape if icon is not found', () => {
@@ -513,23 +496,18 @@ describe('ClarityIcons', () => {
 
     itIgnore(['ie'], 'should inject error shape with title if icon is not found', () => {
       const clarityIcon = document.createElement('clr-icon') as ClarityIconElement;
-      const nonExistingShape = 'non-existing-icon';
       const customTitle = 'my-custom-title';
-
-      clarityIcon.setAttribute('shape', nonExistingShape);
+      clarityIcon.setAttribute('shape', 'non-existing-icon');
       clarityIcon.setAttribute('title', customTitle);
-
-      const clrIconUniqId = clarityIcon.clrIconUniqId;
-
-      expect(removeWhitespace(clarityIcon.innerHTML)).toBe(removeWhitespace(getErrorShape(clrIconUniqId, customTitle)));
+      expect(removeWhitespace(clarityIcon.innerHTML)).toBe(
+        removeWhitespace(getErrorShape(clarityIcon.clrIconUniqId, customTitle))
+      );
     });
 
     itIgnore(['ie'], 'should reflect the updated shape template in injected icon', () => {
       const clarityIcon = document.createElement('clr-icon') as ClarityIconElement;
-      const nonExistingShape = 'non-existing-icon';
-      clarityIcon.setAttribute('shape', nonExistingShape);
+      clarityIcon.setAttribute('shape', 'non-existing-icon');
       document.body.appendChild(clarityIcon);
-
       expect(removeWhitespace(clarityIcon.innerHTML)).toBe(removeWhitespace(getErrorShape()));
 
       let testShape = `<svg><g><title>first</title></g></svg>`;
@@ -620,7 +598,7 @@ describe('ClarityIcons', () => {
       const testShape = `<svg><g></g></svg>`;
       ClarityIcons.add({ 'non-existing-icon': testShape });
 
-      const testShapeAfterTemplateChange = `<svg><g></g></svg><span class="is-off-screen" id="${clrIconUniqId}">${customTitle}</span>`;
+      const testShapeAfterTemplateChange = `<svg aria-labelledby="${clrIconUniqId}"><g></g></svg><span class="is-off-screen" id="${clrIconUniqId}">${customTitle}</span>`;
       expect(removeWhitespace(clarityIcon.innerHTML)).toBe(removeWhitespace(testShapeAfterTemplateChange));
     });
   });

--- a/src/clr-icons/helpers.spec.ts
+++ b/src/clr-icons/helpers.spec.ts
@@ -82,20 +82,30 @@ export function resetCallbacks(): void {
 }
 
 export function giveAngleShapeTitle(titleId: string, titleTxt: string) {
-  return `${clrIconSVG(
+  let angleShape = `${clrIconSVG(
     `<path class="clr-i-outline clr-i-outline-path-1" d="M29.52,22.52,18,10.6,6.48,22.52a1.7,1.7,0,0,0,2.45,2.36L18,15.49l9.08,9.39a1.7,1.7,0,0,0,2.45-2.36Z"></path>`
   )}<span class="is-off-screen" id="${titleId}">${titleTxt}</span>`;
+
+  if (titleId) {
+    angleShape = angleShape.replace('role="img">', `role="img" aria-labelledby="${titleId}">`);
+  }
+
+  return angleShape;
 }
 
 export function getErrorShape(titleId?: string, titleTxt?: string) {
-  const svgTemplate = clrIconSVG(
+  const offScreenSpan = titleTxt ? `<span class="is-off-screen" id="${titleId}">${titleTxt}</span>` : '';
+
+  let svgTemplate = clrIconSVG(
     `<path class="clr-i-outline clr-i-outline-path-1" d="M18,6A12,12,0,1,0,30,18,12,12,0,0,0,18,6Zm0,22A10,10,0,1,1,28,18,10,10,0,0,1,18,28Z"></path>
             <path class="clr-i-outline clr-i-outline-path-2" d="M18,20.07a1.3,1.3,0,0,1-1.3-1.3v-6a1.3,1.3,0,1,1,2.6,0v6A1.3,1.3,0,0,1,18,20.07Z"></path>
             <circle class="clr-i-outline clr-i-outline-path-3" cx="17.95" cy="23.02" r="1.5"></circle>
             <path class="clr-i-solid clr-i-solid-path-1" d="M18,6A12,12,0,1,0,30,18,12,12,0,0,0,18,6Zm-1.49,6a1.49,1.49,0,0,1,3,0v6.89a1.49,1.49,0,1,1-3,0ZM18,25.5a1.72,1.72,0,1,1,1.72-1.72A1.72,1.72,0,0,1,18,25.5Z"></path>`
   );
 
-  const offScreenSpan = titleTxt ? `<span class="is-off-screen" id="${titleId}">${titleTxt}</span>` : '';
+  if (titleId) {
+    svgTemplate = svgTemplate.replace('role="img">', `role="img" aria-labelledby="${titleId}">`);
+  }
 
   return svgTemplate + offScreenSpan;
 }

--- a/src/clr-icons/utils/svg-tag-generator.ts
+++ b/src/clr-icons/utils/svg-tag-generator.ts
@@ -26,10 +26,10 @@ export function clrIconSVG(content: string): string {
   let openingTag: string;
   if (classes) {
     openingTag = `<svg version="1.1" class="${classes}" viewBox="0 0 36 36" preserveAspectRatio="xMidYMid meet"
-    xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" focusable="false" aria-hidden="true" role="img">`;
+    xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" focusable="false" role="img">`;
   } else {
     openingTag = `<svg version="1.1" viewBox="0 0 36 36" preserveAspectRatio="xMidYMid meet"
-    xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" focusable="false" aria-hidden="true" role="img">`;
+    xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" focusable="false" role="img">`;
   }
   const closingTag = `</svg>`;
 

--- a/src/website/src/app/icons/icons-a11y/icons-a11y.component.html
+++ b/src/website/src/app/icons/icons-a11y/icons-a11y.component.html
@@ -1,0 +1,49 @@
+<h2>Icon Accessibility</h2>
+<p>
+  Icons have different accessibility requirements dependent on the context they are being used in.
+</p>
+
+<h3>Presentational</h3>
+<p>
+  Icons by default are presentational only meaning they do not provide any context to screen readers
+  and will be purely cosmetic without additional markup.
+</p>
+
+<clr-icon shape="info-circle" size="36"></clr-icon>
+
+<clr-code-snippet [clrCode]="presentational" clrLanguage="html"></clr-code-snippet>
+
+<h3>Interactive</h3>
+<p>When icons are used in buttons or links they should be used in conjunction with descriptive text.</p>
+
+<button class="btn">
+  <clr-icon shape="bars"></clr-icon> Menu
+</button>
+
+<clr-code-snippet [clrCode]="interactive" clrLanguage="html"></clr-code-snippet>
+
+<p>
+  If the icon in an interactive item does not have text then the parent interactive
+  item (typically a button or link) should have an appropriate <code class="clr-code">aria-label</code>
+  describing the interaction.
+</p>
+
+<button class="btn btn-icon" aria-label="main menu">
+  <clr-icon shape="bars"></clr-icon>
+</button>
+
+<clr-code-snippet [clrCode]="interactiveNoLabel" clrLanguage="html"></clr-code-snippet>
+
+<h3>Status/Indicator</h3>
+<p>
+  If an icon is used to show a status/indicator or part of a larger body of text
+  then the icon should have a title attribute so the icon can be properly
+  read by the screen reader.
+</p>
+
+<p>
+  <clr-icon shape="exclamation-triangle" title="Usage Warning" size="36"></clr-icon>
+  CPU usage is at 99% use.
+</p>
+
+<clr-code-snippet [clrCode]="indicator" clrLanguage="html"></clr-code-snippet>

--- a/src/website/src/app/icons/icons-a11y/icons-a11y.component.ts
+++ b/src/website/src/app/icons/icons-a11y/icons-a11y.component.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component } from '@angular/core';
+
+const presentational = `<clr-icon shape="info-circle"></clr-icon>`;
+
+const interactive = `
+<button class="btn">
+  <clr-icon shape="bars"></clr-icon> Menu
+</button>`;
+
+const interactiveNoLabel = `
+<button class="btn btn-icon" aria-label="main menu">
+  <clr-icon shape="bars"></clr-icon>
+</button>
+`;
+
+const indicator = `
+<p>
+  <clr-icon shape="exclamation-triangle" title="Usage Warning"></clr-icon>
+  CPU usage is at 99% use.
+</p>
+`;
+
+@Component({
+  selector: 'icons-a11y',
+  templateUrl: './icons-a11y.component.html',
+  // styleUrls: ['./icons-a11y.component.scss'],
+})
+export class IconsA11yComponent {
+  presentational = presentational;
+  interactive = interactive;
+  interactiveNoLabel = interactiveNoLabel;
+  indicator = indicator;
+}

--- a/src/website/src/app/icons/icons-routing.module.ts
+++ b/src/website/src/app/icons/icons-routing.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -10,6 +10,7 @@ import { IconsGetStartedComponent } from './icons-get-started/icons-get-started.
 import { IconsHowToUseComponent } from './icons-how-to-use/icons-how-to-use.component';
 import { IconsApiComponent } from './icons-api/icons-api.component';
 import { IconsSetsComponent } from './icons-sets/icons-sets.component';
+import { IconsA11yComponent } from './icons-a11y/icons-a11y.component';
 
 const routes: Routes = [
   {
@@ -20,6 +21,7 @@ const routes: Routes = [
       { path: 'get-started', component: IconsGetStartedComponent },
       { path: 'how-to-use', component: IconsHowToUseComponent },
       { path: 'api', component: IconsApiComponent },
+      { path: 'accessibility', component: IconsA11yComponent },
     ],
   },
 ];

--- a/src/website/src/app/icons/icons.component.html
+++ b/src/website/src/app/icons/icons.component.html
@@ -85,9 +85,10 @@
         <section class="nav-group">
           <label>Overview</label>
           <nav class="nav-list">
-            <a routerLinkActive="active" [routerLink]="['./get-started']" class="nav-link">Get Started</a>
-            <a routerLinkActive="active" [routerLink]="['./how-to-use']" class="nav-link">How To Use</a>
-            <a routerLinkActive="active" [routerLink]="['./api']" class="nav-link">API</a>
+            <a routerLinkActive="active" routerLink="get-started" class="nav-link">Get Started</a>
+            <a routerLinkActive="active" routerLink="how-to-use" class="nav-link">How To Use</a>
+            <a routerLinkActive="active" routerLink="accessibility" class="nav-link">Accessibility</a>
+            <a routerLinkActive="active" routerLink="api" class="nav-link">API</a>
           </nav>
         </section>
 

--- a/src/website/src/app/icons/icons.module.ts
+++ b/src/website/src/app/icons/icons.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -17,6 +17,7 @@ import { IconsSetsComponent } from './icons-sets/icons-sets.component';
 import { FragmentLinkDirective } from './utils/fragment-link.directive';
 import { FragmentContentComponent } from './utils/fragment-content.component';
 import { IconDetailCardComponent } from './icons-sets/icon-detail-card/icon-detail-card.component';
+import { IconsA11yComponent } from './icons-a11y/icons-a11y.component';
 
 @NgModule({
   imports: [ROUTING, CommonModule, ClarityModule, UtilsModule, FormsModule],
@@ -26,6 +27,7 @@ import { IconDetailCardComponent } from './icons-sets/icon-detail-card/icon-deta
     IconsHowToUseComponent,
     IconsApiComponent,
     IconsSetsComponent,
+    IconsA11yComponent,
     FragmentLinkDirective,
     FragmentContentComponent,
     IconDetailCardComponent,


### PR DESCRIPTION
Fixes icon a11y issue as well as documentation for the different use cases. Fixes issue where `aria-labelledby` should be on svg element to be properly read by screen reader. Also removes `aria-hidden` preventing screen reader from finding element.