### PR TITLE
fix(tabs): extra spacing between tab and tab content in ie 11

### DIFF
--- a/src/clr-angular/layout/tabs/_tabs.clarity.scss
+++ b/src/clr-angular/layout/tabs/_tabs.clarity.scss
@@ -32,6 +32,12 @@ button.nav-link {
   display: inline;
 }
 
+@include fixForIE11AndUp {
+  .tab-content {
+    display: inline-block;
+  }
+}
+
 .tabs-vertical {
   display: flex;
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3748 

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Tested on:
Internet Explorer 11 ✔
Edge ✔
Google Chrome ✔
Mozilla ✔
Safari ✔
