### PR TITLE
fix(tooltip): deprecation overwrote dark theme variable

### DIFF
--- a/src/clr-angular/popover/tooltip/_tooltips.clarity.scss
+++ b/src/clr-angular/popover/tooltip/_tooltips.clarity.scss
@@ -3,7 +3,7 @@
 // The full license information can be found in LICENSE in the root directory of this project.
 
 @mixin common-tooltip-styles {
-  color: $clr-tooltip-color;
+  color: $clr-tooltip-font-color;
   font-size: $clr-tooltip-font-size;
   font-weight: $clr-tooltip-font-weight;
   letter-spacing: $clr-tooltip-letter-spacing;


### PR DESCRIPTION
• this is a regression
• a deprecation in 2.0 was improperly applied and broke theming for the text inside a tooltip

Tested in:
✔︎ Chrome
Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

See above.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3740 

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
