### PR TITLE
fix: editable stack view form fields looked unstyled in dev app

### DIFF
--- a/src/dev/src/app/stack-view/stack-view-angular-modal-edit.html
+++ b/src/dev/src/app/stack-view/stack-view-angular-modal-edit.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -29,13 +29,13 @@
         <clr-stack-block *ngFor="let block of blocks; let blockIndex = index" [clrSbNotifyChange]="block.content!=='Content '+ (blockIndex+1)">
           <clr-stack-label>{{block.title}}</clr-stack-label>
           <clr-stack-content>
-            <input type="text" [(ngModel)]="block.content" />
+            <input type="text" [(ngModel)]="block.content" class="clr-input" />
           </clr-stack-content>
 
           <clr-stack-block *ngFor="let child of block.children; let blockChildIndex = index" [clrSbNotifyChange]="child.content!=='Sub-content '+ (blockChildIndex+1)">
             <clr-stack-label>{{child.title}}</clr-stack-label>
             <clr-stack-content>
-              <input type="text" [(ngModel)]="child.content" />
+              <input type="text" [(ngModel)]="child.content" class="clr-input" />
             </clr-stack-content>
           </clr-stack-block>
         </clr-stack-block>

--- a/src/website/src/app/documentation/demos/stack-view/stack-view-angular-modal-edit.html
+++ b/src/website/src/app/documentation/demos/stack-view/stack-view-angular-modal-edit.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -29,13 +29,13 @@
                 <clr-stack-block *ngFor="let block of blocks; let blockIndex = index" [clrSbNotifyChange]="block.content!=='Content '+ (blockIndex+1)">
                     <clr-stack-label>{{block.title}}</clr-stack-label>
                     <clr-stack-content>
-                        <input type="text" [(ngModel)]="block.content" />
+                        <input type="text" [(ngModel)]="block.content" class="clr-input"/>
                     </clr-stack-content>
 
                     <clr-stack-block *ngFor="let child of block.children; let blockChildIndex = index" [clrSbNotifyChange]="child.content!=='Sub-content '+ (blockChildIndex+1)">
                         <clr-stack-label>{{child.title}}</clr-stack-label>
                         <clr-stack-content>
-                            <input type="text" [(ngModel)]="child.content" />
+                            <input type="text" [(ngModel)]="child.content" class="clr-input"/>
                         </clr-stack-content>
                     </clr-stack-block>
                 </clr-stack-block>

--- a/src/website/src/app/documentation/demos/stack-view/stack-view-angular-modal-edit.ts
+++ b/src/website/src/app/documentation/demos/stack-view/stack-view-angular-modal-edit.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -36,7 +36,7 @@ const EXAMPLE = `
                 [clrSbNotifyChange]="block.content!=='Content '+ (blockIndex+1)">
                 <clr-stack-label>{{block.title}}</clr-stack-label>
                 <clr-stack-content>
-                    <input type="text" [(ngModel)]="block.content" />
+                    <input type="text" [(ngModel)]="block.content" class="clr-input"/>
                 </clr-stack-content>
 
                 <clr-stack-block 
@@ -44,7 +44,7 @@ const EXAMPLE = `
                     [clrSbNotifyChange]="child.content!=='Sub-content '+ (blockChildIndex+1)">
                     <clr-stack-label>{{child.title}}</clr-stack-label>
                     <clr-stack-content>
-                        <input type="text" [(ngModel)]="child.content" />
+                        <input type="text" [(ngModel)]="child.content" class="clr-input"/>
                     </clr-stack-content>
                 </clr-stack-block>
             </clr-stack-block>


### PR DESCRIPTION
• added clr-input classname so editable stack view form fields would look as expected

Tested in:
✔︎ Chrome

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [x] clarity.design website / infrastructure changes
* [x] Other... Please describe: Dev app

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Dev app has unstyled form fields in stack view

Issue Number: N/A

## What is the new behavior?

Form fields in stack view are styled

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
