### PR TITLE
fix: ClrAccordionModule and ClrStepperModule missing from default exports

### DIFF
--- a/src/clr-angular/accordion/index.ts
+++ b/src/clr-angular/accordion/index.ts
@@ -9,3 +9,4 @@ export * from './accordion-panel';
 export * from './accordion-title';
 export * from './accordion-content';
 export * from './accordion-description';
+export * from './accordion.module';

--- a/src/clr-angular/accordion/stepper/index.ts
+++ b/src/clr-angular/accordion/stepper/index.ts
@@ -6,4 +6,5 @@
 
 export * from './stepper-panel';
 export * from './stepper';
+export * from './stepper.module';
 export * from './step-button';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

There doesn't appear to be tests for barrel exports.

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently we cannot import the ClrAccordionModule independently (`import { ClrAccordionModule } from '@clr/angular'`). We have to import the entire clarity package. I've added the module as an export to keep consistency with other features.

Issue Number: N/A

## What is the new behavior?

`import { ClrAccordionModule } from '@clr/angular'`
`import { ClrStepperModule } from '@clr/angular'`

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
