### PR TITLE
docs: add text for screen reader support to get started page

### DIFF
--- a/src/website/src/app/documentation/get-started/get-started.component.html
+++ b/src/website/src/app/documentation/get-started/get-started.component.html
@@ -157,13 +157,30 @@ ng update @clr/angular@next'"
     <p class="bump-down"><img src="assets/images/get-started/device_support.png" alt="Device and Browser Support"
                               class="hidden-sm-down img-fluid"></p>
     <ul class="hidden-md-up">
-        <li>Internet Explorer 10 &amp; 11</li>
+        <li>Internet Explorer 11</li>
         <li>MS Edge</li>
         <li>Latest versions of Chrome, Safari, and Firefox</li>
     </ul>
     <p>
         <em>* - Note that Clarity only supports the latest two versions of the listed browsers, with the exception of
             Internet Explorer.</em>
+    </p>
+    <h2>Screen Reader Support</h2>
+    <p class="bump-down">
+        Clarity is tested across several sets of screen reader and browser combinations against the WCAG 2.1 spec.
+        The testing has identified the two combinations that enable us to provide support when fixing
+        issues related to the various assistive technologies available to users. The following are the primary
+        combinations that we focus on when addressing issues on the Windows and macOS platforms:
+    </p>
+    <ul>
+        <li>NVDA + Firefox (Windows)</li>
+        <li>VoiceOver + Safari (Apple)</li>
+    </ul>
+    <p>
+        <em>
+            The latest version of both screen reader and browser is used when testing issues and WCAG 2.1
+            compliance.
+        </em>
     </p>
     <h2 id="contribute_guidelines">Contributing to Clarity</h2>
     <p>The Clarity team welcomes contributions from the community. See our <a


### PR DESCRIPTION
Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [x] Other... Please describe:

## What is the current behavior?
No description of the browser+ScreenReader that is supported by Clarity.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
description of the browser+ScreenReader that is supported by Clarity to the get started page (in v3 docs only)
## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
