### PR TITLE
ClrDropdownTrigger Angular AOT fix

### DIFF
--- a/src/clr-angular/popover/dropdown/dropdown-trigger.ts
+++ b/src/clr-angular/popover/dropdown/dropdown-trigger.ts
@@ -19,7 +19,7 @@ import { DropdownFocusHandler } from './providers/dropdown-focus-handler.service
     '[class.expandable]': '!isRootLevelToggle',
     '[class.active]': 'active',
     '[attr.aria-haspopup]': '"menu"',
-    '[attr.aria-expanded]': 'ifOpenService.open',
+    '[attr.aria-expanded]': 'active',
   },
 })
 export class ClrDropdownTrigger {


### PR DESCRIPTION
Updates ClrDropdownTrigger to not use the private ifOpenService in the host attribute configuration to prevent issues with AOT compilation.