### PR TITLE
Backport * Datagrid focus management (part 2 - show/hide columns)

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -210,6 +210,7 @@ export declare class ClrCommonFormsModule {
 }
 
 export declare abstract class ClrCommonStrings {
+    allColumnsSelected?: string;
     close?: string;
     collapse?: string;
     current?: string;
@@ -235,6 +236,7 @@ export declare abstract class ClrCommonStrings {
     select?: string;
     selectAll?: string;
     show?: string;
+    showColumnsMenuDescription?: string;
     sortColumn?: string;
     success?: string;
     totalPages?: string;
@@ -288,7 +290,6 @@ export declare class ClrDatagridActionOverflow implements OnDestroy {
     commonStrings: ClrCommonStrings;
     open: boolean;
     openChanged: EventEmitter<boolean>;
-    overflowClassName: string;
     popoverId: string;
     popoverPoint: Point;
     constructor(rowActionService: RowActionService, commonStrings: ClrCommonStrings, elementRef: ElementRef, platformId: Object, zone: NgZone);
@@ -344,12 +345,13 @@ export declare class ClrDatagridColumnToggle implements OnInit, OnDestroy {
     open: boolean;
     popoverPoint: Point;
     title: ClrDatagridColumnToggleTitle;
-    constructor(hideableColumnService: HideableColumnService, columnToggleButtons: ColumnToggleButtonsService, commonStrings: ClrCommonStrings);
+    constructor(hideableColumnService: HideableColumnService, columnToggleButtons: ColumnToggleButtonsService, commonStrings: ClrCommonStrings, platformId: Object, zone: NgZone);
     ngOnDestroy(): void;
     ngOnInit(): void;
     selectAll(): void;
     toggleColumn(event: boolean, column: DatagridHideableColumnModel): void;
     toggleUI(): void;
+    trackByFn(index: any): any;
 }
 
 export interface ClrDatagridComparatorInterface<T> {

--- a/src/clr-angular/data/datagrid/datagrid-action-overflow.ts
+++ b/src/clr-angular/data/datagrid/datagrid-action-overflow.ts
@@ -32,7 +32,7 @@ let clrDgActionId = 0;
         </button>
         <ng-template [(clrPopoverOld)]="open" [clrPopoverOldAnchor]="anchor" [clrPopoverOldAnchorPoint]="anchorPoint"
                      [clrPopoverOldPopoverPoint]="popoverPoint">
-            <div [attr.class]="overflowClassName" (clrOutsideClick)="close($event)" [clrStrict]="true" 
+            <div class="datagrid-action-overflow" (clrOutsideClick)="close($event)" [clrStrict]="true" 
                     role="menu" [attr.id]="popoverId" [attr.aria-hidden]="!open">
                 <ng-content></ng-content>
             </div>
@@ -40,7 +40,6 @@ let clrDgActionId = 0;
     `,
 })
 export class ClrDatagridActionOverflow implements OnDestroy {
-  public overflowClassName = 'datagrid-action-overflow';
   public anchorPoint: Point = Point.RIGHT_CENTER;
   public popoverPoint: Point = Point.LEFT_CENTER;
 
@@ -78,9 +77,7 @@ export class ClrDatagridActionOverflow implements OnDestroy {
       if (boolOpen && isPlatformBrowser(this.platformId)) {
         this.zone.runOutsideAngular(() => {
           setTimeout(() => {
-            const firstButton = this.elementRef.nativeElement.querySelector(
-              `.${this.overflowClassName} button.action-item`
-            );
+            const firstButton = this.elementRef.nativeElement.querySelector('button.action-item');
             if (firstButton) {
               firstButton.focus();
             }
@@ -108,9 +105,9 @@ export class ClrDatagridActionOverflow implements OnDestroy {
 
   public close(event: MouseEvent) {
     /*
-         * Because this listener is added synchonously, before the event finishes bubbling up the DOM,
-         * we end up firing on the very click that just opened the menu, p
-         * otentially closing it immediately every time. So we just ignore it.
+         * Because this listener is added synchronously, before the event finishes bubbling up the DOM,
+         * we end up firing on the very click that just opened the menu,
+         * potentially closing it immediately every time. So we just ignore it.
          */
     if (event === this.openingEvent) {
       delete this.openingEvent;

--- a/src/clr-angular/data/datagrid/datagrid-column-toggle.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-toggle.spec.ts
@@ -45,7 +45,7 @@ export default function(): void {
       beforeEach(function() {
         hideableColumnService = new HideableColumnService();
         columnToggleButtons = new ColumnToggleButtonsService();
-        component = new ClrDatagridColumnToggle(hideableColumnService, columnToggleButtons, {});
+        component = new ClrDatagridColumnToggle(hideableColumnService, columnToggleButtons, {}, null, null);
       });
 
       it('gets a list of hideable columns from the HideableColumnService', function() {

--- a/src/clr-angular/utils/i18n/common-strings.interface.ts
+++ b/src/clr-angular/utils/i18n/common-strings.interface.ts
@@ -129,4 +129,12 @@ export abstract class ClrCommonStrings {
    * Modal end of content
    */
   modalContentEnd?: string;
+  /**
+   * Datagrid Show columns menu description
+   */
+  showColumnsMenuDescription?: string;
+  /**
+   * Datagrid Show columns / All columns selected confirmation
+   */
+  allColumnsSelected?: string;
 }

--- a/src/clr-angular/utils/i18n/common-strings.service.ts
+++ b/src/clr-angular/utils/i18n/common-strings.service.ts
@@ -40,6 +40,8 @@ export class ClrCommonStringsService implements ClrCommonStrings {
   maxValue = 'Max value';
   modalContentStart = 'Beginning of Modal Content';
   modalContentEnd = 'End of Modal Content';
+  showColumnsMenuDescription = 'Show or hide columns menu';
+  allColumnsSelected = 'All columns selected';
 }
 
 export function commonStringsFactory(existing?: ClrCommonStrings): ClrCommonStrings {

--- a/src/website/src/app/documentation/demos/i18n/i18n.demo.ts
+++ b/src/website/src/app/documentation/demos/i18n/i18n.demo.ts
@@ -48,6 +48,11 @@ export class I18nDemo extends ClarityDocComponent {
     { key: 'currentPage', role: 'Datagrid: pagination current page button text' },
     { key: 'totalPages', role: 'Datagrid: pagination total pages button text' },
     { key: 'minValue', role: 'Datagrid: minimum value (numeric filters)' },
-    { key: 'maxValue', role: 'Datagrid: maximum value (numeric filters' },
+    { key: 'maxValue', role: 'Datagrid: maximum value (numeric filters)' },
+    {
+      key: 'showColumnsMenuDescription',
+      role: 'Datagrid: screen reader only description of the Show/Hide columns menu',
+    },
+    { key: 'allColumnsSelected', role: 'Datagrid: screen reader only confirmation that all columns were selected' },
   ];
 }


### PR DESCRIPTION
Note! Some parts rewritten due to big codebase difference.
Will appreciate a review!!!
(cherry picked from commit 5de0dd6d456434a743593f80b9336eeeef5639f1)
- fixed focus lost after "select all" button clicked
- fixed no notification on popup opened
- fixed focus lost on column checkbox toggled

Signed-off-by: Ivan Donchev <idonchev@vmware.com>