### PR TITLE
chore: prevent fdescribe, fit, debugger from commiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "format": "prettier --list-different './**/*.{js,json,md,ts,scss}'",
     "format:fix": "pretty-quick --staged",
     "format:file": "prettier --write",
+    "git:check-content": "node ./scripts/commit-content-check.js",
     "gemini": "npm-run-all core:sass 'gemini:light -- {*}' 'gemini:dark -- {*}' --",
     "gemini:light": "./scripts/docker-cdc.js -t",
     "gemini:dark": "./scripts/docker-cdc.js -t -c dark",
@@ -215,7 +216,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run format:fix && npm run license:fix",
+      "pre-commit": "npm run git:check-content && npm run format:fix && npm run license:fix",
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   }

--- a/scripts/commit-content-check.js
+++ b/scripts/commit-content-check.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+ const exec = require('child_process').execSync;
+const result = [];
+
+['fdescribe', 'fit'].forEach((test) => {
+  const files = exec(`git --no-pager diff --staged -G"^\\s*${test}\\(" --name-only`, { encoding: 'utf8' }).split('\n');
+  if (files && files.length > 1) {
+    // trow the last empty line
+    files.pop();
+    result.push([test, files])
+  }
+})
+
+// Check for debugger;
+const files = exec(`git --no-pager diff --staged -G"debugger" --name-only`, { encoding: 'utf8' }).split('\n');
+if (files && files.length > 1) {
+  // trow the last empty line
+  files.pop();
+  result.push(['debugger', files])
+}
+
+if (result.length > 0) {
+  console.log("❗️Git staged files include one or more illigal words, please remove them: \n")
+
+  result.forEach((error) => {
+    console.log("⚠️  file(s) below include '" + error[0] + "':\n");
+    error[1].map((file) => { console.log("\x1b[31m", file, "\x1b[0m")})
+    console.log("\n");
+  })
+
+  process.exit(1);
+  return
+}
+
+return process.exit(0);


### PR DESCRIPTION
For the past week, I manage to push several times `fdescribe`, `debugger` and so on.

This is pre-commit hook that will prevent you from committing this type of content. It could be extended later on. 

There are NPM packages Git Hook packages that could do the same thing, but right now I don't think that there is a big need for that. 

In the rare case that you will need to commit change that include `fdescribe` or some of the other words. This could be done with: 

```bash
$ git commit -m "fix: skip few tests from running " -s -S --no-verify
```

<img width="838" alt="Screen Shot 2019-10-09 at 8 40 16 PM" src="https://user-images.githubusercontent.com/204564/66507724-692e7a80-ead8-11e9-9f30-6237f52b55b2.png">

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [x] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
