### PR TITLE
backport fix(dropdown): handle focus first item when there is non selectable item

### DIFF
--- a/src/clr-angular/popover/dropdown/providers/dropdown-focus-handler.service.ts
+++ b/src/clr-angular/popover/dropdown/providers/dropdown-focus-handler.service.ts
@@ -119,7 +119,7 @@ export class DropdownFocusHandler implements FocusableItem {
       // doesn't receive the esc keydown
       this._unlistenFuncs.push(
         this.renderer.listen(el, 'keydown.esc', event => {
-          this.focusService.move(ArrowKeyDirection.LEFT, event);
+          this.focusService.move(ArrowKeyDirection.LEFT);
           event.stopPropagation();
         })
       );

--- a/src/clr-angular/utils/focus/focus.service.spec.ts
+++ b/src/clr-angular/utils/focus/focus.service.spec.ts
@@ -119,8 +119,9 @@ export default function(): void {
 
       it('does not move focus to another item if current is undefined', function(this: TestContext) {
         const spy = spyOn(this.focusService, 'moveTo');
-        this.focusService.move(ArrowKeyDirection.DOWN, undefined);
+        const result = this.focusService.move(ArrowKeyDirection.DOWN);
         expect(spy).not.toHaveBeenCalled();
+        expect(result).toBe(false);
       });
 
       it('waits for the next item if it is an Observable', function(this: TestContext) {
@@ -136,18 +137,30 @@ export default function(): void {
         expect(spy).toHaveBeenCalledWith(second);
       });
 
+      it('should return boolean state dependend on the focus', function(this: TestContext) {
+        const current = new MockFocusableItem('1');
+        const down = new MockFocusableItem('2');
+        current.down = down;
+        this.focusService.reset(current);
+        const result = this.focusService.move(ArrowKeyDirection.DOWN);
+        const result2 = this.focusService.move(ArrowKeyDirection.DOWN);
+
+        expect(result).toBe(true);
+        expect(result2).toBe(false);
+      });
+
       it('can listen to arrow keys on an element', function(this: TestContext) {
         const spy = spyOn(this.focusService, 'move');
         const el = document.createElement('div');
         this.focusService.listenToArrowKeys(el);
         el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
-        expect(spy).toHaveBeenCalledWith(ArrowKeyDirection.UP, jasmine.any(KeyboardEvent));
+        expect(spy).toHaveBeenCalledWith(ArrowKeyDirection.UP);
         el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
-        expect(spy).toHaveBeenCalledWith(ArrowKeyDirection.DOWN, jasmine.any(KeyboardEvent));
+        expect(spy).toHaveBeenCalledWith(ArrowKeyDirection.DOWN);
         el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }));
-        expect(spy).toHaveBeenCalledWith(ArrowKeyDirection.LEFT, jasmine.any(KeyboardEvent));
+        expect(spy).toHaveBeenCalledWith(ArrowKeyDirection.LEFT);
         el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
-        expect(spy).toHaveBeenCalledWith(ArrowKeyDirection.RIGHT, jasmine.any(KeyboardEvent));
+        expect(spy).toHaveBeenCalledWith(ArrowKeyDirection.RIGHT);
       });
 
       it('makes a given container focusable', function(this: TestContext) {


### PR DESCRIPTION
This is only backporting to this bugfix https://github.com/vmware/clarity/pull/3706 to master

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3610 

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
