### PR TITLE
[BUG] Restoring hidden-[size]-[up|down] utility classes

### DIFF
--- a/src/clr-angular/utils/bootstrap/utilities/_visibility.scss
+++ b/src/clr-angular/utils/bootstrap/utilities/_visibility.scss
@@ -14,7 +14,17 @@
       display: none !important;
     }
   }
+  .clr-hidden-#{$bp}-up {
+    @include media-breakpoint-up($bp) {
+      display: none !important;
+    }
+  }
   .hidden-#{$bp}-down {
+    @include media-breakpoint-down($bp) {
+      display: none !important;
+    }
+  }
+  .clr-hidden-#{$bp}-down {
     @include media-breakpoint-down($bp) {
       display: none !important;
     }


### PR DESCRIPTION
The utility classes were present in 1.x but not prefixed. I added prefixed versions for the backport.

Tested in:
✔︎ Chrome

Closes: #3457

Signed-off-by: Scott Mathis <smathis@vmware.com>