### PR TITLE
docs: fix typos in markdown documents

### DIFF
--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -13,7 +13,7 @@ To ensure the highest quality and maintainability for Clarity components, we adh
 * Interfaces and abstract classes used as interfaces should be named with a suffix like `datagrid-state.interface.ts` \* If the component has a single provider, the provider file can be placed directly in the same folder as the component itself
   * In the case of more complex components (like the Datagrid or the Wizard) where many providers are needed for the various subcomponents to communicate, the providers should be placed inside of a `providers` subfolder of the module folder like `/wizard/providers/wizard-navigation.service.ts`.
 * Interfaces and abstract classes used as interfaces should be named with a suffix like `datagrid-state.interface.ts`.
-  * If the component has one or two interfacees/abstract classes the file can be placed in the same folder as the component itself
+  * If the component has one or two interfaces/abstract classes the file can be placed in the same folder as the component itself
   * In the case of more complex components (w/ 3 or more) interfaces/abstract classes should be placed inside an interface subfolder like `/datagrid/interfaces/string-filter.interface.ts`
 * Enums should be named with a suffix like `sort-order.enum.ts`.
   * If the component has one or two enums the file can be placed in the same folder as the component

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ and finally you can add the corresponding documentation to the website
 ## Contributing to Design
 
 There are three parts to the design contribution process. When beginning the design of a new component, please follow the guidelines outlined in
-[DESIGN_CONSTRIBUTION.md](/DESIGN_CONTRIBUTION.md).
+[DESIGN_CONTRIBUTION.md](/DESIGN_CONTRIBUTION.md).
 
 ## Contributing to Development
 
@@ -56,4 +56,4 @@ You can submit an issue or a bug to our [GitHub repository](https://github.com/v
 * Screenshot is also a good way to show us what is the issue
 
 When providing NPM package version. Make sure to check them from the `package-lock.json` file.
-This is extremely important in the cases that NPM [versioning tags](https://devhints.io/semver) are applyed.
+This is extremely important in the cases that NPM [versioning tags](https://devhints.io/semver) are applied.

--- a/DESIGN_CONTRIBUTION.md
+++ b/DESIGN_CONTRIBUTION.md
@@ -17,7 +17,7 @@ get you started
 
 ### Getting Started
 
-Try answering the following questions to get started on researching and documenting the findings for conseration:
+Try answering the following questions to get started on researching and documenting the findings for consideration:
 
 * What problems does this component solve?
 * How will users interact with it?
@@ -81,7 +81,7 @@ Resources once the component is built in code.
 
 Remember, if (for example) a component has five use cases and ten features you still only need one instance designed
 in sketch (there is a handy way to toggle visibility for various parts of a sketch document). This is how we suggest
-that multiple visual representations be created for documentating the various use cases on github.
+that multiple visual representations be created for documenting the various use cases on github.
 
 ### Considerations
 


### PR DESCRIPTION
I used the Code Spell Checked VSCode extension
* https://github.com/streetsidesoftware/vscode-spell-checker

Signed-off-by: Massimo Costa <costa.massimo@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
