### PR TITLE
fix(datepicker): prevent date from being deleted when selected on mobile

### DIFF
--- a/src/clr-angular/forms/datepicker/date-input.spec.ts
+++ b/src/clr-angular/forms/datepicker/date-input.spec.ts
@@ -369,6 +369,52 @@ export default function() {
       );
     });
 
+    describe('Mobile Datepicker with Reactive Forms', () => {
+      beforeEach(function() {
+        TestBed.configureTestingModule({
+          imports: [ReactiveFormsModule, ClrFormsModule],
+          declarations: [TestComponentWithReactiveForms],
+        });
+
+        TestBed.overrideComponent(ClrDateContainer, {
+          set: {
+            providers: [{ provide: DatepickerEnabledService, useClass: MockDatepickerEnabledService }],
+          },
+        });
+
+        context = this.create(ClrDateInput, TestComponentWithReactiveForms, [
+          ControlClassService,
+          { provide: NgControlService, useClass: MockNgControlService },
+          NgControl,
+          IfErrorService,
+          IfOpenService,
+          FocusService,
+          DatepickerFocusService,
+          DateNavigationService,
+          LocaleHelperService,
+          DateIOService,
+          ControlIdService,
+          DateFormControlService,
+        ]);
+
+        datepickerFocusService = context.fixture.debugElement.injector.get(DatepickerFocusService);
+        enabledService = <MockDatepickerEnabledService>context.fixture.debugElement
+          .query(By.directive(ClrDateContainer))
+          .injector.get(DatepickerEnabledService);
+      });
+
+      it("date doesn't get deleted when setting it on mobile with a control attached", () => {
+        const input: HTMLInputElement = context.fixture.nativeElement.querySelector('input');
+        enabledService.fakeIsEnabled = false;
+        datepickerFocusService.focusInput(input);
+        context.detectChanges();
+
+        input.value = '1997-06-22';
+        input.dispatchEvent(new Event('change'));
+        expect(input.value).not.toBe('');
+      });
+    });
+
     describe('Datepicker with Reactive Forms', () => {
       let fixture: ComponentFixture<TestComponentWithReactiveForms>;
 

--- a/src/clr-angular/forms/datepicker/date-input.ts
+++ b/src/clr-angular/forms/datepicker/date-input.ts
@@ -200,13 +200,12 @@ export class ClrDateInput extends WrappedFormControl<ClrDateContainer> implement
   private updateInput(date: Date) {
     if (date) {
       const dateString = this.dateIOService.toLocaleDisplayFormatString(date);
-
-      if (this.datepickerHasFormControl() && dateString !== this.control.value) {
-        this.control.control.setValue(dateString);
-      } else if (this.usingNativeDatepicker()) {
+      if (this.usingNativeDatepicker()) {
         // valueAsDate expects UTC, date from input is time-zoned
         date.setMinutes(date.getMinutes() - date.getTimezoneOffset());
         this.renderer.setProperty(this.el.nativeElement, 'valueAsDate', date);
+      } else if (this.datepickerHasFormControl() && dateString !== this.control.value) {
+        this.control.control.setValue(dateString);
       } else {
         this.renderer.setProperty(this.el.nativeElement, 'value', dateString);
       }


### PR DESCRIPTION
Signed-off-by: Martin Brom <martinbrom97@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3961 

## What is the new behavior?

Date can now be selected without being deleted when using a mobile device and an input with a control element.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

EDIT: Now contains a unit test. Should I also add the test for template driven?
I have tested this bug fix manually, but am having issues writing a unit test to reflect this faulty behavior.