### PR TITLE
[UI] fix line height issue for custom text spacing

### DIFF
--- a/src/clr-angular/layout/main-container/_variables.header.scss
+++ b/src/clr-angular/layout/main-container/_variables.header.scss
@@ -19,6 +19,7 @@ $clr-header-nav-hover-opacity: 1 !default;
 $clr-header-outline-offset: -0.208333rem !default;
 $clr-header-clarity-icons-size: 1rem !default;
 $clr-header-nav-text-horizontal-padding: 1rem !default;
+$clr-header-nav-text-vertical-padding: 0.75rem !default;
 $clr-header-2-bg-color: #485969 !default; // Hard coded because this color is not in the color palette. Its reserved for headers only
 $clr-header-3-bg-color: $clr-color-secondary-action-1000 !default;
 $clr-header-4-bg-color: $clr-color-action-700 !default;

--- a/src/clr-angular/layout/nav/_header.clarity.scss
+++ b/src/clr-angular/layout/nav/_header.clarity.scss
@@ -105,7 +105,6 @@
     height: $clr-header-height;
 
     .nav-text {
-      padding: 0 $clr-header-nav-text-horizontal-padding;
       font-weight: 500;
     }
 
@@ -117,21 +116,14 @@
     .nav-link {
       position: relative;
       display: inline-block;
+      text-align: center;
+      padding: $clr-header-nav-text-vertical-padding $clr-header-nav-text-horizontal-padding;
       @include remove-text-decoration();
       @include header-nav-appearance();
 
       .fa, /* TODO: deprecated. Remove support for font awesome*/
-      .nav-icon,
-      .nav-text,
-      &.nav-icon,
-      &.nav-text {
-        line-height: $clr-header-height;
-      }
-
-      .fa, /* TODO: deprecated. Remove support for font awesome*/
       .nav-icon {
         font-size: $clr-nav-icon-size;
-        text-align: center;
       }
 
       clr-icon {
@@ -166,13 +158,6 @@
 
       &.active {
         background: rgba($clr-color-neutral-0, 0.15);
-        opacity: 1;
-      }
-
-      &.active.nav-icon,
-      &.active.nav-text,
-      &.active .nav-icon,
-      &.active .nav-text {
         opacity: 1;
       }
 
@@ -335,6 +320,7 @@
 
       input {
         line-height: 1rem;
+        margin: $clr-header-nav-text-vertical-padding 0;
       }
     }
 


### PR DESCRIPTION
Fixes broken links in header layout when custom text spacing is applied to meet a11y spacing requirements. Test and ran gemini locally. Deleted unnecessary scoped header link styles.

closes #3367

Signed-off-by: Cory Rylan <crylan@vmware.com>