### PR TITLE
bug(tooltip): Tooltip contents not visible in Dark theme

### DIFF
--- a/src/clr-angular/utils/_theme.dark.clarity.scss
+++ b/src/clr-angular/utils/_theme.dark.clarity.scss
@@ -667,7 +667,7 @@ $clr-nav-link-color: hsl(203, 16%, 72%);
   *
   * Usage: ../popover/tooltip/_tooltips.clarity.scss
   */
-$clr-tooltip-font-color: hsl(0, 0%, 0%);
+$clr-tooltip-color: hsl(0, 0%, 0%);
 $clr-tooltip-background-color: hsl(0, 0%, 100%);
 // END: Tooltip
 


### PR DESCRIPTION
Fixed the bug that prevents the content of the tooltip to be visible in dark mode.

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3721 

## What is the new behavior?

The content of the tooltip is now visible when the dark theme is activated.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
