### PR TITLE
fix: remove max-height from `pre`

### DIFF
--- a/src/clr-angular/typography/_code.clarity.scss
+++ b/src/clr-angular/typography/_code.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -6,12 +6,8 @@
   //Styles for Clarity Code Snippets
   pre {
     margin: 0.5rem 0;
-  }
-  pre {
     border: $clr-default-borderwidth solid $clr-color-neutral-400;
-    max-height: 15rem;
     border-radius: $clr-default-borderradius;
-    overflow: auto;
   }
   pre code {
     white-space: pre;

--- a/src/website/src/app/utils/code-snippet.ts
+++ b/src/website/src/app/utils/code-snippet.ts
@@ -21,7 +21,6 @@ import { CodeHighlight } from './code-highlight';
         pre {
             background: transparent;
             padding: 12px;
-            max-height: none;
         }
     `,
   ],


### PR DESCRIPTION
BREAKING CHANGE: this changes the default height for a `pre` element, but can be easily overridden on app level

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

The `pre` element has a max height (which we override in our docs by the way)

closes #1138

## What is the new behavior?

The `pre` element is free to grow up and be full size.

## Does this PR introduce a breaking change?

* [x] Yes
* [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
