### PR TITLE
feat(datagrid): preserve selection while filtering

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -331,6 +331,7 @@ export declare class ClrDatagrid<T = any> implements AfterContentInit, AfterView
     _projectedDisplayColumns: ViewContainerRef;
     allSelected: boolean;
     clrDetailExpandableAriaLabel: string;
+    clrDgPreserveSelection: boolean;
     clrDgSingleActionableAriaLabel: string;
     clrDgSingleSelectionAriaLabel: string;
     columns: QueryList<ClrDatagridColumn<T>>;
@@ -536,12 +537,9 @@ export declare class ClrDatagridRow<T = any> implements AfterContentInit, AfterV
     _stickyCells: ViewContainerRef;
     readonly _view: any;
     checkboxId: string;
-<<<<<<< HEAD
     clrDgDetailCloseLabel: string;
     clrDgDetailOpenLabel: string;
-=======
     clrDgSelectable: boolean;
->>>>>>> f8e89c882... feat(datagrid): disable single or multi rows from selection
     commonStrings: ClrCommonStringsService;
     detailButton: any;
     detailService: DetailService;

--- a/src/clr-angular/data/datagrid/datagrid.ts
+++ b/src/clr-angular/data/datagrid/datagrid.ts
@@ -160,6 +160,10 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
   @Input() clrDgSingleActionableAriaLabel: string = this.commonStrings.keys.singleActionableAriaLabel;
   @Input() clrDetailExpandableAriaLabel: string = this.commonStrings.keys.detailExpandableAriaLabel;
 
+  @Input()
+  set clrDgPreserveSelection(state: boolean) {
+    this.selection.preserveSelection = state;
+  }
   /**
    * @deprecated since 2.0, remove in 3.0
    *

--- a/src/clr-angular/data/datagrid/providers/selection.ts
+++ b/src/clr-angular/data/datagrid/providers/selection.ts
@@ -15,6 +15,7 @@ let nbSelection: number = 0;
 @Injectable()
 export class Selection<T = any> {
   public id: string;
+  public preserveSelection: boolean = false;
   private prevSelectionRefs: T[] = []; // Refs of selected items
   private prevSingleSelectionRef: T; // Ref of single selected item
   private lockedRefs: T[] = []; // Ref of licked items
@@ -24,7 +25,7 @@ export class Selection<T = any> {
 
     this.subscriptions.push(
       this._filters.change.subscribe(() => {
-        if (!this._selectable) {
+        if (!this._selectable || this.preserveSelection) {
           return;
         }
         this.clearSelection();

--- a/src/dev/src/app/datagrid/preserve-selection/preserve-selection.html
+++ b/src/dev/src/app/datagrid/preserve-selection/preserve-selection.html
@@ -1,8 +1,212 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
+
+<h2>Preserving Selection while Filtering</h2>
+
+<p>
+    By default, <code class="clr-code">clrDgSelected</code> is cleared whenever a filter is applied
+    to the datagrid.
+</p>
+<ul>
+    <li>
+        To change this default behavior so that the selection is retained while a filter is applied,
+        add a <code class="clr-code">[clrDgPreserveSelection]</code> input with value <code class="clr-code">true</code>
+        to the datagrid.
+    </li>
+    <li>
+        When <code class="clr-code">[clrDgPreserveSelection]</code> is enabled, some selected items
+        may not be visible, the developer must display some kind of preview or confirmation before
+        performing any action on the selected objects.
+    </li>
+</ul>
+
+<h3>Client side, no trackBy</h3>
+
+<clr-checkbox-container clrInline>
+    <clr-checkbox-wrapper>
+        <input type="checkbox" clrCheckbox [(ngModel)]="preserveFilteringNoTrackBy" name="preserveFilteringNoTrackBy">
+        <label>Preserve Selection While Filtering</label>
+    </clr-checkbox-wrapper>
+</clr-checkbox-container>
+
+<div class="card card-block">
+    <p class="card-text username-list">
+        Selected users:
+        <em *ngIf="clientNoTrackBySelected.length == 0">No user selected.</em>
+        <span class="username" *ngFor="let user of clientNoTrackBySelected">{{user.name}}</span>
+    </p>
+</div>
+
+<clr-datagrid [(clrDgSelected)]="clientNoTrackBySelected" [clrDgPreserveSelection]="preserveFilteringNoTrackBy">
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column [clrDgField]="'name'" [(clrFilterValue)]="nameFilterNoTrackBy">Name</clr-dg-column>
+    <clr-dg-column>Creation date</clr-dg-column>
+    <clr-dg-column>Favorite color</clr-dg-column>
+
+    <clr-dg-row *clrDgItems="let user of clientNoTrackByUsers" [clrDgItem]="user">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>
+            <span class="color-square" [style.backgroundColor]="user.color"></span>
+        </clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>
+        {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
+        of {{pagination.totalItems}} users
+        <clr-dg-pagination
+            #pagination
+            [clrDgPageSize]="currentPageSize"
+            [clrDgTotalItems]="pagination.totalItems"></clr-dg-pagination>
+    </clr-dg-footer>
+</clr-datagrid>
+
+
+<h3>Client side, trackBy index</h3>
+
+<clr-checkbox-container clrInline>
+    <clr-checkbox-wrapper>
+        <input type="checkbox" clrCheckbox [(ngModel)]="preserveFilteringTrackByIndex" name="preserveFilteringTrackByIndex">
+        <label>Preserve Selection While Filtering</label>
+    </clr-checkbox-wrapper>
+</clr-checkbox-container>
+
+<div class="card card-block">
+    <p class="card-text username-list">
+        Selected users:
+        <em *ngIf="clientTrackByIndexSelected.length == 0">No user selected.</em>
+        <span class="username" *ngFor="let user of clientTrackByIndexSelected">{{user.name}}</span>
+    </p>
+</div>
+
+<clr-datagrid [(clrDgSelected)]="clientTrackByIndexSelected" [clrDgPreserveSelection]="preserveFilteringTrackByIndex">
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column [clrDgField]="'name'" [(clrFilterValue)]="nameFilterTrackByIndex">Name</clr-dg-column>
+    <clr-dg-column>Creation date</clr-dg-column>
+    <clr-dg-column>
+        <ng-container *clrDgHideableColumn>
+            Favorite color
+        </ng-container>
+    </clr-dg-column>
+
+    <clr-dg-row *clrDgItems="let user of clientTrackByIndexUsers; trackBy: trackByIndex" [clrDgItem]="user">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>
+            <span class="color-square" [style.backgroundColor]="user.color"></span>
+        </clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>
+        {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
+        of {{total}} users
+        <clr-dg-pagination #pagination [clrDgTotalItems]="total"></clr-dg-pagination>
+    </clr-dg-footer>
+</clr-datagrid>
+
+
+<h3>Client side, trackBy item</h3>
+
+<clr-checkbox-container clrInline>
+    <clr-checkbox-wrapper>
+        <input type="checkbox" clrCheckbox [(ngModel)]="preserveFilteringTrackByIdUsers" name="preserveFilteringTrackByIdUsers">
+        <label>Preserve Selection While Filtering</label>
+    </clr-checkbox-wrapper>
+</clr-checkbox-container>
+
+<div class="card card-block">
+    <p class="card-text username-list">
+        Selected users:
+        <em *ngIf="clientTrackByIdSelected.length == 0">No user selected.</em>
+        <span class="username" *ngFor="let user of clientTrackByIdSelected">{{user.name}}</span>
+    </p>
+</div>
+
+<clr-datagrid [(clrDgSelected)]="clientTrackByIdSelected" [clrDgPreserveSelection]="preserveFilteringTrackByIdUsers">
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column [clrDgField]="'name'" [(clrFilterValue)]="nameFilterTrackById">Name</clr-dg-column>
+    <clr-dg-column>Creation date</clr-dg-column>
+    <clr-dg-column>
+        <ng-container *clrDgHideableColumn>
+            Favorite color
+        </ng-container>
+    </clr-dg-column>
+
+    <clr-dg-row *clrDgItems="let user of clientTrackByIdUsers; trackBy: trackById" [clrDgItem]="user">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>
+            <span class="color-square" [style.backgroundColor]="user.color"></span>
+        </clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>
+        {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
+        of {{total}} users
+        <clr-dg-pagination #pagination [clrDgTotalItems]="total"></clr-dg-pagination>
+    </clr-dg-footer>
+</clr-datagrid>
+
+
+<h3>Server-driven, trackBy item</h3>
+
+<clr-checkbox-container clrInline>
+    <clr-checkbox-wrapper>
+        <input type="checkbox" clrCheckbox [(ngModel)]="preserveFilteringServerTrackBy" name="preserveFilteringServerTrackBy">
+        <label>Preserve Selection While Filtering</label>
+    </clr-checkbox-wrapper>
+</clr-checkbox-container>
+
+<div class="card card-block">
+    <p class="card-text username-list">
+        Selected users:
+        <em *ngIf="serverTrackByIdSelected.length == 0">No user selected.</em>
+        <span class="username" *ngFor="let user of serverTrackByIdSelected">{{user.name}}</span>
+    </p>
+</div>
+
+<clr-datagrid [(clrDgSelected)]="serverTrackByIdSelected"
+        (clrDgRefresh)="refresh($event)"
+        [clrDgLoading]="loading"
+        [clrDgPreserveSelection]="preserveFilteringServerTrackBy">
+    <clr-dg-column>User ID</clr-dg-column>
+    <clr-dg-column [clrDgField]="'name'" [(clrFilterValue)]="nameFilterServerTrackBy">Name</clr-dg-column>
+    <clr-dg-column>Creation date</clr-dg-column>
+    <clr-dg-column>
+        <ng-container *clrDgHideableColumn>
+            Favorite color
+        </ng-container>
+    </clr-dg-column>
+
+    <clr-dg-row *ngFor="let user of serverTrackByIdUsers; trackBy: trackById" [clrDgItem]="user">
+        <clr-dg-cell>{{user.id}}</clr-dg-cell>
+        <clr-dg-cell>{{user.name}}</clr-dg-cell>
+        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+        <clr-dg-cell>
+            <span class="color-square" [style.backgroundColor]="user.color"></span>
+        </clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>
+        {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
+        of {{total}} users
+        <clr-dg-pagination #pagination [clrDgTotalItems]="total" [clrDgPageSize]="10"></clr-dg-pagination>
+    </clr-dg-footer>
+</clr-datagrid>
+
+
+<h2>Updating clrDgItems</h2>
+
+<p>
+    We also need to ensure that when the <code class="clr-code">clrDgItems</code> input changes
+    that our selection is not lost.
+</p>
 
 <clr-datagrid [(clrDgSelected)]="selected">
     <clr-dg-column>User ID</clr-dg-column>
@@ -10,7 +214,7 @@
     <clr-dg-column>Creation date</clr-dg-column>
     <clr-dg-column>Favorite color</clr-dg-column>
 
-    <clr-dg-row *clrDgItems="let user of users;trackBy:trackByFn" [clrDgItem]="user">
+    <clr-dg-row *clrDgItems="let user of users; trackBy:trackById" [clrDgItem]="user">
         <clr-dg-cell>{{user.id}}</clr-dg-cell>
         <clr-dg-cell>{{user.name}}</clr-dg-cell>
         <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>

--- a/src/website/src/app/documentation/demos/datagrid/selection/selection.html
+++ b/src/website/src/app/documentation/demos/datagrid/selection/selection.html
@@ -139,3 +139,16 @@
 
     <clr-dg-footer>{{users.length}} users</clr-dg-footer>
 </clr-datagrid>
+
+<h4>Preserving Selection</h4>
+<p>
+    By default, when a filter is applied to the datagrid the selection is cleared. This is done to ensure that all
+    selected items are always visible in the datagrid. In certain instances, this might not be desireable, therefore
+    we provide the <code class="clr-code">[clrDgPreserveSelection]</code> input. Setting this to true will retain the
+    current selection on the datagrid, even if filters are applied and selected items are not visible.
+</p>
+<p>
+    Note: If you do enable <code class="clr-code">[clrDgPreserveSelection]</code>, before performing any action on the
+    selected items, a confirmation should be shown to ensure the end-user is aware of which items they are operating on,
+    since the filters may hide some of the selected items from the user causing a discovery issue.
+</p>


### PR DESCRIPTION
Adds a clrDgPreserveSelection input to the datagrid which will not clear the selection when a filter is applied.

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2342 

## What is the new behavior?

A `clrDgPreserveSelection` input has been added to the datagrid which is disabled by default. When enabled, the selection is not cleared when a filter is applied. 

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Signed-off-by: Kevin Buffington <kbuffington@gmail.com>