### PR TITLE
fix(datagrid): align column header vertically

### DIFF
--- a/src/clr-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clr-angular/data/datagrid/_datagrid.clarity.scss
@@ -303,7 +303,7 @@
         color: $clr-table-font-color;
         text-align: left;
         flex: 1 1 auto;
-        align-items: baseline;
+        align-items: center;
         align-self: center;
         display: flex;
 


### PR DESCRIPTION
Currently, the height of the column title changes when column is sorted and column title & sort icon aren't aligned. That results in strange behavior (adding scrollbar) to the whole datagrid.

Unsorted:
![Unsorted Sort Header (focused)](https://user-images.githubusercontent.com/8677948/66001077-0bc77780-e4a1-11e9-923c-6d8fbe87b62b.png)
Sorted (current state):
![Unaligned Sort Header (focused)](https://user-images.githubusercontent.com/8677948/66001103-1f72de00-e4a1-11e9-9e04-6be7622f59a9.png)
Sorted (with fix from PR):
![Aligned Sort Header (focused)](https://user-images.githubusercontent.com/8677948/66001133-2f8abd80-e4a1-11e9-878e-210da810d85a.png)

Behavior can also be seen in comparison of the docs samples - by sorting of the e.g. name column datagrid's full demo:
https://deploy-preview-3866--vmware-clarity.netlify.com/documentation/datagrid/full
https://clarity.design/documentation/datagrid/full

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
