### PR TITLE
[ng] fix(datepicker): Add HostListener for the datepicker toggle button

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -517,6 +517,7 @@ export declare class ClrDataModule {
 
 export declare class ClrDateContainer implements DynamicWrapper, OnDestroy {
     _dynamic: boolean;
+    actionButton: ElementRef;
     commonStrings: ClrCommonStrings;
     control: NgControl;
     focus: boolean;
@@ -525,6 +526,7 @@ export declare class ClrDateContainer implements DynamicWrapper, OnDestroy {
     label: ClrLabel;
     constructor(_ifOpenService: IfOpenService, _dateNavigationService: DateNavigationService, _datepickerEnabledService: DatepickerEnabledService, dateFormControlService: DateFormControlService, commonStrings: ClrCommonStrings, ifErrorService: IfErrorService, focusService: FocusService, controlClassService: ControlClassService, layoutService: LayoutService, ngControlService: NgControlService);
     addGrid(): boolean;
+    close(): void;
     controlClass(): string;
     ngOnDestroy(): void;
     ngOnInit(): void;

--- a/src/clr-angular/forms/datepicker/date-container.spec.ts
+++ b/src/clr-angular/forms/datepicker/date-container.spec.ts
@@ -72,6 +72,20 @@ export default function() {
         context.detectChanges();
       });
 
+      it('returns focus to the toggle button when closed with the escape key', () => {
+        const actionButton: HTMLButtonElement = context.clarityElement.querySelector('.clr-input-group-icon-action');
+        const actionButtonSpy = spyOn(actionButton, 'focus');
+        expect(actionButtonSpy.calls.count()).toBe(0);
+        actionButton.click();
+        context.detectChanges();
+        const event = new KeyboardEvent('keyup', {
+          key: 'Escape',
+        });
+        document.body.dispatchEvent(event);
+        context.detectChanges();
+        expect(actionButtonSpy.calls.count()).toBe(1);
+      });
+
       it('applies the clr-form-control class', () => {
         expect(context.clarityElement.className).toContain('clr-form-control');
       });

--- a/src/clr-angular/forms/datepicker/date-container.ts
+++ b/src/clr-angular/forms/datepicker/date-container.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { Component, OnDestroy, Optional, ContentChild } from '@angular/core';
+import { Component, OnDestroy, Optional, ContentChild, HostListener, ViewChild, ElementRef } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { NgControl } from '@angular/forms';
 
@@ -33,7 +33,7 @@ import { ClrCommonStrings } from '../../utils/i18n/common-strings.interface';
         <div class="clr-input-wrapper">
           <div class="clr-input-group" [class.clr-focus]="focus">
             <ng-content select="[clrDate]"></ng-content>
-            <button type="button" class="clr-input-group-icon-action" (click)="toggleDatepicker($event)" *ngIf="isEnabled" [attr.title]="commonStrings.open" [disabled]="control?.disabled">
+            <button #actionButton type="button" class="clr-input-group-icon-action" (click)="toggleDatepicker($event)" *ngIf="isEnabled" [attr.title]="commonStrings.open" [disabled]="control?.disabled">
               <clr-icon shape="calendar"></clr-icon>
             </button>
             <clr-datepicker-view-manager *clrIfOpen clrFocusTrap></clr-datepicker-view-manager>
@@ -71,6 +71,12 @@ export class ClrDateContainer implements DynamicWrapper, OnDestroy {
   @ContentChild(ClrLabel, { static: false })
   label: ClrLabel;
 
+  private toggleButton: ElementRef;
+  @ViewChild('actionButton', { static: false })
+  set actionButton(button: ElementRef) {
+    this.toggleButton = button;
+  }
+
   private subscriptions: Subscription[] = [];
 
   constructor(
@@ -102,6 +108,11 @@ export class ClrDateContainer implements DynamicWrapper, OnDestroy {
         this.control = control;
       })
     );
+  }
+
+  @HostListener('body:keyup.escape')
+  close(): void {
+    this.toggleButton.nativeElement.focus();
   }
 
   ngOnInit() {


### PR DESCRIPTION
This change listens for the escape keyboard event and returns focus to the datepicker toggle button when the picker is closed via escape. 

- closes #3468

Signed-off-by: Matt Hippely <mhippely@vmware.com>