### PR TITLE
feat(datagrid): disable single or multi rows from selection

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -536,8 +536,12 @@ export declare class ClrDatagridRow<T = any> implements AfterContentInit, AfterV
     _stickyCells: ViewContainerRef;
     readonly _view: any;
     checkboxId: string;
+<<<<<<< HEAD
     clrDgDetailCloseLabel: string;
     clrDgDetailOpenLabel: string;
+=======
+    clrDgSelectable: boolean;
+>>>>>>> f8e89c882... feat(datagrid): disable single or multi rows from selection
     commonStrings: ClrCommonStringsService;
     detailButton: any;
     detailService: DetailService;

--- a/src/clr-angular/data/datagrid/datagrid-row.html
+++ b/src/clr-angular/data/datagrid/datagrid-row.html
@@ -32,18 +32,27 @@
     <div class="datagrid-row-scrollable" [ngClass]="{'is-replaced': replaced && expanded}">
       <div class="datagrid-scrolling-cells">
         <div *ngIf="selection.selectionType === SELECTION_TYPE.Multi"
-             class="datagrid-select datagrid-fixed-column datagrid-cell" role="gridcell">
+             class="datagrid-select datagrid-fixed-column datagrid-cell" 
+             [ngClass]="{ 'clr-form-control-disabled': !clrDgSelectable }"
+             role="gridcell">
+             
           <input clrCheckbox type="checkbox" [ngModel]="selected" (ngModelChange)="toggle($event)" [id]="checkboxId"
+                 [attr.disabled]="clrDgSelectable ? null : true"
+                 [attr.aria-disabled]="clrDgSelectable ? null : true"
                  [attr.aria-label]="commonStrings.keys.select">
         </div>
         <div *ngIf="selection.selectionType === SELECTION_TYPE.Single"
-             class="datagrid-select datagrid-fixed-column datagrid-cell" role="gridcell">
+             class="datagrid-select datagrid-fixed-column datagrid-cell" role="gridcell"
+             [ngClass]="{ 'clr-form-control-disabled': !clrDgSelectable }"
+             >
             <!-- TODO: it would be better if in addition to the generic "Select" label, we could add aria-labelledby
             to label the radio by the first cell in the row (typically an id or name).
             It's pretty easy to label it with the whole row since we already have an id for it, but in most
             cases the row is far too long to serve as a label, the screenreader reads every single cell content. -->
             <input type="radio" clrRadio [id]="radioId" [name]="selection.id + '-radio'" [value]="item"
                    [(ngModel)]="selection.currentSingle" [checked]="selection.currentSingle === item"
+                   [attr.disabled]="clrDgSelectable ? null : true"
+                   [attr.aria-disabled]="clrDgSelectable ? null : true"
                    [attr.aria-label]="commonStrings.keys.select">
         </div>
         <div *ngIf="rowActionService.hasActionableRow"

--- a/src/clr-angular/data/datagrid/datagrid-row.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-row.spec.ts
@@ -87,6 +87,42 @@ export default function(): void {
       });
     });
 
+    describe('Conditional selection', function() {
+      let context: TestContext<ClrDatagridRow, SelectableRow>;
+      let selectionProvider: Selection;
+
+      let radio: HTMLElement;
+      let checkbox: HTMLElement;
+
+      beforeEach(function() {
+        context = this.create(ClrDatagridRow, SelectableRow, DATAGRID_SPEC_PROVIDERS);
+        selectionProvider = TestBed.get(Selection);
+        TestBed.get(Items).all = [{ id: 1 }, { id: 2 }];
+      });
+
+      it('should toggle when clrDgSelectable is false for type  SelectionType.Multi', () => {
+        selectionProvider.selectionType = SelectionType.Multi;
+        context.testComponent.clrDgSelectable = false;
+        context.detectChanges();
+        checkbox = context.clarityElement.querySelector("input[type='checkbox']");
+
+        expect(checkbox.getAttribute('disabled')).toBe('true');
+        expect(checkbox.getAttribute('aria-disabled')).toBe('true');
+
+        context.clarityDirective.toggle();
+        expect(context.clarityDirective.selected).toBe(true);
+      });
+
+      it('should be able you toggle the state of selection when clrDgSelectable is false', () => {
+        selectionProvider.selectionType = SelectionType.Multi;
+        context.clarityDirective.toggle(true);
+        context.testComponent.clrDgSelectable = false;
+        context.detectChanges();
+        context.clarityDirective.toggle();
+        expect(context.clarityDirective.selected).toBe(false);
+      });
+    });
+
     describe('Selection', function() {
       // Until we can properly type "this"
       let context: TestContext<ClrDatagridRow, FullTest>;
@@ -422,6 +458,14 @@ export default function(): void {
     `,
 })
 class ProjectionTest {}
+
+@Component({
+  template: `<clr-dg-row [clrDgSelectable]="clrDgSelectable" [clrDgItem]="item">None</clr-dg-row>`,
+})
+class SelectableRow {
+  clrDgSelectable = true;
+  item: Item = { id: 42 };
+}
 
 @Component({ template: `<clr-dg-row [clrDgItem]="item" [(clrDgSelected)]="selected">Hello world</clr-dg-row>` })
 class FullTest {

--- a/src/clr-angular/data/datagrid/datagrid-row.ts
+++ b/src/clr-angular/data/datagrid/datagrid-row.ts
@@ -131,6 +131,16 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
     }
   }
 
+  // By default every item is selectable
+  @Input('clrDgSelectable')
+  public set clrDgSelectable(value: boolean) {
+    this.selection.lockItem(this.item, value === false);
+  }
+
+  public get clrDgSelectable() {
+    return !this.selection.isLocked(this.item);
+  }
+
   @Output('clrDgSelectedChange') selectedChanged = new EventEmitter<boolean>(false);
 
   public toggle(selected = !this.selected) {

--- a/src/clr-angular/data/datagrid/datagrid.ts
+++ b/src/clr-angular/data/datagrid/datagrid.ts
@@ -182,11 +182,11 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
    * @param value
    */
   public set allSelected(value: boolean) {
-    /*
-         * This is a setter but we ignore the value.
-         * It's strange, but it lets us have an indeterminate state where only
-         * some of the items are selected.
-         */
+    /**
+     * This is a setter but we ignore the value.
+     * It's strange, but it lets us have an indeterminate state where only
+     * some of the items are selected.
+     */
     this.selection.toggleAll();
   }
 

--- a/src/dev/src/app/datagrid/conditional-selection/conditional-selection.html
+++ b/src/dev/src/app/datagrid/conditional-selection/conditional-selection.html
@@ -1,0 +1,82 @@
+<!--
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<h2>Datagrid: Conditional selection</h2>
+
+<h3>Single selection rows</h3>
+
+<button class="btn btn-primary" (click)="singleSelectionLockRows()">Lock Rows</button>
+<button class="btn btn-primary" (click)="singleSelectionUnlockRows()">Unlock Rows</button>
+
+<clr-datagrid [(clrDgSingleSelected)]="selected">
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column>Name</clr-dg-column>
+    <clr-dg-column>Creation date</clr-dg-column>
+    <clr-dg-column>Favorite color</clr-dg-column>
+
+    <clr-dg-row [clrDgSelectable]="!user.locked" *clrDgItems="let user of users" [clrDgItem]="user">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>
+            <span class="color-square" [style.backgroundColor]="user.color"></span>
+        </clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>{{users.length}} users</clr-dg-footer>
+</clr-datagrid>
+
+<h3>Multi selection rows</h3>
+
+<button class="btn btn-primary" (click)="multiSelectionLockRows()">Lock Rows</button>
+<button class="btn btn-primary" (click)="multiSelectionUnlockRows()">Unlock Rows</button>
+
+<clr-datagrid [(clrDgSelected)]="selectedRows">
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column>Name</clr-dg-column>
+    <clr-dg-column>Creation date</clr-dg-column>
+    <clr-dg-column>Favorite color</clr-dg-column>
+
+    <clr-dg-row [clrDgSelectable]="!user.locked" *clrDgItems="let user of usersMulti" [clrDgItem]="user">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>
+            <span class="color-square" [style.backgroundColor]="user.color"></span>
+        </clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>{{usersMulti.length}} users</clr-dg-footer>
+</clr-datagrid>
+
+<h3>Paged Multi selection rows</h3>
+
+<button class="btn btn-primary" (click)="pagedMultiSelectionLockRows()">Lock Rows</button>
+<button class="btn btn-primary" (click)="pagedMultiSelectionUnlockRows()">Unlock Rows</button>
+
+<clr-datagrid [(clrDgSelected)]="selectedRows">
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column>Name</clr-dg-column>
+    <clr-dg-column>Creation date</clr-dg-column>
+    <clr-dg-column>Favorite color</clr-dg-column>
+
+    <clr-dg-row [clrDgSelectable]="!user.locked" *clrDgItems="let user of pagedUsers" [clrDgItem]="user">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>
+            <span class="color-square" [style.backgroundColor]="user.color"></span>
+        </clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>
+        <clr-dg-pagination #pagination [clrDgPageSize]="5">
+            <clr-dg-page-size [clrPageSizeOptions]="[10,20,50,100]">Users per page</clr-dg-page-size>
+                {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
+                of {{pagination.totalItems}} users
+        </clr-dg-pagination>
+    </clr-dg-footer>
+</clr-datagrid>

--- a/src/dev/src/app/datagrid/conditional-selection/conditional-selection.ts
+++ b/src/dev/src/app/datagrid/conditional-selection/conditional-selection.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component } from '@angular/core';
+
+import { Inventory } from '../inventory/inventory';
+import { User } from '../inventory/user';
+
+@Component({
+  selector: 'clr-datagrid-conditional-selection-demo',
+  providers: [Inventory],
+  templateUrl: './conditional-selection.html',
+  styleUrls: ['../datagrid.demo.scss'],
+})
+export class DatagridConditionalSelectionsDemo {
+  users: User[];
+  usersMulti: User[] = [];
+  selected: User;
+  selectedRows: User[] = [];
+  pagedUsers: User[] = [];
+
+  constructor(inventory: Inventory) {
+    inventory.size = 10;
+    inventory.reset();
+
+    this.users = inventory.all;
+    inventory.reset();
+
+    this.usersMulti = inventory.all;
+
+    inventory.size = 30;
+    inventory.reset();
+    this.pagedUsers = inventory.all;
+  }
+
+  // Single
+
+  singleSelectionUnlockRows() {
+    this.users = this.users.map(user => {
+      delete user.locked;
+      return user;
+    });
+  }
+
+  singleSelectionLockRows() {
+    this.users = this.users.map((user, index) => {
+      // lock few rows
+      if ([2, 3, 5, 9].includes(index)) {
+        user.locked = true;
+      }
+      return user;
+    });
+  }
+
+  // Multi
+
+  multiSelectionUnlockRows() {
+    this.usersMulti = this.usersMulti.map(user => {
+      delete user.locked;
+      return user;
+    });
+  }
+
+  multiSelectionLockRows() {
+    this.usersMulti = this.usersMulti.map((user, index) => {
+      // lock few rows
+      if ([2, 3, 5, 7, 9].includes(index)) {
+        user.locked = true;
+      }
+      return user;
+    });
+  }
+
+  // Paged Multi Select
+  pagedMultiSelectionUnlockRows() {
+    this.pagedUsers = this.pagedUsers.map(user => {
+      delete user.locked;
+      return user;
+    });
+  }
+
+  pagedMultiSelectionLockRows() {
+    this.pagedUsers = this.pagedUsers.map((user, index) => {
+      // lock few rows
+      if ([2, 3, 5, 7, 9].includes(index)) {
+        user.locked = true;
+      }
+      return user;
+    });
+  }
+}

--- a/src/dev/src/app/datagrid/datagrid.demo.html
+++ b/src/dev/src/app/datagrid/datagrid.demo.html
@@ -34,6 +34,8 @@
     <li><a [routerLink]="['./test-cases-async']">Asynchronous Test Cases</a></li>
     <li><a [routerLink]="['./hide-show']">Hide-show columns demo</a></li>
     <li><a [routerLink]="['./responsive-footer']">Responsive Footer</a></li>
+    <li><a [routerLink]="['./conditional-selections']">Conditional selection</a></li>
+
 </ul>
 
 <router-outlet></router-outlet>

--- a/src/dev/src/app/datagrid/datagrid.demo.module.ts
+++ b/src/dev/src/app/datagrid/datagrid.demo.module.ts
@@ -41,6 +41,7 @@ import { DatagridTestCasesAsyncDemo } from './test-cases-async/test-cases-async'
 import { DatagridTestCasesDemo } from './test-cases/test-cases';
 import { ColorFilter } from './utils/color-filter';
 import { DatagridDetailDemo } from './detail/detail';
+import { DatagridConditionalSelectionsDemo } from './conditional-selection/conditional-selection';
 
 @NgModule({
   imports: [CommonModule, FormsModule, ClarityModule, ROUTING, UtilsDemoModule],
@@ -72,6 +73,7 @@ import { DatagridDetailDemo } from './detail/detail';
     DatagridTestCasesDemo,
     DatagridTestCasesAsyncDemo,
     DatagridKitchenSinkDemo,
+    DatagridConditionalSelectionsDemo,
     ColorFilter,
     DatagridDetailDemo,
     DetailWrapper,

--- a/src/dev/src/app/datagrid/datagrid.demo.routing.ts
+++ b/src/dev/src/app/datagrid/datagrid.demo.routing.ts
@@ -34,6 +34,7 @@ import { DatagridBuiltInFiltersDemo } from './built-in-filters/built-in-filters'
 import { DatagridTestCasesAsyncDemo } from './test-cases-async/test-cases-async';
 import { DatagridTestCasesDemo } from './test-cases/test-cases';
 import { DatagridDetailDemo } from './detail/detail';
+import { DatagridConditionalSelectionsDemo } from './conditional-selection/conditional-selection';
 
 const ROUTES: Routes = [
   {
@@ -68,6 +69,7 @@ const ROUTES: Routes = [
       { path: 'test-cases-async', component: DatagridTestCasesAsyncDemo },
       { path: 'hide-show', component: DatagridHideShowDemo },
       { path: 'responsive-footer', component: DatagridResponsiveFooterDemo },
+      { path: 'conditional-selections', component: DatagridConditionalSelectionsDemo },
     ],
   },
 ];

--- a/src/dev/src/app/datagrid/selection-row-mode/selection-row-mode.html
+++ b/src/dev/src/app/datagrid/selection-row-mode/selection-row-mode.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->

--- a/src/website/src/app/documentation/demos/datagrid/selection/selection.html
+++ b/src/website/src/app/documentation/demos/datagrid/selection/selection.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -90,6 +90,16 @@
 </clr-datagrid>
 
 <clr-code-snippet [clrCode]="rowSelectionExample" clrLanguage="html"></clr-code-snippet>
+<clr-alert [clrAlertType]="'danger'" [clrAlertClosable]="false">
+    <clr-alert-item>
+          <span class="alert-text">
+            <code class="clr-code">clrDgRowSelection</code> has been deprecated in 2.0 and will be removed in a future major release.
+            It is impossible to support this functionality properly and also comply with accessibility standards for Clarity, and
+            we no longer can recommend using this pattern. The workaround is to simply use single selection without row selection.
+          </span>
+    </clr-alert-item>
+</clr-alert>
+
 <p>
     If you need an easier access to the selected state of a row, without having to go through the entire array,
     we also provide a boolean <code class="clr-code">[(clrDgSelected)]</code> two-way binding on the
@@ -102,3 +112,30 @@
     If you need to listen to when the selection changes, you can use Angular's <a href="https://angular.io/guide/template-syntax">two way binding</a> to listen to the <code class="clr-code">(clrDgSelectedChange)</code> event:
 </p>
 <clr-code-snippet [clrCode]="selectionChangeEventExample" clrLanguage="html"></clr-code-snippet>
+
+<p>
+    Mark a row with <code class="clr-code">clrDgSelectable</code>, this way the state of the row could not be changed by
+    user interactions. This property works only when using single or multi-selection modes.
+</p>
+<clr-code-snippet [clrCode]="unselectableRow" clrLanguage="html"></clr-code-snippet>
+
+<button class="btn btn-primary" (click)="lockRows()">Lock Rows</button>
+<button class="btn btn-primary" (click)="unlockRows()">Unlock Rows</button>
+
+<clr-datagrid [(clrDgSelected)]="selected">
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column>Name</clr-dg-column>
+    <clr-dg-column>Creation date</clr-dg-column>
+    <clr-dg-column>Favorite color</clr-dg-column>
+
+    <clr-dg-row [clrDgSelectable]="!user.locked" *clrDgItems="let user of lockedUsers" [clrDgItem]="user">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>
+            <span class="color-square" [style.backgroundColor]="user.color"></span>
+        </clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>{{users.length}} users</clr-dg-footer>
+</clr-datagrid>

--- a/src/website/src/app/documentation/demos/datagrid/selection/selection.ts
+++ b/src/website/src/app/documentation/demos/datagrid/selection/selection.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -44,6 +44,13 @@ const SELECTION_CHANGE_EVENT_EXAMPLE = `
     <-- ... -->
 </clr-datagrid>
 `;
+const UNSELECTABLE_ROW = `
+<clr-dg-row [clrDgSelectable]="!user.locked" *clrDgItems="let user of users" [clrDgItem]="user">
+  <clr-dg-cell>{{user.id}}</clr-dg-cell>
+    <-- ... -->
+  </clr-dg-row>
+</clr-dg-row>
+`;
 
 @Component({
   selector: 'clr-datagrid-selection-demo',
@@ -56,13 +63,34 @@ export class DatagridSelectionDemo {
   rowSelectionExample = ROW_SELECTION_EXAMPLE;
   singleRowExample = SINGLE_ROW_EXAMPLE;
   selectionChangeEventExample = SELECTION_CHANGE_EVENT_EXAMPLE;
+  unselectableRow = UNSELECTABLE_ROW;
   users: User[];
   selected: User[] = [];
   rowSelected: User[] = [];
+  lockedUsers: User[] = [];
 
   constructor(inventory: Inventory) {
     inventory.size = 10;
     inventory.reset();
     this.users = inventory.all;
+
+    this.lockedUsers = [...inventory.all];
+  }
+
+  unlockRows() {
+    this.lockedUsers = this.lockedUsers.map(row => {
+      delete row.locked;
+      return row;
+    });
+  }
+
+  lockRows() {
+    this.lockedUsers = this.lockedUsers.map((user, index) => {
+      // lock few rows
+      if ([2, 3, 5, 9].includes(index)) {
+        user.locked = true;
+      }
+      return user;
+    });
   }
 }

--- a/src/website/src/app/documentation/demos/datagrid/single-selection/single-selection.html
+++ b/src/website/src/app/documentation/demos/datagrid/single-selection/single-selection.html
@@ -90,7 +90,7 @@
     </p>
 </div>
 
-<clr-datagrid [(clrDgSingleSelected)]="rowSelected" [clrDgRowSelection]="true">
+<clr-datagrid [(clrDgSingleSelected)]="rowSelected">
 
     <clr-dg-column>User ID</clr-dg-column>
     <clr-dg-column>Name</clr-dg-column>
@@ -115,3 +115,31 @@
     If you need to listen to when the selection changes, you can use Angular's <a href="https://angular.io/guide/template-syntax">two way binding</a> to listen to the <code class="clr-code">(clrDgSingleSelectedChange)</code> event:
 </p>
 <clr-code-snippet [clrCode]="selectionChangeEventExample" clrLanguage="html"></clr-code-snippet>
+
+<p>
+    In order to conditionally disable selection on a row, use the <code class="clr-code">clrDgSelectable</code> 
+    input to disable selection state changes. This has to be done on each row you wish to disable, and works with 
+    single and multi selection.
+</p>
+<clr-code-snippet [clrCode]="unselectableRow" clrLanguage="html"></clr-code-snippet>
+
+<button class="btn btn-primary" (click)="lockRows()">Lock Rows</button>
+<button class="btn btn-primary" (click)="unlockRows()">Unlock Rows</button>
+
+<clr-datagrid [(clrDgSingleSelected)]="rowSelected">
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column>Name</clr-dg-column>
+    <clr-dg-column>Creation date</clr-dg-column>
+    <clr-dg-column>Favorite color</clr-dg-column>
+
+    <clr-dg-row [clrDgSelectable]="!user.locked" *clrDgItems="let user of lockedUsers" [clrDgItem]="user">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>
+            <span class="color-square" [style.backgroundColor]="user.color"></span>
+        </clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>{{users.length}} users</clr-dg-footer>
+</clr-datagrid>

--- a/src/website/src/app/documentation/demos/datagrid/single-selection/single-selection.ts
+++ b/src/website/src/app/documentation/demos/datagrid/single-selection/single-selection.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -39,6 +39,14 @@ const SELECTION_CHANGE_EVENT_EXAMPLE = `
 </clr-datagrid>
 `;
 
+const UNSELECTABLE_ROW = `
+<clr-dg-row [clrDgSelectable]="!user.locked" *clrDgItems="let user of users" [clrDgItem]="user">
+  <clr-dg-cell>{{user.id}}</clr-dg-cell>
+    <-- ... -->
+  </clr-dg-row>
+</clr-dg-row>
+`;
+
 @Component({
   moduleId: module.id,
   selector: 'clr-datagrid-selection-single-demo',
@@ -50,13 +58,34 @@ export class DatagridSelectionSingleDemo {
   example = EXAMPLE;
   rowSelectionExample = ROW_SELECTION_EXAMPLE;
   selectionChangeEventExample = SELECTION_CHANGE_EVENT_EXAMPLE;
+  unselectableRow = UNSELECTABLE_ROW;
   users: User[];
   singleSelected: User;
   rowSelected: User;
+  lockedUsers: User[] = [];
 
   constructor(inventory: Inventory) {
     inventory.size = 10;
     inventory.reset();
     this.users = inventory.all;
+
+    this.lockedUsers = [...inventory.all];
+  }
+
+  unlockRows() {
+    this.lockedUsers = this.lockedUsers.map(row => {
+      delete row.locked;
+      return row;
+    });
+  }
+
+  lockRows() {
+    this.lockedUsers = this.lockedUsers.map((user, index) => {
+      // lock few rows
+      if ([2, 3, 5, 10].includes(index)) {
+        user.locked = true;
+      }
+      return user;
+    });
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

Right now there is no way to disable a row from Datagrid and prevent interaction with the row.

Issue Number: #1018 

## What is the new behavior?

Added new input to `ClrDatagridRow` called `cldDgUnselectable` that except `boolean`. When set to true it will prevent the click event from firing and won't let the user change the state of the row. Also will mark the checkbox or radio button as disabled and change the cursor to mark the row as locked.

This is valid for both Single and Multi selectable rows. 

#### Single selection
* Normal
* Disabled and can't be changed
* Disabled and marked as selected, also can't be changed
![Screen Shot 2019-08-27 at 5 09 32 PM](https://user-images.githubusercontent.com/204564/63778905-5c6e1280-c8ee-11e9-97cd-a0d9803a216b.png)

#### Multi selection
* Disabled and marked as selected
* Disabled and can't be changed
* Normal
![Screen Shot 2019-08-27 at 5 08 27 PM](https://user-images.githubusercontent.com/204564/63778945-6d1e8880-c8ee-11e9-89e0-d46de71c208d.png)

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No


## Other information
Close: #1018 

Todo: need to be backported to V1