### PR TITLE
fix(ng): dropdown item should add disabled attribute if set by input

### DIFF
--- a/src/clr-angular/popover/dropdown/dropdown-item.spec.ts
+++ b/src/clr-angular/popover/dropdown/dropdown-item.spec.ts
@@ -38,6 +38,13 @@ export default function(): void {
       expect(this.clarityElement.getAttribute('role')).toBe('menuitem');
     });
 
+    it('sets the disabled attribute if set by input', function(this: Context) {
+      expect(this.clarityElement.getAttribute('disabled')).toBeNull();
+      this.hostComponent.disabled = true;
+      this.detectChanges();
+      expect(this.clarityElement.getAttribute('disabled')).toBe('');
+    });
+
     it('sets aria-disabled to true if the FocusableItem is disabled', function(this: Context) {
       expect(this.clarityElement.getAttribute('aria-disabled')).toBe('false');
       this.hostComponent.disabled = true;

--- a/src/clr-angular/popover/dropdown/dropdown-item.ts
+++ b/src/clr-angular/popover/dropdown/dropdown-item.ts
@@ -16,6 +16,7 @@ import { RootDropdownService } from './providers/dropdown.service';
     '[class.dropdown-item]': 'true',
     '[attr.role]': '"menuitem"',
     '[attr.aria-disabled]': 'disabled',
+    '[attr.disabled]': "disabled? '' : null",
   },
   providers: [BASIC_FOCUSABLE_ITEM_PROVIDER],
 })


### PR DESCRIPTION
After introducing `disabled` as an input, missed connecting that to the disabled attribute in the dropdown item host element.

Note: I considered also automatically adding `disabled` class when the input is set. However, that breaks existing code in the case when the dropdown item is not a button (e.g. anchor tag). Since disabled attribute is not a valid attribute for things like anchor tag, it doesn't make sense to automatically handle the `disabled` css class. Just documenting for posterity. =)

Also note to self: Need to backport this to 1.1.x.

Signed-off-by: Jeeyun Lim <jeeyun.lim@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3634

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
