### PR TITLE
fix(stack-view): a11y add aria-controls to stack-view

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -1221,6 +1221,7 @@ export declare class ClrStackBlock implements OnInit {
     uniqueId: string;
     constructor(parent: ClrStackBlock, uniqueId: string, commonStrings: ClrCommonStringsService);
     addChild(): void;
+    getStackChildrenId(): string;
     ngOnInit(): void;
     toggleExpand(): void;
 }

--- a/src/clr-angular/data/stack-view/stack-block.spec.ts
+++ b/src/clr-angular/data/stack-view/stack-block.spec.ts
@@ -265,5 +265,20 @@ export default function(): void {
       fixture.detectChanges();
       expect(fixture.componentInstance.expanded).toBeFalsy();
     });
+
+    it('sets aria-controls attribute corresponding to stack-children id', () => {
+      fixture = TestBed.createComponent(DynamicBlock);
+      fixture.detectChanges();
+
+      const stackLabel = fixture.nativeElement.querySelector('.stack-block-label');
+      // make sure the attribute does not exist when collapsed
+      expect(stackLabel.getAttribute('aria-controls')).toBeNull();
+      fixture.componentInstance.expanded = true;
+      fixture.detectChanges();
+      const controlsId = stackLabel.getAttribute('aria-controls');
+      expect(controlsId).not.toBeNull();
+      const childrenId = fixture.nativeElement.querySelector('.stack-children').getAttribute('id');
+      expect(childrenId).toBe(controlsId);
+    });
   });
 }

--- a/src/clr-angular/data/stack-view/stack-block.ts
+++ b/src/clr-angular/data/stack-view/stack-block.ts
@@ -19,7 +19,8 @@ import { UNIQUE_ID, UNIQUE_ID_PROVIDER } from '../../utils/id-generator/id-gener
         [id]="uniqueId"
         [attr.role]="role"
         [attr.tabindex]="tabIndex"
-        [attr.aria-expanded]="ariaExpanded">
+        [attr.aria-expanded]="ariaExpanded"
+        [attr.aria-controls]="getStackChildrenId()">
       <clr-icon shape="caret"
                 class="stack-block-caret"
                 *ngIf="expandable"
@@ -31,7 +32,7 @@ import { UNIQUE_ID, UNIQUE_ID_PROVIDER } from '../../utils/id-generator/id-gener
     <dd class="stack-block-content">
       <ng-content></ng-content>
     </dd>
-    <clr-expandable-animation [@clrExpandTrigger]="expanded" class="stack-children">
+    <clr-expandable-animation [@clrExpandTrigger]="expanded" class="stack-children" [attr.id]="getStackChildrenId()">
       <div [style.height]="expanded ? 'auto' : 0">
         <ng-content select="clr-stack-block"></ng-content>
       </div>
@@ -140,5 +141,9 @@ export class ClrStackBlock implements OnInit {
     } else {
       return this.expanded ? 'true' : 'false';
     }
+  }
+
+  getStackChildrenId() {
+    return this.expanded ? `clr-stack-children-${this.uniqueId}` : null;
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [x] Other... Please describe: A11Y

## What is the current behavior?

Can't jump from header to controlled content. This is a IE/JAWS only issue, and JAWS only supports this functionality. No other screen reader does!

Issue Number: #3564 

## What is the new behavior?

JAWSKey + Alt + M jumps to controlled content.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

