### PR TITLE
[UI] fix accordion button width

### DIFF
--- a/src/clr-angular/accordion/_accordion.clarity.scss
+++ b/src/clr-angular/accordion/_accordion.clarity.scss
@@ -54,6 +54,7 @@
   }
 
   .clr-accordion-header-button {
+    flex: 1 1 0%;
     width: 100%;
     border: 0;
     padding: $clr-accordion-padding;
@@ -63,7 +64,7 @@
     color: $clr-accordion-text-color;
 
     @media (min-width: $clr-accordion-responsive-breakpoint) {
-      max-width: 280px;
+      min-width: 280px;
     }
   }
 

--- a/src/dev/src/app/accordion/accordion.demo.html
+++ b/src/dev/src/app/accordion/accordion.demo.html
@@ -9,7 +9,7 @@
 <h2>Angular - simple accordion</h2>
 
 <clr-accordion>
-  <clr-accordion-panel [clrAccordionPanelDisabled]="true">
+  <clr-accordion-panel>
     <clr-accordion-title>Step 1</clr-accordion-title>
     <clr-accordion-content>Content 1</clr-accordion-content>
   </clr-accordion-panel>


### PR DESCRIPTION
When no step or accordion content is given the button will now span the full width of the component.

closes #3454

Signed-off-by: Cory Rylan <crylan@vmware.com>