### PR TITLE
fix: on website input grouping heading overlaps example

### DIFF
--- a/src/website/src/app/documentation/demos/timeline/timeline.demo.html
+++ b/src/website/src/app/documentation/demos/timeline/timeline.demo.html
@@ -37,7 +37,7 @@
         <div class="clr-col-12 clr-col-md-6">
           <div class="clrweb-DoxMedia">
             <div class="clrweb-DoxMedia-block" style="height: 297px">
-              <div class="clrweb-DoxMedia-img">
+              <div class="clrweb-DoxMedia-img" style="height: 100%">
                 <img src="assets/images/documentation/timeline/timeline-vertical-example.svg" alt=""/>
               </div>
             </div>

--- a/src/website/src/styles/components.scss
+++ b/src/website/src/styles/components.scss
@@ -420,7 +420,6 @@ _:-ms-fullscreen,
   &-img {
     margin: 0 auto;
     width: 100%;
-    height: 100%;
     text-align: center;
     > * {
       margin: 0;


### PR DESCRIPTION
closes #3802

Signed-off-by: Florin Borceanu <florin.borceanu@bytex.ro>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?
The heading of the Input groups section overlaps previous Do/Don't section.

Issue Number: #3802 

## What is the new behavior?
Everything is ok.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
The `height: 100%` set to `clrweb-DoxMedia-img` class was added for the Timeline component documentation, where one of the images was misaligned. I reverted that change and I added to the specific image a inline style. 