### PR TITLE
[NG] fixes modal body content keyboard scroll support

### DIFF
--- a/src/clr-angular/modal/modal-body.spec.ts
+++ b/src/clr-angular/modal/modal-body.spec.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component, ViewChild, ElementRef } from '@angular/core';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { ClrModalBody } from './modal-body';
+
+describe('ClrModalBody Directive', () => {
+  let fixture: ComponentFixture<TestComponent>;
+
+  beforeEach(function() {
+    TestBed.configureTestingModule({
+      declarations: [ClrModalBody, TestComponent],
+    });
+    fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+  });
+
+  it('adds tabindex="0" to modal body to make content focusable and scrollable with keyboards', () => {
+    expect(fixture.componentInstance.testElement.nativeElement.getAttribute('tabindex')).toBe('0');
+  });
+});
+
+@Component({ template: `<div class="modal-body" #testElement></div>` })
+class TestComponent {
+  @ViewChild('testElement', { static: false })
+  testElement: ElementRef<HTMLElement>;
+}

--- a/src/clr-angular/modal/modal-body.ts
+++ b/src/clr-angular/modal/modal-body.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Directive } from '@angular/core';
+
+@Directive({
+  selector: '.modal-body',
+  host: {
+    '[attr.tabindex]': '"0"',
+  },
+})
+export class ClrModalBody {}

--- a/src/clr-angular/modal/modal.module.ts
+++ b/src/clr-angular/modal/modal.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -10,8 +10,9 @@ import { NgModule, Type } from '@angular/core';
 import { ClrIconModule } from '../icon/icon.module';
 import { ClrFocusTrapModule } from '../utils/focus-trap/focus-trap.module';
 import { ClrModal } from './modal';
+import { ClrModalBody } from './modal-body';
 
-export const CLR_MODAL_DIRECTIVES: Type<any>[] = [ClrModal];
+export const CLR_MODAL_DIRECTIVES: Type<any>[] = [ClrModal, ClrModalBody];
 
 @NgModule({
   imports: [CommonModule, ClrIconModule, ClrFocusTrapModule],


### PR DESCRIPTION
Adds a directive to dynamically attach the proper tabindex on instances of `.modal-body`.

closes #3424

Signed-off-by: Cory Rylan <crylan@vmware.com>