### PR TITLE
fix(datepicker): adds aria-labels for buttons

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -237,6 +237,18 @@ export interface ClrCommonStrings {
     current?: string;
     currentPage?: string;
     danger?: string;
+    datepickerCurrentDecade?: string;
+    datepickerCurrentMonth?: string;
+    datepickerNextDecade?: string;
+    datepickerNextMonth?: string;
+    datepickerPreviousDecade?: string;
+    datepickerPreviousMonth?: string;
+    datepickerSelectMonthText?: string;
+    datepickerSelectYearText?: string;
+    datepickerToggle?: string;
+    daypickerSRCurrentDecadePhrase?: string;
+    daypickerSRCurrentMonthPhrase?: string;
+    daypickerSRCurrentYearPhrase?: string;
     detailExpandableAriaLabel?: string;
     expand?: string;
     firstPage?: string;
@@ -597,6 +609,7 @@ export declare class ClrDatepickerViewManager extends AbstractPopover {
 }
 
 export declare class ClrDay {
+    dayString: string;
     dayView: DayViewModel;
     constructor(_dateNavigationService: DateNavigationService, _ifOpenService: IfOpenService, dateFormControlService: DateFormControlService);
     onDayViewFocus(): void;
@@ -604,9 +617,13 @@ export declare class ClrDay {
 }
 
 export declare class ClrDaypicker {
+    readonly ariaLiveMonth: string;
     readonly calendarMonth: string;
     readonly calendarYear: number;
     commonStrings: ClrCommonStringsService;
+    readonly monthAttrString: string;
+    readonly updateAriaLiveYear: string;
+    readonly yearAttrString: string;
     constructor(_viewManagerService: ViewManagerService, _dateNavigationService: DateNavigationService, _localeHelperService: LocaleHelperService, commonStrings: ClrCommonStringsService);
     changeToMonthView(): void;
     changeToYearView(): void;
@@ -1521,6 +1538,7 @@ export declare class ClrWizardStepnavItem {
 }
 
 export declare class ClrYearpicker implements AfterViewInit {
+    readonly ariaLiveDecadeText: string;
     readonly calendarYear: number;
     commonStrings: ClrCommonStringsService;
     yearRangeModel: YearRangeModel;

--- a/src/clr-angular/forms/datepicker/all.spec.ts
+++ b/src/clr-angular/forms/datepicker/all.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/forms/datepicker/date-container.spec.ts
+++ b/src/clr-angular/forms/datepicker/date-container.spec.ts
@@ -135,6 +135,16 @@ export default function() {
           expect(context.clarityElement.className).toContain('clr-form-control-disabled');
         });
       }));
+
+      it('has an accessible title on the calendar toggle button', () => {
+        const toggleButton: HTMLButtonElement = context.clarityElement.querySelector('.clr-input-group-icon-action');
+        expect(toggleButton.title).toEqual('Toggle datepicker');
+      });
+
+      it('has an accessible aria-label on the calendar toggle button', () => {
+        const toggleButton: HTMLButtonElement = context.clarityElement.querySelector('.clr-input-group-icon-action');
+        expect(toggleButton.attributes['aria-label'].value).toEqual('Toggle datepicker');
+      });
     });
 
     describe('Typescript API', () => {

--- a/src/clr-angular/forms/datepicker/date-container.ts
+++ b/src/clr-angular/forms/datepicker/date-container.ts
@@ -33,7 +33,14 @@ import { ClrCommonStringsService } from '../../utils/i18n/common-strings.service
         <div class="clr-input-wrapper">
           <div class="clr-input-group" [class.clr-focus]="focus">
             <ng-content select="[clrDate]"></ng-content>
-            <button #actionButton type="button" class="clr-input-group-icon-action" (click)="toggleDatepicker($event)" *ngIf="isEnabled" [attr.title]="commonStrings.keys.open" [disabled]="control?.disabled">
+            <button #actionButton 
+                    type="button" 
+                    class="clr-input-group-icon-action"
+                    [attr.title]="commonStrings.keys.datepickerToggle"
+                    [attr.aria-label]="commonStrings.keys.datepickerToggle"
+                    [disabled]="control?.disabled"
+                    (click)="toggleDatepicker($event)"
+                    *ngIf="isEnabled">
               <clr-icon shape="calendar"></clr-icon>
             </button>
             <clr-datepicker-view-manager *clrIfOpen clrFocusTrap></clr-datepicker-view-manager>
@@ -56,6 +63,7 @@ import { ClrCommonStringsService } from '../../utils/i18n/common-strings.service
     DateNavigationService,
     DatepickerEnabledService,
     DateFormControlService,
+    ClrCommonStringsService,
   ],
   host: {
     '[class.clr-form-control-disabled]': 'control?.disabled',

--- a/src/clr-angular/forms/datepicker/datepicker-view-manager.spec.ts
+++ b/src/clr-angular/forms/datepicker/datepicker-view-manager.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/forms/datepicker/datepicker-view-manager.ts
+++ b/src/clr-angular/forms/datepicker/datepicker-view-manager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/forms/datepicker/day.spec.ts
+++ b/src/clr-angular/forms/datepicker/day.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -112,6 +112,11 @@ export default function() {
         expect(context.clarityDirective.selectDay).toHaveBeenCalled();
       });
 
+      it('sets the correct value for the aria-label attribute', () => {
+        const dayBtn: HTMLButtonElement = context.clarityElement.children[0];
+        const dvm: DayViewModel = context.clarityDirective.dayView;
+        expect(dayBtn.attributes['aria-label'].value).toEqual(dvm.dayModel.toDateString());
+      });
       // @TODO determine if this actually fails in IE
       itIgnore(['ie'], 'updates the focusable date when a button is focused', () => {
         spyOn(context.clarityDirective, 'onDayViewFocus');

--- a/src/clr-angular/forms/datepicker/day.ts
+++ b/src/clr-angular/forms/datepicker/day.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -24,13 +24,17 @@ import { DateNavigationService } from './providers/date-navigation.service';
             [class.is-selected]="dayView.isSelected"
             [attr.tabindex]="dayView.tabIndex"
             (click)="selectDay()"
-            (focus)="onDayViewFocus()">
+            (focus)="onDayViewFocus()"
+            [attr.aria-label]="dayString">
             {{dayView.dayModel.date}}
         </button>
     `,
   host: { '[class.day]': 'true' },
 })
 export class ClrDay {
+  private _dayView: DayViewModel;
+  public dayString: string;
+
   constructor(
     private _dateNavigationService: DateNavigationService,
     private _ifOpenService: IfOpenService,
@@ -40,7 +44,16 @@ export class ClrDay {
   /**
    * DayViewModel input which is used to build the Day View.
    */
-  @Input('clrDayView') dayView: DayViewModel;
+
+  @Input('clrDayView')
+  public set dayView(day: DayViewModel) {
+    this._dayView = day;
+    this.dayString = this._dayView.dayModel.toDateString();
+  }
+
+  public get dayView(): DayViewModel {
+    return this._dayView;
+  }
 
   /**
    * Updates the focusedDay in the DateNavigationService when the ClrDay is focused.

--- a/src/clr-angular/forms/datepicker/daypicker.html
+++ b/src/clr-angular/forms/datepicker/daypicker.html
@@ -1,21 +1,45 @@
 <div class="calendar-header">
+    <div aria-live="polite" class="clr-sr-only">
+      {{ ariaLiveMonth }}.  {{updateAriaLiveYear}}.
+    </div>
     <div class="calendar-pickers">
-        <button class="calendar-btn monthpicker-trigger" type="button" (click)="changeToMonthView()">
-            {{calendarMonth}}
+        <button
+                class="calendar-btn monthpicker-trigger"
+                type="button" (click)="changeToMonthView()"
+                [attr.aria-label]="monthAttrString"
+                [attr.title]="monthAttrString">
+                {{calendarMonth}}
         </button>
-        <button class="calendar-btn yearpicker-trigger" type="button" (click)="changeToYearView()">
+        <button
+                class="calendar-btn yearpicker-trigger"
+                type="button"
+                (click)="changeToYearView()"
+                [attr.aria-label]="yearAttrString"
+                [attr.title]="yearAttrString">
             {{calendarYear}}
         </button>
     </div>
     <div class="calendar-switchers">
-        <button class="calendar-btn switcher" type="button" (click)="previousMonth()">
-            <clr-icon shape="angle" dir="left" [attr.title]="commonStrings.keys.previous"></clr-icon>
+        <button
+            class="calendar-btn switcher"
+            type="button"
+            (click)="previousMonth()"
+            [attr.aria-label]="commonStrings.keys.datepickerPreviousMonth">
+            <clr-icon shape="angle" dir="left" [attr.title]="commonStrings.keys.datepickerPreviousMonth"></clr-icon>
         </button>
-        <button class="calendar-btn switcher" type="button" (click)="currentMonth()">
-            <clr-icon shape="event" [attr.title]="commonStrings.keys.current"></clr-icon>
+        <button
+            class="calendar-btn switcher"
+            type="button"
+            (click)="currentMonth()"
+            [attr.aria-label]="commonStrings.keys.datepickerCurrentMonth">
+            <clr-icon shape="event" [attr.title]="commonStrings.keys.datepickerCurrentMonth"></clr-icon>
         </button>
-        <button class="calendar-btn switcher" type="button" (click)="nextMonth()">
-            <clr-icon shape="angle" dir="right" [attr.title]="commonStrings.keys.next"></clr-icon>
+        <button
+            class="calendar-btn switcher"
+            type="button"
+            (click)="nextMonth()"
+            [attr.aria-label]="commonStrings.keys.datepickerNextMonth">
+            <clr-icon shape="angle" dir="right" [attr.title]="commonStrings.keys.datepickerNextMonth"></clr-icon>
         </button>
     </div>
 </div>

--- a/src/clr-angular/forms/datepicker/daypicker.spec.ts
+++ b/src/clr-angular/forms/datepicker/daypicker.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -17,6 +17,7 @@ import { DateNavigationService } from './providers/date-navigation.service';
 import { DatepickerFocusService } from './providers/datepicker-focus.service';
 import { LocaleHelperService } from './providers/locale-helper.service';
 import { ViewManagerService } from './providers/view-manager.service';
+import { ClrCommonStringsService } from '@clr/angular';
 
 export default function() {
   describe('Daypicker Component', () => {
@@ -39,6 +40,7 @@ export default function() {
         LocaleHelperService,
         DatepickerFocusService,
         DateFormControlService,
+        ClrCommonStringsService,
       ]);
       viewManagerService = context.getClarityProvider(ViewManagerService);
       localeHelperService = context.getClarityProvider(LocaleHelperService);
@@ -100,6 +102,55 @@ export default function() {
         context.detectChanges();
 
         expect(context.clarityDirective.nextMonth).toHaveBeenCalled();
+      });
+
+      it('has correct title and aria-label for monthpicker button', () => {
+        const button: HTMLButtonElement = context.clarityElement.querySelector('.monthpicker-trigger');
+        const currentMonth = localeHelperService.localeMonthsAbbreviated[dateNavigationService.displayedCalendar.month];
+        const expectedString = `Select month, the current month is ${currentMonth}`;
+        expect(button.title).toEqual(expectedString);
+        expect(button.attributes['aria-label'].value).toEqual(expectedString);
+      });
+
+      it('has correct title and aria-label for yearpicker button', () => {
+        const button: HTMLButtonElement = context.clarityElement.querySelector('.yearpicker-trigger');
+        const currentYear = dateNavigationService.displayedCalendar.year;
+        const expectedString = `Select year, the current year is ${currentYear}`;
+        expect(button.title).toEqual(expectedString);
+        expect(button.attributes['aria-label'].value).toEqual(expectedString);
+      });
+
+      it('sets the correct aria-label value on the previous month button', () => {
+        const switchers: HTMLElement = context.clarityElement.querySelector('.calendar-switchers');
+        const previousButton: HTMLButtonElement = <HTMLButtonElement>switchers.children[0];
+        expect(previousButton.attributes['aria-label'].value).toEqual('Previous month');
+      });
+
+      it('sets the correct aria-label value on the current month button', () => {
+        const switchers: HTMLElement = context.clarityElement.querySelector('.calendar-switchers');
+        const currentButton: HTMLButtonElement = <HTMLButtonElement>switchers.children[1];
+        expect(currentButton.attributes['aria-label'].value).toEqual('Current month');
+      });
+
+      it('sets the correct aria-label value on the next month button', () => {
+        const switchers: HTMLElement = context.clarityElement.querySelector('.calendar-switchers');
+        const nextButton: HTMLButtonElement = <HTMLButtonElement>switchers.children[2];
+        expect(nextButton.attributes['aria-label'].value).toEqual('Next month');
+      });
+
+      it('updates the aria-live view element when the month and year are changed', () => {
+        const liveElement: HTMLDivElement = context.clarityElement.querySelector('.clr-sr-only');
+        let testMonth = localeHelperService.localeMonthsAbbreviated[dateNavigationService.displayedCalendar.month];
+        let testYear = dateNavigationService.displayedCalendar.year;
+
+        expect(liveElement.innerText).toEqual(`The current month is ${testMonth}. The current year is ${testYear}.`);
+
+        dateNavigationService.selectedDay = new DayModel(2025, 9, 1);
+        context.detectChanges();
+        testMonth = localeHelperService.localeMonthsAbbreviated[dateNavigationService.displayedCalendar.month];
+        testYear = dateNavigationService.displayedCalendar.year;
+
+        expect(liveElement.innerText).toEqual(`The current month is ${testMonth}. The current year is ${testYear}.`);
       });
     });
 

--- a/src/clr-angular/forms/datepicker/daypicker.ts
+++ b/src/clr-angular/forms/datepicker/daypicker.ts
@@ -19,6 +19,30 @@ export class ClrDaypicker {
     public commonStrings: ClrCommonStringsService
   ) {}
 
+  get monthAttrString(): string {
+    return this.commonStrings.parse(this.commonStrings.keys.datepickerSelectMonthText, {
+      CALENDAR_MONTH: this.calendarMonth,
+    });
+  }
+
+  get yearAttrString(): string {
+    return this.commonStrings.parse(this.commonStrings.keys.datepickerSelectYearText, {
+      CALENDAR_YEAR: this.calendarYear.toString(),
+    });
+  }
+
+  get ariaLiveMonth(): string {
+    return this.commonStrings.parse(this.commonStrings.keys.daypickerSRCurrentMonthPhrase, {
+      CURRENT_MONTH: this.calendarMonth,
+    });
+  }
+
+  get updateAriaLiveYear(): string {
+    return this.commonStrings.parse(this.commonStrings.keys.daypickerSRCurrentYearPhrase, {
+      CURRENT_YEAR: this.calendarYear.toString(),
+    });
+  }
+
   /**
    * Calls the ViewManagerService to change to the monthpicker view.
    */

--- a/src/clr-angular/forms/datepicker/model/day.model.spec.ts
+++ b/src/clr-angular/forms/datepicker/model/day.model.spec.ts
@@ -67,5 +67,10 @@ export default function(): void {
       testDayModel = dayModel2.clone();
       expect(assertEqualDates(testDayModel.toDate(), dayModel2.toDate())).toBe(true);
     });
+
+    it('provides a toDateString method that returns the local date string', () => {
+      const testString = dayModel1.toDateString();
+      expect(testString).toEqual('1/1/2018');
+    });
   });
 }

--- a/src/clr-angular/forms/datepicker/model/day.model.ts
+++ b/src/clr-angular/forms/datepicker/model/day.model.ts
@@ -17,9 +17,6 @@ export class DayModel {
     return false;
   }
 
-  /**
-   * Converts the CalendarDate into the Javascript Date object.
-   */
   toDate(): Date {
     return new Date(this.year, this.month, this.date);
   }
@@ -40,5 +37,9 @@ export class DayModel {
    */
   clone(): DayModel {
     return new DayModel(this.year, this.month, this.date);
+  }
+
+  public toDateString(): string {
+    return this.toDate().toLocaleDateString();
   }
 }

--- a/src/clr-angular/forms/datepicker/monthpicker.spec.ts
+++ b/src/clr-angular/forms/datepicker/monthpicker.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/clr-angular/forms/datepicker/yearpicker.spec.ts
+++ b/src/clr-angular/forms/datepicker/yearpicker.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -19,6 +19,8 @@ import { LocaleHelperService } from './providers/locale-helper.service';
 import { ViewManagerService } from './providers/view-manager.service';
 import { createKeyboardEvent } from './utils/test-utils';
 import { ClrYearpicker } from './yearpicker';
+import { YearRangeModel } from './model/year-range.model';
+import { ClrCommonStringsService } from '@clr/angular';
 
 export default function() {
   describe('Yearpicker Component', () => {
@@ -43,6 +45,7 @@ export default function() {
           { provide: DateNavigationService, useValue: dateNavigationService },
           LocaleHelperService,
           DateIOService,
+          ClrCommonStringsService,
         ]);
       });
 
@@ -59,7 +62,7 @@ export default function() {
       it('calls to navigate to the previous decade', () => {
         spyOn(context.clarityDirective, 'previousDecade');
         const switchers: HTMLElement = context.clarityElement.querySelector('.year-switchers');
-        const button: HTMLButtonElement = <HTMLButtonElement>switchers.children[0];
+        const button: HTMLButtonElement = <HTMLButtonElement>switchers.children[1];
 
         button.click();
         context.detectChanges();
@@ -70,7 +73,7 @@ export default function() {
       it('calls to navigate to the current decade', () => {
         spyOn(context.clarityDirective, 'currentDecade');
         const switchers: HTMLElement = context.clarityElement.querySelector('.year-switchers');
-        const button: HTMLButtonElement = <HTMLButtonElement>switchers.children[1];
+        const button: HTMLButtonElement = <HTMLButtonElement>switchers.children[2];
 
         button.click();
         context.detectChanges();
@@ -81,7 +84,7 @@ export default function() {
       it('calls to navigate to the next decade', () => {
         spyOn(context.clarityDirective, 'nextDecade');
         const switchers: HTMLElement = context.clarityElement.querySelector('.year-switchers');
-        const button: HTMLButtonElement = <HTMLButtonElement>switchers.children[2];
+        const button: HTMLButtonElement = <HTMLButtonElement>switchers.children[3];
 
         button.click();
         context.detectChanges();
@@ -117,6 +120,71 @@ export default function() {
           }
           count++;
         }
+      });
+
+      it('has the correct aria-label for the previousDecade button', () => {
+        const switchers: HTMLElement = context.clarityElement.querySelector('.year-switchers');
+        const previousDecadeBtn: HTMLButtonElement = <HTMLButtonElement>switchers.children[1];
+        expect(previousDecadeBtn.attributes['aria-label'].value).toEqual('Previous decade');
+      });
+
+      it('has the correct aria-label for the currentDecade button', () => {
+        const switchers: HTMLElement = context.clarityElement.querySelector('.year-switchers');
+        const currentDecadeBtn: HTMLButtonElement = <HTMLButtonElement>switchers.children[2];
+        expect(currentDecadeBtn.attributes['aria-label'].value).toEqual('Current decade');
+      });
+
+      it('has the correct aria-label for the nextDecade button', () => {
+        const switchers: HTMLElement = context.clarityElement.querySelector('.year-switchers');
+        const nextDecadeBtn: HTMLButtonElement = <HTMLButtonElement>switchers.children[3];
+        expect(nextDecadeBtn.attributes['aria-label'].value).toEqual('Next decade');
+      });
+
+      function checkLiveElementYearRangeModel(element: HTMLDivElement, yrm: YearRangeModel) {
+        const yearFloor = yrm.yearRange[0];
+        const yearCeil = yrm.yearRange[yrm.yearRange.length - 1];
+        expect(element.innerText).toEqual(`The current decade is ${yearFloor} to ${yearCeil}.`);
+      }
+
+      it('updates the aria-live element when the next decade button is clicked', () => {
+        const liveElement: HTMLDivElement = context.clarityElement.querySelector('.clr-sr-only');
+        checkLiveElementYearRangeModel(liveElement, context.clarityDirective.yearRangeModel);
+
+        const switchers: HTMLElement = context.clarityElement.querySelector('.year-switchers');
+        const button: HTMLButtonElement = <HTMLButtonElement>switchers.children[3];
+        button.click();
+        context.detectChanges();
+
+        checkLiveElementYearRangeModel(liveElement, context.clarityDirective.yearRangeModel);
+      });
+
+      it('updates the aria-live element when the previous button is clicked', () => {
+        const liveElement: HTMLDivElement = context.clarityElement.querySelector('.clr-sr-only');
+        checkLiveElementYearRangeModel(liveElement, context.clarityDirective.yearRangeModel);
+
+        const switchers: HTMLElement = context.clarityElement.querySelector('.year-switchers');
+        const button: HTMLButtonElement = <HTMLButtonElement>switchers.children[1];
+        button.click();
+        context.detectChanges();
+
+        checkLiveElementYearRangeModel(liveElement, context.clarityDirective.yearRangeModel);
+      });
+
+      it('updates the aria-live element when the current button is clicked', () => {
+        const liveElement: HTMLDivElement = context.clarityElement.querySelector('.clr-sr-only');
+
+        // Go back first
+        const switchers: HTMLElement = context.clarityElement.querySelector('.year-switchers');
+        const previousButton: HTMLButtonElement = <HTMLButtonElement>switchers.children[1];
+        previousButton.click();
+        context.detectChanges();
+        checkLiveElementYearRangeModel(liveElement, context.clarityDirective.yearRangeModel);
+
+        const currentButton: HTMLButtonElement = <HTMLButtonElement>switchers.children[2];
+        currentButton.click();
+        context.detectChanges();
+
+        checkLiveElementYearRangeModel(liveElement, context.clarityDirective.yearRangeModel);
       });
 
       // IE doesn't handle KeyboardEvent constructor
@@ -166,6 +234,7 @@ export default function() {
           { provide: DateNavigationService, useValue: dateNavigationService },
           LocaleHelperService,
           DateIOService,
+          ClrCommonStringsService,
         ]);
       });
 
@@ -272,6 +341,7 @@ export default function() {
           { provide: DateNavigationService, useValue: dateNavigationService },
           LocaleHelperService,
           DateIOService,
+          ClrCommonStringsService,
         ]);
       }
 

--- a/src/clr-angular/forms/datepicker/yearpicker.ts
+++ b/src/clr-angular/forms/datepicker/yearpicker.ts
@@ -17,15 +17,30 @@ import { ClrCommonStringsService } from '../../utils/i18n/common-strings.service
   selector: 'clr-yearpicker',
   template: `
         <div class="year-switchers">
-            <button class="calendar-btn switcher" type="button" (click)="previousDecade()">
-                <clr-icon shape="angle" dir="left" [attr.title]="commonStrings.keys.previous"></clr-icon>
-            </button>
-            <button class="calendar-btn switcher" type="button" (click)="currentDecade()">
-                <clr-icon shape="event" [attr.title]="commonStrings.keys.current"></clr-icon>
-            </button>
-            <button class="calendar-btn switcher" type="button" (click)="nextDecade()">
-                <clr-icon shape="angle" dir="right" [attr.title]="commonStrings.keys.next"></clr-icon>
-            </button>
+          <div aria-live="polite" class="clr-sr-only">
+            {{ ariaLiveDecadeText  }}.
+          </div>
+          <button 
+              class="calendar-btn switcher" 
+              type="button" 
+              (click)="previousDecade()"
+              [attr.aria-label]="commonStrings.keys.datepickerPreviousDecade">
+              <clr-icon shape="angle" dir="left" [attr.title]="commonStrings.keys.datepickerPreviousDecade"></clr-icon>
+          </button>
+          <button 
+              class="calendar-btn switcher" 
+              type="button" 
+              (click)="currentDecade()"
+              [attr.aria-label]="commonStrings.keys.datepickerCurrentDecade">
+              <clr-icon shape="event" [attr.title]="commonStrings.keys.datepickerCurrentDecade"></clr-icon>
+          </button>
+          <button 
+              class="calendar-btn switcher" 
+              type="button" 
+              (click)="nextDecade()"
+              [attr.aria-label]="commonStrings.keys.datepickerNextDecade">
+              <clr-icon shape="angle" dir="right" [attr.title]="commonStrings.keys.datepickerNextDecade"></clr-icon>
+          </button>
         </div>
         <div class="years">
             <button
@@ -53,7 +68,16 @@ export class ClrYearpicker implements AfterViewInit {
   ) {
     this.yearRangeModel = new YearRangeModel(this.calendarYear);
     this._focusedYear = this.calendarYear;
+    this.updateRange(this.yearRangeModel);
   }
+
+  get ariaLiveDecadeText(): string {
+    return this.commonStrings.parse(this.commonStrings.keys.daypickerSRCurrentDecadePhrase, {
+      DECADE_RANGE: this.decadeRange,
+    });
+  }
+
+  private decadeRange;
 
   /**
    * YearRangeModel which is used to build the YearPicker view.
@@ -102,6 +126,7 @@ export class ClrYearpicker implements AfterViewInit {
    */
   previousDecade(): void {
     this.yearRangeModel = this.yearRangeModel.previousDecade();
+    this.updateRange(this.yearRangeModel);
     // Year in the yearpicker is not focused because while navigating to a different decade,
     // you want the focus to remain on the decade switcher arrows.
   }
@@ -114,6 +139,7 @@ export class ClrYearpicker implements AfterViewInit {
       this.yearRangeModel = this.yearRangeModel.currentDecade();
     }
     this._datepickerFocusService.focusCell(this._elRef);
+    this.updateRange(this.yearRangeModel);
   }
 
   /**
@@ -121,6 +147,7 @@ export class ClrYearpicker implements AfterViewInit {
    */
   nextDecade(): void {
     this.yearRangeModel = this.yearRangeModel.nextDecade();
+    this.updateRange(this.yearRangeModel);
     // Year in the yearpicker is not focused because while navigating to a different decade,
     // you want the focus to remain on the decade switcher arrows.
   }
@@ -165,10 +192,18 @@ export class ClrYearpicker implements AfterViewInit {
     }
   }
 
+  private updateRange(yrm: YearRangeModel): void {
+    const floor = yrm.yearRange[0];
+    const ceil = yrm.yearRange[yrm.yearRange.length - 1];
+    this.decadeRange = `${floor} to ${ceil}`;
+  }
+
   /**
    * Focuses on the current calendar year when the View is initialized.
    */
   ngAfterViewInit() {
     this._datepickerFocusService.focusCell(this._elRef);
+
+    // update the value for  decade range
   }
 }

--- a/src/clr-angular/utils/i18n/common-strings.default.ts
+++ b/src/clr-angular/utils/i18n/common-strings.default.ts
@@ -47,4 +47,17 @@ export const commonStringsDefault: ClrCommonStrings = {
   detailExpandableAriaLabel: 'Toggle more row content',
   // Alert
   alertCloseButtonAriaLabel: 'Close alert',
+  // DatePicker
+  datepickerToggle: 'Toggle datepicker',
+  datepickerPreviousMonth: 'Previous month',
+  datepickerCurrentMonth: 'Current month',
+  datepickerNextMonth: 'Next month',
+  datepickerPreviousDecade: 'Previous decade',
+  datepickerNextDecade: 'Next decade',
+  datepickerCurrentDecade: 'Current decade',
+  datepickerSelectMonthText: 'Select month, the current month is {CALENDAR_MONTH}',
+  datepickerSelectYearText: 'Select year, the current year is {CALENDAR_YEAR}',
+  daypickerSRCurrentMonthPhrase: 'The current month is {CURRENT_MONTH}',
+  daypickerSRCurrentYearPhrase: 'The current year is {CURRENT_YEAR}',
+  daypickerSRCurrentDecadePhrase: 'The current decade is {DECADE_RANGE}',
 };

--- a/src/clr-angular/utils/i18n/common-strings.interface.ts
+++ b/src/clr-angular/utils/i18n/common-strings.interface.ts
@@ -164,4 +164,20 @@ export interface ClrCommonStrings {
    * Alert: Close alert button
    */
   alertCloseButtonAriaLabel?: string;
+
+  /**
+   * Datepicker UI labels
+   */
+  datepickerToggle?: string;
+  datepickerPreviousMonth?: string;
+  datepickerCurrentMonth?: string;
+  datepickerNextMonth?: string;
+  datepickerPreviousDecade?: string;
+  datepickerNextDecade?: string;
+  datepickerCurrentDecade?: string;
+  datepickerSelectMonthText?: string;
+  datepickerSelectYearText?: string;
+  daypickerSRCurrentMonthPhrase?: string;
+  daypickerSRCurrentYearPhrase?: string;
+  daypickerSRCurrentDecadePhrase?: string;
 }

--- a/src/dev/src/app/datepicker/datepicker.demo.module.ts
+++ b/src/dev/src/app/datepicker/datepicker.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/src/website/src/app/documentation/demos/i18n/i18n.demo.html
+++ b/src/website/src/app/documentation/demos/i18n/i18n.demo.html
@@ -54,7 +54,7 @@ import &#123; klingonLocale &#125; from './translations/klingon';
 @Component(&#123;...&#125;)
 export class AppComponent &#123;
   constructor(commonStrings: ClrCommonStringsService) &#123;
-    // Call this method to set the new locale values into the service, defaults for English 
+    // Call this method to set the new locale values into the service, defaults for English
     // will be used for in any missing strings
     commonStrings.localize(klingonLocale);
   &#125;
@@ -102,7 +102,7 @@ export class MyCommonStringsService implements ClrCommonStrings &#123;
       </table>
 
       <h3 id="updating-to-latest">Updating to v1.2.1 or 2.1.1</h3>
-      
+
       <p>If you used the original implementation of <code class="clr-code">ClrCommonStrings</code> found in versions prior to v1.2.1 and v2.1.1, you need to follow
         these steps to update to the new API.
       </p>

--- a/src/website/src/app/documentation/demos/i18n/i18n.demo.ts
+++ b/src/website/src/app/documentation/demos/i18n/i18n.demo.ts
@@ -53,11 +53,69 @@ export class I18nDemo extends ClarityDocComponent {
       key: 'showColumnsMenuDescription',
       role: 'Datagrid: screen reader only description of the Show/Hide columns menu',
     },
+    {
+      key: 'allColumnsSelected',
+      role: 'Datagrid: screen reader only confirmation that all columns were selected',
+    },
+    { key: 'loading', role: 'Display loading text (Default: Loading)' },
+    { key: 'datepickerToggle', role: 'The open/close button for a datepicker' },
+    {
+      key: 'datepickerPreviousMonth',
+      role: 'The button that navigates daypicker to a monthpicker',
+    },
+    {
+      key: 'datepickerCurrentMonth',
+      role: 'The button that navigates a daypicker to current month',
+    },
     { key: 'allColumnsSelected', role: 'Datagrid: screen reader only confirmation that all columns were selected' },
     { key: 'loading', role: 'Display loading text (Default: Loading)' },
     { key: 'singleSelectionAriaLabel', role: 'Datagrid: aria label for header single selection header column' },
     { key: 'singleActionableAriaLabel', role: 'Datagrid: aria label for row action header column' },
     { key: 'detailExpandableAriaLabel', role: 'Datagrid: aria label for expandable row toggle button' },
     { key: 'alertCloseButtonAriaLabel', role: 'Alert: aria label for closing alert' },
+    { key: 'datepickerOpen', role: 'The open/close button for a datepicker' },
+    { key: 'datepickerPreviousMonth', role: 'The button that navigates daypicker to a monthpicker' },
+    { key: 'datepickerCurrentMonth', role: 'The button that navigates a daypicker to current month' },
+    {
+      key: 'datepickerNextMonth',
+      role: 'The button that navigates a daypicker to the next month',
+    },
+    {
+      key: 'datepickerPreviousDecade',
+      role: 'The button that navigates a yearpicker to previous decade',
+    },
+    {
+      key: 'datepickerNextDecade',
+      role: 'The button that navigates a yearpicker to next decade',
+    },
+    {
+      key: 'datepickerCurrentDecade',
+      role: 'The button that navigates the yearpicker to current decade',
+    },
+    {
+      key: 'datepickerSelectMonthText',
+      role:
+        'Populates aria-label and title for monthpicker button. Is concatenated with the (localized) value for calendarMonth as well as this value',
+    },
+    {
+      key: 'datepickerSelectYearText',
+      role:
+        'Populates aria-label and title for yearpicker button. Is concatenated with the (localized) value for calendarYear as well as this value',
+    },
+    {
+      key: 'daypickerSRCurrentMonthPhrase',
+      role:
+        'Used in an aria-live region. Makes up one part of a phrase that is read to screen reader users when the month changes.',
+    },
+    {
+      key: 'daypickerSRCurrentYearPhrase',
+      role:
+        'Used in an aria-live region. Makes up one part of a phrase that is read to screen reader users when the year changes.',
+    },
+    {
+      key: 'daypickerSRCurrentDecadePhrase',
+      role:
+        'Used in an aria-live region. Makes up one part of a phrase that is read to screen reader users when the decade changes.',
+    },
   ];
 }


### PR DESCRIPTION
- adds proper labels for all datepicker buttons
- adds live region for calendar view that updates month/year values for screen readers
- adds live region to year view that updates the decade range for screen readers
- closes #3467

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Date picker needs the correct aria-labels on all of its buttons. It also needs two aria-live regions that will update screen readers in the daypicker view **and** the yearpicker view. 

Issue Number: #3467

## What is the new behavior?
All datepicker buttons have an aria-label related to what the button action does. There are two aria-live regions that change depending on user interactions with the datepicker. 

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
