### PR TITLE
[ng] fix(datepicker): Add HostListener to focus on the datepicker toggle button

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -515,8 +515,9 @@ export declare class ClrDateContainer implements DynamicWrapper, OnDestroy {
     readonly isEnabled: boolean;
     label: ClrLabel;
     newFormsLayout: boolean;
-    constructor(_ifOpenService: IfOpenService, _dateNavigationService: DateNavigationService, _datepickerEnabledService: DatepickerEnabledService, dateFormControlService: DateFormControlService, commonStrings: ClrCommonStrings, ifErrorService: IfErrorService, focusService: FocusService, controlClassService: ControlClassService, layoutService: LayoutService, newFormsLayout: boolean, ngControlService: NgControlService);
+    constructor(_ifOpenService: IfOpenService, _dateNavigationService: DateNavigationService, _datepickerEnabledService: DatepickerEnabledService, dateFormControlService: DateFormControlService, commonStrings: ClrCommonStrings, ifErrorService: IfErrorService, focusService: FocusService, controlClassService: ControlClassService, layoutService: LayoutService, newFormsLayout: boolean, ngControlService: NgControlService, elementRef: ElementRef);
     addGrid(): boolean;
+    close(event: any): void;
     controlClass(): string;
     ngOnDestroy(): void;
     ngOnInit(): void;

--- a/src/clr-angular/forms/datepicker/date-container.spec.ts
+++ b/src/clr-angular/forms/datepicker/date-container.spec.ts
@@ -115,6 +115,20 @@ export default function() {
         context.detectChanges();
       });
 
+      it('returns focus to the toggle button when closed with the escape key', () => {
+        const actionButton: HTMLButtonElement = context.clarityElement.querySelector('.clr-input-group-icon-action');
+        const actionButtonSpy = spyOn(actionButton, 'focus');
+        expect(actionButtonSpy.calls.count()).toBe(0);
+        actionButton.click();
+        context.detectChanges();
+        const event = new KeyboardEvent('keyup', {
+          key: 'Escape',
+        });
+        document.body.dispatchEvent(event);
+        context.detectChanges();
+        expect(actionButtonSpy.calls.count()).toBe(1);
+      });
+
       it('applies the clr-form-control class', () => {
         expect(context.clarityElement.className).toContain('clr-form-control');
       });


### PR DESCRIPTION
This is a backport of the fix for v1 into the v1 codebase. 

I had to modify the fix because of the dual templates that support both old and new forms in v1. 
I don't really like this fix but it avoids modifying other parts of v1 (AbstractPopover also has an escape listener and that seems to interfere with the HostListener in v1). Also ran into an issue where I couldn't `@ViewChild` the buttons because they are in templates. 

- closes #3468

Signed-off-by: Matt Hippely <mhippely@vmware.com>