### PR TITLE
[BUG] Restoring hidden-[size]-down utility classes

### DIFF
--- a/src/clr-angular/layout/grid/mixins/_breakpoint.clarity.scss
+++ b/src/clr-angular/layout/grid/mixins/_breakpoint.clarity.scss
@@ -1,10 +1,23 @@
-// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
+
+@function clr-breakpoint-next($name, $breakpoints: $clr-grid-breakpoints, $breakpoint-names: map-keys($breakpoints)) {
+  $n: index($breakpoint-names, $name);
+  @if not $n {
+    @error 'breakpoint `#{$name}` not found in `#{$breakpoints}`';
+  }
+  @return if($n < length($breakpoint-names), nth($breakpoint-names, $n + 1), null);
+}
 
 @function clr-breakpoint-min($name, $breakpoints: $clr-grid-breakpoints) {
   $min: map-get($breakpoints, $name);
   @return if($min != 0, $min, null);
+}
+
+@function clr-breakpoint-max($name, $breakpoints: $clr-grid-breakpoints) {
+  $next: clr-breakpoint-next($name, $breakpoints);
+  @return if($next, clr-breakpoint-min($next, $breakpoints) - 0.02, null);
 }
 
 @function clr-breakpoint-infix($name, $breakpoints: $clr-grid-breakpoints) {
@@ -17,6 +30,19 @@
   $min: clr-breakpoint-min($name, $breakpoints);
   @if $min {
     @media (min-width: $min) {
+      @content;
+    }
+  } @else {
+    @content;
+  }
+}
+
+// Media of at most the maximum breakpoint width. No query for the largest breakpoint.
+// Makes the @content apply to the given breakpoint and narrower.
+@mixin clr-media-breakpoint-down($name, $breakpoints: $clr-grid-breakpoints) {
+  $max: clr-breakpoint-max($name, $breakpoints);
+  @if $max {
+    @media (max-width: $max) {
       @content;
     }
   } @else {

--- a/src/clr-angular/layout/grid/utilities/_visibility.clarity.scss
+++ b/src/clr-angular/layout/grid/utilities/_visibility.clarity.scss
@@ -13,6 +13,11 @@
       display: none !important;
     }
   }
+  .clr-hidden-#{$bp}-down {
+    @include clr-media-breakpoint-down($bp) {
+      display: none !important;
+    }
+  }
 }
 
 // Print utilities


### PR DESCRIPTION
This utility classes hide elements responsively when the window crosses a maximum width threshold. They were unintentionally removed when we got rid of the old Bootstrap grid.

It's worth noting that Bootstrap removed these in a BS4-beta version.

Tested in:
✔︎ Chrome
✔︎ IE11
✔︎ Edge

Closes: #3457

Signed-off-by: Scott Mathis <smathis@vmware.com>