### PR TITLE
fix: datagrid custom filter for 2nd column doesn't work

### DIFF
--- a/src/clr-angular/data/datagrid/providers/filters.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/filters.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -127,6 +127,32 @@ export default function(): void {
       expect(filters.length).toBe(2);
     });
   });
+
+  describe('FiltersProvider provider unregisters filters correctly', function() {
+    beforeEach(function() {
+      const stateDebouncer = new StateDebouncer();
+      this.filtersInstance = new FiltersProvider(new Page(stateDebouncer), stateDebouncer);
+      this.registeredFilters = [];
+      for (let i = 0; i < 8; i++) {
+        this.registeredFilters.push(this.filtersInstance.add(new NumFilter(i)));
+      }
+    });
+
+    it('should unregister the designated filters', function() {
+      expect(this.registeredFilters.length).toBe(this.filtersInstance.getActiveFilters().length);
+
+      this.registeredFilters[0].unregister();
+      this.registeredFilters[2].unregister();
+      this.registeredFilters[4].unregister();
+      this.registeredFilters[6].unregister();
+
+      expect(this.filtersInstance.getActiveFilters().length).toBe(this.registeredFilters.length - 4);
+      expect(this.filtersInstance.getActiveFilters()[0]).toEqual(this.registeredFilters[1].filter);
+      expect(this.filtersInstance.getActiveFilters()[1]).toEqual(this.registeredFilters[3].filter);
+      expect(this.filtersInstance.getActiveFilters()[2]).toEqual(this.registeredFilters[5].filter);
+      expect(this.filtersInstance.getActiveFilters()[3]).toEqual(this.registeredFilters[7].filter);
+    });
+  });
 }
 
 abstract class TestFilter implements ClrDatagridFilterInterface<number> {
@@ -175,5 +201,19 @@ class ActiveFilter extends TestFilter {
 
   accepts(n: number): boolean {
     return n > 0;
+  }
+}
+
+class NumFilter extends TestFilter {
+  indexNumber: number;
+  constructor(_indexNumber: number) {
+    super();
+    this.indexNumber = _indexNumber;
+  }
+  accepts(n: number): boolean {
+    return n % 2 === 0;
+  }
+  isActive(): boolean {
+    return true;
   }
 }

--- a/src/clr-angular/data/datagrid/providers/filters.ts
+++ b/src/clr-angular/data/datagrid/providers/filters.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -60,7 +60,6 @@ export class FiltersProvider<T = any> {
    * Registers a filter, and returns a deregistration function
    */
   public add<F extends ClrDatagridFilterInterface<T>>(filter: F): RegisteredFilter<T, F> {
-    const index = this._all.length;
     const subscription = filter.changes.subscribe(() => this.resetPageAndEmitFilterChange([filter]));
     let hasUnregistered = false;
     const registered = new RegisteredFilter(filter, () => {
@@ -68,7 +67,10 @@ export class FiltersProvider<T = any> {
         return;
       }
       subscription.unsubscribe();
-      this._all.splice(index, 1);
+      const matchIndex = this._all.findIndex(item => item.filter === filter);
+      if (matchIndex >= 0) {
+        this._all.splice(matchIndex, 1);
+      }
       if (filter.isActive()) {
         this.resetPageAndEmitFilterChange([]);
       }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [n] Tests for the changes have been added (for bug fixes / features)
* [n/a] Docs have been added / updated (for bug fixes / features)
* [n/a] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?
Before the fix, custom filter doesn't  work for the 2nd column. 

Issue Number: 3486
https://github.com/vmware/clarity/issues/3486

## What is the new behavior?
After the fix, custom filter will work for all columns including the 2nd column. 

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

Signed-off-by: Kathy Laird <kathy.laird@emc.com>