### PR TITLE
[WEB] Bug/3505

### DIFF
--- a/src/clr-angular/utils/_helpers.clarity.scss
+++ b/src/clr-angular/utils/_helpers.clarity.scss
@@ -28,7 +28,10 @@
   border-radius: 0;
   box-shadow: none;
   background: none;
-  cursor: pointer;
+
+  @at-root button#{&} {
+    cursor: pointer;
+  }
 }
 
 //Dropdowns & Tooltips

--- a/src/website/src/app/documentation/demos/datagrid/expandable-rows/expandable-rows.html
+++ b/src/website/src/app/documentation/demos/datagrid/expandable-rows/expandable-rows.html
@@ -105,7 +105,10 @@
 <clr-datagrid>
     <clr-dg-column>User ID</clr-dg-column>
     <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
-    <clr-dg-column [clrDgField]="'creation'">Creation date</clr-dg-column>
+    <clr-dg-column [clrDgField]="'creation'" >
+        Creation date
+        <clr-dg-string-filter [clrDgStringFilter]="dateFilter"></clr-dg-string-filter>
+    </clr-dg-column>
     <clr-dg-column [clrDgField]="'pokemon.name'">Pokemon</clr-dg-column>
     <clr-dg-column [clrDgField]="'color'">Favorite color</clr-dg-column>
 

--- a/src/website/src/app/documentation/demos/datagrid/expandable-rows/expandable-rows.ts
+++ b/src/website/src/app/documentation/demos/datagrid/expandable-rows/expandable-rows.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -8,6 +8,15 @@ import { Component } from '@angular/core';
 import { Inventory } from '../inventory/inventory';
 import { User } from '../inventory/user';
 import { EXAMPLES } from './examples';
+
+import { ClrDatagridStringFilterInterface } from '@clr/angular';
+
+class DateFilter implements ClrDatagridStringFilterInterface<User> {
+  accepts(user: User, search: string): boolean {
+    const date = user.creation.toDateString();
+    return date === search || date.toLowerCase().indexOf(search) >= 0;
+  }
+}
 
 @Component({
   selector: 'clr-datagrid-expandable-rows-demo',
@@ -22,6 +31,8 @@ export class DatagridExpandableRowsDemo {
   detail = 'default';
   replace = false;
   slowLoad = false;
+
+  dateFilter = new DateFilter();
 
   constructor(inventory: Inventory) {
     inventory.size = 10;

--- a/src/website/src/app/documentation/demos/datagrid/filtering/examples.ts
+++ b/src/website/src/app/documentation/demos/datagrid/filtering/examples.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -117,4 +117,17 @@ class ColorFilter implements ClrDatagridFilterInterface<User> {
     Name
 </clr-dg-column>
 `,
+  filterSearchResults: `
+<-- 
+  Will search into user.creation that in this case is 'Date' object
+  and not the result of the pipe 'Jan 6, 2018' 
+-->
+<clr-dg-cell [clrDgField]="'creation'">{{ user.creation | date }}</clr-dg-cell>
+
+<-- 
+  Will search into user.name and will not include user.id, 
+  searching for user.id will not return any result.
+-->
+<clr-dg-cell [clrDgField]="'name'">{{ user.id }} : {{ user.name }}</clr-dg-cell>
+  `,
 };

--- a/src/website/src/app/documentation/demos/datagrid/filtering/filtering.html
+++ b/src/website/src/app/documentation/demos/datagrid/filtering/filtering.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -80,6 +80,18 @@
 
 <clr-code-snippet [clrCode]="examples.colorFilterTS" clrLanguage="typescript"></clr-code-snippet>
 <clr-code-snippet [clrCode]="examples.colorFilterHTML" clrLanguage="html"></clr-code-snippet>
+
+<p>
+    By default, filtering searches the original model value for matches. In cases where you format the text 
+    for display (such as using a pipe), you may want to create a custom filter to handle searching the
+    formatted text. Otherwise, the results you see may not be filtered in the way you expect.
+</p>
+
+<clr-code-snippet [clrCode]="examples.filterSearchResults" clrLanguage="html"></clr-code-snippet>
+<p>
+    In the example above you will need to go with custom filters that will take into account 
+    the data that the user sees is the same that he is searching into.
+</p>
 
 <h4>Preset Column Filters</h4>
 

--- a/src/website/src/app/documentation/demos/datagrid/utils/pokemon-comparator.ts
+++ b/src/website/src/app/documentation/demos/datagrid/utils/pokemon-comparator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */


### PR DESCRIPTION
* Fix issue with sorting by Pokemon name column.
* User ID was not sortable but the 'hand' cursor was used when hovering the column. Remove 'hand' cursor when the column is not clickable.
* Filter for Date column is working as expected. 

The reason for showing columns that at first don't include the number `19` or any other number - is that the rows are created with `new Date()` 

```js
const row = new Date();
row.toString()
// => "Mon Jul 08 2018 19:40:56 GMT+0300 (Eastern European Summer Time)"

// We display 
"Jul 8 2018"

// When filtering 
row.toString().includes('19') 
// => true
```

So keep in mind what type of date have to be filtered and what is the exact value of the row.


Close #3505 