### PR TITLE
feat: add aria-label for alert close button

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -93,6 +93,7 @@ export declare class ClrAlert {
     alertType: string;
     cdr: ChangeDetectorRef;
     closable: boolean;
+    clrCloseButtonAriaLabel: string;
     commonStrings: ClrCommonStringsService;
     iconService: AlertIconAndTypesService;
     isAppLevel: boolean;
@@ -229,6 +230,7 @@ export declare class ClrCommonFormsModule {
 }
 
 export interface ClrCommonStrings {
+    alertCloseButtonAriaLabel?: string;
     allColumnsSelected?: string;
     close?: string;
     collapse?: string;

--- a/src/clr-angular/emphasis/alert/alert.html
+++ b/src/clr-angular/emphasis/alert/alert.html
@@ -15,7 +15,13 @@
     <div class="alert-items">
         <ng-content></ng-content>
     </div>
-    <button type="button" class="close" *ngIf="closable" (click)="close()">
-        <clr-icon shape="close" [attr.title]="commonStrings.keys.close"></clr-icon>
+    <button 
+        type="button" 
+        class="close" 
+        *ngIf="closable" 
+        (click)="close()" 
+        [attr.aria-label]="clrCloseButtonAriaLabel"
+        >
+        <clr-icon shape="close"></clr-icon>
     </button>
 </div>

--- a/src/clr-angular/emphasis/alert/alert.spec.ts
+++ b/src/clr-angular/emphasis/alert/alert.spec.ts
@@ -9,6 +9,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ClrAlert } from './alert';
 import { ClrAlertModule } from './alert.module';
 
+const CLOSE_ARIA_LABEL = 'Close Test Alert';
+
 @Component({
   template: `
         <clr-alert
@@ -16,7 +18,8 @@ import { ClrAlertModule } from './alert.module';
             [clrAlertSizeSmall]="isSmall"
             [clrAlertClosable]="isClosable"
             [(clrAlertClosed)]="closed"
-            [clrAlertAppLevel]="isAppLevel">
+            [clrAlertAppLevel]="isAppLevel"
+            [clrCloseButtonAriaLabel]="closeAriaLabel">
             <div class="alert-item">
                 <span class="alert-text">
                 {{alertMsg}}
@@ -34,6 +37,7 @@ class TestComponent {
   isClosable: boolean = false;
   closed: boolean = false;
   isAppLevel: boolean = false;
+  closeAriaLabel: string = CLOSE_ARIA_LABEL;
 
   alertMsg: string = 'This is an alert!';
 }
@@ -120,6 +124,12 @@ export default function(): void {
     it('Has an ARIA role of alert', () => {
       const myAlert: HTMLElement = compiled.querySelector('.alert');
       expect(myAlert.getAttribute('role')).toBe('alert');
+    });
+
+    it('should be able to set close button text', () => {
+      fixture.componentInstance.isClosable = true;
+      fixture.detectChanges();
+      expect(compiled.querySelector('.close').getAttribute('aria-label')).toBe(CLOSE_ARIA_LABEL);
     });
 
     it('should not have an aria-live when using role alert', () => {

--- a/src/clr-angular/emphasis/alert/alert.ts
+++ b/src/clr-angular/emphasis/alert/alert.ts
@@ -28,6 +28,9 @@ export class ClrAlert {
   @Input('clrAlertClosable') closable: boolean = true;
   @Input('clrAlertAppLevel') isAppLevel: boolean = false;
 
+  // Aria
+  @Input() clrCloseButtonAriaLabel: string = this.commonStrings.keys.alertCloseButtonAriaLabel;
+
   @Input('clrAlertClosed') _closed: boolean = false;
   @Output('clrAlertClosedChange') _closedChanged: EventEmitter<boolean> = new EventEmitter<boolean>(false);
 

--- a/src/clr-angular/utils/i18n/common-strings.default.ts
+++ b/src/clr-angular/utils/i18n/common-strings.default.ts
@@ -45,4 +45,6 @@ export const commonStringsDefault: ClrCommonStrings = {
   singleSelectionAriaLabel: 'Single selection header',
   singleActionableAriaLabel: 'Single actionable header',
   detailExpandableAriaLabel: 'Toggle more row content',
+  // Alert
+  alertCloseButtonAriaLabel: 'Close alert',
 };

--- a/src/clr-angular/utils/i18n/common-strings.interface.ts
+++ b/src/clr-angular/utils/i18n/common-strings.interface.ts
@@ -159,4 +159,9 @@ export interface ClrCommonStrings {
    * Datagrid: Expandable row
    */
   detailExpandableAriaLabel?: string;
+
+  /**
+   * Alert: Close alert button
+   */
+  alertCloseButtonAriaLabel?: string;
 }

--- a/src/website/src/app/documentation/demos/alert/alerts.demo.html
+++ b/src/website/src/app/documentation/demos/alert/alerts.demo.html
@@ -555,6 +555,17 @@
                     <td class="hidden-xs-down">false</td>
                     <td class="left">If true, renders an app-level alert.</td>
                 </tr>
+
+                <tr>
+                    <td class="left">
+                        <b>[clrCloseButtonAriaLabel]</b>
+                        <div class="hidden-sm-up">Type: String</div>
+                        <div class="hidden-sm-up">Default: Close alert</div>
+                    </td>
+                    <td class="left hidden-xs-down">Close alert</td>
+                    <td class="hidden-xs-down">Close alert</td>
+                    <td class="left">Overwrite default aria-label for close alert button</td>
+                </tr>
                 </tbody>
             </table>
 

--- a/src/website/src/app/documentation/demos/i18n/i18n.demo.ts
+++ b/src/website/src/app/documentation/demos/i18n/i18n.demo.ts
@@ -58,5 +58,6 @@ export class I18nDemo extends ClarityDocComponent {
     { key: 'singleSelectionAriaLabel', role: 'Datagrid: aria label for header single selection header column' },
     { key: 'singleActionableAriaLabel', role: 'Datagrid: aria label for row action header column' },
     { key: 'detailExpandableAriaLabel', role: 'Datagrid: aria label for expandable row toggle button' },
+    { key: 'alertCloseButtonAriaLabel', role: 'Alert: aria label for closing alert' },
   ];
 }

--- a/src/website/src/app/documentation/demos/wizard/wizard-async-completion.demo.html
+++ b/src/website/src/app/documentation/demos/wizard/wizard-async-completion.demo.html
@@ -19,7 +19,7 @@
     <clr-wizard-page>
         <ng-template clrPageTitle>Form question</ng-template> <!-- mandatory -->
 
-        <clr-alert [clrAlertType]="'alert-info'" [clrAlertClosable]="false">
+        <clr-alert [clrAlertType]="'alert-info'" [clrAlertClosable]="false" [clrCloseButtonAriaLabel]="'Close Wiki alert'">
             <clr-alert-item>
                 This&nbsp;<a
                     href="https://en.wikipedia.org/wiki/42_(number)#The_Hitchhiker.27s_Guide_to_the_Galaxy"
@@ -40,7 +40,7 @@
         (clrWizardPagePrevious)="goBack()">
         <ng-template clrPageTitle>Async validation on finish</ng-template> <!-- mandatory -->
 
-        <clr-alert *ngIf="errorFlag" [clrAlertType]="'alert-danger'">
+        <clr-alert *ngIf="errorFlag" [clrAlertType]="'alert-danger'" [clrCloseButtonAriaLabel]="'Close Answer alert'">
             <clr-alert-item>
                 Your answer is incorrect.
             </clr-alert-item>

--- a/src/website/src/app/documentation/demos/wizard/wizard-async-completion.demo.ts
+++ b/src/website/src/app/documentation/demos/wizard/wizard-async-completion.demo.ts
@@ -154,7 +154,7 @@ export class WizardAsyncCompletion {
     <clr-wizard-page>
         <ng-template clrPageTitle>Form question</ng-template> <!-- mandatory -->
 
-        <clr-alert [clrAlertType]="'alert-info'" [clrAlertClosable]="false">
+        <clr-alert [clrAlertType]="'alert-info'" [clrAlertClosable]="false" [clrCloseButtonAriaLabel]="'Close Wiki alert'">
             <div class="alert-item">
                 This&nbsp;<a
                     href="https://en.wikipedia.org/wiki/42_(number)#The_Hitchhiker.27s_Guide_to_the_Galaxy"
@@ -175,7 +175,7 @@ export class WizardAsyncCompletion {
         (clrWizardPagePrevious)="goBack()">
         <ng-template clrPageTitle>Async validation on finish</ng-template> <!-- mandatory -->
 
-        <clr-alert *ngIf="errorFlag" [clrAlertType]="'alert-danger'">
+        <clr-alert *ngIf="errorFlag" [clrAlertType]="'alert-danger'" [clrCloseButtonAriaLabel]="'Close Answer alert'">
             <div class="alert-item">
                 Your answer is incorrect.
             </div>

--- a/src/website/src/app/documentation/demos/wizard/wizard-async-validation.demo.html
+++ b/src/website/src/app/documentation/demos/wizard/wizard-async-validation.demo.html
@@ -23,14 +23,14 @@
         <clr-spinner *ngIf="loadingFlag">
             Loading
         </clr-spinner>
-        <clr-alert [clrAlertType]="'alert-info'" [clrAlertClosable]="false">
+        <clr-alert [clrAlertType]="'alert-info'" [clrAlertClosable]="false" [clrCloseButtonAriaLabel]="'Close Wiki alert'">
             <clr-alert-item>
                 This&nbsp;<a
                     href="https://en.wikipedia.org/wiki/42_(number)#The_Hitchhiker.27s_Guide_to_the_Galaxy"
                     target="_blank">wiki article</a>&nbsp;might help you answer the question.
             </clr-alert-item>
         </clr-alert>
-        <clr-alert *ngIf="errorFlag" [clrAlertType]="'alert-danger'">
+        <clr-alert *ngIf="errorFlag" [clrAlertType]="'alert-danger'" [clrCloseButtonAriaLabel]="'Close Answer alert'">
             <clr-alert-item>
                 Your answer is incorrect.
             </clr-alert-item>

--- a/src/website/src/app/documentation/demos/wizard/wizard-async-validation.demo.ts
+++ b/src/website/src/app/documentation/demos/wizard/wizard-async-validation.demo.ts
@@ -99,14 +99,14 @@ export class WizardAsyncValidation {
       <clr-spinner *ngIf="loadingFlag">
           Loading
       </clr-spinner>
-      <clr-alert [clrAlertType]="'alert-info'" [clrAlertClosable]="false">
+      <clr-alert [clrAlertType]="'alert-info'" [clrAlertClosable]="false" [clrCloseButtonAriaLabel]="'Close Wiki alert'">
           <clr-alert-item>
               This&nbsp;<a
                   href="https://en.wikipedia.org/wiki/42_(number)#The_Hitchhiker.27s_Guide_to_the_Galaxy"
                   target="_blank">wiki article</a>&nbsp;might help you answer the question.
           </clr-alert-item>
       </clr-alert>
-      <clr-alert *ngIf="errorFlag" [clrAlertType]="'alert-danger'">
+      <clr-alert *ngIf="errorFlag" [clrAlertType]="'alert-danger'" [clrCloseButtonAriaLabel]="'Close Answer alert'">
           <clr-alert-item>
               Your answer is incorrect.
           </clr-alert-item>

--- a/src/website/src/app/documentation/demos/wizard/wizard-design.demo.html
+++ b/src/website/src/app/documentation/demos/wizard/wizard-design.demo.html
@@ -92,7 +92,7 @@
                 <ng-template clrPageTitle>Power</ng-template>
                 <ng-template clrPageNavTitle>{{ pageThreeTitle }}</ng-template>
 
-                <clr-alert [clrAlertClosable]="false" clrAlertType="alert-error" *ngIf="showPowerError">
+                <clr-alert [clrAlertClosable]="false" clrAlertType="alert-error" *ngIf="showPowerError"[clrCloseButtonAriaLabel]="'Close Wiki alert'">
                     <clr-alert-item>
                         <span class="alert-text">
                             Your power and weakness cannot be from the same source.


### PR DESCRIPTION
Add `aria-label` that the developer could overwrite if needed to provide additional information on the close button text.

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?
Right now there is no way to change the alert close button text - also we use generic `Close` text that could be misleading.

Issue Number: #3489 

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Close: #3498 

**NEED TO BE BACKPORTED TO V1**