### PR TITLE
fix: removes unnecessary text from the mobile header title

### DIFF
--- a/src/website/src/styles/code.scss
+++ b/src/website/src/styles/code.scss
@@ -14,6 +14,12 @@
     .content-area {
       overflow-y: hidden;
     }
+    header.header {
+      .branding {
+        position: static;
+        z-index: 1;
+      }
+    }
   }
   &.squeeze {
     padding: $clr_baselineRem_2;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [x] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Unnecessary "Header" text fills up the title bar in mobile view.

<img width="392" alt="Screen Shot 2019-10-04 at 2 37 19 PM" src="https://user-images.githubusercontent.com/347483/66231428-81576180-e6b4-11e9-9020-81b491ab965d.png">

Issue Number: #3853 

## What is the new behavior?
Fixes positioning of header tags in the examples.

<img width="589" alt="Screen Shot 2019-10-04 at 2 03 13 PM" src="https://user-images.githubusercontent.com/347483/66231460-90d6aa80-e6b4-11e9-961e-5f3cc58a2696.png">

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
