### PR TITLE
fix: selecting content in modal body

### DIFF
--- a/src/clr-angular/modal/modal-body.spec.ts
+++ b/src/clr-angular/modal/modal-body.spec.ts
@@ -10,6 +10,7 @@ import { ClrModalBody } from './modal-body';
 
 describe('ClrModalBody Directive', () => {
   let fixture: ComponentFixture<TestComponent>;
+  let modalBodyEl: HTMLElement;
 
   beforeEach(function() {
     TestBed.configureTestingModule({
@@ -17,10 +18,20 @@ describe('ClrModalBody Directive', () => {
     });
     fixture = TestBed.createComponent(TestComponent);
     fixture.detectChanges();
+    modalBodyEl = fixture.componentInstance.testElement.nativeElement;
   });
 
   it('adds tabindex="0" to modal body to make content focusable and scrollable with keyboards', () => {
-    expect(fixture.componentInstance.testElement.nativeElement.getAttribute('tabindex')).toBe('0');
+    expect(modalBodyEl.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('toggles tabindex="0" on mousedown and mouseup events', () => {
+    modalBodyEl.dispatchEvent(new Event('mousedown'));
+    fixture.detectChanges();
+    expect(modalBodyEl.getAttribute('tabindex')).toBeNull();
+    modalBodyEl.dispatchEvent(new Event('mouseup'));
+    fixture.detectChanges();
+    expect(modalBodyEl.getAttribute('tabindex')).toBe('0');
   });
 
   // https://github.com/vmware/clarity/issues/3424

--- a/src/clr-angular/modal/modal-body.ts
+++ b/src/clr-angular/modal/modal-body.ts
@@ -15,26 +15,22 @@ import { Directive, HostListener } from '@angular/core';
 @Directive({
   selector: '.modal-body',
   host: {
-    '[attr.tabindex]': '"0"',
+    '[attr.tabindex]': 'tabindex',
   },
 })
 export class ClrModalBody {
-  private _mouseDown = false;
-
-  @HostListener('focus', ['$event'])
-  focus(event) {
-    if (this._mouseDown) {
-      event.target.blur();
-    }
-  }
+  tabindex = 0;
 
   @HostListener('mousedown')
   mouseDown() {
-    this._mouseDown = true;
+    // tabindex = 0 binding should be removed
+    // so it won't be focused when click starts with mousedown
+    delete this.tabindex;
   }
 
   @HostListener('mouseup')
   mouseUp() {
-    this._mouseDown = false;
+    // set the tabindex binding back when click is completed with mouseup
+    this.tabindex = 0;
   }
 }


### PR DESCRIPTION
Signed-off-by: stsogoo <stsogoo@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

Modal body starts with default `tabindex = 0` binding. But the binding gets removed once `mousedown` event gets registered so that when a user tries to click on or to select something in it, we won't set the focus on it. But once user release mouse click with `mouseup`, we would set the default `tabindex` binding back so it will continue to be keyboard focusable

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/vmware/clarity/issues/3754

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
