### PR TITLE
[NG] stepper a11y states

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -69,6 +69,9 @@ export declare class ClrAccordionPanel implements OnInit, OnChanges {
     panelOpenChange: EventEmitter<boolean>;
     constructor(commonStrings: ClrCommonStrings, accordionService: AccordionService, ifExpandService: IfExpandService, id: string);
     collapsePanelOnAnimationDone(panel: AccordionPanelModel): void;
+    getAccordionContentId(id: string): string;
+    getAccordionHeaderId(id: string): string;
+    getAccordionStatusId(id: string): string;
     getPanelStateClasses(panel: AccordionPanelModel): string;
     ngOnChanges(changes: SimpleChanges): void;
     ngOnInit(): void;

--- a/src/clr-angular/accordion/accordion-panel.html
+++ b/src/clr-angular/accordion/accordion-panel.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="panel | async; let panel">
-  <div *ngIf="panel.status !== AccordionStatus.Inactive" aria-live="assertive" class="clr-sr-only">
+  <div *ngIf="panel.status !== AccordionStatus.Inactive" [id]="getAccordionStatusId(panel.templateId)" aria-live="assertive" class="clr-sr-only">
     <ng-container *ngIf="panel.status === AccordionStatus.Error">{{commonStrings.danger}}</ng-container>
     <ng-container *ngIf="panel.status === AccordionStatus.Complete">{{commonStrings.success}}</ng-container>
   </div>
@@ -12,10 +12,11 @@
         (click)="togglePanel()"
         (focus)="focusHeader = true"
         (blur)="focusHeader = false"
-        [id]="'clr-accordion-header-' + panel.templateId"
-        [attr.aria-controls]="'clr-accordion-content-' + panel.templateId"
-        [attr.aria-expanded]="panel.open"
+        [id]="getAccordionHeaderId(panel.templateId)"
         [disabled]="panel.disabled"
+        [attr.aria-controls]="getAccordionContentId(panel.templateId)"
+        [attr.aria-expanded]="panel.open"
+        [attr.aria-describedby]="getAccordionStatusId(panel.templateId)"
       >
         <span class="clr-accordion-status">
           <clr-icon shape="angle" dir="right" class="clr-accordion-angle"></clr-icon>
@@ -30,9 +31,9 @@
     <div
       @skipInitialRender
       role="region"
-      [id]="'clr-accordion-content-' + panel.templateId"
+      [id]="getAccordionContentId(panel.templateId)"
       [attr.aria-hidden]="!panel.open"
-      [attr.aria-labelledby]="'clr-accordion-header-' + panel.templateId"
+      [attr.aria-labelledby]="getAccordionHeaderId(panel.templateId)"
     >
       <div
         *ngIf="panel.open"

--- a/src/clr-angular/accordion/accordion-panel.ts
+++ b/src/clr-angular/accordion/accordion-panel.ts
@@ -81,6 +81,18 @@ export class ClrAccordionPanel implements OnInit, OnChanges {
     return `clr-accordion-panel-${panel.status} ${panel.open ? 'clr-accordion-panel-open' : ''}`;
   }
 
+  getAccordionContentId(id: string) {
+    return `clr-accordion-content-${id}'`;
+  }
+
+  getAccordionStatusId(id: string) {
+    return `clr-accordion-header-status-${id}'`;
+  }
+
+  getAccordionHeaderId(id: string) {
+    return `clr-accordion-header-${id}`;
+  }
+
   private emitPanelChange(panel: AccordionPanelModel) {
     this.panelOpenChange.emit(panel.open);
 

--- a/src/clr-angular/accordion/stepper/models/stepper.model.spec.ts
+++ b/src/clr-angular/accordion/stepper/models/stepper.model.spec.ts
@@ -30,6 +30,28 @@ describe('StepperModel', () => {
     expect(stepper.panels[1].status).toBe(AccordionStatus.Inactive);
   });
 
+  it('should disable the header buttons by default until a step is completed', () => {
+    // default
+    expect(stepper.panels[0].status).toBe(AccordionStatus.Inactive);
+    expect(stepper.panels[0].disabled).toBe(true);
+    expect(stepper.panels[1].disabled).toBe(true);
+    expect(stepper.panels[2].disabled).toBe(true);
+
+    // valid next step
+    stepper.navigateToNextPanel(step1Id, true);
+    expect(stepper.panels[0].status).toBe(AccordionStatus.Complete);
+    expect(stepper.panels[0].disabled).toBe(false);
+    expect(stepper.panels[1].disabled).toBe(true);
+    expect(stepper.panels[2].disabled).toBe(true);
+
+    // invalid next step
+    stepper.navigateToNextPanel(step2Id, false);
+    expect(stepper.panels[1].status).toBe(AccordionStatus.Error);
+    expect(stepper.panels[0].disabled).toBe(false);
+    expect(stepper.panels[1].disabled).toBe(true);
+    expect(stepper.panels[2].disabled).toBe(true);
+  });
+
   it('should navigate to next step if current step is valid and mark step complete', () => {
     stepper.navigateToNextPanel(step1Id);
     expect(stepper.panels[0].status).toBe(AccordionStatus.Complete);

--- a/src/clr-angular/accordion/stepper/models/stepper.model.ts
+++ b/src/clr-angular/accordion/stepper/models/stepper.model.ts
@@ -19,7 +19,7 @@ export class StepperModel extends AccordionModel {
 
   updatePanelOrder(ids: string[]) {
     super.updatePanelOrder(ids);
-    this.openFirstPanel(ids);
+    this.openFirstPanel();
   }
 
   togglePanel(panelId: string) {
@@ -38,7 +38,7 @@ export class StepperModel extends AccordionModel {
   }
 
   overrideInitialPanel(panelId: string) {
-    this.panels.filter(panel => this._panels[panelId] !== undefined).forEach(panel => {
+    this.panels.filter(() => this._panels[panelId] !== undefined).forEach(panel => {
       if (panel.index < this._panels[panelId].index) {
         this.completePanel(panel.id);
       } else if (panel.id === panelId) {
@@ -55,6 +55,7 @@ export class StepperModel extends AccordionModel {
 
   resetPanels() {
     this.panels.forEach(p => this.resetPanel(p.id));
+    this.openFirstPanel();
   }
 
   private resetAllFuturePanels(panelId: string) {
@@ -63,11 +64,14 @@ export class StepperModel extends AccordionModel {
 
   private resetPanel(panelId: string) {
     this._panels[panelId].status = AccordionStatus.Inactive;
-    this._panels[panelId].open = this._panels[panelId].index === 0; // if first panel set to be open
+    this._panels[panelId].open = false;
+    this._panels[panelId].disabled = true;
   }
 
-  private openFirstPanel(ids: string[]) {
-    ids.forEach(id => (this._panels[id].open = this._panels[id].index === 0));
+  private openFirstPanel() {
+    const firstPanel = this.getFirstPanel();
+    this._panels[firstPanel.id].open = true;
+    this._panels[firstPanel.id].disabled = true;
   }
 
   private completePanel(panelId: string) {
@@ -77,11 +81,12 @@ export class StepperModel extends AccordionModel {
   }
 
   private openNextPanel(currentPanelId: string) {
-    const nextPanel = this.panels.find(s => s.index === this._panels[currentPanelId].index + 1);
+    const nextPanel = this.getNextPanel(currentPanelId);
 
     if (nextPanel) {
       this.resetAllFuturePanels(nextPanel.id);
       this._panels[nextPanel.id].open = true;
+      this._panels[nextPanel.id].disabled = true;
     }
   }
 
@@ -89,6 +94,14 @@ export class StepperModel extends AccordionModel {
     this.resetAllFuturePanels(panelId);
     this._panels[panelId].open = true;
     this._panels[panelId].status = AccordionStatus.Error;
+  }
+
+  private getFirstPanel() {
+    return this.panels.find(panel => panel.index === 0);
+  }
+
+  private getNextPanel(currentPanelId: string) {
+    return this.panels.find(s => s.index === this._panels[currentPanelId].index + 1);
   }
 
   private getNumberOfIncompletePanels() {

--- a/src/clr-angular/accordion/stepper/stepper-panel.spec.ts
+++ b/src/clr-angular/accordion/stepper/stepper-panel.spec.ts
@@ -84,20 +84,45 @@ describe('ClrStep Reactive Forms', () => {
     it('should show the appropriate aria-live message based on form state', () => {
       const mockStep = new AccordionPanelModel('groupName', 0);
       const stepperService = fixture.debugElement.query(By.directive(ClrStepperPanel)).injector.get(StepperService);
-      let liveSection: HTMLElement = fixture.nativeElement.querySelector('.clr-sr-only');
+      let liveSection: HTMLElement = fixture.nativeElement.querySelector('[aria-live="assertive"]');
       expect(liveSection).toBe(null);
 
       mockStep.status = AccordionStatus.Error;
       (stepperService as MockStepperService).step.next(mockStep);
       fixture.detectChanges();
-      liveSection = fixture.nativeElement.querySelector('.clr-sr-only');
-      expect(liveSection.getAttribute('aria-live')).toBe('assertive');
+      liveSection = fixture.nativeElement.querySelector('[aria-live="assertive"]');
+      expect(liveSection).toBeTruthy();
       expect(liveSection.innerText.trim()).toBe('Error');
 
       mockStep.status = AccordionStatus.Complete;
       (stepperService as MockStepperService).step.next(mockStep);
       fixture.detectChanges();
       expect(liveSection.innerText.trim()).toBe('Success');
+    });
+
+    it('should associate the header button to the step status message', () => {
+      const mockStep = new AccordionPanelModel('groupName', 0);
+      const stepperService = fixture.debugElement.query(By.directive(ClrStepperPanel)).injector.get(StepperService);
+      mockStep.status = AccordionStatus.Error;
+      (stepperService as MockStepperService).step.next(mockStep);
+      fixture.detectChanges();
+
+      const liveSectionId: string = fixture.nativeElement.querySelector('[aria-live="assertive"]').id;
+      const headerButtonDescribeBy: string = fixture.nativeElement
+        .querySelector('.clr-accordion-header-button')
+        .getAttribute('aria-describedby');
+      expect(liveSectionId).toBe(headerButtonDescribeBy);
+    });
+
+    it('should disable the header button based on the appropriate step state', () => {
+      const mockStep = new AccordionPanelModel('groupName', 0);
+      const stepperService = fixture.debugElement.query(By.directive(ClrStepperPanel)).injector.get(StepperService);
+
+      mockStep.status = AccordionStatus.Error;
+      mockStep.disabled = true;
+      (stepperService as MockStepperService).step.next(mockStep);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('.clr-accordion-header-button').getAttribute('disabled')).toBe('');
     });
   });
 });

--- a/src/clr-angular/accordion/stepper/stepper-panel.ts
+++ b/src/clr-angular/accordion/stepper/stepper-panel.ts
@@ -41,7 +41,7 @@ export class ClrStepperPanel extends ClrAccordionPanel implements OnInit {
     public commonStrings: ClrCommonStrings,
     @Optional() private formGroupName: FormGroupName,
     @Optional() private ngModelGroup: NgModelGroup,
-    stepperService: StepperService,
+    private stepperService: StepperService,
     ifExpandService: IfExpandService,
     @Inject(UNIQUE_ID) id: string
   ) {
@@ -51,6 +51,7 @@ export class ClrStepperPanel extends ClrAccordionPanel implements OnInit {
   ngOnInit() {
     super.ngOnInit();
     this.panel = this.panel.pipe(tap(panel => this.triggerAllFormControlValidationIfError(panel)));
+    this.stepperService.disablePanel(this.id, true);
   }
 
   private triggerAllFormControlValidationIfError(panel: AccordionPanelModel) {


### PR DESCRIPTION
- Describe current state with button, helpful for screen reader users who tab back to a prior step.
- Disable button when locked on step (error or inactive)

closes #3529