### PR TITLE
fix(header): clarity icons with text misaligned in ie11

### DIFF
--- a/src/clr-angular/layout/nav/_header.clarity.scss
+++ b/src/clr-angular/layout/nav/_header.clarity.scss
@@ -138,8 +138,8 @@
       &.nav-icon-text {
         clr-icon {
           position: relative;
-          top: initial;
-          left: initial;
+          top: auto;
+          left: auto;
           transform: none;
           margin-left: 1rem;
         }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

![image](https://user-images.githubusercontent.com/53469024/64112989-ac872200-cd91-11e9-8bf9-2ece894ab063.png)
 The right icon in `clr-header` component is misaligned in IE11.

Issue Number: #3519 

## What is the new behavior?
The icon and the text are now aligned, like in any other browser that I tested on (Chrome, Mozilla, Edge).

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
The `initial` keyword is not supported in IE11. 