### PR TITLE
build: use circleci for unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,24 @@
+version: 2
+# Jobs
+jobs:
+  build:
+    docker:
+      - image: circleci/node:dubnium-browsers
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - modules{{checksum "package.json"}}
+            - modules
+      - run: npm install
+      - save_cache:
+          paths:
+            - node_modules
+          key: modules{{checksum "package.json"}}
+      - run: npm run build:ci
+# Workflows
+workflows:
+  version: 2
+  test:
+    jobs:
+      - build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   - CXX=g++-4.8
   - APPLITOOLS_BATCH_ID=`echo ${TRAVIS_PULL_REQUEST_SHA:=$TRAVIS_JOB_ID}`
   matrix:
-  - TEST_SUITE='build:ci'
+  # - TEST_SUITE='build:ci' # Moved to Circle CI
   - TEST_SUITE='gemini set1'
   - TEST_SUITE='gemini set2'
   - TEST_SUITE='gemini set3'


### PR DESCRIPTION
Travis builds have been slower and with the changes to Core tests are going around 25 minutes. I've moved just the `build:ci` piece to CircleCI in this (which we can trial here) as part of our process, which in my test runs has been going under around 12-13 minutes. This will also free up a job in Travis, so we can run gemini and applitools tests at once, reducing overall build time.

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [x] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

It would be easy to disable and go back to Travis if we have issues. I also attempted to setup gemini testing on Circle, and found that using docker containers is problematic because it doesn't allow networking. I'm sure there is a way, but I didn't dig into it yet and our plan is to remove gemini anyways so maybe we won't need to do this.