### PR TITLE
fix(wizard): prevent closing non closable wizards

### DIFF
--- a/src/clr-angular/wizard/wizard.spec.ts
+++ b/src/clr-angular/wizard/wizard.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -65,6 +65,19 @@ export default function(): void {
             wizard.close();
 
             expect(wizard._open).toBe(true, 'wizard._open should not have changed');
+          });
+
+          it('should not close on escape if clrWizardClosable is set to false', () => {
+            wizard.open();
+            expect(wizard.closable).toBe(true);
+            expect(wizard._open).toBe(true);
+
+            wizard.closable = false;
+            document.body.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape' }));
+            context.detectChanges();
+
+            expect(wizard.closable).toBe(false);
+            expect(wizard._open).toBe(true);
           });
         });
 

--- a/src/clr-angular/wizard/wizard.ts
+++ b/src/clr-angular/wizard/wizard.ts
@@ -393,7 +393,9 @@ export class ClrWizard implements OnDestroy, AfterContentInit, DoCheck {
    * alternative cancel functionality. In most cases, use `ClrWizard.cancel()` instead.
    */
   public modalCancel(): void {
-    this.checkAndCancel();
+    if (this.closable) {
+      this.checkAndCancel();
+    }
   }
 
   /**


### PR DESCRIPTION
Prevent non closable wizards from closing with
the escape key.

closes #3499

Signed-off-by: Cory Rylan <crylan@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

When disabling a wizard from closing the user could still close by using the escape key.

Issue Number: N/A

## What is the new behavior?
When the wizard is not closable the wizard will not close after pressing the escape key.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
