### PR TITLE
refactor(datagrid): move row controls into sticky container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '10'
+- '11'
 env:
   global:
   - CXX=g++-4.8

--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -19,7 +19,7 @@ describe(`Clarity - ${Cypress.env('CLARITY_THEME')}`, () => {
   // ButtonSpecs();
   CheckboxesSpec();
   ColorSpec();
-  // DatagridSpec();
+  DatagridSpec();
   // ListsSpec();
   TogglesSpec();
   SelectSpec();

--- a/src/clr-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clr-angular/data/datagrid/_datagrid.clarity.scss
@@ -96,6 +96,9 @@
 
     &:hover {
       @include css-var(background-color, clr-datagrid-row-hover, $clr-datagrid-row-hover, $clr-use-custom-properties);
+      .datagrid-row-sticky {
+        @include css-var(background-color, clr-datagrid-row-hover, $clr-datagrid-row-hover, $clr-use-custom-properties);
+      }
     }
 
     &.datagrid-selected {
@@ -106,6 +109,15 @@
         $clr-global-selection-color,
         $clr-use-custom-properties
       );
+      .datagrid-row-sticky {
+        @include css-var(color, clr-datagrid-row-selected, $clr-datagrid-row-selected, $clr-use-custom-properties);
+        @include css-var(
+          background-color,
+          clr-global-selection-color,
+          $clr-global-selection-color,
+          $clr-use-custom-properties
+        );
+      }
     }
 
     .datagrid-action-overflow {
@@ -502,6 +514,10 @@
     .datagrid-action-overflow {
       z-index: map-get($clr-layers, datagrid-popover);
     }
+
+    .datagrid-row-sticky {
+      z-index: map-get($clr-layers, datagrid-row-sticky);
+    }
   }
 
   .datagrid-row-sticky {
@@ -510,6 +526,18 @@
     flex-wrap: nowrap;
     position: sticky;
     left: 0;
+    z-index: map-get($clr-layers, datagrid-header-sticky);
+    .datagrid-cell:last-child {
+      &:after {
+        content: '';
+        width: 0.05rem;
+        height: calc(100% - 0.5rem);
+        position: absolute;
+        right: 0;
+        top: 0.25rem;
+        @include css-var(background-color, clr-table-border-color, $clr-table-border-color, $clr-use-custom-properties);
+      }
+    }
   }
 
   .datagrid-row-scrollable {
@@ -524,12 +552,18 @@
         flex: 0 0 auto;
       }
     }
+
+    .datagrid-column:last-child {
+      .datagrid-column-separator {
+        display: none;
+      }
+    }
   }
 
   .datagrid-row-flex {
     flex: 1 1 auto;
     display: flex;
-    flex-flow: column nowrap;
+    flex-flow: row nowrap;
 
     .datagrid-row-detail {
       display: flex;
@@ -632,12 +666,6 @@
       vertical-align: top;
       border: none;
 
-      &:last-child {
-        .datagrid-column-separator {
-          display: none;
-        }
-      }
-
       clr-dg-filter,
       clr-dg-string-filter,
       clr-dg-numeric-filter {
@@ -661,7 +689,7 @@
         float: right;
         vertical-align: middle;
         @include equilateral($clr-datagrid-icon-size);
-        margin: 0 $clr_baselineRem_0_25;
+        margin-left: $clr_baselineRem_0_25;
         background-repeat: no-repeat;
         background-size: contain;
         @include css-var(color, clr-color-neutral-500, $clr-color-neutral-500, $clr-use-custom-properties);
@@ -794,12 +822,6 @@
         flex: 0 0 auto;
       }
 
-      &.datagrid-fixed-column {
-        flex: 0 0 $clr-datagrid-fixed-column-size;
-        max-width: $clr-datagrid-fixed-column-size;
-        min-width: $clr-datagrid-fixed-column-size;
-      }
-
       .datagrid-column-flex {
         display: flex;
         flex: 1 1 auto;
@@ -817,6 +839,13 @@
         .signpost .signpost-action.btn {
           height: inherit;
           line-height: inherit;
+        }
+
+        // Override checkbox labels only when they are in a column. This allows them to be vertically centered.
+        .clr-checkbox-wrapper label {
+          &:before {
+            top: 0;
+          }
         }
       }
 
@@ -899,6 +928,13 @@
           line-height: $clr_baselineRem_1;
         }
       }
+
+      &.datagrid-select,
+      &.datagrid-expandable-caret,
+      &.datagrid-row-actions {
+        max-width: $clr-datagrid-fixed-column-size;
+        min-width: $clr-datagrid-fixed-column-size;
+      }
     }
 
     .datagrid-cell {
@@ -907,14 +943,11 @@
       min-width: $clr_baselineRem_4;
       border: none;
 
-      &.datagrid-fixed-column {
-        flex: 0 0 $clr-datagrid-fixed-column-size;
-      }
-
+      // TODO can width/column classes be combined? width is added programetically as part of rendering, column is
+      //  class in template
       &.datagrid-fixed-width {
         flex: 0 0 auto;
       }
-
       &.datagrid-fixed-column {
         flex: 0 0 $clr-datagrid-fixed-column-size;
         max-width: $clr-datagrid-fixed-column-size;

--- a/src/clr-angular/data/datagrid/datagrid-row-detail.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-row-detail.spec.ts
@@ -7,10 +7,6 @@ import { Component } from '@angular/core';
 
 import { ClrDatagridRowDetail } from './datagrid-row-detail';
 import { DATAGRID_SPEC_PROVIDERS, TestContext } from './helpers.spec';
-import { ExpandableRowsCount } from './providers/global-expandable-rows';
-import { RowActionService } from './providers/row-action-service';
-import { Selection } from './providers/selection';
-import { SelectionType } from './enums/selection-type';
 import { DatagridIfExpandService } from './datagrid-if-expanded.service';
 
 export default function(): void {
@@ -50,36 +46,6 @@ export default function(): void {
       context.testComponent.replace = true;
       context.detectChanges();
       expect(expandState).toBe(true);
-    });
-
-    it('displays an empty cell in place of the caret', function() {
-      context.getClarityProvider(ExpandableRowsCount).register();
-      context.detectChanges();
-      expect(context.clarityElement.querySelectorAll('.datagrid-fixed-column').length).toBe(1);
-    });
-
-    it('displays an extra empty cell when the datagrid is selectable', function() {
-      const selection: Selection = context.getClarityProvider(Selection);
-      selection.selectionType = SelectionType.Multi;
-      context.detectChanges();
-      expect(context.clarityElement.querySelectorAll('.datagrid-fixed-column').length).toBe(1);
-      selection.selectionType = SelectionType.Single;
-      context.detectChanges();
-      expect(context.clarityElement.querySelectorAll('.datagrid-fixed-column').length).toBe(1);
-    });
-
-    it('displays an extra empty cell when the datagrid has an actionable row when replaced', function() {
-      context.getClarityProvider(RowActionService).register();
-      context.detectChanges();
-      expect(context.clarityElement.querySelectorAll('.datagrid-fixed-column').length).toBe(1);
-    });
-
-    it('displays as many extra empty cells as needed', function() {
-      const selection: Selection = context.getClarityProvider(Selection);
-      selection.selectionType = SelectionType.Multi;
-      context.getClarityProvider(RowActionService).register();
-      context.detectChanges();
-      expect(context.clarityElement.querySelectorAll('.datagrid-fixed-column').length).toBe(2);
     });
   });
 }

--- a/src/clr-angular/data/datagrid/datagrid-row-detail.ts
+++ b/src/clr-angular/data/datagrid/datagrid-row-detail.ts
@@ -19,25 +19,7 @@ import { DatagridIfExpandService } from './datagrid-if-expanded.service';
  */
 @Component({
   selector: 'clr-dg-row-detail',
-  template: `
-        <ng-container *ngIf="!replacedRow">
-            <!-- space for multiselection state -->
-            <div class="datagrid-cell datagrid-select datagrid-fixed-column"
-                *ngIf="selection.selectionType === SELECTION_TYPE.Multi">
-            </div>
-            <!-- space for single selection state -->
-            <div class="datagrid-cell datagrid-select datagrid-fixed-column"
-                *ngIf="selection.selectionType === SELECTION_TYPE.Single">
-            </div>
-            <!-- space for single row action; only displayType if we have at least one actionable row in datagrid -->
-            <div class="datagrid-cell datagrid-row-actions datagrid-fixed-column"
-                *ngIf="rowActionService.hasActionableRow">
-            </div>
-            <!-- space for expandable caret action; only displayType if we have at least one expandable row in datagrid -->
-            <div *ngIf="expandableRows.hasExpandableRow"
-                        class="datagrid-expandable-caret datagrid-fixed-column datagrid-cell">
-            </div>
-        </ng-container>
+  template: `  
         <ng-content></ng-content>
     `,
   host: {

--- a/src/clr-angular/data/datagrid/datagrid-row.html
+++ b/src/clr-angular/data/datagrid/datagrid-row.html
@@ -27,15 +27,12 @@
   <div role="row" [id]="id" class="datagrid-row-master datagrid-row-flex" [class.datagrid-row-detail-open]="detailService.isRowOpen(item)">
   <div class="datagrid-row-sticky">
       <!-- Sticky elements here -->
-      <ng-container #stickyCells></ng-container> <!-- placeholder for projecting other sticky cells as pinned-->
-    </div>
-    <div class="datagrid-row-scrollable" [ngClass]="{'is-replaced': replaced && expanded}">
-      <div class="datagrid-scrolling-cells">
+      <ng-container #stickyCells>
         <div *ngIf="selection.selectionType === SELECTION_TYPE.Multi"
-             class="datagrid-select datagrid-fixed-column datagrid-cell" 
+             class="datagrid-select datagrid-fixed-column datagrid-cell"
              [ngClass]="{ 'clr-form-control-disabled': !clrDgSelectable }"
              role="gridcell">
-             
+
           <input clrCheckbox type="checkbox" [ngModel]="selected" (ngModelChange)="toggle($event)" [id]="checkboxId"
                  [attr.disabled]="clrDgSelectable ? null : true"
                  [attr.aria-disabled]="clrDgSelectable ? null : true"
@@ -44,16 +41,16 @@
         <div *ngIf="selection.selectionType === SELECTION_TYPE.Single"
              class="datagrid-select datagrid-fixed-column datagrid-cell" role="gridcell"
              [ngClass]="{ 'clr-form-control-disabled': !clrDgSelectable }"
-             >
-            <!-- TODO: it would be better if in addition to the generic "Select" label, we could add aria-labelledby
-            to label the radio by the first cell in the row (typically an id or name).
-            It's pretty easy to label it with the whole row since we already have an id for it, but in most
-            cases the row is far too long to serve as a label, the screenreader reads every single cell content. -->
-            <input type="radio" clrRadio [id]="radioId" [name]="selection.id + '-radio'" [value]="item"
-                   [(ngModel)]="selection.currentSingle" [checked]="selection.currentSingle === item"
-                   [attr.disabled]="clrDgSelectable ? null : true"
-                   [attr.aria-disabled]="clrDgSelectable ? null : true"
-                   [attr.aria-label]="commonStrings.keys.select">
+        >
+          <!-- TODO: it would be better if in addition to the generic "Select" label, we could add aria-labelledby
+          to label the radio by the first cell in the row (typically an id or name).
+          It's pretty easy to label it with the whole row since we already have an id for it, but in most
+          cases the row is far too long to serve as a label, the screenreader reads every single cell content. -->
+          <input type="radio" clrRadio [id]="radioId" [name]="selection.id + '-radio'" [value]="item"
+                 [(ngModel)]="selection.currentSingle" [checked]="selection.currentSingle === item"
+                 [attr.disabled]="clrDgSelectable ? null : true"
+                 [attr.aria-disabled]="clrDgSelectable ? null : true"
+                 [attr.aria-label]="commonStrings.keys.select">
         </div>
         <div *ngIf="rowActionService.hasActionableRow"
              class="datagrid-row-actions datagrid-fixed-column datagrid-cell" role="gridcell">
@@ -63,7 +60,7 @@
              class="datagrid-expandable-caret datagrid-fixed-column datagrid-cell" role="gridcell">
           <ng-container *ngIf="expand.expandable">
             <button (click)="toggleExpand()" *ngIf="!expand.loading" type="button" class="datagrid-expandable-caret-button" [attr.aria-label]="detailService.isOpen ? clrDgDetailCloseLabel : clrDgDetailOpenLabel">
-            <clr-icon shape="caret"
+              <clr-icon shape="caret"
                         class="datagrid-expandable-caret-icon"
                         [attr.dir]="expand.expanded ? 'down' : 'right'"
                         [attr.title]="expand.expanded ? commonStrings.keys.collapse : commonStrings.keys.expand"></clr-icon>
@@ -82,14 +79,18 @@
                       [attr.title]="detailService.isRowOpen(item) ? commonStrings.keys.close: commonStrings.keys.open"></clr-icon>
           </button>
         </div>
+      </ng-container> <!-- placeholder for projecting other sticky cells as pinned-->
+    </div>
+    <div class="datagrid-row-scrollable" [ngClass]="{'is-replaced': replaced && expanded}">
+      <div class="datagrid-scrolling-cells">
         <ng-container #scrollableCells></ng-container>
       </div>
       <!-- details here when replace, re-visit when sticky container is used for pinned cells -->
       <ng-template *ngIf="replaced && !expand.loading"
                    [ngTemplateOutlet]="detail"></ng-template>
+      <ng-template *ngIf="!replaced && !expand.loading"
+                   [ngTemplateOutlet]="detail"></ng-template>
     </div>
-    <ng-template *ngIf="!replaced && !expand.loading"
-                 [ngTemplateOutlet]="detail"></ng-template>
   </div>
 </ng-template>
 

--- a/src/clr-angular/data/datagrid/datagrid-row.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-row.spec.ts
@@ -355,7 +355,9 @@ export default function(): void {
           expand.expanded = true;
           tick();
           context.detectChanges();
-          const cellStyle = <HTMLElement>context.clarityElement.querySelector('.datagrid-cell:nth-child(2)');
+          const cellStyle = <HTMLElement>context.clarityElement.querySelector(
+            '.datagrid-scrolling-cells > .datagrid-cell'
+          );
           const details = <HTMLElement>context.clarityElement.querySelector('.datagrid-row-detail');
           expect(window.getComputedStyle(cellStyle).display).toBe('none');
           expect(window.getComputedStyle(details).display).toBe('flex');

--- a/src/clr-angular/data/datagrid/datagrid.html
+++ b/src/clr-angular/data/datagrid/datagrid.html
@@ -14,9 +14,6 @@
             <div role="row" class="datagrid-row">
               <div class="datagrid-row-master datagrid-row-flex">
                 <div class="datagrid-row-sticky">
-                  <!-- Sticky elements here -->
-                </div>
-                <div class="datagrid-row-scrollable">
                   <!--header for datagrid where you can select multiple rows -->
                   <div role="columnheader" class="datagrid-column datagrid-select datagrid-fixed-column"
                        *ngIf="selection.selectionType === SELECTION_TYPE.Multi">
@@ -42,6 +39,8 @@
                        *ngIf="expandableRows.hasExpandableRow || detailService.enabled" [attr.aria-label]="clrDetailExpandableAriaLabel">
                     <div class="datagrid-column-separator"></div>
                   </div>
+                </div>
+                <div class="datagrid-row-scrollable">
                   <ng-container #projectedDisplayColumns></ng-container>
                 </div>
               </div>

--- a/src/clr-angular/utils/_layers.clarity.scss
+++ b/src/clr-angular/utils/_layers.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -7,7 +7,10 @@
 $clr-layers: (
   content: 0,
   select-box: 2,
-  datagrid-header: 500,
+  datagrid-row: 500,
+  datagrid-row-sticky: 500,
+  datagrid-header: 501,
+  datagrid-header-sticky: 502,
   datagrid-host: 590,
   column-switch: 600,
   dropdown-menu: 1000,

--- a/src/dev/src/app/datagrid/inventory/inventory.ts
+++ b/src/dev/src/app/datagrid/inventory/inventory.ts
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { User } from './user';
-import { BEGINNING, COLORS, NAMES, NOW, POKEMONS } from './values';
+import { COLORS, NAMES, POKEMONS } from './values';
 
 export class Inventory {
   public size = 100;
@@ -21,13 +21,18 @@ export class Inventory {
     this._all = [];
     for (let i = 0; i < this.size; i++) {
       this._all.push({
-        id: randomInt(100000),
-        name: NAMES[randomInt(NAMES.length)],
-        creation: new Date(BEGINNING + randomInt(NOW - BEGINNING)),
-        color: COLORS[randomInt(COLORS.length)],
-        pokemon: POKEMONS[randomInt(POKEMONS.length)],
+        id: i + 10000,
+        name: this.getItem(i, NAMES),
+        creation: new Date('June 23, 1912'),
+        color: this.getItem(i, COLORS),
+        pokemon: this.getItem(i, POKEMONS),
       });
     }
+  }
+
+  // Used by an iterator to pull an item out of an array in a repeatable way.
+  private getItem<T>(num: number, array: T[]): T {
+    return array[num % array.length];
   }
 
   private _checkCurrentQuery() {

--- a/src/dev/src/app/datagrid/kitchen-sink/kitchen-sink-data.ts
+++ b/src/dev/src/app/datagrid/kitchen-sink/kitchen-sink-data.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -8,7 +8,7 @@ export class DatagridKitchenSinkData {
     {
       id: 3379,
       name: 'Rhona',
-      creation: '2014-04-11T03:02:57.974Z',
+      creation: '2014-04-11T20:02:57.974Z',
       color: 'Brown',
       pokemon: { number: 72, name: 'Tentacool' },
     },
@@ -29,7 +29,7 @@ export class DatagridKitchenSinkData {
     {
       id: 67461,
       name: 'Shenika',
-      creation: '2015-03-04T03:56:00.596Z',
+      creation: '2015-03-04T20:56:00.596Z',
       color: 'Yellow',
       pokemon: { number: 114, name: 'Tangela' },
     },
@@ -43,28 +43,28 @@ export class DatagridKitchenSinkData {
     {
       id: 81766,
       name: 'Alica',
-      creation: '2017-04-28T01:21:03.849Z',
+      creation: '2017-04-28T19:21:03.849Z',
       color: 'Brown',
       pokemon: { number: 136, name: 'Flareon' },
     },
     {
       id: 61317,
       name: 'Jeana',
-      creation: '2015-02-17T02:24:31.117Z',
+      creation: '2015-02-17T19:24:31.117Z',
       color: 'Magenta',
       pokemon: { number: 41, name: 'Zubat' },
     },
     {
       id: 34496,
       name: 'Nelson',
-      creation: '2014-10-01T05:27:24.819Z',
+      creation: '2014-10-01T19:27:24.819Z',
       color: 'Gray',
       pokemon: { number: 51, name: 'Dugtrio' },
     },
     {
       id: 24521,
       name: 'Nelson',
-      creation: '2016-12-08T03:03:36.589Z',
+      creation: '2016-12-08T19:03:36.589Z',
       color: 'Black',
       pokemon: { number: 42, name: 'Golbat' },
     },
@@ -92,7 +92,7 @@ export class DatagridKitchenSinkData {
     {
       id: 35217,
       name: 'Desirae',
-      creation: '2014-05-21T00:47:07.586Z',
+      creation: '2014-05-21T19:47:07.586Z',
       color: 'Red',
       pokemon: { number: 49, name: 'Venomoth' },
     },
@@ -211,7 +211,7 @@ export class DatagridKitchenSinkData {
     {
       id: 5106,
       name: 'Nelson',
-      creation: '2017-04-27T06:14:23.230Z',
+      creation: '2017-04-27T20:14:23.230Z',
       color: 'Red',
       pokemon: { number: 67, name: 'Machoke' },
     },

--- a/src/dev/src/app/datagrid/pagination/pagination.html
+++ b/src/dev/src/app/datagrid/pagination/pagination.html
@@ -81,7 +81,7 @@
   </clr-dg-row>
 
   <clr-dg-footer>
-    <clr-dg-pagination #pagination [clrDgPageSize]="20" (clrDgPageChange)="pageChange($event)">
+    <clr-dg-pagination #pagination [clrDgPageSize]="5" (clrDgPageChange)="pageChange($event)">
       <clr-dg-page-size [clrPageSizeOptions]="[10,20,50,100]">Users per page</clr-dg-page-size>
       {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}} of {{pagination.totalItems}} users
     </clr-dg-pagination>


### PR DESCRIPTION
This moves the datagrid row controls into the stick container and prepares for pinned columns (frontside). Styles were adjusted to handle the column separaters and flex the sticky and scrollable elements in the header as a row instead of a column.

RELATED CHANGES:
The pokemon generator was modified to produce consistent items from the three arrays that are used to generate data so that visual regression tests could be turned on and utilized for visual regression testing of the datagrid use cases. This commit will generate reference images for the baseline.

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [x] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [x] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Datagrid row control buttons scroll on the x-axis when there is overflow. 
Issue Number: N/A

## What is the new behavior?
Datagrid row control buttons do not scroll in the x-axis but do scroll in the y-axis when content overflows. 

## Does this PR introduce a breaking change?

* [x] Yes (Visually this breaks the display consumers are expecting)
* [ ] No 
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
