### PR TITLE
chore: remove shape zips from NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "website:news": "node src/website/generate-news",
     "website:prerender": "npm-run-all website:news website:build website:functions website:404",
     "website:preview": "lite-server --core=dist/website/browser",
-    "icons:build": "npm-run-all icons:build:css icons:build:optimize icons:build:web icons:build:package icons:build:svg",
+    "icons:build": "npm-run-all icons:build:css icons:build:optimize icons:build:web icons:build:package",
     "icons:build:web": "webpack --config ./src/clr-icons/webpack.icons.config.js",
     "icons:build:css": "sass --source-map --precision=8 ./src/clr-icons/clr-icons.scss ./dist/clr-icons/clr-icons.css",
     "icons:build:optimize": "csso -i ./dist/clr-icons/clr-icons.css -o ./dist/clr-icons/clr-icons.min.css -s file;",


### PR DESCRIPTION
This change allows smaller icon bundles because we aren't zipping and including all of the raw sets. People should download these from our assets directory instead.

Its unnecessary weight to ship these zipped files (plus they are duplicated in the all-shapes zip and individual shape sets). 

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [x] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
