### PR TITLE
fix(table): table font-size not overrideable

### DIFF
--- a/src/clr-angular/data/_variables.tables.scss
+++ b/src/clr-angular/data/_variables.tables.scss
@@ -31,7 +31,7 @@ $clr-table-borderstyle: $clr-table-borderwidth solid $clr-table-bordercolor !def
 $clr-table-font-color: $clr-color-neutral-700 !default;
 
 // Table dims and sizing
-$clr-table-fontsize: 0.541667rem;
+$clr-table-fontsize: 0.541667rem !default;
 $clr-table-lineheight: 0.5833334rem !default;
 $clr-table-lineheightPaddingShim: (1rem - $clr-table-lineheight)/2 !default;
 $clr-table-cellpadding: 0.5rem !default;


### PR DESCRIPTION
notes:
• just missing default
• i will backport to 1.x

Tested in:
✔︎ Chrome

Fixes: #3544

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

Can't override table font size

Issue Number: N/A

## What is the new behavior?

Table font size can be overridden

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

See up top...