### PR TITLE
docs: updating documentation language

### DIFF
--- a/src/website/src/app/documentation/demos/grid/grid.demo.html
+++ b/src/website/src/app/documentation/demos/grid/grid.demo.html
@@ -219,6 +219,14 @@
 
             <h3 id="column-ordering">Column Ordering</h3>
 
+            <clr-alert [clrAlertType]="'danger'" [clrAlertClosable]="false">
+                <clr-alert-item>
+                      <span class="alert-text">
+                        The usage of the CSS <code class="clr-code">order</code> property is no longer recommended by Clarity due to its potential to cause accessibility issues with respect to reading order. Screen reader software uses DOM order to render content to users and when doing so, does not honor the CSS <code class="clr-code">order</code> property. Usage of this property can result in violating the WCAG Success Criterion - <a href="https://www.w3.org/TR/WCAG21/#meaningful-sequence">1.3.2 Meaningful Sequence</a>. For more information about this issue see <a href="https://www.w3.org/TR/css-flexbox-1/#order-accessibility">https://www.w3.org/TR/css-flexbox-1/#order-accessibility</a>.
+                      </span>
+                </clr-alert-item>
+              </clr-alert>
+
             <p>The responsive <code class="clr-code">clr-order-*</code> class modifiers
                 change the order of columns where <code class="clr-code">*</code> represents the order.</p>
 

--- a/src/website/src/app/documentation/demos/toggles/toggles.demo.html
+++ b/src/website/src/app/documentation/demos/toggles/toggles.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -312,7 +312,7 @@
 
       <h4>Toggle States</h4>
 
-      <p>Toggle switches do not include “ON” and “OFF” text because these states are clearly implied.</p>
+      <p>Toggle switches should always be preceded with a visual label such as ON/OFF</p>
 
       <h4>Label</h4>
 


### PR DESCRIPTION
1. remove text supporting use of CSS order property, close #3412
2. fixed toggle docs language to reflect the need for visual labelling

Signed-off-by: Chris Lane <chlane@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

Documentation is incorrect regarding CSS order property usage and visual labelling for toggle buttons

Issue Number: #3412

## What is the new behavior?
NA
## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
