### PR TITLE
bug(modal): clrModalOpenChange was fired more than once when closing

### DIFF
--- a/src/clr-angular/modal/modal.spec.ts
+++ b/src/clr-angular/modal/modal.spec.ts
@@ -4,6 +4,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { Component, ViewChild } from '@angular/core';
+import { AnimationEvent } from '@angular/animations';
+
 import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -143,6 +145,29 @@ describe('Modal', () => {
       spyOn(getModalInstance(fixture)._openChanged, 'emit');
       getModalInstance(fixture).open();
       expect(getModalInstance(fixture)._openChanged.emit).not.toHaveBeenCalled();
+    })
+  );
+
+  it(
+    'should not emit clrModalOpenChange - animation will do that for us',
+    fakeAsync(() => {
+      /**
+       * Needed just to mock the event so I could enter the `if` statement.
+       */
+      const fakeAnimationEvent: AnimationEvent = {
+        fromState: '',
+        toState: 'void',
+        totalTime: 0,
+        phaseName: '',
+        element: {},
+        triggerName: '',
+        disabled: false,
+      };
+
+      spyOn(getModalInstance(fixture)._openChanged, 'emit');
+      getModalInstance(fixture).close();
+      getModalInstance(fixture).fadeDone(fakeAnimationEvent);
+      expect(getModalInstance(fixture)._openChanged.emit).toHaveBeenCalledTimes(1);
     })
   );
 

--- a/src/clr-angular/modal/modal.ts
+++ b/src/clr-angular/modal/modal.ts
@@ -109,9 +109,6 @@ export class ClrModal implements OnChanges, OnDestroy {
       return;
     }
     this._open = false;
-    // todo: remove this after animation bug is fixed https://github.com/angular/angular/issues/15798
-    // this was handled by the fadeDone event below, but that AnimationEvent is not firing in Angular 4.0.
-    this._openChanged.emit(false);
     // SPECME
     this.focusTrap.setPreviousFocus(); // Handles moving focus back to the element that had it before.
   }


### PR DESCRIPTION
Removing unneeded todo for fixing already resolved Angular issue.

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3149 

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The bug is originally reported for v1, but also apply to v2. 
So here is the branch with the fix for v1 - that must be applied as well.

https://github.com/bdryanovski/clarity/tree/bug/modal-3149

NOTE: this pull-request is cherry-picked from this branch.