### PR TITLE
bug(sidenav): Sidenav in website documentation page doesn't collapse

### DIFF
--- a/src/website/src/app/documentation/documentation-nav-links.component.ts
+++ b/src/website/src/app/documentation/documentation-nav-links.component.ts
@@ -10,21 +10,19 @@ import * as COMPONENTS from '../../settings/componentlist.json';
 @Component({
   selector: 'documentation-nav-links',
   template: `
-    <ul class="nav-list">
-        <ng-container *ngFor="let component of components">
-            <li *ngIf="component.url && !component.noDemo && component.type == type">
-                <a class="nav-link" [routerLink]="component.url" routerLinkActive="active">
-                    {{component.text}}
-                    <span *ngIf="component.isNew" class="new nav-link-tag">New!</span>
-                    <span *ngIf="component.isUpdated" class="updated nav-link-tag">Updated</span>
-                </a>
-            </li>
-        </ng-container>
-    </ul>
+    <ng-container *ngFor="let component of components">
+        <li *ngIf="component.url && !component.noDemo && component.type == type">
+            <a class="nav-link" [routerLink]="component.url" routerLinkActive="active">
+                {{component.text}}
+                <span *ngIf="component.isNew" class="new nav-link-tag">New!</span>
+                <span *ngIf="component.isUpdated" class="updated nav-link-tag">Updated</span>
+            </a>
+        </li>
+    </ng-container>
     `,
 })
 export class DocumentationNavLinksComponent {
-  components = COMPONENTS.list;
+    components = COMPONENTS.list;
 
-  @Input() type: string;
+    @Input() type: string;
 }

--- a/src/website/src/app/documentation/documentation.component.html
+++ b/src/website/src/app/documentation/documentation.component.html
@@ -4,20 +4,24 @@
         <version-switcher></version-switcher>
 
         <a class="nav-link" routerLink="/documentation" routerLinkActive="active"
-           [routerLinkActiveOptions]="{exact:true}">Component Status</a>
+            [routerLinkActiveOptions]="{exact:true}">Component Status</a>
 
         <a class="nav-link" routerLink="get-started" routerLinkActive="active"
-           [routerLinkActiveOptions]="{exact:true}">Get Started</a>
+            [routerLinkActiveOptions]="{exact:true}">Get Started</a>
 
         <section class="nav-group collapsible">
             <input id="tab2" type="checkbox">
             <label for="tab2">Patterns</label>  
-            <documentation-nav-links type="pattern"></documentation-nav-links>
+            <ul class="nav-list">
+                <documentation-nav-links type="pattern"></documentation-nav-links>
+            </ul>
         </section>
         <section class="nav-group collapsible">
             <input id="tab1" type="checkbox">
             <label for="tab1">Components</label>
-            <documentation-nav-links type="component"></documentation-nav-links>
+            <ul class="nav-list">
+                <documentation-nav-links type="component"></documentation-nav-links>
+            </ul>
         </section>
     </section>
 </nav>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #3704 

## What is the new behavior?
The sidenav in website documentation collapse. 
The "ul" tags must be in the parent component. If it is in child one, the selector does not work properly.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
