### PR TITLE
Datagrid focus management (#3370)

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -279,7 +279,7 @@ export declare class ClrDatagrid<T = any> implements AfterContentInit, AfterView
     placeholder: ClrDatagridPlaceholder<T>;
     refresh: EventEmitter<ClrDatagridStateInterface<T>>;
     rowActionService: RowActionService;
-    /** @deprecated */ rowSelectionMode: boolean;
+    rowSelectionMode: boolean;
     rows: QueryList<ClrDatagridRow<T>>;
     scrollableColumns: ViewContainerRef;
     selected: T[];
@@ -334,8 +334,8 @@ export declare class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<
     sortOrder: ClrDatagridSortOrder;
     sortOrderChange: EventEmitter<ClrDatagridSortOrder>;
     readonly sortable: boolean;
-    /** @deprecated */ sorted: boolean;
-    /** @deprecated */ sortedChange: EventEmitter<boolean>;
+    sorted: boolean;
+    sortedChange: EventEmitter<boolean>;
     updateFilterValue: string | [number, number];
     constructor(_sort: Sort<T>, filters: FiltersProvider<T>, vcr: ViewContainerRef, commonStrings: ClrCommonStrings);
     ngOnDestroy(): void;
@@ -700,7 +700,7 @@ export declare class ClrExpandableAnimation {
 export declare class ClrForm {
     layoutService: LayoutService;
     constructor(layoutService: LayoutService, markControlService: MarkControlService);
-    /** @deprecated */ markAsDirty(): void;
+    markAsDirty(): void;
     markAsTouched(): void;
 }
 

--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -306,7 +306,7 @@ export declare class ClrDatagridActionOverflow implements OnDestroy {
     overflowClassName: string;
     popoverId: string;
     popoverPoint: Point;
-    constructor(rowActionService: RowActionService, commonStrings: ClrCommonStrings, ref: ElementRef, platformId: Object, zone: NgZone);
+    constructor(rowActionService: RowActionService, commonStrings: ClrCommonStrings, elementRef: ElementRef, platformId: Object, zone: NgZone);
     close(event: MouseEvent): void;
     ngOnDestroy(): void;
     toggle(event: any): void;
@@ -371,7 +371,7 @@ export declare class ClrDatagridFilter<T = any> extends DatagridFilterRegistrar<
     openChanged: EventEmitter<boolean>;
     popoverOptions: PopoverOptions;
     popoverPoint: Point;
-    constructor(_filters: FiltersProvider<T>, commonStrings: ClrCommonStrings);
+    constructor(_filters: FiltersProvider<T>, commonStrings: ClrCommonStrings, platformId: Object);
     toggle(): void;
 }
 

--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -271,6 +271,7 @@ export declare class ClrDatagrid<T = any> implements AfterContentInit, AfterView
     allSelected: boolean;
     columns: QueryList<ClrDatagridColumn<T>>;
     commonStrings: ClrCommonStrings;
+    datagridTable: ElementRef;
     expandableRows: ExpandableRowsCount;
     items: Items<T>;
     iterator: ClrDatagridItems<T>;
@@ -278,7 +279,7 @@ export declare class ClrDatagrid<T = any> implements AfterContentInit, AfterView
     placeholder: ClrDatagridPlaceholder<T>;
     refresh: EventEmitter<ClrDatagridStateInterface<T>>;
     rowActionService: RowActionService;
-    rowSelectionMode: boolean;
+    /** @deprecated */ rowSelectionMode: boolean;
     rows: QueryList<ClrDatagridRow<T>>;
     scrollableColumns: ViewContainerRef;
     selected: T[];
@@ -286,7 +287,7 @@ export declare class ClrDatagrid<T = any> implements AfterContentInit, AfterView
     selection: Selection<T>;
     singleSelected: T;
     singleSelectedChanged: EventEmitter<T>;
-    constructor(organizer: DatagridRenderOrganizer, items: Items<T>, expandableRows: ExpandableRowsCount, selection: Selection<T>, rowActionService: RowActionService, stateProvider: StateProvider<T>, displayMode: DisplayModeService, renderer: Renderer2, el: ElementRef, commonStrings: ClrCommonStrings);
+    constructor(organizer: DatagridRenderOrganizer, items: Items<T>, expandableRows: ExpandableRowsCount, selection: Selection<T>, rowActionService: RowActionService, stateProvider: StateProvider<T>, displayMode: DisplayModeService, renderer: Renderer2, el: ElementRef, page: Page, commonStrings: ClrCommonStrings);
     dataChanged(): void;
     ngAfterContentInit(): void;
     ngAfterViewInit(): void;
@@ -302,8 +303,10 @@ export declare class ClrDatagridActionOverflow implements OnDestroy {
     commonStrings: ClrCommonStrings;
     open: boolean;
     openChanged: EventEmitter<boolean>;
+    overflowClassName: string;
+    popoverId: string;
     popoverPoint: Point;
-    constructor(rowActionService: RowActionService, commonStrings: ClrCommonStrings);
+    constructor(rowActionService: RowActionService, commonStrings: ClrCommonStrings, ref: ElementRef, platformId: Object, zone: NgZone);
     close(event: MouseEvent): void;
     ngOnDestroy(): void;
     toggle(event: any): void;
@@ -331,8 +334,8 @@ export declare class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<
     sortOrder: ClrDatagridSortOrder;
     sortOrderChange: EventEmitter<ClrDatagridSortOrder>;
     readonly sortable: boolean;
-    sorted: boolean;
-    sortedChange: EventEmitter<boolean>;
+    /** @deprecated */ sorted: boolean;
+    /** @deprecated */ sortedChange: EventEmitter<boolean>;
     updateFilterValue: string | [number, number];
     constructor(_sort: Sort<T>, filters: FiltersProvider<T>, vcr: ViewContainerRef, commonStrings: ClrCommonStrings);
     ngOnDestroy(): void;
@@ -360,6 +363,7 @@ export interface ClrDatagridComparatorInterface<T> {
 
 export declare class ClrDatagridFilter<T = any> extends DatagridFilterRegistrar<T, ClrDatagridFilterInterface<T>> implements CustomFilter {
     readonly active: boolean;
+    anchor: ElementRef;
     anchorPoint: Point;
     commonStrings: ClrCommonStrings;
     customFilter: ClrDatagridFilterInterface<T> | RegisteredFilter<T, ClrDatagridFilterInterface<T>>;
@@ -696,7 +700,7 @@ export declare class ClrExpandableAnimation {
 export declare class ClrForm {
     layoutService: LayoutService;
     constructor(layoutService: LayoutService, markControlService: MarkControlService);
-    markAsDirty(): void;
+    /** @deprecated */ markAsDirty(): void;
     markAsTouched(): void;
 }
 

--- a/src/clr-angular/data/datagrid/datagrid-action-overflow.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-action-overflow.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -9,6 +9,7 @@ import { Component } from '@angular/core';
 import { ClrDatagridActionOverflow } from './datagrid-action-overflow';
 import { TestContext } from './helpers.spec';
 import { RowActionService } from './providers/row-action-service';
+import { fakeAsync, tick } from '@angular/core/testing';
 
 export default function(): void {
   describe('DatagridActionOverflow component', function() {
@@ -83,6 +84,46 @@ export default function(): void {
       context.detectChanges();
       expect(context.clarityDirective.open).toBe(false);
     });
+
+    it(
+      'first item is focused when opened',
+      fakeAsync(function() {
+        toggle.click();
+        context.detectChanges();
+        tick();
+        const firstButton = context.clarityElement.querySelector('.action-item');
+        expect(document.activeElement).toBe(firstButton);
+        // Verify focus has moved on close
+        toggle.click();
+        context.detectChanges();
+        tick();
+        expect(document.activeElement).not.toBe(firstButton);
+      })
+    );
+
+    it(
+      'focus is applied only once per click',
+      fakeAsync(function() {
+        // Open
+        toggle.click();
+        context.detectChanges();
+        const firstButton = context.clarityElement.querySelector('.action-item');
+        expect(firstButton).toBeTruthy();
+        const focusSpy = spyOn(firstButton, 'focus');
+        tick();
+        expect(focusSpy.calls.count()).toBe(1);
+        // Close
+        toggle.click();
+        context.detectChanges();
+        tick();
+        expect(focusSpy.calls.count()).toBe(1);
+        // Reopen
+        toggle.click();
+        context.detectChanges();
+        tick();
+        expect(focusSpy.calls.count()).toBe(2);
+      })
+    );
   });
 }
 

--- a/src/clr-angular/data/datagrid/datagrid-action-overflow.ts
+++ b/src/clr-angular/data/datagrid/datagrid-action-overflow.ts
@@ -10,7 +10,6 @@ import {
   OnDestroy,
   Output,
   ElementRef,
-  Directive,
   NgZone,
   Inject,
   PLATFORM_ID,
@@ -21,8 +20,7 @@ import { Point } from '../../popover/common/popover';
 import { RowActionService } from './providers/row-action-service';
 import { ClrCommonStrings } from '../../utils/i18n/common-strings.interface';
 import { isPlatformBrowser } from '@angular/common';
-import { filter, first, last, take, takeLast, debounceTime } from 'rxjs/operators';
-import { Subscription } from 'rxjs';
+import { take, debounceTime } from 'rxjs/operators';
 
 let clrDgActionId = 0;
 
@@ -51,7 +49,7 @@ export class ClrDatagridActionOverflow implements OnDestroy {
     private rowActionService: RowActionService,
     public commonStrings: ClrCommonStrings,
     private ref: ElementRef,
-    @Inject(PLATFORM_ID) private platformId: object,
+    @Inject(PLATFORM_ID) private platformId: Object,
     private zone: NgZone
   ) {
     this.rowActionService.register();

--- a/src/clr-angular/data/datagrid/datagrid-action-overflow.ts
+++ b/src/clr-angular/data/datagrid/datagrid-action-overflow.ts
@@ -48,7 +48,7 @@ export class ClrDatagridActionOverflow implements OnDestroy {
   constructor(
     private rowActionService: RowActionService,
     public commonStrings: ClrCommonStrings,
-    private ref: ElementRef,
+    private elementRef: ElementRef,
     @Inject(PLATFORM_ID) private platformId: Object,
     private zone: NgZone
   ) {
@@ -84,7 +84,7 @@ export class ClrDatagridActionOverflow implements OnDestroy {
             .asObservable()
             .pipe(debounceTime(0), take(1))
             .subscribe(() => {
-              const firstButton = this.ref.nativeElement.querySelector(`.${this.overflowClassName} button`);
+              const firstButton = this.elementRef.nativeElement.querySelector(`.${this.overflowClassName} button`);
               if (firstButton) {
                 firstButton.focus();
               }

--- a/src/clr-angular/data/datagrid/datagrid-action-overflow.ts
+++ b/src/clr-angular/data/datagrid/datagrid-action-overflow.ts
@@ -20,7 +20,6 @@ import { Point } from '../../popover/common/popover';
 import { RowActionService } from './providers/row-action-service';
 import { ClrCommonStrings } from '../../utils/i18n/common-strings.interface';
 import { isPlatformBrowser } from '@angular/common';
-import { take, debounceTime } from 'rxjs/operators';
 
 let clrDgActionId = 0;
 
@@ -78,17 +77,14 @@ export class ClrDatagridActionOverflow implements OnDestroy {
       this.openChanged.emit(boolOpen);
       if (boolOpen && isPlatformBrowser(this.platformId)) {
         this.zone.runOutsideAngular(() => {
-          // It emits 2+ onStable events in a synchronous sequence. We need to wait for the last one.
-          // Some of them are probably only in dev mode, but some are caused by collapsing the previous overflow window.
-          this.zone.onStable
-            .asObservable()
-            .pipe(debounceTime(0), take(1))
-            .subscribe(() => {
-              const firstButton = this.elementRef.nativeElement.querySelector(`.${this.overflowClassName} button`);
-              if (firstButton) {
-                firstButton.focus();
-              }
-            });
+          setTimeout(() => {
+            const firstButton = this.elementRef.nativeElement.querySelector(
+              `.${this.overflowClassName} button.action-item`
+            );
+            if (firstButton) {
+              firstButton.focus();
+            }
+          });
         });
       }
     }

--- a/src/clr-angular/data/datagrid/datagrid-filter.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-filter.spec.ts
@@ -25,7 +25,7 @@ export default function(): void {
         const stateDebouncer = new StateDebouncer();
         filterService = new FiltersProvider(new Page(stateDebouncer), stateDebouncer);
         filter = new TestFilter();
-        component = new ClrDatagridFilter(filterService, {});
+        component = new ClrDatagridFilter(filterService, {}, null);
       });
 
       afterEach(function() {

--- a/src/clr-angular/data/datagrid/datagrid-filter.ts
+++ b/src/clr-angular/data/datagrid/datagrid-filter.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 
 import { Point } from '../../popover/common/popover';
 import { PopoverOptions } from '../../popover/common/popover-options.interface';
@@ -57,6 +57,10 @@ export class ClrDatagridFilter<T = any> extends DatagridFilterRegistrar<T, ClrDa
   public anchorPoint: Point = Point.RIGHT_BOTTOM;
   public popoverPoint: Point = Point.RIGHT_TOP;
   public popoverOptions: PopoverOptions = { allowMultipleOpen: true };
+
+  @ViewChild('anchor', { static: false, read: ElementRef })
+  anchor: ElementRef;
+
   /**
    * Tracks whether the filter dropdown is open or not
    */
@@ -71,6 +75,9 @@ export class ClrDatagridFilter<T = any> extends DatagridFilterRegistrar<T, ClrDa
     if (boolOpen !== this._open) {
       this._open = boolOpen;
       this.openChanged.emit(boolOpen);
+      if (!boolOpen) {
+        this.anchor.nativeElement.focus();
+      }
     }
   }
 

--- a/src/clr-angular/data/datagrid/datagrid-filter.ts
+++ b/src/clr-angular/data/datagrid/datagrid-filter.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Inject, Input, Output, PLATFORM_ID, ViewChild } from '@angular/core';
 
 import { Point } from '../../popover/common/popover';
 import { PopoverOptions } from '../../popover/common/popover-options.interface';
@@ -13,6 +13,7 @@ import { CustomFilter } from './providers/custom-filter';
 import { FiltersProvider, RegisteredFilter } from './providers/filters';
 import { DatagridFilterRegistrar } from './utils/datagrid-filter-registrar';
 import { ClrCommonStrings } from '../../utils/i18n/common-strings.interface';
+import { isPlatformBrowser } from '@angular/common';
 
 /**
  * Custom filter that can be added in any column to override the default object property string filter.
@@ -50,7 +51,11 @@ import { ClrCommonStrings } from '../../utils/i18n/common-strings.interface';
 })
 export class ClrDatagridFilter<T = any> extends DatagridFilterRegistrar<T, ClrDatagridFilterInterface<T>>
   implements CustomFilter {
-  constructor(_filters: FiltersProvider<T>, public commonStrings: ClrCommonStrings) {
+  constructor(
+    _filters: FiltersProvider<T>,
+    public commonStrings: ClrCommonStrings,
+    @Inject(PLATFORM_ID) private platformId: Object
+  ) {
     super(_filters);
   }
 
@@ -75,7 +80,7 @@ export class ClrDatagridFilter<T = any> extends DatagridFilterRegistrar<T, ClrDa
     if (boolOpen !== this._open) {
       this._open = boolOpen;
       this.openChanged.emit(boolOpen);
-      if (!boolOpen) {
+      if (!boolOpen && isPlatformBrowser(this.platformId)) {
         this.anchor.nativeElement.focus();
       }
     }

--- a/src/clr-angular/data/datagrid/datagrid.html
+++ b/src/clr-angular/data/datagrid/datagrid.html
@@ -7,7 +7,7 @@
 <ng-content select="clr-dg-action-bar"></ng-content>
 <div class="datagrid" #datagrid>
     <div class="datagrid-table-wrapper">
-      <div role="grid" class="datagrid-table">
+      <div role="grid" class="datagrid-table" tabindex="-1" #datagridTable>
         <div role="rowgroup" class="datagrid-header">
           <div role="row" class="datagrid-row">
             <div class="datagrid-row-master datagrid-row-flex">

--- a/src/clr-angular/data/datagrid/datagrid.ts
+++ b/src/clr-angular/data/datagrid/datagrid.ts
@@ -74,6 +74,7 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
     private displayMode: DisplayModeService,
     private renderer: Renderer2,
     private el: ElementRef,
+    private page: Page,
     public commonStrings: ClrCommonStrings
   ) {}
 
@@ -194,6 +195,9 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
   @ViewChild('scrollableColumns', { static: false, read: ViewContainerRef })
   scrollableColumns: ViewContainerRef;
 
+  @ViewChild('datagridTable', { static: false, read: ElementRef })
+  datagridTable: ElementRef;
+
   ngAfterContentInit() {
     if (!this.items.smart) {
       this.items.all = this.rows.map((row: ClrDatagridRow<T>) => row.item);
@@ -225,6 +229,9 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
         } else if (this.selection.selectionType === SelectionType.Multi) {
           this.selectedChanged.emit(<T[]>s);
         }
+      }),
+      this.page.change.subscribe(() => {
+        this.datagridTable.nativeElement.focus();
       })
     );
     // A subscription that listens for displayMode changes on the datagrid

--- a/src/clr-angular/data/datagrid/datagrid.ts
+++ b/src/clr-angular/data/datagrid/datagrid.ts
@@ -221,8 +221,8 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
   ngAfterViewInit() {
     // TODO: determine if we can get rid of provider wiring in view init so that subscriptions can be done earlier
     this.refresh.emit(this.stateProvider.state);
-    this._subscriptions.push(this.stateProvider.change.subscribe(state => this.refresh.emit(state)));
     this._subscriptions.push(
+      this.stateProvider.change.subscribe(state => this.refresh.emit(state)),
       this.selection.change.subscribe(s => {
         if (this.selection.selectionType === SelectionType.Single) {
           this.singleSelectedChanged.emit(<T>s);
@@ -232,46 +232,46 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
       }),
       this.page.change.subscribe(() => {
         this.datagridTable.nativeElement.focus();
+      }),
+      // A subscription that listens for displayMode changes on the datagrid
+      this.displayMode.view.subscribe(viewChange => {
+        // Remove any projected columns from the projectedDisplayColumns container
+        for (let i = this._projectedDisplayColumns.length; i > 0; i--) {
+          this._projectedDisplayColumns.detach();
+        }
+        // Remove any projected columns from the projectedCalculationColumns container
+        for (let i = this._projectedCalculationColumns.length; i > 0; i--) {
+          this._projectedCalculationColumns.detach();
+        }
+        // Remove any projected rows from the calculationRows container
+        for (let i = this._calculationRows.length; i > 0; i--) {
+          this._calculationRows.detach();
+        }
+        // Remove any projected rows from the displayedRows container
+        for (let i = this._displayedRows.length; i > 0; i--) {
+          this._displayedRows.detach();
+        }
+        if (viewChange === DatagridDisplayMode.DISPLAY) {
+          // Set state, style for the datagrid to DISPLAY and insert row & columns into containers
+          this.renderer.removeClass(this.el.nativeElement, 'datagrid-calculate-mode');
+          this.columns.forEach(column => {
+            this._projectedDisplayColumns.insert(column._view);
+          });
+          this.rows.forEach(row => {
+            this._displayedRows.insert(row._view);
+          });
+        } else {
+          // Set state, style for the datagrid to CALCULATE and insert row & columns into containers
+          this.renderer.addClass(this.el.nativeElement, 'datagrid-calculate-mode');
+          this.columns.forEach(column => {
+            this._projectedCalculationColumns.insert(column._view);
+          });
+          this.rows.forEach(row => {
+            this._calculationRows.insert(row._view);
+          });
+        }
       })
     );
-    // A subscription that listens for displayMode changes on the datagrid
-    this.displayMode.view.subscribe(viewChange => {
-      // Remove any projected columns from the projectedDisplayColumns container
-      for (let i = this._projectedDisplayColumns.length; i > 0; i--) {
-        this._projectedDisplayColumns.detach();
-      }
-      // Remove any projected columns from the projectedCalculationColumns container
-      for (let i = this._projectedCalculationColumns.length; i > 0; i--) {
-        this._projectedCalculationColumns.detach();
-      }
-      // Remove any projected rows from the calculationRows container
-      for (let i = this._calculationRows.length; i > 0; i--) {
-        this._calculationRows.detach();
-      }
-      // Remove any projected rows from the displayedRows container
-      for (let i = this._displayedRows.length; i > 0; i--) {
-        this._displayedRows.detach();
-      }
-      if (viewChange === DatagridDisplayMode.DISPLAY) {
-        // Set state, style for the datagrid to DISPLAY and insert row & columns into containers
-        this.renderer.removeClass(this.el.nativeElement, 'datagrid-calculate-mode');
-        this.columns.forEach(column => {
-          this._projectedDisplayColumns.insert(column._view);
-        });
-        this.rows.forEach(row => {
-          this._displayedRows.insert(row._view);
-        });
-      } else {
-        // Set state, style for the datagrid to CALCULATE and insert row & columns into containers
-        this.renderer.addClass(this.el.nativeElement, 'datagrid-calculate-mode');
-        this.columns.forEach(column => {
-          this._projectedCalculationColumns.insert(column._view);
-        });
-        this.rows.forEach(row => {
-          this._calculationRows.insert(row._view);
-        });
-      }
-    });
   }
 
   /**


### PR DESCRIPTION
Done (4/5)
- When using the page count select box, when the selection is changed the focus should move back to the start of the newly displayed content.
- When using the previous/next pagination buttons, the focus should move back to the start of the newly displayed content.
- When closing a filter, the focus is lost to the page when it should return to the filter toggle button.
- Screen reader users will not be aware of actions available from the clr-dg-action-overflow component when it appears because focus remains on the trigger but should move into the menu.

Todo (1/5)
- When using the select all button, the focus is lost to the page when it should remain on the select all button.

Submitting 4/5 for early discussion on the clr-dg-action-overflow focus approach, which was inspired by Cory's work on the date-picker focus management. (Separate commits/per feature available)

Signed-off-by: Ivan Donchev <idonchev@vmware.com>