### PR TITLE
build: adds file formatting script for npm users

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -115,3 +115,10 @@ to manually fix those.
 These scripts use Docker to start up a container with selenium and chrome to run the Gemini tests. Currently there are 4 sets
 in our code base and these are arbitrary sets to parallelize running them in Travis builds. You must pass in the set(s) for both
 of these scripts (e.g. `npm run test:visual set1 set3`).
+
+##### `npm run format:file -- path/to/file`
+
+When contributing to clarity there is a post commit hook installed and run with
+[husky](https://github.com/typicode/husky) that will only format the files staged before they are committed. There are
+corner cases and editors that may not behave as expected and it is possible to create a pull request that fails because
+the files are not properly formatted. This command can be used to format a specific file or a space separated list of files.

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "test": "ng test clr-angular --watch false --code-coverage",
     "test:watch": "ng test clr-angular --watch --code-coverage",
     "test:travis": "npm-run-all test:format test:lint test build build:ks build:dev test:golden",
+    "format:file": "prettier --write",
     "format:fix": "pretty-quick --staged",
     "license:fix": "node scripts/update-license",
     "visual:fix": "npm-run-all 'visual:fix:light -- {*}' 'visual:fix:dark -- {*}' --",


### PR DESCRIPTION
- usage: `npm run format:file -- path/to/file`
- multiple files can be passed to the script as needed

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [x] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

N/A

Issue Number: N/A

## What is the new behavior?
Clarity developers can format one or more files:
`npm run format:file -- path/to/file`

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
