### PR TITLE
[NG] improve modal a11y for screen readers

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -234,6 +234,8 @@ export declare abstract class ClrCommonStrings {
     lastPage?: string;
     maxValue?: string;
     minValue?: string;
+    modalContentEnd?: string;
+    modalContentStart?: string;
     more?: string;
     next?: string;
     nextPage?: string;

--- a/src/clr-angular/accordion/accordion-panel.html
+++ b/src/clr-angular/accordion/accordion-panel.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="panel | async; let panel">
-  <div *ngIf="panel.status !== AccordionStatus.Inactive" aria-live="assertive" class="clr-screen-reader-only">
+  <div *ngIf="panel.status !== AccordionStatus.Inactive" aria-live="assertive" class="clr-sr-only">
     <ng-container *ngIf="panel.status === AccordionStatus.Error">{{commonStrings.danger}}</ng-container>
     <ng-container *ngIf="panel.status === AccordionStatus.Complete">{{commonStrings.success}}</ng-container>
   </div>

--- a/src/clr-angular/accordion/stepper/stepper-panel.spec.ts
+++ b/src/clr-angular/accordion/stepper/stepper-panel.spec.ts
@@ -84,13 +84,13 @@ describe('ClrStep Reactive Forms', () => {
     it('should show the appropriate aria-live message based on form state', () => {
       const mockStep = new AccordionPanelModel('groupName', 0);
       const stepperService = fixture.debugElement.query(By.directive(ClrStepperPanel)).injector.get(StepperService);
-      let liveSection: HTMLElement = fixture.nativeElement.querySelector('.clr-screen-reader-only');
+      let liveSection: HTMLElement = fixture.nativeElement.querySelector('.clr-sr-only');
       expect(liveSection).toBe(null);
 
       mockStep.status = AccordionStatus.Error;
       (stepperService as MockStepperService).step.next(mockStep);
       fixture.detectChanges();
-      liveSection = fixture.nativeElement.querySelector('.clr-screen-reader-only');
+      liveSection = fixture.nativeElement.querySelector('.clr-sr-only');
       expect(liveSection.getAttribute('aria-live')).toBe('assertive');
       expect(liveSection.innerText.trim()).toBe('Error');
 

--- a/src/clr-angular/modal/modal.html
+++ b/src/clr-angular/modal/modal.html
@@ -15,7 +15,7 @@
          role="dialog"
          [attr.aria-hidden]="!_open"
          [attr.aria-labelledby]="modalId">
-
+      <div class="clr-sr-only">{{commonStrings.modalContentStart}}</div>
       <div class="modal-content-wrapper">
         <!-- only used in wizards -->
         <ng-content select=".modal-nav"></ng-content>
@@ -33,6 +33,7 @@
           <ng-content select=".modal-footer"></ng-content>
         </div>
       </div>
+      <div class="clr-sr-only">{{commonStrings.modalContentEnd}}</div>
     </div>
 
     <div [@fade] class="modal-backdrop"

--- a/src/clr-angular/modal/modal.spec.ts
+++ b/src/clr-angular/modal/modal.spec.ts
@@ -275,4 +275,18 @@ describe('Modal', () => {
   it('close button should have attribute aria-label', () => {
     expect(compiled.querySelector('.close').getAttribute('aria-label')).toBe(commonStrings.close);
   });
+
+  it(
+    'should have text based boundaries for screen readers',
+    fakeAsync(() => {
+      // MacOS + Voice Over does not properly isolate modal content so
+      // we must give screen reader users text based warnings when they
+      // are entering and leaving modal content.
+      getModalInstance(fixture).open();
+      fixture.detectChanges();
+      const messages = compiled.querySelectorAll('.clr-sr-only');
+      expect(messages[0].innerText).toBe('Beginning of Modal Content');
+      expect(messages[1].innerText).toBe('End of Modal Content');
+    })
+  );
 });

--- a/src/clr-angular/utils/_a11y.clarity.scss
+++ b/src/clr-angular/utils/_a11y.clarity.scss
@@ -17,7 +17,7 @@
 }
 
 @include exports('a11y.clarity') {
-  .clr-screen-reader-only {
+  .clr-sr-only {
     @include screen-reader-only();
   }
 }

--- a/src/clr-angular/utils/i18n/common-strings.interface.ts
+++ b/src/clr-angular/utils/i18n/common-strings.interface.ts
@@ -125,4 +125,12 @@ export abstract class ClrCommonStrings {
    * Datagrid numeric filter: max
    */
   maxValue?: string;
+  /**
+   * Modal start of content
+   */
+  modalContentStart?: string;
+  /**
+   * Modal end of content
+   */
+  modalContentEnd?: string;
 }

--- a/src/clr-angular/utils/i18n/common-strings.service.ts
+++ b/src/clr-angular/utils/i18n/common-strings.service.ts
@@ -39,6 +39,8 @@ export class ClrCommonStringsService implements ClrCommonStrings {
   totalPages = 'Total Pages';
   minValue = 'Min value';
   maxValue = 'Max value';
+  modalContentStart = 'Beginning of Modal Content';
+  modalContentEnd = 'End of Modal Content';
 }
 
 export function commonStringsFactory(existing?: ClrCommonStrings): ClrCommonStrings {

--- a/src/website/src/app/utils/skip-link.component.ts
+++ b/src/website/src/app/utils/skip-link.component.ts
@@ -11,7 +11,7 @@ import { Component, Input } from '@angular/core';
   template: `
     <button
       class="btn btn-warning btn-sm clr-docs-skip-link"
-      [class.clr-screen-reader-only]="hideSkipLink"
+      [class.clr-sr-only]="hideSkipLink"
       (click)="skipToContent()"
       (focus)="hideSkipLink = false"
       (blur)="hideSkipLink = true">


### PR DESCRIPTION
MacOS Safari + Voice Over do not properly support aria/role attributes for modals. This PR introduces screen reader only text that allows a screen reader only user to know when they are entering and leaving a modal.

closes #3414

Signed-off-by: Cory Rylan <crylan@vmware.com>