### PR TITLE
fix(datepicker): prevent date input from displaying -1 day for specific timezones

### DIFF
--- a/src/clr-angular/forms/datepicker/date-input.spec.ts
+++ b/src/clr-angular/forms/datepicker/date-input.spec.ts
@@ -224,6 +224,17 @@ export default function() {
       });
 
       describe('Date Display', () => {
+        it('displays correct date on mobile in specific timezones', () => {
+          const inputEl: HTMLInputElement = context.testElement.querySelector('input');
+          enabledService.fakeIsEnabled = false;
+          context.detectChanges();
+
+          const userInputDate = '1997-06-22';
+          inputEl.value = userInputDate;
+          inputEl.dispatchEvent(new Event('change'));
+          expect(inputEl.value).toBe(userInputDate);
+        });
+
         it('displays the date on the input when the selectedDay is updated', () => {
           dateNavigationService.notifySelectedDayChanged(new DayModel(2015, 1, 1));
           expect(context.clarityElement.value).toBe('02/01/2015');

--- a/src/clr-angular/forms/datepicker/date-input.ts
+++ b/src/clr-angular/forms/datepicker/date-input.ts
@@ -204,6 +204,8 @@ export class ClrDateInput extends WrappedFormControl<ClrDateContainer> implement
       if (this.datepickerHasFormControl() && dateString !== this.control.value) {
         this.control.control.setValue(dateString);
       } else if (this.usingNativeDatepicker()) {
+        // valueAsDate expects UTC, date from input is time-zoned
+        date.setMinutes(date.getMinutes() - date.getTimezoneOffset());
         this.renderer.setProperty(this.el.nativeElement, 'valueAsDate', date);
       } else {
         this.renderer.setProperty(this.el.nativeElement, 'value', dateString);


### PR DESCRIPTION
Signed-off-by: Martin Brom <martinbrom97@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3224 

## What is the new behavior?

Datepicker now displays the correct day when selecting it on mobile devices in timezones greater than GMT+0.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Unit test without the fix only fails in time zones greater than GMT+0. To have the test without the fix failing for all time zones, it would be necessary to somehow mock the test browser time zone.