### PR TITLE
fix: removes unnecessary text from the mobile header title

### DIFF
--- a/src/website/src/app/documentation/demos/alert/angular/alert-angular-app-level-alerts.demo.html
+++ b/src/website/src/app/documentation/demos/alert/angular/alert-angular-app-level-alerts.demo.html
@@ -38,11 +38,6 @@
                 </div>
             </clr-alert>
         </clr-alerts>
-        <header class="header header-6">
-            <div class="branding">
-                <span class="title">Header</span>
-            </div>
-        </header>
         <div class="content-container">
             <div class="content-area">
                 <p>

--- a/src/website/src/app/documentation/demos/alert/angular/alert-angular-app-level.demo.html
+++ b/src/website/src/app/documentation/demos/alert/angular/alert-angular-app-level.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -16,11 +16,6 @@
                 </div>
             </clr-alert-item>
         </clr-alert>
-        <header class="header header-6">
-            <div class="branding">
-                <span class="title">Header</span>
-            </div>
-        </header>
         <div class="content-container">
             <div class="content-area">
                 <p>

--- a/src/website/src/app/documentation/demos/alert/angular/alert-angular-close-event.demo.html
+++ b/src/website/src/app/documentation/demos/alert/angular/alert-angular-close-event.demo.html
@@ -1,16 +1,11 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
 
 <div class="clr-example">
     <div class="main-container">
-        <header class="header header-6">
-            <div class="branding">
-                <span class="title">Header</span>
-            </div>
-        </header>
         <div class="content-container">
             <div class="content-area">
                 <clr-alert [clrAlertType]="'success'" (clrAlertClosedChange)="onClose()">

--- a/src/website/src/app/documentation/demos/alert/angular/alert-angular-not-closable.demo.html
+++ b/src/website/src/app/documentation/demos/alert/angular/alert-angular-not-closable.demo.html
@@ -1,16 +1,11 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
 
 <div class="clr-example">
     <div class="main-container">
-        <header class="header header-6">
-            <div class="branding">
-                <span class="title">Header</span>
-            </div>
-        </header>
         <div class="content-container">
             <div class="content-area">
                 <clr-alert [clrAlertClosable]="false">

--- a/src/website/src/app/documentation/demos/alert/angular/alert-angular-small.demo.html
+++ b/src/website/src/app/documentation/demos/alert/angular/alert-angular-small.demo.html
@@ -1,16 +1,11 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
 
 <div class="clr-example">
     <div class="main-container">
-        <header class="header header-6">
-            <div class="branding">
-                <span class="title">Header</span>
-            </div>
-        </header>
         <div class="content-container">
             <div class="content-area">
                 <clr-alert [clrAlertSizeSmall]="true">

--- a/src/website/src/app/documentation/demos/alert/angular/alert-angular-success.demo.html
+++ b/src/website/src/app/documentation/demos/alert/angular/alert-angular-success.demo.html
@@ -1,16 +1,11 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
 
 <div class="clr-example">
     <div class="main-container">
-        <header class="header header-6">
-            <div class="branding">
-                <span class="title">Header</span>
-            </div>
-        </header>
         <div class="content-container">
             <div class="content-area">
                 <clr-alert [clrAlertType]="'success'">

--- a/src/website/src/app/documentation/demos/alert/static/alert-app-level.demo.html
+++ b/src/website/src/app/documentation/demos/alert/static/alert-app-level.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -86,11 +86,6 @@
                 <clr-icon aria-hidden="true" shape="close"></clr-icon>
             </button>
         </div>
-        <header class="header header-6">
-            <div class="branding">
-                <span class="title">Header</span>
-            </div>
-        </header>
         <div class="content-container">
             <div class="content-area">
                 <p>Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collaborative thinking to further the overall value proposition. Organically grow the holistic world view
@@ -122,11 +117,6 @@
                 <clr-icon aria-hidden="true" shape="close"></clr-icon>
             </button>
         </div>
-        <header class="header header-6">
-            <div class="branding">
-                <span class="title">Header</span>
-            </div>
-        </header>
         <div class="content-container">
             <div class="content-area">
                 <p>Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collaborative thinking to further the overall value proposition. Organically grow the holistic world view

--- a/src/website/src/app/documentation/demos/alert/static/alert-content-area.demo.html
+++ b/src/website/src/app/documentation/demos/alert/static/alert-content-area.demo.html
@@ -1,16 +1,11 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
 
 <div class="clr-example">
     <div class="main-container">
-        <header class="header header-6">
-            <div class="branding">
-                <span class="title">Header</span>
-            </div>
-        </header>
         <div class="content-container">
             <div class="content-area">
                 <div class="alert alert-danger">

--- a/src/website/src/app/documentation/demos/alert/static/alert-sizes.demo.html
+++ b/src/website/src/app/documentation/demos/alert/static/alert-sizes.demo.html
@@ -1,16 +1,11 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
 
 <div class="clr-example">
     <div class="main-container">
-        <header class="header header-6">
-            <div class="branding">
-                <span class="title">Header</span>
-            </div>
-        </header>
         <div class="content-container">
             <div class="content-area">
                 <div class="alert alert-danger">

--- a/src/website/src/app/documentation/demos/alert/static/alert-styles.demo.html
+++ b/src/website/src/app/documentation/demos/alert/static/alert-styles.demo.html
@@ -1,16 +1,11 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
 
 <div ngNonBindable class="clr-example">
     <div class="main-container">
-        <header class="header header-6">
-            <div class="branding">
-                <span class="title">Header</span>
-            </div>
-        </header>
         <div class="content-container">
             <div class="content-area">
                 <div class="alert alert-danger">


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [x] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Unnecessary "Header" text fills up the title bar in mobile view.

<img width="392" alt="Screen Shot 2019-10-04 at 2 37 19 PM" src="https://user-images.githubusercontent.com/347483/66231428-81576180-e6b4-11e9-9020-81b491ab965d.png">

Issue Number: #3853 

## What is the new behavior?
Removes unnecessary header tags from the Alert examples.

<img width="589" alt="Screen Shot 2019-10-04 at 2 03 13 PM" src="https://user-images.githubusercontent.com/347483/66231460-90d6aa80-e6b4-11e9-961e-5f3cc58a2696.png">

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
