### PR TITLE
fix: adding the text-edit set to the svg icon build script

### DIFF
--- a/scripts/clr-icons-svg.js
+++ b/scripts/clr-icons-svg.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -16,6 +16,7 @@ const SHAPE_SETS = [
   'technology-shapes',
   'travel-shapes',
   'chart-shapes',
+  'text-edit-shapes',
 ];
 
 writeSVGIcons(SHAPE_SETS, () => {


### PR DESCRIPTION
Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [x] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The SVG build script wasn't building the text-edit icon set.

## What is the new behavior?

The SVG build script now builds the text-edit icon set.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Verified locally that the script works as expected. End result can be seen here https://github.com/vmware/clarity-assets/commit/865169f6ceeaa06152b653bb9d22d2b316bc7ba9

Those icons were built using this script.