### PR TITLE
fix(a11y): add bumpers to the datepicker

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -206,7 +206,7 @@ export declare class ClrCalendar implements OnDestroy {
     readonly calendar: CalendarModel;
     calendarViewModel: CalendarViewModel;
     readonly focusedDay: DayModel;
-    readonly localeDaysNarrow: ReadonlyArray<string>;
+    readonly localeDays: ReadonlyArray<ClrDayOfWeek>;
     readonly selectedDay: DayModel;
     readonly today: DayModel;
     constructor(_localeHelperService: LocaleHelperService, _dateNavigationService: DateNavigationService, _datepickerFocusService: DatepickerFocusService, _elRef: ElementRef);

--- a/src/clr-angular/forms/datepicker/calendar.html
+++ b/src/clr-angular/forms/datepicker/calendar.html
@@ -1,12 +1,9 @@
-<table class="calendar-table weekdays">
-    <tr class="calendar-row">
-        <td *ngFor="let day of localeDaysNarrow" class="calendar-cell weekday">
-            {{day}}
+<table class="calendar-table">
+    <tr class="calendar-row weekdays">
+        <td *ngFor="let day of localeDays" class="calendar-cell weekday" role="heading" [attr.aria-label]="day.day">
+            {{day.narrow}}
         </td>
     </tr>
-</table>
-<table
-    class="calendar-table calendar-dates">
     <tr class="calendar-row" *ngFor="let row of calendarViewModel.calendarView">
         <td *ngFor="let dayView of row" class="calendar-cell">
             <clr-day [clrDayView]="dayView"></clr-day>

--- a/src/clr-angular/forms/datepicker/calendar.spec.ts
+++ b/src/clr-angular/forms/datepicker/calendar.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -96,8 +96,8 @@ export default function() {
       });
 
       it('has access to the locale days', () => {
-        expect(context.clarityDirective.localeDaysNarrow).not.toBeNull();
-        expect(context.clarityDirective.localeDaysNarrow.length).toBe(7);
+        expect(context.clarityDirective.localeDays).not.toBeNull();
+        expect(context.clarityDirective.localeDays.length).toBe(7);
       });
 
       // IE doesn't handle KeyboardEvent constructor

--- a/src/clr-angular/forms/datepicker/calendar.ts
+++ b/src/clr-angular/forms/datepicker/calendar.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -15,6 +15,7 @@ import { DateNavigationService } from './providers/date-navigation.service';
 import { DatepickerFocusService } from './providers/datepicker-focus.service';
 import { LocaleHelperService } from './providers/locale-helper.service';
 import { NO_OF_DAYS_IN_A_WEEK } from './utils/constants';
+import { ClrDayOfWeek } from './interfaces/day-of-week.interface';
 
 @Component({ selector: 'clr-calendar', templateUrl: './calendar.html' })
 export class ClrCalendar implements OnDestroy {
@@ -38,8 +39,8 @@ export class ClrCalendar implements OnDestroy {
   /**
    * Gets the locale days according to the TranslationWidth.Narrow format.
    */
-  get localeDaysNarrow(): ReadonlyArray<string> {
-    return this._localeHelperService.localeDaysNarrow;
+  get localeDays(): ReadonlyArray<ClrDayOfWeek> {
+    return this._localeHelperService.localeDays;
   }
 
   get calendar(): CalendarModel {

--- a/src/clr-angular/forms/datepicker/datepicker-view-manager.ts
+++ b/src/clr-angular/forms/datepicker/datepicker-view-manager.ts
@@ -17,7 +17,10 @@ import { ViewManagerService } from './providers/view-manager.service';
   selector: 'clr-datepicker-view-manager',
   templateUrl: './datepicker-view-manager.html',
   providers: [ViewManagerService, DatepickerFocusService],
-  host: { '[class.datepicker]': 'true' },
+  host: {
+    '[class.datepicker]': 'true',
+    '[attr.aria-modal]': 'true',
+  },
 })
 export class ClrDatepickerViewManager extends AbstractPopover {
   constructor(@SkipSelf() parent: ElementRef, _injector: Injector, private _viewManagerService: ViewManagerService) {

--- a/src/clr-angular/forms/datepicker/daypicker.html
+++ b/src/clr-angular/forms/datepicker/daypicker.html
@@ -1,3 +1,4 @@
+<div class="clr-sr-only">{{commonStrings.keys.modalContentStart}}</div>
 <div class="calendar-header">
     <div aria-live="polite" class="clr-sr-only">
       {{ ariaLiveMonth }}.  {{updateAriaLiveYear}}.
@@ -44,3 +45,4 @@
     </div>
 </div>
 <clr-calendar></clr-calendar>
+<div class="clr-sr-only">{{commonStrings.keys.modalContentEnd}}</div>

--- a/src/clr-angular/forms/datepicker/daypicker.spec.ts
+++ b/src/clr-angular/forms/datepicker/daypicker.spec.ts
@@ -139,7 +139,7 @@ export default function() {
       });
 
       it('updates the aria-live view element when the month and year are changed', () => {
-        const liveElement: HTMLDivElement = context.clarityElement.querySelector('.clr-sr-only');
+        const liveElement: HTMLDivElement = context.clarityElement.querySelector('.clr-sr-only[aria-live]');
         let testMonth = localeHelperService.localeMonthsAbbreviated[dateNavigationService.displayedCalendar.month];
         let testYear = dateNavigationService.displayedCalendar.year;
 
@@ -151,6 +151,15 @@ export default function() {
         testYear = dateNavigationService.displayedCalendar.year;
 
         expect(liveElement.innerText).toEqual(`The current month is ${testMonth}. The current year is ${testYear}.`);
+      });
+
+      it('should have text based boundaries for screen readers', () => {
+        const srOnlyElements: HTMLDivElement[] = context.clarityElement.querySelectorAll(
+          '.clr-sr-only:not([aria-live])'
+        );
+
+        expect(srOnlyElements[0].innerText).toBe('Beginning of Modal Content');
+        expect(srOnlyElements[1].innerText).toBe('End of Modal Content');
       });
     });
 

--- a/src/clr-angular/forms/datepicker/interfaces/day-of-week.interface.ts
+++ b/src/clr-angular/forms/datepicker/interfaces/day-of-week.interface.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+export interface ClrDayOfWeek {
+  readonly day: string;
+  readonly narrow: string;
+}


### PR DESCRIPTION
closes #3466
Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

No indication of beginning and end of modal when using screen reader.
Weekdays headings (SMTWTFS) are only read as a letter.
Issue Number: #3466

## What is the new behavior?
Begin/End bumpers added, only visible to screen readers.
Weekdays are read with their full names.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
