### PR TITLE
fix: focus indicator for multi select

### DIFF
--- a/src/clr-angular/forms/styles/_select.clarity.scss
+++ b/src/clr-angular/forms/styles/_select.clarity.scss
@@ -99,6 +99,11 @@
 
   .clr-error select[multiple] {
     border-color: $clr-forms-invalid-color;
+
+    &:focus {
+      outline: 0;
+      box-shadow: 0 0 2px 2px lighten($clr-forms-invalid-color, 30%);
+    }
   }
 
   .clr-form-control-disabled .clr-select {


### PR DESCRIPTION
Adding focus outline for multi selects which don't have a proper focus indicator right now.

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 

closes #3398 
closes #3587 

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
