### PR TITLE
chore: fix website version urls

### DIFF
--- a/src/website/src/app/app.component.html
+++ b/src/website/src/app/app.component.html
@@ -11,7 +11,7 @@
         <div class="header-nav" [clr-nav-level]="1">
             <a id="home-link" class="nav-link" routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{exact:true}"><span class="nav-text">Home</span></a>
             <a class="nav-link" routerLink="/documentation" *ngIf="environment.latest == environment.version" routerLinkActive="active"><span class="nav-text">Documentation</span></a>
-            <a class="nav-link" href="https://{{environment.version}}.clarity.design" *ngIf="environment.latest !==
+            <a class="nav-link" [href]="getDocumentationUrl()" *ngIf="environment.latest !==
             environment.version"><span class="nav-text">Documentation</span></a>
             <a class="nav-link" routerLink="/icons" routerLinkActive="active"><span class="nav-text">Icons</span></a>
             <a class="nav-link" routerLink="/community" routerLinkActive="active"><span class="nav-text">Community</span></a>

--- a/src/website/src/app/app.component.ts
+++ b/src/website/src/app/app.component.ts
@@ -80,6 +80,14 @@ export class AppComponent implements OnInit {
     this.setTitle(filteredTitles.join(this.browserTitleSeparator));
   }
 
+  getDocumentationUrl() {
+    if (window.location.hostname === 'clarity.design' && environment.latest !== environment.version) {
+      return `https://${environment.latest}.clarity.design`;
+    } else {
+      return `/documentation`;
+    }
+  }
+
   private defaultBrowserTitle = 'Clarity Design System';
   private browserTitleSeparator = ' - ';
 

--- a/src/website/src/app/home/home.component.html
+++ b/src/website/src/app/home/home.component.html
@@ -9,7 +9,7 @@
             <div class="home-hero-btn">
                 <a routerLink="get-started" class="btn btn-primary">Get Started</a>
                 <a routerLink="documentation" *ngIf="environment.latest == environment.version" class="btn btn-secondary btn-outline">Documentation</a>
-                <a href="https://{{environment.version}}.clarity.design" *ngIf="environment.latest !== environment.version" class="btn btn-secondary btn-outline">Documentation</a>
+                <a href="https://{{environment.latest}}.clarity.design" *ngIf="environment.latest !== environment.version" class="btn btn-secondary btn-outline">Documentation</a>
             </div>
             <p class="subtext">
                 View the <a rel="noopener" target="_blank" href="https://github.com/vmware/clarity">source</a> on GitHub


### PR DESCRIPTION
This fixes the website urls for documentation links to align with a prerelease. Also for build previews/localhost it won't redirect to v2, only on clarity.design.

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [x] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
