### PR TITLE
fix(forms) link helper text to input with aria-describedby

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -264,6 +264,8 @@ export declare class ClrControlError {
 }
 
 export declare class ClrControlHelper {
+    controlIdService: ControlIdService;
+    constructor(controlIdService: ControlIdService);
 }
 
 export declare class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, OnDestroy {

--- a/src/clr-angular/forms/common/helper.spec.ts
+++ b/src/clr-angular/forms/common/helper.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -8,6 +8,7 @@ import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { ClrControlHelper } from './helper';
+import { ControlIdService } from './providers/control-id.service';
 
 @Component({ template: `<clr-control-helper>Test helper</clr-control-helper>` })
 class SimpleTest {}
@@ -17,7 +18,7 @@ export default function(): void {
     let fixture;
 
     beforeEach(function() {
-      TestBed.configureTestingModule({ declarations: [ClrControlHelper, SimpleTest] });
+      TestBed.configureTestingModule({ declarations: [ClrControlHelper, SimpleTest], providers: [ControlIdService] });
       fixture = TestBed.createComponent(SimpleTest);
       fixture.detectChanges();
     });
@@ -32,6 +33,10 @@ export default function(): void {
       expect(
         fixture.debugElement.query(By.directive(ClrControlHelper)).nativeElement.classList.contains('clr-subtext')
       ).toBeTrue();
+    });
+
+    it('adds the id to host', function() {
+      expect(fixture.debugElement.query(By.directive(ClrControlHelper)).nativeElement.id).toContain('clr-form-control');
     });
   });
 }

--- a/src/clr-angular/forms/common/helper.ts
+++ b/src/clr-angular/forms/common/helper.ts
@@ -1,16 +1,22 @@
 /**
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component } from '@angular/core';
+import { Component, Optional } from '@angular/core';
+import { ControlIdService } from './providers/control-id.service';
 
 @Component({
   selector: 'clr-control-helper',
   template: `
     <ng-content></ng-content>
     `,
-  host: { '[class.clr-subtext]': 'true' },
+  host: {
+    '[class.clr-subtext]': 'true',
+    '[id]': 'controlIdService?.id + "-helper"',
+  },
 })
-export class ClrControlHelper {}
+export class ClrControlHelper {
+  constructor(@Optional() public controlIdService: ControlIdService) {}
+}

--- a/src/clr-angular/forms/common/wrapped-control.spec.ts
+++ b/src/clr-angular/forms/common/wrapped-control.spec.ts
@@ -227,5 +227,12 @@ export default function(): void {
         expect(this.control.ngOnDestroy).toBeDefined();
       });
     });
+
+    describe('aria roles', function() {
+      it('adds the aria-describedby for helper', function() {
+        setupTest(this, WithControl, TestControl3);
+        expect(this.input.getAttribute('aria-describedby')).toContain('-helper');
+      });
+    });
   });
 }

--- a/src/clr-angular/forms/common/wrapped-control.ts
+++ b/src/clr-angular/forms/common/wrapped-control.ts
@@ -33,6 +33,8 @@ export class WrappedFormControl<W extends DynamicWrapper> implements OnInit, OnD
   private ifErrorService: IfErrorService;
   private controlClassService: ControlClassService;
   private markControlService: MarkControlService;
+  protected renderer: Renderer2;
+  protected el: ElementRef<any>;
 
   protected subscriptions: Subscription[] = [];
   protected index = 0;
@@ -50,6 +52,8 @@ export class WrappedFormControl<W extends DynamicWrapper> implements OnInit, OnD
     renderer: Renderer2,
     el: ElementRef
   ) {
+    this.renderer = renderer;
+    this.el = el;
     try {
       this.ngControlService = injector.get(NgControlService);
       this.ifErrorService = injector.get(IfErrorService);
@@ -110,6 +114,9 @@ export class WrappedFormControl<W extends DynamicWrapper> implements OnInit, OnD
       this.controlIdService.id = this._id;
     } else {
       this._id = this.controlIdService.id;
+    }
+    if (this.renderer && this.el) {
+      this.renderer.setAttribute(this.el.nativeElement, 'aria-describedby', this.controlIdService.id + '-helper');
     }
 
     if (this.ngControlService) {

--- a/src/clr-angular/forms/tests/container.spec.ts
+++ b/src/clr-angular/forms/tests/container.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -14,6 +14,7 @@ import { IfErrorService } from '../common/if-error/if-error.service';
 import { NgControlService } from '../common/providers/ng-control.service';
 import { Layouts, LayoutService } from '../common/providers/layout.service';
 import { MarkControlService } from '../common/providers/mark-control.service';
+import { ControlIdService } from '../common/providers/control-id.service';
 
 export function ContainerNoLabelSpec(testContainer, testControl, testComponent): void {
   describe('no label', () => {
@@ -64,7 +65,7 @@ function fullSpec(description, testContainer, directives: any | any[], testCompo
       TestBed.configureTestingModule({
         imports: [ClrIconModule, ClrCommonFormsModule, FormsModule, ReactiveFormsModule],
         declarations: [testContainer, ...directives, testComponent],
-        providers: [NgControl, NgControlService, IfErrorService, LayoutService, MarkControlService],
+        providers: [NgControl, NgControlService, IfErrorService, LayoutService, MarkControlService, ControlIdService],
       });
       fixture = TestBed.createComponent(testComponent);
 


### PR DESCRIPTION
closes #3554

This makes it possible for a screen reader to hear the helper text while they are on the input by using aria-described by in forms.