### PR TITLE
fix(modal): tab focus style

### DIFF
--- a/src/clr-angular/modal/modal-body.spec.ts
+++ b/src/clr-angular/modal/modal-body.spec.ts
@@ -22,10 +22,26 @@ describe('ClrModalBody Directive', () => {
   it('adds tabindex="0" to modal body to make content focusable and scrollable with keyboards', () => {
     expect(fixture.componentInstance.testElement.nativeElement.getAttribute('tabindex')).toBe('0');
   });
+
+  // https://github.com/vmware/clarity/issues/3424
+  // https://github.com/vmware/clarity/issues/3642
+  it('focuses modal body on tab only, does not focus parent on inner content click', () => {
+    fixture.componentInstance.testLabel.nativeElement.click();
+    expect(fixture.componentInstance.testElement.nativeElement === document.activeElement).toBe(false);
+  });
 });
 
-@Component({ template: `<div class="modal-body" #testElement></div>` })
+@Component({
+  template: `
+    <div class="modal-body" #testElement>
+      <label #testLabel>test label</label>
+    </div>
+  `,
+})
 class TestComponent {
+  @ViewChild('testLabel', { static: false })
+  testLabel: ElementRef<HTMLElement>;
+
   @ViewChild('testElement', { static: false })
   testElement: ElementRef<HTMLElement>;
 }

--- a/src/clr-angular/modal/modal-body.ts
+++ b/src/clr-angular/modal/modal-body.ts
@@ -4,12 +4,37 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Directive } from '@angular/core';
+import { Directive, HostListener } from '@angular/core';
 
+/**
+ * Allows modal overflow area to be scrollable via keyboard.
+ * The modal body will focus with keyboard navigation only.
+ * This allows inner focusable items to be focused without
+ * the overflow scroll being focused.
+ */
 @Directive({
   selector: '.modal-body',
   host: {
     '[attr.tabindex]': '"0"',
   },
 })
-export class ClrModalBody {}
+export class ClrModalBody {
+  private _mouseDown = false;
+
+  @HostListener('focus', ['$event'])
+  focus(event) {
+    if (this._mouseDown) {
+      event.target.blur();
+    }
+  }
+
+  @HostListener('mousedown')
+  mouseDown() {
+    this._mouseDown = true;
+  }
+
+  @HostListener('mouseup')
+  mouseUp() {
+    this._mouseDown = false;
+  }
+}


### PR DESCRIPTION
Only add focus style on modal content when tabbed to allow keyboard access. Example of desired behavior in vanilla JS https://stackblitz.com/edit/js-ich6zf 

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?
When focusing the modal content using tab a keyboard user can use the arrows to scroll. This is causing focus styles to be applied on the modal body when inner elements are clicked.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #3642

## What is the new behavior?
Keyboard users can tab to modal body to navigate overflow content and get focus style. When a user focuses or clicks a inner element the focus style is no longer applied on the parent modal body.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
