### PR TITLE
fix(datagrid): mixed expandable non expandable bug

### DIFF
--- a/src/clr-angular/data/datagrid/datagrid-column-toggle.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-toggle.spec.ts
@@ -28,13 +28,18 @@ export default function(): void {
     });
 
     describe('Typescript API', function() {
-      it('toggles switch panel', function() {
-        expect(columnToggle.open).toBeFalsy();
-        columnToggle.toggleSwitchPanel();
-        expect(columnToggle.open).toBeTruthy();
-        columnToggle.toggleSwitchPanel();
-        expect(columnToggle.open).toBeFalsy();
-      });
+      it(
+        'toggles switch panel',
+        fakeAsync(function() {
+          expect(columnToggle.open).toBeFalsy();
+          columnToggle.toggleSwitchPanel();
+          tick();
+          expect(columnToggle.open).toBeTruthy();
+          columnToggle.toggleSwitchPanel();
+          tick();
+          expect(columnToggle.open).toBeFalsy();
+        })
+      );
 
       it('returns states of hideable columns hideable columns', function() {
         columnsService.mockPartialHideable(0, 1);
@@ -247,7 +252,7 @@ export default function(): void {
 }
 
 @Component({
-  template: `    
+  template: `
     <ng-template>Template Content</ng-template>
     <!--The above ng-template is required/used as a hideable column template-->
     <clr-dg-column-toggle>

--- a/src/clr-angular/data/datagrid/datagrid-column-toggle.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column-toggle.ts
@@ -25,7 +25,7 @@ import { UNIQUE_ID_PROVIDER, UNIQUE_ID } from '../../utils/id-generator/id-gener
       #anchor
       (click)="toggleSwitchPanel()"
       class="btn btn-sm btn-link column-toggle--action"
-      [attr.aria-controls]="columnSwitchId" 
+      [attr.aria-controls]="columnSwitchId"
       type="button">
       <clr-icon shape="view-columns" [attr.title]="commonStrings.pickColumns"></clr-icon>
     </button>
@@ -117,7 +117,7 @@ export class ClrDatagridColumnToggle {
 
   toggleSwitchPanel() {
     this.open = !this.open;
-    if (this.open && isPlatformBrowser(this.platformId)) {
+    if (this.open && isPlatformBrowser(this.platformId) && this.menuDescriptionElement) {
       this.zone.runOutsideAngular(() => {
         setTimeout(() => {
           this.menuDescriptionElement.nativeElement.focus();

--- a/src/clr-angular/data/datagrid/datagrid-row.html
+++ b/src/clr-angular/data/datagrid/datagrid-row.html
@@ -3,17 +3,17 @@
   Clicking of that wrapper label will equate to clicking on the whole row, which triggers the checkbox to toggle.
 -->
 <label class="datagrid-row-clickable" *ngIf="selection.rowSelectionMode">
-  <clr-expandable-animation [clrExpandTrigger]="expandAnimationTrigger" *ngIf="globalExpandable.hasExpandableRow">
+  <clr-expandable-animation [clrExpandTrigger]="expandAnimationTrigger" *ngIf="expand.expandable">
     <ng-template [ngTemplateOutlet]="rowContent"></ng-template>
   </clr-expandable-animation>
-  <ng-template [ngTemplateOutlet]="rowContent" *ngIf="!globalExpandable.hasExpandableRow"></ng-template>
+  <ng-template [ngTemplateOutlet]="rowContent" *ngIf="!expand.expandable"></ng-template>
 </label>
 
-<clr-expandable-animation *ngIf="!selection.rowSelectionMode && globalExpandable.hasExpandableRow" [clrExpandTrigger]="expandAnimationTrigger">
+<clr-expandable-animation *ngIf="!selection.rowSelectionMode && expand.expandable" [clrExpandTrigger]="expandAnimationTrigger">
   <ng-template [ngTemplateOutlet]="rowContent"></ng-template>
 </clr-expandable-animation>
 
-<ng-template *ngIf="!selection.rowSelectionMode && !globalExpandable.hasExpandableRow" [ngTemplateOutlet]="rowContent"></ng-template>
+<ng-template *ngIf="!selection.rowSelectionMode && !expand.expandable" [ngTemplateOutlet]="rowContent"></ng-template>
 
 <!--
     We need the "project into template" hacks because we need this in 2 different places

--- a/src/clr-angular/data/datagrid/datagrid.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid.spec.ts
@@ -32,10 +32,10 @@ import { ClrCommonStringsService } from '../../utils/i18n/common-strings.service
 
 @Component({
   template: `
-    <clr-datagrid 
+    <clr-datagrid
       *ngIf="!destroy"
-      [(clrDgSelected)]="selected" 
-      [clrDgLoading]="loading" 
+      [(clrDgSelected)]="selected"
+      [clrDgLoading]="loading"
       (clrDgRefresh)="refresh($event)"
       >
         <clr-dg-column>
@@ -43,12 +43,12 @@ import { ClrCommonStringsService } from '../../utils/i18n/common-strings.service
             <clr-dg-filter *ngIf="filter" [clrDgFilter]="testFilter"></clr-dg-filter>
         </clr-dg-column>
         <clr-dg-column>Second</clr-dg-column>
-    
+
         <clr-dg-row *clrDgItems="let item of items">
             <clr-dg-cell>{{item}}</clr-dg-cell>
             <clr-dg-cell>{{item * item}}</clr-dg-cell>
         </clr-dg-row>
-    
+
         <clr-dg-footer>{{items.length}} items</clr-dg-footer>
     </clr-datagrid>
 `,
@@ -82,12 +82,12 @@ class FullTest {
     <clr-datagrid>
         <clr-dg-column>First</clr-dg-column>
         <clr-dg-column>Second</clr-dg-column>
-    
+
         <clr-dg-row *ngFor="let item of items">
             <clr-dg-cell>{{item}}</clr-dg-cell>
             <clr-dg-cell>{{item * item}}</clr-dg-cell>
         </clr-dg-row>
-    
+
         <clr-dg-footer>{{items.length}} items</clr-dg-footer>
     </clr-datagrid>
 `,
@@ -114,7 +114,7 @@ class OnPushTest {
     <clr-datagrid [(clrDgSelected)]="selected">
         <clr-dg-column>First</clr-dg-column>
         <clr-dg-column>Second</clr-dg-column>
-    
+
         <clr-dg-row *clrDgItems="let item of items;" [clrDgItem]="item">
             <clr-dg-cell>{{item}}</clr-dg-cell>
             <clr-dg-cell>{{item * item}}</clr-dg-cell>
@@ -132,12 +132,12 @@ class MultiSelectionTest {
     <clr-datagrid [(clrDgSingleSelected)]="selected" clrDgSingleSelectionAriaLabel="Select row from Datagrid">
         <clr-dg-column>First</clr-dg-column>
         <clr-dg-column>Second</clr-dg-column>
-    
+
         <clr-dg-row *clrDgItems="let item of items;" [clrDgItem]="item">
             <clr-dg-cell>{{item}}</clr-dg-cell>
             <clr-dg-cell>{{item * item}}</clr-dg-cell>
         </clr-dg-row>
-    
+
         <clr-dg-footer (click)="selected = null">{{selected}}</clr-dg-footer>
     </clr-datagrid>
 `,
@@ -152,17 +152,17 @@ class SingleSelectionTest {
     <clr-datagrid clrDgSingleActionableAriaLabel="Select one of actionable rows">
         <clr-dg-column>First</clr-dg-column>
         <clr-dg-column>Second</clr-dg-column>
-    
+
         <clr-dg-row *clrDgItems="let item of items;">
-        
+
             <clr-dg-action-overflow *ngIf="item > showIfGreaterThan">
                 <button class="action-item">Edit</button>
             </clr-dg-action-overflow>
-                
+
             <clr-dg-cell>{{item}}</clr-dg-cell>
             <clr-dg-cell>{{item * item}}</clr-dg-cell>
         </clr-dg-row>
-    
+
         <clr-dg-footer>{{items.length}} items</clr-dg-footer>
     </clr-datagrid>
 `,
@@ -177,7 +177,7 @@ class ActionableRowTest {
     <clr-datagrid clrDetailExpandableAriaLabel="Expand one of the rows">
         <clr-dg-column>First</clr-dg-column>
         <clr-dg-column>Second</clr-dg-column>
-    
+
         <clr-dg-row *clrDgItems="let item of items;" [clrDgItem]="item">
             <clr-dg-cell>{{item}}</clr-dg-cell>
             <clr-dg-cell>{{item * item}}</clr-dg-cell>
@@ -185,7 +185,7 @@ class ActionableRowTest {
                 <clr-dg-row-detail *clrIfExpanded>Detail</clr-dg-row-detail>
             </ng-template>
         </clr-dg-row>
-    
+
         <clr-dg-footer>{{items.length}} items</clr-dg-footer>
     </clr-datagrid>
 `,
@@ -268,6 +268,32 @@ class ChocolateNgForTest {
   expandable = false;
 }
 
+@Component({
+  template: `
+    <clr-datagrid>
+        <clr-dg-column>First</clr-dg-column>
+        <clr-dg-column>Second</clr-dg-column>
+
+        <clr-dg-row *clrDgItems="let item of items;" [clrDgItem]="item">
+            <clr-dg-cell>{{item}}</clr-dg-cell>
+            <ng-template [ngIf]="expandable">
+                <clr-dg-row-detail *clrIfExpanded>Detail</clr-dg-row-detail>
+            </ng-template>
+        </clr-dg-row>
+
+        <clr-dg-footer>{{items.length}} items</clr-dg-footer>
+    </clr-datagrid>
+`,
+})
+class MixedExpandableRowTest {
+  items = [1, 2, 3, 4];
+  private _expandable = true;
+  get expandable() {
+    this._expandable = !this._expandable;
+    return this._expandable;
+  }
+}
+
 class TestComparator implements ClrDatagridComparatorInterface<number> {
   compare(a: number, b: number): number {
     return 0;
@@ -314,7 +340,7 @@ class TestStringFilter implements ClrDatagridStringFilterInterface<number> {
             </ng-container>
         </clr-dg-column>
         <clr-dg-column>Second</clr-dg-column>
-    
+
         <clr-dg-row *ngFor="let item of items;">
             <clr-dg-cell>{{item}}</clr-dg-cell>
             <clr-dg-cell>{{item * item}}</clr-dg-cell>
@@ -330,7 +356,7 @@ class HiddenColumnTest {
     <clr-datagrid>
         <clr-dg-column>First</clr-dg-column>
         <clr-dg-column>Second</clr-dg-column>
-    
+
         <clr-dg-row *ngFor="let item of items;">
             <clr-dg-cell>{{item}}</clr-dg-cell>
             <clr-dg-cell>{{item * item}}</clr-dg-cell>
@@ -355,13 +381,13 @@ class ProjectionTest {
 
       <clr-dg-row *ngFor="let item of items;">
           <clr-dg-cell>{{item}}</clr-dg-cell>
-          <clr-dg-cell>{{item * item}}</clr-dg-cell>    
+          <clr-dg-cell>{{item * item}}</clr-dg-cell>
           <clr-dg-row-detail *clrIfExpanded="true" [clrDgReplace]="true">
               <clr-dg-cell class="hidden-cell">{{item}} (col 1 detail)</clr-dg-cell>
               <clr-dg-cell>{{item * item}} detail (col 2 detail)</clr-dg-cell>
           </clr-dg-row-detail>
       </clr-dg-row>
-  </clr-datagrid>    
+  </clr-datagrid>
   `,
 })
 class ExpandedReplacedCellsTest {
@@ -713,6 +739,14 @@ export default function(): void {
         expect(window.getComputedStyle(hiddenCell).display).toBe('none');
       });
 
+      it('can render mixed expandable/non-expandable', function() {
+        const context = this.create(ClrDatagrid, MixedExpandableRowTest);
+        const caretIcons = context.clarityElement.querySelectorAll('.datagrid-expandable-caret-icon');
+        expect(caretIcons.length).toBe(2);
+        const datagridCells = context.clarityElement.querySelectorAll('.datagrid-cell');
+        expect(datagridCells.length).toBe(8); // 4 items * (1 for the data + 1 for the caret/placeholder)
+      });
+
       it('should have aria-label with value `Expand one of the rows`', function() {
         const context = this.create(ClrDatagrid, ExpandableRowTest);
         context.getClarityProvider(RowActionService);
@@ -816,9 +850,9 @@ export default function(): void {
 
       describe('View', function() {
         /*
-         * For some reason this test is breaking all other tests. 
-         * Not sure why - need to investigate more 
-         * 
+         * For some reason this test is breaking all other tests.
+         * Not sure why - need to investigate more
+         *
         it('should have aria-label with  value Select', function() {
           expect(context.clarityElement.querySelector('.datagrid-header .datagrid-column.datagrid-select')
           .getAttribute('aria-label')).toBe('Select row from Datagrid');

--- a/src/dev/src/app/datagrid/expandable-rows/expandable-rows.html
+++ b/src/dev/src/app/datagrid/expandable-rows/expandable-rows.html
@@ -91,8 +91,24 @@
             </ng-template>
         </clr-dg-row-detail>
     </clr-dg-row>
-
-
     <clr-dg-footer>{{users.length}} users</clr-dg-footer>
 </clr-datagrid>
 
+<h3>Mixed expandable and non expandable rows</h3>
+
+<clr-datagrid>
+  <clr-dg-column>Name</clr-dg-column>
+  <clr-dg-column>Pokemon</clr-dg-column>
+
+  <clr-dg-row *ngFor="let user of users.slice(0, 4);let i = index">
+    <clr-dg-cell>{{ user.name }}</clr-dg-cell>
+    <clr-dg-cell>{{ user.pokemon.name }}</clr-dg-cell>
+    <ng-container *ngIf="i % 2" ngProjectAs="clr-dg-row-detail">
+      <clr-dg-row-detail *clrIfExpanded>
+        Lorem ipsum...{{user|json}}
+      </clr-dg-row-detail>
+    </ng-container>
+  </clr-dg-row>
+
+  <clr-dg-footer>{{ users.length }} users</clr-dg-footer>
+</clr-datagrid>


### PR DESCRIPTION
non-expandable rows may fail to get rendered

Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [x] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

May fail to render non-expandable rows in mixed content
Issue Number: #3617 

## What is the new behavior?
Renders non-expandable rows correctly

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
