### PR TITLE
doc(datepicker): Remove outdated comments

### DIFF
--- a/src/dev/src/app/datepicker/css-regression.ts
+++ b/src/dev/src/app/datepicker/css-regression.ts
@@ -7,7 +7,6 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'clr-datepicker-css-regression-demo',
-  // Note the .css extension here, not .scss. That's the best we can have at the moment.
   styleUrls: ['./datepicker.demo.scss'],
   templateUrl: './css-regression.html',
 })

--- a/src/dev/src/app/datepicker/datepicker-AK.ts
+++ b/src/dev/src/app/datepicker/datepicker-AK.ts
@@ -7,7 +7,6 @@ import { Component, LOCALE_ID } from '@angular/core';
 
 @Component({
   selector: 'clr-datepicker-ak-demo',
-  // Note the .css extension here, not .scss. That's the best we can have at the moment.
   styleUrls: ['./datepicker.demo.scss'],
   template: ` 
       <div clrForm>

--- a/src/dev/src/app/datepicker/datepicker-AR.ts
+++ b/src/dev/src/app/datepicker/datepicker-AR.ts
@@ -7,7 +7,6 @@ import { Component, LOCALE_ID } from '@angular/core';
 
 @Component({
   selector: 'clr-datepicker-ar-demo',
-  // Note the .css extension here, not .scss. That's the best we can have at the moment.
   styleUrls: ['./datepicker.demo.scss'],
   template: ` 
       <div clrForm>

--- a/src/dev/src/app/datepicker/datepicker-DE.ts
+++ b/src/dev/src/app/datepicker/datepicker-DE.ts
@@ -7,7 +7,6 @@ import { Component, LOCALE_ID } from '@angular/core';
 
 @Component({
   selector: 'clr-datepicker-de-demo',
-  // Note the .css extension here, not .scss. That's the best we can have at the moment.
   styleUrls: ['./datepicker.demo.scss'],
   template: `        
   <div clrForm>

--- a/src/dev/src/app/datepicker/datepicker-HI.ts
+++ b/src/dev/src/app/datepicker/datepicker-HI.ts
@@ -7,7 +7,6 @@ import { Component, LOCALE_ID } from '@angular/core';
 
 @Component({
   selector: 'clr-datepicker-hi-demo',
-  // Note the .css extension here, not .scss. That's the best we can have at the moment.
   styleUrls: ['./datepicker.demo.scss'],
   template: `        
   <div clrForm>

--- a/src/dev/src/app/datepicker/datepicker-KKJ.ts
+++ b/src/dev/src/app/datepicker/datepicker-KKJ.ts
@@ -7,7 +7,6 @@ import { Component, LOCALE_ID } from '@angular/core';
 
 @Component({
   selector: 'clr-datepicker-kkj-demo',
-  // Note the .css extension here, not .scss. That's the best we can have at the moment.
   styleUrls: ['./datepicker.demo.scss'],
   template: `
   <div clrForm>        

--- a/src/dev/src/app/datepicker/datepicker-date-input-explicit-wrapper.ts
+++ b/src/dev/src/app/datepicker/datepicker-date-input-explicit-wrapper.ts
@@ -7,7 +7,6 @@ import { Component, LOCALE_ID } from '@angular/core';
 
 @Component({
   selector: 'clr-datepicker-date-input-wrapper-present-demo',
-  // Note the .css extension here, not .scss. That's the best we can have at the moment.
   styleUrls: ['./datepicker.demo.scss'],
   templateUrl: './datepicker-date-input-explicit-wrapper.html',
   providers: [{ provide: LOCALE_ID, useValue: 'en' }],

--- a/src/dev/src/app/datepicker/datepicker-date-input.ts
+++ b/src/dev/src/app/datepicker/datepicker-date-input.ts
@@ -10,7 +10,6 @@ const date2: Date = new Date(2017, 4, 5);
 
 @Component({
   selector: 'clr-datepicker-date-input-demo',
-  // Note the .css extension here, not .scss. That's the best we can have at the moment.
   styleUrls: ['./datepicker.demo.scss'],
   templateUrl: './datepicker-date-input.html',
   // providers: [{provide: LOCALE_ID, useValue: "en"}],

--- a/src/dev/src/app/datepicker/datepicker-hr.ts
+++ b/src/dev/src/app/datepicker/datepicker-hr.ts
@@ -7,7 +7,6 @@ import { Component, LOCALE_ID } from '@angular/core';
 
 @Component({
   selector: 'clr-datepicker-hr-demo',
-  // Note the .css extension here, not .scss. That's the best we can have at the moment.
   styleUrls: ['./datepicker.demo.scss'],
   template: `   
     <div clrForm>     

--- a/src/dev/src/app/datepicker/datepicker-in-reactive-forms.ts
+++ b/src/dev/src/app/datepicker/datepicker-in-reactive-forms.ts
@@ -8,7 +8,6 @@ import { FormControl, FormGroup } from '@angular/forms';
 
 @Component({
   selector: 'clr-datepicker-in-reactive-forms-demo',
-  // Note the .css extension here, not .scss. That's the best we can have at the moment.
   styleUrls: ['./datepicker.demo.scss'],
   templateUrl: './datepicker-in-reactive-forms.html',
 })

--- a/src/dev/src/app/datepicker/datepicker-in-template-driven-forms.ts
+++ b/src/dev/src/app/datepicker/datepicker-in-template-driven-forms.ts
@@ -7,7 +7,6 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'clr-datepicker-in-template-driven-forms-demo',
-  // Note the .css extension here, not .scss. That's the best we can have at the moment.
   styleUrls: ['./datepicker.demo.scss'],
   templateUrl: './datepicker-in-template-driven-forms.html',
 })

--- a/src/dev/src/app/datepicker/datepicker-locale-data.ts
+++ b/src/dev/src/app/datepicker/datepicker-locale-data.ts
@@ -7,7 +7,6 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'clr-datepicker-locale-data-demo',
-  // Note the .css extension here, not .scss. That's the best we can have at the moment.
   styleUrls: ['./datepicker.demo.scss'],
   template: `  
         <h6>Locale Data</h6>

--- a/src/dev/src/app/datepicker/datepicker.demo.ts
+++ b/src/dev/src/app/datepicker/datepicker.demo.ts
@@ -25,7 +25,6 @@ registerLocaleData(localeHR);
 
 @Component({
   selector: 'clr-datepicker-demo',
-  // Note the .css extension here, not .scss. That's the best we can have at the moment.
   styleUrls: ['./datepicker.demo.scss'],
   templateUrl: './datepicker.demo.html',
 })

--- a/src/dev/src/app/datepicker/ngmodel-auto-wrapped.ts
+++ b/src/dev/src/app/datepicker/ngmodel-auto-wrapped.ts
@@ -7,7 +7,6 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'clr-ng-model-auto-wrapped-datepicker-demo',
-  // Note the .css extension here, not .scss. That's the best we can have at the moment.
   styleUrls: ['./datepicker.demo.scss'],
   templateUrl: './ngmodel-auto-wrapped.html',
   // providers: [{provide: LOCALE_ID, useValue: "en"}],

--- a/src/dev/src/app/datepicker/ngmodel-wrapper-explicit-wrapper.ts
+++ b/src/dev/src/app/datepicker/ngmodel-wrapper-explicit-wrapper.ts
@@ -10,7 +10,6 @@ const DATE2: string = '05/05/2017';
 
 @Component({
   selector: 'clr-ng-model-wrapped-present-datepicker-demo',
-  // Note the .css extension here, not .scss. That's the best we can have at the moment.
   styleUrls: ['./datepicker.demo.scss'],
   templateUrl: './ngmodel-wrapper-explicit-wrapper.html',
   // providers: [{provide: LOCALE_ID, useValue: "en"}],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [X] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [X] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Comments in some files under `src/app/datepicker`:
```
// Note the .css extension here, not .scss. That's the best we can have at the moment.
```
could be removed as the files in question have `.scss` extension now.

Issue Number: N/A

## What is the new behavior?
Outdated comments are removed.

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
