### PR TITLE
chore: use circle ci for applitools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,21 +4,53 @@ jobs:
   build:
     docker:
       - image: circleci/node:dubnium-browsers
+    environment:
+      NG_CLI_ANALYTICS: ci
     steps:
       - checkout
       - restore_cache:
           keys:
-            - modules{{checksum "package.json"}}
-            - modules
+            - v1-build{{checksum "package.json"}}
       - run: npm install
       - save_cache:
           paths:
             - node_modules
-          key: modules{{checksum "package.json"}}
+          key: v1-build{{checksum "package.json"}}
       - run: npm run build:ci
+  visual:
+    docker:
+      - image: circleci/node:dubnium-browsers
+    environment:
+      NG_CLI_ANALYTICS: 'ci'
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-visual{{checksum "package.json"}}
+      - run: npm install
+      - save_cache:
+          paths:
+            - node_modules
+            - /home/circleci/.cache/Cypress
+          key: v1-visual{{checksum "package.json"}}
+      - run: sh ./scripts/circleci/visual.sh
 # Workflows
 workflows:
   version: 2
   test:
     jobs:
-      - build
+      - build:
+          filters:
+            branches:
+              ignore:
+                - v2
+                - v1
+                - v0.13
+      - visual:
+          context: Applitools
+          filters:
+            branches:
+              ignore:
+                - v2
+                - v1
+                - v0.13

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,14 @@ node_js:
 env:
   global:
   - CXX=g++-4.8
-  - APPLITOOLS_BATCH_ID=`echo ${TRAVIS_PULL_REQUEST_SHA:=$TRAVIS_JOB_ID}`
+#  - APPLITOOLS_BATCH_ID=`echo ${TRAVIS_PULL_REQUEST_SHA:=$TRAVIS_JOB_ID}`
   matrix:
   # - TEST_SUITE='build:ci' # Moved to Circle CI
   - TEST_SUITE='gemini set1'
   - TEST_SUITE='gemini set2'
   - TEST_SUITE='gemini set3'
   - TEST_SUITE='gemini set4'
-  - TEST_SUITE='applitools:ci'
+#  - TEST_SUITE='applitools:ci'
 sudo: required
 dist: trusty
 group: edge

--- a/scripts/circleci/visual.sh
+++ b/scripts/circleci/visual.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+export APPLITOOLS_BATCH_ID=$CIRCLE_SHA1
+npm run applitools


### PR DESCRIPTION
This moves the build job for applitools from Travis to Circle. This should be faster to execute, as well as helping us align our build tooling to one place long term.

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [x] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
