### PR TITLE
Datagrid focus management (part 2 - show/hide columns)

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -222,6 +222,7 @@ export declare class ClrCommonFormsModule {
 }
 
 export declare abstract class ClrCommonStrings {
+    allColumnsSelected?: string;
     close?: string;
     collapse?: string;
     current?: string;
@@ -248,6 +249,7 @@ export declare abstract class ClrCommonStrings {
     selectAll?: string;
     show?: string;
     showColumns?: string;
+    showColumnsMenuDescription?: string;
     sortColumn?: string;
     success?: string;
     totalPages?: string;
@@ -305,7 +307,6 @@ export declare class ClrDatagridActionOverflow implements OnDestroy {
     commonStrings: ClrCommonStrings;
     open: boolean;
     openChanged: EventEmitter<boolean>;
-    overflowClassName: string;
     popoverId: string;
     popoverPoint: Point;
     constructor(rowActionService: RowActionService, commonStrings: ClrCommonStrings, elementRef: ElementRef, platformId: Object, zone: NgZone);
@@ -346,6 +347,7 @@ export declare class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<
 }
 
 export declare class ClrDatagridColumnToggle {
+    allSelectedElement: ElementRef<HTMLElement>;
     anchorPoint: Point;
     columnSwitchId: string;
     commonStrings: ClrCommonStrings;
@@ -353,11 +355,14 @@ export declare class ClrDatagridColumnToggle {
     customToggleTitle: ClrDatagridColumnToggleTitle;
     readonly hasOnlyOneVisibleColumn: boolean;
     readonly hideableColumnStates: ColumnState[];
+    menuDescriptionElement: ElementRef<HTMLElement>;
     open: boolean;
     popoverPoint: Point;
-    constructor(commonStrings: ClrCommonStrings, columnsService: ColumnsService, columnSwitchId: string);
+    constructor(commonStrings: ClrCommonStrings, columnsService: ColumnsService, columnSwitchId: string, platformId: Object, zone: NgZone);
+    allColumnsSelected(): void;
     toggleColumnState(columnState: ColumnState, event: boolean): void;
     toggleSwitchPanel(): void;
+    trackByFn(index: any): any;
 }
 
 export interface ClrDatagridComparatorInterface<T> {

--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -347,7 +347,6 @@ export declare class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<
 }
 
 export declare class ClrDatagridColumnToggle {
-    allSelectedElement: ElementRef<HTMLElement>;
     anchorPoint: Point;
     columnSwitchId: string;
     commonStrings: ClrCommonStrings;
@@ -355,7 +354,6 @@ export declare class ClrDatagridColumnToggle {
     customToggleTitle: ClrDatagridColumnToggleTitle;
     readonly hasOnlyOneVisibleColumn: boolean;
     readonly hideableColumnStates: ColumnState[];
-    menuDescriptionElement: ElementRef<HTMLElement>;
     open: boolean;
     popoverPoint: Point;
     constructor(commonStrings: ClrCommonStrings, columnsService: ColumnsService, columnSwitchId: string, platformId: Object, zone: NgZone);

--- a/src/clr-angular/data/datagrid/datagrid-action-overflow.ts
+++ b/src/clr-angular/data/datagrid/datagrid-action-overflow.ts
@@ -32,7 +32,7 @@ let clrDgActionId = 0;
         </button>
         <ng-template [(clrPopoverOld)]="open" [clrPopoverOldAnchor]="anchor" [clrPopoverOldAnchorPoint]="anchorPoint"
                      [clrPopoverOldPopoverPoint]="popoverPoint">
-            <div [attr.class]="overflowClassName" (clrOutsideClick)="close($event)" [clrStrict]="true" 
+            <div class="datagrid-action-overflow" (clrOutsideClick)="close($event)" [clrStrict]="true" 
                     role="menu" [attr.id]="popoverId" [attr.aria-hidden]="!open">
                 <ng-content></ng-content>
             </div>
@@ -40,7 +40,6 @@ let clrDgActionId = 0;
     `,
 })
 export class ClrDatagridActionOverflow implements OnDestroy {
-  public overflowClassName = 'datagrid-action-overflow';
   public anchorPoint: Point = Point.RIGHT_CENTER;
   public popoverPoint: Point = Point.LEFT_CENTER;
 
@@ -78,9 +77,7 @@ export class ClrDatagridActionOverflow implements OnDestroy {
       if (boolOpen && isPlatformBrowser(this.platformId)) {
         this.zone.runOutsideAngular(() => {
           setTimeout(() => {
-            const firstButton = this.elementRef.nativeElement.querySelector(
-              `.${this.overflowClassName} button.action-item`
-            );
+            const firstButton = this.elementRef.nativeElement.querySelector('button.action-item');
             if (firstButton) {
               firstButton.focus();
             }
@@ -108,9 +105,9 @@ export class ClrDatagridActionOverflow implements OnDestroy {
 
   public close(event: MouseEvent) {
     /*
-         * Because this listener is added synchonously, before the event finishes bubbling up the DOM,
-         * we end up firing on the very click that just opened the menu, p
-         * otentially closing it immediately every time. So we just ignore it.
+         * Because this listener is added synchronously, before the event finishes bubbling up the DOM,
+         * we end up firing on the very click that just opened the menu,
+         * potentially closing it immediately every time. So we just ignore it.
          */
     if (event === this.openingEvent) {
       delete this.openingEvent;

--- a/src/clr-angular/data/datagrid/datagrid-column-toggle-button.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-toggle-button.ts
@@ -3,10 +3,10 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { Component } from '@angular/core';
+import { Component, EventEmitter, Output } from '@angular/core';
 import { ColumnsService } from './providers/columns.service';
 import { ColumnState } from './interfaces/column-state.interface';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { DatagridColumnChanges } from './enums/column-changes.enum';
 
 @Component({
@@ -24,6 +24,13 @@ import { DatagridColumnChanges } from './enums/column-changes.enum';
 export class ClrDatagridColumnToggleButton {
   constructor(private columnsService: ColumnsService) {}
 
+  private allSelected: Subject<boolean> = new EventEmitter();
+
+  @Output('clrAllSelected')
+  get clrAllSelected(): Observable<boolean> {
+    return this.allSelected.asObservable();
+  }
+
   private hideableColumns(): BehaviorSubject<ColumnState>[] {
     return this.columnsService.columns.filter(column => column.value.hideable);
   }
@@ -39,5 +46,6 @@ export class ClrDatagridColumnToggleButton {
         changes: [DatagridColumnChanges.HIDDEN],
       })
     );
+    this.allSelected.next(true);
   }
 }

--- a/src/clr-angular/data/datagrid/datagrid-column-toggle.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-toggle.spec.ts
@@ -62,43 +62,61 @@ export default function(): void {
     });
 
     describe('View', function() {
-      it('toggles switch panel', function() {
-        context.detectChanges();
-        expect(context.clarityElement.querySelectorAll('.column-switch').length).toBe(0);
-        columnToggle.toggleSwitchPanel();
-        context.detectChanges();
-        expect(context.clarityElement.querySelectorAll('.column-switch').length).toBe(1);
-        columnToggle.toggleSwitchPanel();
-        context.detectChanges();
-        expect(context.clarityElement.querySelectorAll('.column-switch').length).toBe(0);
-      });
+      it(
+        'toggles switch panel',
+        fakeAsync(function() {
+          context.detectChanges();
+          expect(context.clarityElement.querySelectorAll('.column-switch').length).toBe(0);
+          columnToggle.toggleSwitchPanel();
+          context.detectChanges();
+          tick();
+          expect(context.clarityElement.querySelectorAll('.column-switch').length).toBe(1);
+          columnToggle.toggleSwitchPanel();
+          context.detectChanges();
+          tick();
+          expect(context.clarityElement.querySelectorAll('.column-switch').length).toBe(0);
+        })
+      );
 
-      it('closes switch panel when close button is clicked', function() {
-        expect(context.clarityElement.querySelectorAll('.column-switch').length).toBe(0);
-        columnToggle.toggleSwitchPanel();
-        context.detectChanges();
-        expect(context.clarityElement.querySelectorAll('.column-switch').length).toBe(1);
-        context.clarityElement.querySelector('.toggle-switch-close-button').click();
-        context.detectChanges();
-        expect(context.clarityElement.querySelectorAll('.column-switch').length).toBe(0);
-      });
+      it(
+        'closes switch panel when close button is clicked',
+        fakeAsync(function() {
+          expect(context.clarityElement.querySelectorAll('.column-switch').length).toBe(0);
+          columnToggle.toggleSwitchPanel();
+          context.detectChanges();
+          tick();
+          expect(context.clarityElement.querySelectorAll('.column-switch').length).toBe(1);
+          context.clarityElement.querySelector('.toggle-switch-close-button').click();
+          context.detectChanges();
+          tick();
+          expect(context.clarityElement.querySelectorAll('.column-switch').length).toBe(0);
+        })
+      );
 
-      it('.column-switch should have id and it have to match the aria-control', function() {
-        columnToggle.toggleSwitchPanel();
-        context.detectChanges();
-        expect(
-          context.clarityElement.querySelector('button.column-toggle--action').attributes['aria-controls'].value
-        ).toBe(context.clarityElement.querySelector('div.column-switch').attributes.id.value);
-      });
+      it(
+        '.column-switch should have id and it have to match the aria-control',
+        fakeAsync(function() {
+          columnToggle.toggleSwitchPanel();
+          context.detectChanges();
+          tick();
+          expect(
+            context.clarityElement.querySelector('button.column-toggle--action').attributes['aria-controls'].value
+          ).toBe(context.clarityElement.querySelector('div.column-switch').attributes.id.value);
+        })
+      );
 
-      it('toggle switch close button should have aria-label for close', function() {
-        /* Open it */
-        columnToggle.toggleSwitchPanel();
-        context.detectChanges();
-        expect(
-          context.clarityElement.querySelector('button.toggle-switch-close-button').attributes['aria-label'].value
-        ).toBe(new ClrCommonStringsService().close);
-      });
+      it(
+        'toggle switch close button should have aria-label for close',
+        fakeAsync(function() {
+          /* Open it */
+          columnToggle.toggleSwitchPanel();
+          context.detectChanges();
+          tick();
+          expect(
+            context.clarityElement.querySelector('button.toggle-switch-close-button').attributes['aria-label'].value
+          ).toBe(new ClrCommonStringsService().close);
+        })
+      );
 
       it('projects template as switch content', function() {
         columnsService.mockAllHideable();

--- a/src/clr-angular/data/datagrid/datagrid-column-toggle.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-toggle.ts
@@ -82,9 +82,9 @@ export class ClrDatagridColumnToggle {
   @ContentChild(ClrDatagridColumnToggleButton, { static: false })
   customToggleButton: ClrDatagridColumnToggleButton;
   @ViewChild('menuDescription', { read: ElementRef, static: false })
-  menuDescriptionElement: ElementRef<HTMLElement>;
+  private menuDescriptionElement: ElementRef<HTMLElement>;
   @ViewChild('allSelected', { read: ElementRef, static: false })
-  allSelectedElement: ElementRef<HTMLElement>;
+  private allSelectedElement: ElementRef<HTMLElement>;
 
   constructor(
     public commonStrings: ClrCommonStrings,

--- a/src/clr-angular/data/datagrid/datagrid-column-toggle.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-toggle.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { Component, ContentChild, Inject } from '@angular/core';
+import { Component, ContentChild, ElementRef, Inject, NgZone, PLATFORM_ID, ViewChild } from '@angular/core';
 
 import { Point } from '../../popover/common/popover';
 
@@ -14,6 +14,7 @@ import { ClrCommonStrings } from '../../utils/i18n/common-strings.interface';
 import { ColumnsService } from './providers/columns.service';
 import { ColumnState } from './interfaces/column-state.interface';
 import { DatagridColumnChanges } from './enums/column-changes.enum';
+import { isPlatformBrowser } from '@angular/common';
 
 import { UNIQUE_ID_PROVIDER, UNIQUE_ID } from '../../utils/id-generator/id-generator.service';
 
@@ -31,6 +32,8 @@ import { UNIQUE_ID_PROVIDER, UNIQUE_ID } from '../../utils/id-generator/id-gener
     <div [id]="columnSwitchId" class="column-switch"
          *clrPopoverOld="open; anchor: anchor; anchorPoint: anchorPoint; popoverPoint: popoverPoint">
       <div class="switch-header">
+        <div class="clr-sr-only" tabindex="-1" #menuDescription>{{commonStrings.showColumnsMenuDescription}}</div>
+        <div class="clr-sr-only" tabindex="-1" #allSelected>{{commonStrings.allColumnsSelected}}</div>
         <ng-container *ngIf="!customToggleTitle">{{commonStrings.showColumns}}</ng-container>
         <ng-content select="clr-dg-column-toggle-title"></ng-content>
         <button
@@ -42,7 +45,7 @@ import { UNIQUE_ID_PROVIDER, UNIQUE_ID } from '../../utils/id-generator/id-gener
         </button>
       </div>
       <ul class="switch-content list-unstyled">
-        <li *ngFor="let columnState of hideableColumnStates;">
+        <li *ngFor="let columnState of hideableColumnStates;trackBy: trackByFn">
           <clr-checkbox-wrapper>
             <input clrCheckbox type="checkbox"
                    [disabled]="hasOnlyOneVisibleColumn && !columnState.hidden"
@@ -56,7 +59,9 @@ import { UNIQUE_ID_PROVIDER, UNIQUE_ID } from '../../utils/id-generator/id-gener
       </ul>
       <div class="switch-footer">
         <ng-content select="clr-dg-column-toggle-button"></ng-content>
-        <clr-dg-column-toggle-button *ngIf="!customToggleButton">{{commonStrings.selectAll}}</clr-dg-column-toggle-button>
+        <clr-dg-column-toggle-button *ngIf="!customToggleButton" (clrAllSelected)="allColumnsSelected()">
+          {{commonStrings.selectAll}}
+        </clr-dg-column-toggle-button>
       </div>
     </div>
   `,
@@ -76,11 +81,17 @@ export class ClrDatagridColumnToggle {
   customToggleTitle: ClrDatagridColumnToggleTitle;
   @ContentChild(ClrDatagridColumnToggleButton, { static: false })
   customToggleButton: ClrDatagridColumnToggleButton;
+  @ViewChild('menuDescription', { read: ElementRef, static: false })
+  menuDescriptionElement: ElementRef<HTMLElement>;
+  @ViewChild('allSelected', { read: ElementRef, static: false })
+  allSelectedElement: ElementRef<HTMLElement>;
 
   constructor(
     public commonStrings: ClrCommonStrings,
     private columnsService: ColumnsService,
-    @Inject(UNIQUE_ID) public columnSwitchId: string
+    @Inject(UNIQUE_ID) public columnSwitchId: string,
+    @Inject(PLATFORM_ID) private platformId: Object,
+    private zone: NgZone
   ) {}
 
   get hideableColumnStates(): ColumnState[] {
@@ -106,5 +117,22 @@ export class ClrDatagridColumnToggle {
 
   toggleSwitchPanel() {
     this.open = !this.open;
+    if (this.open && isPlatformBrowser(this.platformId)) {
+      this.zone.runOutsideAngular(() => {
+        setTimeout(() => {
+          this.menuDescriptionElement.nativeElement.focus();
+        });
+      });
+    }
+  }
+
+  allColumnsSelected() {
+    this.allSelectedElement.nativeElement.focus();
+  }
+
+  // Without tracking the checkboxes get rerendered on model update, which leads
+  // to loss of focus after checkbox toggle.
+  trackByFn(index) {
+    return index;
   }
 }

--- a/src/clr-angular/utils/i18n/common-strings.interface.ts
+++ b/src/clr-angular/utils/i18n/common-strings.interface.ts
@@ -133,4 +133,12 @@ export abstract class ClrCommonStrings {
    * Modal end of content
    */
   modalContentEnd?: string;
+  /**
+   * Datagrid Show columns menu description
+   */
+  showColumnsMenuDescription?: string;
+  /**
+   * Datagrid Show columns / All columns selected confirmation
+   */
+  allColumnsSelected?: string;
 }

--- a/src/clr-angular/utils/i18n/common-strings.service.ts
+++ b/src/clr-angular/utils/i18n/common-strings.service.ts
@@ -41,6 +41,8 @@ export class ClrCommonStringsService implements ClrCommonStrings {
   maxValue = 'Max value';
   modalContentStart = 'Beginning of Modal Content';
   modalContentEnd = 'End of Modal Content';
+  showColumnsMenuDescription = 'Show or hide columns menu';
+  allColumnsSelected = 'All columns selected';
 }
 
 export function commonStringsFactory(existing?: ClrCommonStrings): ClrCommonStrings {

--- a/src/website/src/app/documentation/demos/i18n/i18n.demo.ts
+++ b/src/website/src/app/documentation/demos/i18n/i18n.demo.ts
@@ -48,6 +48,11 @@ export class I18nDemo extends ClarityDocComponent {
     { key: 'currentPage', role: 'Datagrid: pagination current page button text' },
     { key: 'totalPages', role: 'Datagrid: pagination total pages button text' },
     { key: 'minValue', role: 'Datagrid: minimum value (numeric filters)' },
-    { key: 'maxValue', role: 'Datagrid: maximum value (numeric filters' },
+    { key: 'maxValue', role: 'Datagrid: maximum value (numeric filters)' },
+    {
+      key: 'showColumnsMenuDescription',
+      role: 'Datagrid: screen reader only description of the Show/Hide columns menu',
+    },
+    { key: 'allColumnsSelected', role: 'Datagrid: screen reader only confirmation that all columns were selected' },
   ];
 }


### PR DESCRIPTION
- fixed focus lost after "select all" button clicked
- fixed no notification on popup opened
- fixed focus lost on column checkbox toggled
- minor selector improvement suggested by Shijir in part 1

closes #3370

Signed-off-by: Ivan Donchev <idonchev@vmware.com>