### PR TITLE
feat(datagrid): Expose current page for clrDgRefresh

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -533,6 +533,7 @@ export interface ClrDatagridStateInterface<T = any> {
         from?: number;
         to?: number;
         size?: number;
+        current?: number;
     };
     sort?: {
         by: string | ClrDatagridComparatorInterface<T>;

--- a/src/clr-angular/data/datagrid/datagrid.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid.spec.ts
@@ -570,6 +570,7 @@ export default function(): void {
               from: 2,
               to: 3,
               size: 2,
+              current: 2,
             },
             sort: {
               by: comparator,

--- a/src/clr-angular/data/datagrid/interfaces/state.interface.ts
+++ b/src/clr-angular/data/datagrid/interfaces/state.interface.ts
@@ -6,7 +6,7 @@
 import { ClrDatagridComparatorInterface } from './comparator.interface';
 
 export interface ClrDatagridStateInterface<T = any> {
-  page?: { from?: number; to?: number; size?: number };
+  page?: { from?: number; to?: number; size?: number; current?: number };
   sort?: { by: string | ClrDatagridComparatorInterface<T>; reverse: boolean };
   filters?: any[];
 }

--- a/src/clr-angular/data/datagrid/providers/state.provider.ts
+++ b/src/clr-angular/data/datagrid/providers/state.provider.ts
@@ -39,7 +39,12 @@ export class StateProvider<T> {
   get state(): ClrDatagridStateInterface<T> {
     const state: ClrDatagridStateInterface<T> = {};
     if (this.page.size > 0) {
-      state.page = { from: this.page.firstItem, to: this.page.lastItem, size: this.page.size };
+      state.page = {
+        from: this.page.firstItem,
+        to: this.page.lastItem,
+        size: this.page.size,
+        current: this.page.current,
+      };
     }
     if (this.sort.comparator) {
       if (this.sort.comparator instanceof DatagridPropertyComparator) {

--- a/src/website/src/app/documentation/demos/datagrid/server-driven/examples.ts
+++ b/src/website/src/app/documentation/demos/datagrid/server-driven/examples.ts
@@ -10,6 +10,7 @@ interface ClrDatagridStateInterface<T = any> {
         from?: number;
         to?: number;
         size?: number;
+        current?: number;
     }
     sort?: {
         by: string | ClrDatagridComparatorInterface<T>;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [X] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

* [ ] Bugfix
* [X] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?
The `page` of a `ClrDatagridStateInterface` does not provide the current page of the `Page` from the `clrDgRefresh` event.  And with a paginated API that takes a page number as part of the parameters (ex. `some-paginated-api?page=1&size=10&sort=column,desc` ), this makes it unnecessarily difficult to consume the data using a server driven datagrid.

I found this related issue: https://github.com/vmware/clarity/issues/3100

## What is the new behavior?
Expose the current page in `page` of `ClrDatagridStateInterface` (from the `StateProvider`'s `Page`) as part of the `clrDgRefresh` event in order to get the current page for a paginated API request.

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No

## Other information
