### PR TITLE
fix: preventing duplicate style declarations in CSS

### DIFF
--- a/src/clr-angular/layout/nav/_links.clarity.scss
+++ b/src/clr-angular/layout/nav/_links.clarity.scss
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
+
+@include exports('links.clarity') {
+  // only imported for demos. gives a static view of links in various states.
+  a.link-normal:link {
+    color: $clr-link-color;
+    text-decoration: none;
+  }
+
+  a.link-hovered:link {
+    color: $clr-link-hover-color;
+    text-decoration: underline;
+  }
+
+  a.link-clicked:link {
+    color: $clr-link-active-color;
+    text-decoration: underline;
+  }
+
+  a.link-visited:link {
+    color: $clr-link-visited-color;
+    text-decoration: none;
+  }
+}

--- a/src/clr-angular/layout/nav/_variables.nav.scss
+++ b/src/clr-angular/layout/nav/_variables.nav.scss
@@ -9,25 +9,3 @@ $clr-link-color: $clr-color-action-600 !default;
 $clr-link-hover-color: $clr-color-action-600 !default;
 $clr-link-visited-color: hsl(238, 41%, 53%) !default;
 $clr-custom-links-hover-color: $clr-color-neutral-200 !default;
-
-// These utility styles get used in demos.
-// To test theming they need to live here.
-a.link-normal:link {
-  color: $clr-link-color;
-  text-decoration: none;
-}
-
-a.link-hovered:link {
-  color: $clr-link-hover-color;
-  text-decoration: underline;
-}
-
-a.link-clicked:link {
-  color: $clr-link-active-color;
-  text-decoration: underline;
-}
-
-a.link-visited:link {
-  color: $clr-link-visited-color;
-  text-decoration: none;
-}

--- a/src/clr-angular/utils/_components.clarity.scss
+++ b/src/clr-angular/utils/_components.clarity.scss
@@ -87,6 +87,7 @@
 
 //Nav
 @import '../layout/nav/header.clarity'; // depends on variables.clarity, mixins.clarity, helpers.clarity, color.clarity, layers.clarity
+@import '../layout/nav/links.clarity'; // depends on variables.clarity, mixins.clarity, helpers.clarity, color.clarity
 @import '../layout/nav/nav.clarity'; // depends on variables.clarity, mixins.clarity, helpers.clarity, color.clarity, layers.clarity
 @import '../layout/nav/subnav.clarity'; // depends on variables.clarity, mixins.clarity, helpers.clarity, color.clarity, layers.clarity
 @import '../layout/nav/sidenav.clarity'; // depends on variables.clarity, mixins.clarity, helpers.clarity, color.clarity


### PR DESCRIPTION
notes:
• the link styles we were using for the dev app and website typography pages was getting duplicated each time the link variables were being imported
• i moved the styles to their own file and imported them where they were needed
• because these styles are only used for the dev app demos and typography demo on the website, i did not consider this a breaking change
• i have verified the styles are no longer duplicated
• i have tested the changes locally on the website and dev-app
• i have also tested the changes against gemini in both light and dark themes

Tested in:
✔︎ Chrome

Fixes|Closes: #3540

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

See above.

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [x] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 3540

## What is the new behavior?

CSS removed from variables file

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No - see notes above

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

see above