### PR TITLE
fix: website routing focus management

### DIFF
--- a/src/website/src/app/documentation/component-status/component-status.component.html
+++ b/src/website/src/app/documentation/component-status/component-status.component.html
@@ -1,5 +1,5 @@
 <section class="dox-content">
-  <h1>Component Status</h1>
+  <h1 clrFocusOnViewInit>Component Status</h1>
 
   <p>
       The Clarity team is building a robust library of components as quickly as possible. Check back often for updates.

--- a/src/website/src/app/documentation/demos/_doc-wrapper/doc-wrapper.html
+++ b/src/website/src/app/documentation/demos/_doc-wrapper/doc-wrapper.html
@@ -1,6 +1,6 @@
 <div class="dox-wrapper dox-header" [class.new-component-layout]="useNewLayout">
     <section>
-        <h1>{{title}}</h1>
+        <h1 clrFocusOnViewInit>{{title}}</h1>
         <h5 *ngIf="description">
             {{ description }}
         </h5>

--- a/src/website/src/app/documentation/get-started/get-started.component.html
+++ b/src/website/src/app/documentation/get-started/get-started.component.html
@@ -1,5 +1,5 @@
 <section class="dox-content">
-    <h1 id="introduction">Clarity Design System</h1>
+    <h1 id="introduction" clrFocusOnViewInit>Get started with Clarity Design System</h1>
     <p>Project Clarity is an open source design system that brings together UX guidelines, an HTML/CSS framework, and
         Angular components. Clarity is for both designers and developers.
     </p>


### PR DESCRIPTION
Signed-off-by: stsogoo <stsogoo@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

After activating any of the component demo router links in the first column on the left, the focus remains on the given router link. Screen reader users will not know what happened as a result of clicking the router link and will not know how to find the newly added content that appeared as a result of activating the router link.

Issue Number: #3173 

## What is the new behavior?

Once clicked on the component demo link in the first column, the focus will be set to the h1 of the each corresponding demo page.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
