### PR TITLE
Icons in buttons need accessible names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@clr/clarity",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/clr-icons/clr-icons-element.ts
+++ b/src/clr-icons/clr-icons-element.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -57,6 +57,10 @@ ClarityIconElement.prototype._setIconSize = function(size: string) {
   }
 };
 
+ClarityIconElement.prototype._normalizeShape = function(value: string): string {
+  return value.split(/\s/)[0].toLowerCase();
+};
+
 ClarityIconElement.prototype.connectedCallback = function() {
   // One thing to note here is that the attributeChangedCallback method is called for every attribute first
   // before this connectedCallback method called only once when the custom element is inserted into the DOM.
@@ -82,7 +86,7 @@ ClarityIconElement.prototype.connectedCallback = function() {
   // This means even if the shape is not found, the injected shape will have the user-given size.
 
   if (this.hasAttribute('shape')) {
-    const shapeAttrValue = this.getAttribute('shape').split(/\s/)[0];
+    const shapeAttrValue = this._normalizeShape(this.getAttribute('shape'));
 
     this._shapeTemplateSubscription = ShapeTemplateObserver.instance.subscribeTo(
       shapeAttrValue,
@@ -135,7 +139,7 @@ ClarityIconElement.prototype.attributeChangedCallback = function(
   // This means even if the shape is not found, the injected shape will have the user-given size.
 
   if (attributeName === 'shape') {
-    this.currentShapeAttrVal = newValue.split(/\s/)[0];
+    this.currentShapeAttrVal = this._normalizeShape(newValue);
 
     // transfer change handler callback to new shape name
     if (this._shapeTemplateSubscription) {

--- a/src/clr-icons/clr-icons.spec.ts
+++ b/src/clr-icons/clr-icons.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -311,9 +311,9 @@ describe('ClarityIcons', () => {
       resetCallbacks();
     });
 
-    it('should insert the SVG markup', () => {
+    it('should insert the SVG markup also make sure that the shape is case-insensitive', () => {
       const clarityIcon = document.createElement('clr-icon');
-      clarityIcon.setAttribute('shape', 'home');
+      clarityIcon.setAttribute('shape', 'HoMe ');
 
       const divSampleElement = document.createElement('div');
       divSampleElement.innerHTML = ClarityIcons.get('home');

--- a/src/website/src/app/documentation/demos/button-group/button-group.demo.html
+++ b/src/website/src/app/documentation/demos/button-group/button-group.demo.html
@@ -185,16 +185,13 @@
                             <div class="clrweb-DoxMedia-img">
                                 <div class="btn-group btn-primary btn-icon">
                                     <button class="btn">
-                                        <clr-icon shape="plus"></clr-icon>
-                                        <span class="clr-icon-title">Add</span>
+                                        <clr-icon shape="check" title="check"></clr-icon>
                                     </button>
                                     <button class="btn">
-                                        <clr-icon shape="favorite"></clr-icon>
-                                        <span class="clr-icon-title">Favorite</span>
+                                        <clr-icon shape="home" title="home"></clr-icon>
                                     </button>
                                     <button class="btn">
-                                        <clr-icon shape="download"></clr-icon>
-                                        <span class="clr-icon-title">Download</span>
+                                        <clr-icon shape="user" title="user"></clr-icon>
                                     </button>
                                 </div>
                             </div>
@@ -215,16 +212,13 @@
                             <div class="clrweb-DoxMedia-img">
                                 <div class="btn-group btn-primary btn-sm btn-icon">
                                     <button class="btn">
-                                        <clr-icon shape="plus"></clr-icon>
-                                        <span class="clr-icon-title">Add</span>
+                                        <clr-icon shape="check" title="check"></clr-icon>
                                     </button>
                                     <button class="btn">
-                                        <clr-icon shape="favorite"></clr-icon>
-                                        <span class="clr-icon-title">Favorite</span>
+                                        <clr-icon shape="home" title="home"></clr-icon>
                                     </button>
                                     <button class="btn">
-                                        <clr-icon shape="download"></clr-icon>
-                                        <span class="clr-icon-title">Download</span>
+                                        <clr-icon shape="user" title="user"></clr-icon>
                                     </button>
                                 </div>
                             </div>
@@ -248,16 +242,16 @@
                             <div class="clrweb-DoxMedia-img">
                                 <div class="btn-group btn-primary">
                                     <button class="btn">
-                                        <clr-icon shape="plus"></clr-icon>
-                                        Add
+                                        <clr-icon shape="check"></clr-icon>
+                                        Check
                                     </button>
                                     <button class="btn">
-                                        <clr-icon shape="favorite"></clr-icon>
-                                        Favorite
+                                        <clr-icon shape="home"></clr-icon>
+                                        Home
                                     </button>
                                     <button class="btn">
-                                        <clr-icon shape="download"></clr-icon>
-                                        Download
+                                        <clr-icon shape="user"></clr-icon>
+                                        User Profile
                                     </button>
                                 </div>
                             </div>
@@ -278,16 +272,16 @@
                             <div class="clrweb-DoxMedia-img">
                                 <div class="btn-group btn-primary">
                                     <button class="btn">
-                                        Add
-                                        <clr-icon shape="plus"></clr-icon>
+                                        Check
+                                        <clr-icon shape="check"></clr-icon>
                                     </button>
                                     <button class="btn">
-                                        Favorite
-                                        <clr-icon shape="favorite"></clr-icon>
+                                        Home
+                                        <clr-icon shape="home"></clr-icon>
                                     </button>
                                     <button class="btn">
-                                        Download
-                                        <clr-icon shape="download"></clr-icon>
+                                        User Profile
+                                        <clr-icon shape="user"></clr-icon>
                                     </button>
                                 </div>
                             </div>
@@ -302,6 +296,15 @@
                     </div>
                 </div>
             </div>
+
+            <h3>Accessibility</h3>
+            <p>
+                If your icon button has no text, we recommend adding the <code class="clr-code">title=""</code> attribute to 
+                your icon buttons. This adds some additional context for users unfamiliar with what action your icon button 
+                might produce. The text should reflect the action being completed.
+            </p>
+
+            <clr-code-snippet [clrCode]="accessibilityExample"></clr-code-snippet>
 
             <h3>Overflow</h3>
 
@@ -335,7 +338,7 @@
                                     </button>
                                     <div class="btn-group-overflow open">
                                         <button class="btn dropdown-toggle">
-                                            <clr-icon shape="ellipsis-horizontal"></clr-icon>
+                                            <clr-icon shape="ellipsis-horizontal" title="Expand dropdown"></clr-icon>
                                         </button>
                                         <div class="dropdown-menu">
                                             <button class="btn">Download</button>
@@ -366,24 +369,24 @@
                             <div class="clrweb-DoxMedia-img is-left-aligned">
                                 <div class="btn-group btn-primary">
                                     <button class="btn">
-                                        <clr-icon shape="plus"></clr-icon>
+                                        <clr-icon shape="check" title="Add"></clr-icon>
                                         Add
                                     </button>
                                     <button class="btn">
-                                        <clr-icon shape="favorite"></clr-icon>
-                                        Favorite
+                                        <clr-icon shape="folder" title="Folder"></clr-icon>
+                                        Folder
                                     </button>
                                     <div class="btn-group-overflow open">
                                         <button class="btn dropdown-toggle">
-                                            <clr-icon shape="ellipsis-horizontal"></clr-icon>
+                                            <clr-icon shape="ellipsis-horizontal" title="Expand dropdown"></clr-icon>
                                         </button>
                                         <div class="dropdown-menu">
                                             <button class="btn">
-                                                <clr-icon shape="download"></clr-icon>
+                                                <clr-icon shape="download" title="Download"></clr-icon>
                                                 Download
                                             </button>
                                             <button class="btn">
-                                                <clr-icon shape="refresh"></clr-icon>
+                                                <clr-icon shape="refresh" title="Refresh"></clr-icon>
                                                 Refresh
                                             </button>
                                         </div>
@@ -399,16 +402,14 @@
                             <div class="clrweb-DoxMedia-img">
                                 <div class="btn-group btn-primary btn-icon">
                                     <button class="btn">
-                                        <clr-icon shape="plus"></clr-icon>
-                                        <span class="clr-icon-title">Add</span>
+                                        <clr-icon shape="check" title="Add"></clr-icon>
                                     </button>
                                     <button class="btn">
-                                        <clr-icon shape="favorite"></clr-icon>
-                                        <span class="clr-icon-title">Favorite</span>
+                                        <clr-icon shape="folder" title="Folder"></clr-icon>
                                     </button>
                                     <div class="btn-group-overflow open">
                                         <button class="btn dropdown-toggle">
-                                            <clr-icon shape="ellipsis-horizontal"></clr-icon>
+                                            <clr-icon shape="ellipsis-horizontal" title="Expand dropdown"></clr-icon>
                                         </button>
                                         <div class="dropdown-menu">
                                             <button class="btn">

--- a/src/website/src/app/documentation/demos/button-group/button-group.demo.ts
+++ b/src/website/src/app/documentation/demos/button-group/button-group.demo.ts
@@ -1,10 +1,24 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { Component } from '@angular/core';
 import { ClarityDocComponent } from '../clarity-doc';
+
+const ACCESSIBILITY_EXAMPLE = `
+<div class="btn-group btn-primary btn-icon">
+    <button class="btn">
+        <clr-icon shape="check" title="Check"></clr-icon>
+    </button>
+    <button class="btn">
+        <clr-icon shape="home" title="home"></clr-icon>
+    </button>
+    <button class="btn">
+        <clr-icon shape="user" title="user"></clr-icon>
+    </button>
+</div>
+`;
 
 @Component({
   selector: 'clr-button-group-demo',
@@ -15,6 +29,7 @@ import { ClarityDocComponent } from '../clarity-doc';
   },
 })
 export class ButtonGroupDemo extends ClarityDocComponent {
+  accessibilityExample = ACCESSIBILITY_EXAMPLE;
   constructor() {
     super('button-group');
   }

--- a/src/website/src/app/documentation/demos/buttons/buttons.demo.html
+++ b/src/website/src/app/documentation/demos/buttons/buttons.demo.html
@@ -267,13 +267,13 @@
                         <div class="clrweb-DoxMedia-block">
                             <div class="clrweb-DoxMedia-img">
                                 <button class="btn btn-primary btn-icon" aria-label="add" style="margin-right: 12px">
-                                    <clr-icon shape="plus"></clr-icon>
+                                    <clr-icon shape="check"></clr-icon>
                                 </button>
                                 <button class="btn btn-icon" aria-label="favorite" style="margin-right: 12px">
-                                    <clr-icon shape="star"></clr-icon>
+                                    <clr-icon shape="folder"></clr-icon>
                                 </button>
                                 <button class="btn btn-link btn-icon" aria-label="download">
-                                    <clr-icon shape="download"></clr-icon>
+                                    <clr-icon shape="cog"></clr-icon>
                                 </button>
                             </div>
                         </div>
@@ -294,13 +294,13 @@
                         <div class="clrweb-DoxMedia-block">
                             <div class="clrweb-DoxMedia-img">
                                 <button class="btn btn-primary btn-sm btn-icon" aria-label="add" style="margin-right: 12px">
-                                    <clr-icon shape="plus"></clr-icon>
+                                    <clr-icon shape="check"></clr-icon>
                                 </button>
                                 <button class="btn btn-sm btn-icon" aria-label="favorite" style="margin-right: 12px">
-                                    <clr-icon shape="star"></clr-icon>
+                                    <clr-icon shape="folder"></clr-icon>
                                 </button>
                                 <button class="btn btn-sm btn-link btn-icon" aria-label="download">
-                                    <clr-icon shape="download"></clr-icon>
+                                    <clr-icon shape="cog"></clr-icon>
                                 </button>
                             </div>
                         </div>
@@ -321,11 +321,11 @@
                         <div class="clrweb-DoxMedia-block">
                             <div class="clrweb-DoxMedia-img">
                                 <button class="btn btn-primary btn-icon" style="margin-right: 12px">
-                                    <clr-icon shape="plus"></clr-icon>
+                                    <clr-icon shape="check"></clr-icon>
                                     Create
                                 </button>
                                 <button class="btn btn-danger btn-icon">
-                                    <clr-icon shape="trash"></clr-icon>
+                                    <clr-icon shape="times"></clr-icon>
                                     Delete
                                 </button>
                             </div>
@@ -348,11 +348,11 @@
                             <div class="clrweb-DoxMedia-img">
                                 <button class="btn btn-primary btn-icon" style="margin-right: 12px">
                                     Create
-                                    <clr-icon shape="plus"></clr-icon>
+                                    <clr-icon shape="check"></clr-icon>
                                 </button>
                                 <button class="btn btn-danger btn-icon">
                                     Delete
-                                    <clr-icon shape="trash"></clr-icon>
+                                    <clr-icon shape="times"></clr-icon>
                                 </button>
                             </div>
                         </div>


### PR DESCRIPTION
* Update website button group examples by adding `title` to button groups that have only icons.
* Adding a reminder for Developers to add a title to icons when the button doesn't have human-readable text
* Use only `Core Icons` inside the Buttons & Buttons Group examples. No need to load other icons sets.

* Make `clrIcon` shape attribute case-insensitive - `HOME` and `home` must equal the same icon.

Close #3530 

TODO: 
Backport it to V1