### PR TITLE
fix: website is missing code-highlight utils module for navigation page

### DIFF
--- a/src/website/src/app/documentation/demos/nav/nav.demo.module.ts
+++ b/src/website/src/app/documentation/demos/nav/nav.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -25,6 +25,7 @@ import { LayoutOnlyHeaderDemo } from './layout-only-header';
 import { LayoutSidenavPrimaryDemo } from './layout-sidenav-primary';
 import { LayoutSubnavPrimaryDemo } from './layout-subnav-primary';
 import { NavCodeInfoAlert } from './nav-code-info-alert';
+import { UtilsModule } from '../../../utils/utils.module';
 
 @NgModule({
   imports: [
@@ -32,6 +33,7 @@ import { NavCodeInfoAlert } from './nav-code-info-alert';
     ClarityModule,
     RouterModule.forChild([{ path: '', component: NavigationDemo }]),
     DocWrapperModule,
+    UtilsModule,
   ],
   declarations: [
     NavsDemo,


### PR DESCRIPTION
Website navigation documentation was missing module so the syntax highlighting was not working.

Also adding `website` as a valid scope for commit linting.

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

### Before:
<img width="880" alt="Screen Shot 2019-10-23 at 11 06 31 AM" src="https://user-images.githubusercontent.com/204564/67371568-4181ec80-f585-11e9-81a3-c17831349596.png">

### After:
<img width="879" alt="Screen Shot 2019-10-23 at 11 07 37 AM" src="https://user-images.githubusercontent.com/204564/67371632-58c0da00-f585-11e9-9f0d-9e5d0f83ed58.png">

