### PR TITLE
Modal close button needs an accessible name 

### DIFF
--- a/src/clr-angular/modal/modal.html
+++ b/src/clr-angular/modal/modal.html
@@ -1,6 +1,6 @@
 
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -22,7 +22,7 @@
 
         <div class="modal-content">
           <div class="modal-header">
-            <button type="button" class="close" *ngIf="closable" (click)="close()">
+            <button type="button" [attr.aria-label]="commonStrings.close" class="close" *ngIf="closable" (click)="close()">
               <clr-icon shape="close" [attr.title]="commonStrings.close"></clr-icon>
             </button>
             <div class="modal-title-wrapper" id="{{modalId}}">

--- a/src/clr-angular/modal/modal.html
+++ b/src/clr-angular/modal/modal.html
@@ -23,7 +23,7 @@
         <div class="modal-content">
           <div class="modal-header">
             <button type="button" [attr.aria-label]="commonStrings.close" class="close" *ngIf="closable" (click)="close()">
-              <clr-icon shape="close" [attr.title]="commonStrings.close"></clr-icon>
+              <clr-icon shape="close"></clr-icon>
             </button>
             <div class="modal-title-wrapper" id="{{modalId}}">
               <ng-content select=".modal-title"></ng-content>

--- a/src/clr-angular/modal/modal.spec.ts
+++ b/src/clr-angular/modal/modal.spec.ts
@@ -11,6 +11,8 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FocusTrapDirective } from '../utils/focus-trap/focus-trap.directive';
 import { ClrFocusTrapModule } from '../utils/focus-trap/focus-trap.module';
 
+import { ClrCommonStringsService } from '../utils/i18n/common-strings.service';
+
 import { ClrModal } from './modal';
 import { ClrModalModule } from './modal.module';
 
@@ -60,6 +62,7 @@ class TestDefaultsComponent {
 describe('Modal', () => {
   let fixture: ComponentFixture<any>;
   let compiled: any;
+  const commonStrings = new ClrCommonStringsService();
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -267,5 +270,9 @@ describe('Modal', () => {
     const focusable = fixture.debugElement.query(By.directive(FocusTrapDirective));
 
     expect(focusable).toBeDefined();
+  });
+
+  it('close button should have attribute aria-label', () => {
+    expect(compiled.querySelector('.close').getAttribute('aria-label')).toBe(commonStrings.close);
   });
 });


### PR DESCRIPTION
Adding `aria-label` to the close button on top of the modal header.

Close #3413 