### PR TITLE
fix(website): add padding-right to responsive footer

### DIFF
--- a/src/website/src/app/home/home.component.scss
+++ b/src/website/src/app/home/home.component.scss
@@ -344,6 +344,7 @@ a.home-contact_link {
 
     footer {
       padding-left: $bl-1_0;
+      padding-right: $bl-1_0;
     }
   }
 }


### PR DESCRIPTION
Adds missing `padding-right` to the responsive footer of the clarity.design website.

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [X] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

In the responsive view of the footer on the website, the footer has `padding-left` but interestingly omits the corresponding `padding-right`. This has missing symmetry of padding. See image below.

![before](https://user-images.githubusercontent.com/3681440/66013228-690afb00-e498-11e9-9fd6-9f0948dc16ed.png)

Issue Number: N/A

## What is the new behavior?
Add symmetrical `padding-right` of the same value as the `padding-left` to the responsive footer of the website.

![after](https://user-images.githubusercontent.com/3681440/66013321-c4d58400-e498-11e9-9a48-6fb6d1c6ed33.png)

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No

## Other information
