### PR TITLE
fix: templates for private/unused variables

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -707,6 +707,7 @@ export declare class ClrDroppable<T> implements OnInit, OnDestroy {
     dropEmitter: EventEmitter<ClrDragEvent<T>>;
     dropTolerance: number | string | ClrDropToleranceInterface;
     group: string | string[];
+    isDraggableMatch: boolean;
     isDraggableOver: boolean;
     constructor(el: ElementRef, eventBus: DragAndDropEventBusService<T>, domAdapter: DomAdapter, renderer: Renderer2);
     ngOnDestroy(): void;

--- a/src/clr-angular/utils/drag-and-drop/droppable/droppable.ts
+++ b/src/clr-angular/utils/drag-and-drop/droppable/droppable.ts
@@ -34,7 +34,7 @@ export class ClrDroppable<T> implements OnInit, OnDestroy {
     this.droppableEl = this.el.nativeElement;
   }
 
-  private isDraggableMatch: boolean = false;
+  isDraggableMatch: boolean = false;
   private _isDraggableOver: boolean = false;
 
   set isDraggableOver(value: boolean) {

--- a/src/dev/src/app/datagrid/compact/compact.html
+++ b/src/dev/src/app/datagrid/compact/compact.html
@@ -398,7 +398,7 @@
       <clr-dg-cell>
         {{user.id}}
         <clr-signpost>
-          <button type="button" class="signpost-action btn btn-small btn-link" [class.active]="open" clrSignpostTrigger>
+          <button type="button" class="signpost-action btn btn-small btn-link" clrSignpostTrigger>
             <clr-icon shape="help-info"></clr-icon>
           </button>
           <clr-signpost-content *clrIfOpen [clrPosition]="'top-middle'">

--- a/src/dev/src/app/datagrid/hide-show-columns/hide-show.html
+++ b/src/dev/src/app/datagrid/hide-show-columns/hide-show.html
@@ -66,7 +66,6 @@
                 <button
                     type="button"
                     class="signpost-action btn btn-small btn-link"
-                    [class.active]="open"
                     clrSignpostTrigger>
                     <clr-icon shape="help-info"></clr-icon>
                 </button>
@@ -131,7 +130,6 @@
                 <button
                     type="button"
                     class="signpost-action btn btn-small btn-link"
-                    [class.active]="open"
                     clrSignpostTrigger>
                     <clr-icon shape="help-info"></clr-icon>
                 </button>

--- a/src/dev/src/app/datagrid/kitchen-sink/kitchen-sink.ts
+++ b/src/dev/src/app/datagrid/kitchen-sink/kitchen-sink.ts
@@ -85,7 +85,7 @@ export class DatagridKitchenSinkDemo {
     this.toExport = [];
   }
 
-  onDelete(user: User) {
+  onDelete(user?: User) {
     this.cleanUp();
     if (user) {
       this.toDelete = [user];
@@ -94,7 +94,7 @@ export class DatagridKitchenSinkDemo {
     }
   }
 
-  onEdit(user: User) {
+  onEdit(user?: User) {
     this.cleanUp();
     if (user) {
       this.toEdit = user;

--- a/src/dev/src/app/datagrid/responsive-footer/responsive-footer.html
+++ b/src/dev/src/app/datagrid/responsive-footer/responsive-footer.html
@@ -64,7 +64,6 @@
           <button
             type="button"
             class="signpost-action btn btn-small btn-link"
-            [class.active]="open"
             clrSignpostTrigger>
             <clr-icon shape="help-info"></clr-icon>
           </button>

--- a/src/dev/tsconfig.dev.json
+++ b/src/dev/tsconfig.dev.json
@@ -6,6 +6,5 @@
     "moduleResolution": "node",
     "target": "es5"
   },
-
   "exclude": ["test.ts", "**/*.spec.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,8 @@
 {
+  "angularCompilerOptions": {
+    "fullTemplateTypeCheck": true,
+    "strictInjectionParameters": true
+  },
   "compileOnSave": false,
   "compilerOptions": {
     "baseUrl": "./",


### PR DESCRIPTION
Fix templates for private/unused variables.

- This enables to set `"fullTemplateTypeCheck": true` in `angularCompilerOptions` (current Angular CLI sets this).
- Enable `fullTemplateTypeCheck` in dev application

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

Angular prod build fails when `"fullTemplateTypeCheck": true` is set in `angularCompilerOptions` in `tsconfig.json`.

Issue Number: #3932

## What is the new behavior?

Angular build works :-)

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

None