### PR TITLE
build: supress output from visual test script

### DIFF
--- a/scripts/docker-cdc.js
+++ b/scripts/docker-cdc.js
@@ -62,7 +62,7 @@ if (program.update) {
  */
 function runGemini(config) {
   // Kill docker if already running in past failure
-  shell.exec('docker stop clarity_chrome');
+  shell.exec('docker stop clarity_chrome', { silent: true });
   const ngConfig = program.configuration ? '-c ' + program.configuration : '';
   shell.exec(`ng build dev ${ngConfig}`);
   let server = shell.exec('node_modules/.bin/lite-server --baseDir=dist/dev', { async: true });


### PR DESCRIPTION
The docker kill command was logging output to the command line when trying to kill an instance of clarity_chrome that wasn't already running.
Initially I think I put this there to prevent issues restarting but its changed over time. Because we are moving away from gemin I'm supressing the output of the kill command so its not logged rather than re-working the script logic.

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [x] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Prevent output from the script that manages docker when running the visual tests. 

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
