### PR TITLE
fix(datepicker): remove circular reference

### DIFF
--- a/src/clr-angular/forms/datepicker/model/day.model.spec.ts
+++ b/src/clr-angular/forms/datepicker/model/day.model.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -55,17 +55,6 @@ export default function(): void {
 
       incrementDayModelAndCompare(dayModel1, 1);
       incrementDayModelAndCompare(dayModel1, -1);
-    });
-
-    it('returns the Calendar in which the DayModel belongs in', () => {
-      expect(dayModel1.calendar).not.toBeNull();
-      expect(dayModel2.calendar).not.toBeNull();
-
-      expect(dayModel1.calendar.month).toBe(0);
-      expect(dayModel1.calendar.year).toBe(2018);
-
-      expect(dayModel2.calendar.month).toBe(5);
-      expect(dayModel2.calendar.year).toBe(2018);
     });
 
     it('returns a clone of the DayModel', () => {

--- a/src/clr-angular/forms/datepicker/model/day.model.ts
+++ b/src/clr-angular/forms/datepicker/model/day.model.ts
@@ -1,20 +1,11 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { CalendarModel } from './calendar.model';
-
 export class DayModel {
   constructor(public readonly year: number, public readonly month: number, public readonly date: number) {}
-
-  /**
-   * Returns the Calendar for the current DayModel.
-   */
-  get calendar(): CalendarModel {
-    return new CalendarModel(this.year, this.month);
-  }
 
   /**
    * Checks if the passed CalendarDate is equal to itself.

--- a/src/clr-angular/forms/datepicker/providers/date-navigation.service.ts
+++ b/src/clr-angular/forms/datepicker/providers/date-navigation.service.ts
@@ -120,7 +120,7 @@ export class DateNavigationService {
     if (this._displayedCalendar.isDayInCalendar(this.focusedDay)) {
       this._focusedDayChange.next(this.focusedDay);
     } else {
-      this.setDisplayedCalendar(this.focusedDay.calendar);
+      this.setDisplayedCalendar(new CalendarModel(this.focusedDay.year, this.focusedDay.month));
     }
     this._focusOnCalendarChange.next();
   }


### PR DESCRIPTION
Remove unnecessary circular reference between day and calendar model. This removes the last of the circular ref warnings in the build.

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?
There is a circular dependency between the day and calendar models. This is unnecessary and causes warnings in the build output.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Remove the circular dependency between day and calendar models.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
