### PR TITLE
[core] skip deleted files in script to update licensing info

### DIFF
--- a/scripts/update-license.js
+++ b/scripts/update-license.js
@@ -17,7 +17,7 @@ const path = require('path');
 const supported = ['.js', '.ts', '.html', '.css', '.scss', '.sass'];
 
 // Grab list of staged files
-const files = exec('git diff --name-only --cached', { encoding: 'utf8' }).split('\n');
+const files = exec('git diff --name-only --cached --diff-filter=d', { encoding: 'utf8' }).split('\n');
 const year = new Date().getFullYear();
 
 files.forEach(file => {


### PR DESCRIPTION
Currently, the update-license script that updates the year for modified files is throwing an error for deleted files and preventing me from committing deletion of files. Modifying the script to skip deleted files. Refer to documentation on `--diff-filter` here: https://git-scm.com/docs/git-diff

Signed-off-by: Jeeyun Lim <jeeyun.lim@gmail.com>