### PR TITLE
Stackview animation fix (#3350)

### DIFF
--- a/src/clr-angular/data/stack-view/stack-block.ts
+++ b/src/clr-angular/data/stack-view/stack-block.ts
@@ -1,9 +1,8 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { animate, state, style, transition, trigger } from '@angular/animations';
 import { Component, EventEmitter, HostBinding, Input, OnInit, Optional, Output, SkipSelf } from '@angular/core';
 import { ClrCommonStrings } from '../../utils/i18n/common-strings.interface';
 
@@ -29,10 +28,11 @@ import { ClrCommonStrings } from '../../utils/i18n/common-strings.interface';
     <dd class="stack-block-content">
       <ng-content></ng-content>
     </dd>
-    <!-- FIXME: remove this string concatenation when boolean states are supported -->
-    <div [@collapse]="''+!expanded" class="stack-children" >
-      <ng-content select="clr-stack-block"></ng-content>
-    </div>
+    <clr-expandable-animation [@clrExpandTrigger]="expanded" class="stack-children">
+      <div class="stack-children" [style.height]="expanded ? 'auto' : 0">
+        <ng-content select="clr-stack-block"></ng-content>
+      </div>
+    </clr-expandable-animation>
   `,
   // Custom elements are inline by default
   styles: [
@@ -42,13 +42,6 @@ import { ClrCommonStrings } from '../../utils/i18n/common-strings.interface';
   ],
   // Make sure the host has the proper class for styling purposes
   host: { '[class.stack-block]': 'true' },
-  animations: [
-    trigger('collapse', [
-      state('true', style({ height: 0, display: 'none' })),
-      transition('true => false', [animate('0.2s ease-in-out', style({ height: '*', display: '*' }))]),
-      transition('false => true', [style({ height: '*', display: '*' }), animate('0.2s ease-in-out')]),
-    ]),
-  ],
 })
 export class ClrStackBlock implements OnInit {
   @HostBinding('class.stack-block-expanded')

--- a/src/clr-angular/data/stack-view/stack-block.ts
+++ b/src/clr-angular/data/stack-view/stack-block.ts
@@ -29,7 +29,7 @@ import { ClrCommonStrings } from '../../utils/i18n/common-strings.interface';
       <ng-content></ng-content>
     </dd>
     <clr-expandable-animation [@clrExpandTrigger]="expanded" class="stack-children">
-      <div class="stack-children" [style.height]="expanded ? 'auto' : 0">
+      <div [style.height]="expanded ? 'auto' : 0">
         <ng-content select="clr-stack-block"></ng-content>
       </div>
     </clr-expandable-animation>

--- a/src/clr-angular/data/stack-view/stack-view.module.ts
+++ b/src/clr-angular/data/stack-view/stack-view.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -15,6 +15,7 @@ import { ClrStackSelect } from './stack-select';
 import { ClrStackView } from './stack-view';
 import { ClrStackViewCustomTags } from './stack-view-custom-tags';
 import { ClrIconModule } from '../../icon/icon.module';
+import { ClrExpandableAnimationModule } from '../../utils/animations/expandable-animation/expandable-animation.module';
 
 export const CLR_STACK_VIEW_DIRECTIVES: Type<any>[] = [
   ClrStackView,
@@ -32,7 +33,7 @@ export const CLR_STACK_VIEW_DIRECTIVES: Type<any>[] = [
 ];
 
 @NgModule({
-  imports: [CommonModule, FormsModule, ClrIconModule],
+  imports: [CommonModule, FormsModule, ClrIconModule, ClrExpandableAnimationModule],
   declarations: [CLR_STACK_VIEW_DIRECTIVES],
   exports: [CLR_STACK_VIEW_DIRECTIVES],
 })

--- a/src/clr-angular/utils/animations/expandable-animation/expandable-animation.ts
+++ b/src/clr-angular/utils/animations/expandable-animation/expandable-animation.ts
@@ -30,6 +30,7 @@ import { DomAdapter } from '../../dom-adapter/dom-adapter';
       ]),
     ]),
   ],
+  providers: [DomAdapter],
 })
 export class ClrExpandableAnimation {
   @Input() clrExpandTrigger: any;


### PR DESCRIPTION
Replaced with the animation component we created for datagrid
expandable rows.
Tested in safari - OK now.

closes #3350 

Signed-off-by: Ivan Donchev <idonchev@vmware.com>