### PR TITLE
fix: css vars pony fill needs to run on module init

### DIFF
--- a/src/dev/src/app/custom-props/custom-props.demo.ts
+++ b/src/dev/src/app/custom-props/custom-props.demo.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { runCssVarsPolyfill } from '@clr/base';
 
 const themes = {
@@ -88,10 +88,14 @@ function getNewTheme(oldTheme: string): string {
   templateUrl: 'custom-props.demo.html',
   styleUrls: ['./custom-props.demo.scss'],
 })
-export class CustomPropsDemo {
+export class CustomPropsDemo implements OnInit {
   private _theme = 'default';
 
   cycleThemes(): void {
     this._theme = getNewTheme(this._theme);
+  }
+
+  ngOnInit() {
+    runCssVarsPolyfill();
   }
 }


### PR DESCRIPTION
When you start out in the dev app on a non-custom-props module and then go to the custom-props demo, the polyfill doesn't run and the header that says it should never be red or black indeed shows up as black (warning sign!)

This change fixes that by forcing the polyfill to run on the component's init

Tested in:
✔︎ IE11

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

See above.

Issue Number: N/A

## What is the new behavior?

See above.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
