### PR TITLE
fix(select): add select option font color

### DIFF
--- a/cypress/integration/select.js
+++ b/cypress/integration/select.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { checkEyes, setup } from '../util';
+
+const test = 'Select';
+
+export function SelectSpec() {
+  describe(test, () => {
+    beforeEach(() => {
+      setup(test);
+    });
+
+    it('default', () => {
+      cy.visit('/selects');
+      // Cypress doesn't let me open the options box so it can be included in the screenshot.
+      // We had an issue with option font color in the dark theme but don't seem to have a way
+      // test it.
+      // cy
+      //   .get('#horizontal-select-basic')
+      //   .first()
+      //   .click();
+      checkEyes('default');
+    });
+  });
+}

--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -10,6 +10,7 @@ import { ColorSpec } from './color';
 import { DatagridSpec } from './datagrid';
 import { ListsSpec } from './lists';
 import { TogglesSpec } from './toggles';
+import { SelectSpec } from './select';
 
 // Organized this way to make one batch for all of the tests in Applitools,
 // otherwise it treats each file as a different batch and makes it hard to
@@ -21,4 +22,5 @@ describe(`Clarity - ${Cypress.env('CLARITY_THEME')}`, () => {
   // DatagridSpec();
   // ListsSpec();
   TogglesSpec();
+  SelectSpec();
 });

--- a/src/clr-angular/utils/_theme.dark.clarity.scss
+++ b/src/clr-angular/utils/_theme.dark.clarity.scss
@@ -432,7 +432,7 @@ $clr-forms-select-multiple-border-color: hsl(0, 0%, 0%);
 //$clr-forms-select-hover-background: rgba(221, 221, 221, 0.5); // CAN WE KEY THIS FROM A KNOWN COLOR
 //$clr-forms-select-caret-hover-color: $clr-color-neutral-600;
 //$clr-forms-select-caret-color: hsl(0, 0%, 60%);
-//$clr-forms-select-option-color: $clr-forms-text-color;
+$clr-forms-select-option-color: hsl(201, 30%, 13%); // Option bg color on chrome/windows is white.
 //$clr-forms-select-multiple-background-color: hsl(0, 0%, 100%);
 //$clr-forms-select-multiple-border-color: $clr-color-neutral-400;
 //$clr-forms-select-multiple-option-color: $clr-forms-text-color;


### PR DESCRIPTION
Adds back a scss var for select option elements. Issue with dark theme on windows chrome.
All browser combos were checked.

NOTE: This PR also adds in the select input visual regression tests

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for visual regression on applitools)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?
chrome on windows with select inputs had the wrong font color for option text color. 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
option text color on chrome+windows has a black font color. 

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
