### PR TITLE
fix(datagrid): numeric filters are not working 

### DIFF
--- a/src/clr-angular/data/datagrid/all.spec.ts
+++ b/src/clr-angular/data/datagrid/all.spec.ts
@@ -14,6 +14,8 @@ import DatagridPropertyComparatorSpecs from './built-in/comparators/datagrid-pro
 import DatagridPropertyStringFilterSpecs from './built-in/filters/datagrid-property-string-filter.spec';
 import DatagridStringFilterSpecs from './built-in/filters/datagrid-string-filter.spec';
 import DatagridStringFilterImplSpecs from './built-in/filters/datagrid-string-filter-impl.spec';
+import DatagridNumericFilterSpecs from './built-in/filters/datagrid-numeric-filter.spec';
+import DatagridNumericFilterImplSpecs from './built-in/filters/datagrid-numeric-filter-impl.spec';
 import NestedPropertySpecs from './built-in/nested-property.spec';
 import DatagridActionBarSpecs from './datagrid-action-bar.spec';
 import DatagridActionOverflowSpecs from './datagrid-action-overflow.spec';
@@ -106,5 +108,7 @@ describe('Datagrid', function() {
     DatagridPropertyStringFilterSpecs();
     DatagridStringFilterSpecs();
     DatagridStringFilterImplSpecs();
+    DatagridNumericFilterSpecs();
+    DatagridNumericFilterImplSpecs();
   });
 });

--- a/src/clr-angular/data/datagrid/built-in/filters/datagrid-numeric-filter-impl.spec.ts
+++ b/src/clr-angular/data/datagrid/built-in/filters/datagrid-numeric-filter-impl.spec.ts
@@ -61,7 +61,7 @@ export default function(): void {
     });
 
     it('compares filters', function() {
-      let otherFilter = fullFilter;
+      let otherFilter: ClrDatagridFilterInterface<any> = fullFilter;
       expect(fullFilter.equals(otherFilter)).toBe(true);
       // Reference only comparison should be enough for the common case
       otherFilter = new DatagridNumericFilterImpl(new TestFilter());
@@ -99,10 +99,14 @@ export default function(): void {
 
 class TestFilter implements ClrDatagridNumericFilterInterface<number> {
   accepts(item: number, low: number, high: number) {
-    return (
-      // Make sure the limits are set and not null before checking them
-      low === null || item >= low || (high === null || item <= high)
-    );
+    if (low !== null && item < low) {
+      return false;
+    }
+
+    if (high !== null && item > high) {
+      return false;
+    }
+    return true;
   }
 }
 

--- a/src/clr-angular/data/datagrid/built-in/filters/datagrid-numeric-filter-impl.ts
+++ b/src/clr-angular/data/datagrid/built-in/filters/datagrid-numeric-filter-impl.ts
@@ -105,6 +105,8 @@ export class DatagridNumericFilterImpl<T = any> implements ClrDatagridFilterInte
           other.high === this._high
         );
       }
+      return other === this;
     }
+    return false;
   }
 }

--- a/src/clr-angular/data/datagrid/built-in/filters/datagrid-numeric-filter.spec.ts
+++ b/src/clr-angular/data/datagrid/built-in/filters/datagrid-numeric-filter.spec.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, ViewChild } from '@angular/core';
+import { Component, ViewChild, Renderer2 } from '@angular/core';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 
 import { TestContext } from '../../helpers.spec';
@@ -14,12 +14,30 @@ import { FiltersProvider } from '../../providers/filters';
 import { Page } from '../../providers/page';
 import { StateDebouncer } from '../../providers/state-debouncer.provider';
 import { DomAdapter } from '../../../../utils/dom-adapter/dom-adapter';
+import { ClrPopoverToggleService } from '../../../../utils/popover/providers/popover-toggle.service';
+import { ClrPopoverPositionService } from '../../../../utils/popover/providers/popover-position.service';
+import { ClrPopoverEventsService } from '../../../../utils/popover/providers/popover-events.service';
 
 import { DatagridNumericFilter } from './datagrid-numeric-filter';
 import { DatagridNumericFilterImpl } from './datagrid-numeric-filter-impl';
 
-const PROVIDERS = [FiltersProvider, DomAdapter, Page, StateDebouncer];
+class MockRenderer {
+  listen() {}
+}
 
+const PROVIDERS = [
+  FiltersProvider,
+  DomAdapter,
+  Page,
+  StateDebouncer,
+  ClrPopoverEventsService,
+  ClrPopoverPositionService,
+  ClrPopoverToggleService,
+  {
+    provide: Renderer2,
+    useClass: MockRenderer,
+  },
+];
 export default function(): void {
   describe('DatagridNumericFilter component', function() {
     // Until we can properly type "this"
@@ -47,7 +65,7 @@ export default function(): void {
     it('receives an input for the filter value', function() {
       context.testComponent.filterValue = [null, 10];
       context.detectChanges();
-      expect(context.clarityDirective.filter.value).toBe([null, 10]);
+      expect(context.clarityDirective.filter.value).toEqual([null, 10]);
     });
 
     it('wires the RegisteredFilter correctly', function() {
@@ -74,16 +92,16 @@ export default function(): void {
     });
 
     it('displays numeric inputs when open', function() {
-      expect(context.clarityElement.querySelectorAll("input[type='number']")).toBeNull();
+      expect(document.querySelector("input[type='number']")).toBeNull();
       openFilter();
-      expect(context.clarityElement.querySelectorAll("input[type='number']")).not.toBeNull();
+      expect(document.querySelector("input[type='number']")).not.toBeNull();
     });
 
     it(
       'focuses on the input when the filter opens',
       fakeAsync(function() {
         openFilter();
-        const input = context.clarityElement.querySelector("input[type='number']");
+        const input: HTMLInputElement = document.querySelector("input[type='number']");
         spyOn(input, 'focus');
         expect(input.focus).not.toHaveBeenCalled();
         tick();
@@ -94,20 +112,10 @@ export default function(): void {
     it('offers two way binding on the filtered state', function() {
       context.testComponent.filterValue = [1, 10];
       context.detectChanges();
-      expect(context.clarityDirective.value).toBe([1, 10]);
+      expect(context.clarityDirective.value).toEqual([1, 10]);
       context.clarityDirective.value = [null, 10];
       context.detectChanges();
-      expect(context.testComponent.filterValue).toBe([null, 10]);
-    });
-
-    xit('closes when the user presses Enter in the input', function() {
-      // TODO
-      openFilter();
-    });
-
-    xit('closes when the user presses Escape in the input', function() {
-      // TODO
-      openFilter();
+      expect(context.testComponent.filterValue).toEqual([null, 10]);
     });
   });
 }

--- a/src/clr-angular/data/datagrid/datagrid-column.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column.spec.ts
@@ -411,7 +411,7 @@ export default function(): void {
       });
     });
 
-    describe('View filters', function() {
+    describe('Build-in string and numeric filters', function() {
       let context;
       beforeEach(function() {
         context = this.create(ClrDatagridColumn, ColTypeTest, DATAGRID_SPEC_PROVIDERS);

--- a/src/clr-angular/data/datagrid/datagrid-column.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column.spec.ts
@@ -23,6 +23,9 @@ import { StateDebouncer } from './providers/state-debouncer.provider';
 import { ClrCommonStringsService } from '../../utils/i18n/common-strings.service';
 import { commonStringsDefault } from 'src/clr-angular/utils/i18n/common-strings.default';
 
+import { DatagridNumericFilterImpl } from './built-in/filters/datagrid-numeric-filter-impl';
+import { DatagridStringFilterImpl } from './built-in/filters/datagrid-string-filter-impl';
+
 export default function(): void {
   describe('DatagridColumn component', function() {
     describe('Typescript API', function() {
@@ -407,6 +410,41 @@ export default function(): void {
         expect(activeFiltersTest.length).toBe(2);
       });
     });
+
+    fdescribe('View filters', function() {
+      let context;
+      beforeEach(function() {
+        context = this.create(ClrDatagridColumn, ColTypeTest, DATAGRID_SPEC_PROVIDERS);
+      });
+
+      it('should let you set `number` as clrDgColType', function() {
+        context.testComponent.type = 'number';
+        context.detectChanges();
+        expect(context.clarityDirective.colType).toBe('number');
+      });
+
+      it('should let you set `string` as clrDgColType', function() {
+        context.testComponent.type = 'string';
+        context.detectChanges();
+        expect(context.clarityDirective.colType).toBe('string');
+      });
+
+      it('when setting clrDgColType to `number` it should use the numeric filter', function() {
+        context.testComponent.type = 'number';
+        context.testComponent.field = 'id';
+        context.detectChanges();
+        expect(context.clarityDirective.registered.filter instanceof DatagridNumericFilterImpl).toBe(true);
+        expect(context.clarityElement.querySelector('clr-dg-numeric-filter')).toBeDefined();
+      });
+
+      it('when clrDgColType is set to `string` it shoul use the string filter', function() {
+        context.testComponent.type = 'string';
+        context.testComponent.field = 'id';
+        context.detectChanges();
+        expect(context.clarityDirective.registered.filter instanceof DatagridStringFilterImpl).toBe(true);
+        expect(context.clarityElement.querySelector('clr-dg-string-filter')).toBeDefined();
+      });
+    });
   });
 }
 
@@ -522,4 +560,16 @@ class UnregisterTest {
   show: boolean;
   filter = new TestStringFilter();
   filterValue = 'M';
+}
+
+@Component({
+  template: `
+        <clr-dg-column [clrDgField]="field" [clrDgColType]="type">
+            Column Title
+        </clr-dg-column>
+    `,
+})
+class ColTypeTest {
+  field: string;
+  type: string;
 }

--- a/src/clr-angular/data/datagrid/datagrid-column.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column.spec.ts
@@ -411,7 +411,7 @@ export default function(): void {
       });
     });
 
-    fdescribe('View filters', function() {
+    describe('View filters', function() {
       let context;
       beforeEach(function() {
         context = this.create(ClrDatagridColumn, ColTypeTest, DATAGRID_SPEC_PROVIDERS);

--- a/src/clr-angular/data/datagrid/datagrid-column.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column.ts
@@ -47,7 +47,7 @@ import { ClrPopoverToggleService } from '../../utils/popover/providers/popover-t
                   *ngIf="field && !customFilter && (colType=='string')"
                   [clrDgStringFilter]="registered"
                   [(clrFilterValue)]="filterValue"></clr-dg-string-filter>
-          
+
           <clr-dg-numeric-filter
                   *ngIf="field && !customFilter && (colType=='number')"
                   [clrDgNumericFilter]="registered"
@@ -57,11 +57,11 @@ import { ClrPopoverToggleService } from '../../utils/popover/providers/popover-t
               <ng-content></ng-content>
           </ng-template>
 
-          <button 
-            class="datagrid-column-title" 
+          <button
+            class="datagrid-column-title"
             [attr.aria-label]="commonStrings.keys.sortColumn"
-            *ngIf="sortable" 
-            (click)="sort()" 
+            *ngIf="sortable"
+            (click)="sort()"
             type="button">
               <ng-container  *ngTemplateOutlet="columnTitle"></ng-container>
               <clr-icon
@@ -129,6 +129,15 @@ export class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<T, ClrDa
     return this._field;
   }
 
+  /*
+  * What type is this column?  This defaults to STRING, but can also be
+  * set to NUMBER.  Unsupported types default to STRING. Users can set it
+  * via the [clrDgColType] input by setting it to 'string' or 'number'.
+  */
+
+  // TODO: We might want to make this an enum in the future
+  @Input('clrDgColType') colType: 'string' | 'number' = 'string';
+
   @Input('clrDgField')
   public set field(field: string) {
     if (typeof field === 'string') {
@@ -172,15 +181,6 @@ export class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<T, ClrDa
       }
     }
   }
-
-  /*
-    * What type is this column?  This defaults to STRING, but can also be
-    * set to NUMBER.  Unsupported types default to STRING. Users can set it
-    * via the [clrDgColType] input by setting it to 'string' or 'number'.
-    */
-
-  // TODO: We might want to make this an enum in the future
-  @Input('clrDgColType') colType: 'string' | 'number' = 'string';
 
   /**
    * Indicates if the column is sortable


### PR DESCRIPTION
Numeric filter was not working when you only use binding input

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type


<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?
Changing the order of `@Input` fix the issue with `colType` beeing undefined at the time when `numeric` filter is selected.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3483

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Close: #3483 