### PR TITLE
[WEBSITE] fix add missing robots.txt file

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -240,6 +240,7 @@
               "src/website/src/favicon.ico",
               "src/website/src/manifest.json",
               "src/website/src/sitemap.xml",
+              "src/website/src/robots.txt",
               {
                 "glob": "versions.json",
                 "input": "src/website/src/settings/",

--- a/src/website/src/robots.txt
+++ b/src/website/src/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Sitemap: https://clarity.design/sitemap.xml
+Disallow:


### PR DESCRIPTION
Adds missing robots.txt file. This is for SEO related to search engine crawlers.

closes #3447

Signed-off-by: Cory Rylan <crylan@vmware.com>