### PR TITLE
fix: datagrid clrDgFilterOpenChange was not fired

### DIFF
--- a/src/clr-angular/data/datagrid/datagrid-filter.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-filter.spec.ts
@@ -154,6 +154,15 @@ export default function(): void {
         context.detectChanges();
         expect(context.clarityDirective.open).toBe(false);
       });
+
+      it('should call clrDgFilterOpenChange output when open changed', function() {
+        spyOn(context.fixture.componentInstance, 'clrDgFilterOpenChangeFn');
+        const toggle = context.clarityElement.querySelector('.datagrid-filter-toggle');
+        toggle.click();
+        expect(context.fixture.componentInstance.clrDgFilterOpenChangeFn).toHaveBeenCalledWith(true);
+        toggle.click();
+        expect(context.fixture.componentInstance.clrDgFilterOpenChangeFn).toHaveBeenCalledWith(true);
+      });
     });
   });
 }
@@ -172,11 +181,15 @@ class TestFilter implements ClrDatagridFilterInterface<number> {
   changes = new Subject<boolean>();
 }
 
-@Component({ template: `<clr-dg-filter [clrDgFilter]="filter" [clrDgFilterOpen]="open">Hello world</clr-dg-filter>` })
+@Component({
+  template: `<clr-dg-filter [clrDgFilter]="filter" [clrDgFilterOpen]="open" (clrDgFilterOpenChange)="clrDgFilterOpenChangeFn($event)">Hello world</clr-dg-filter>`,
+})
 class FullTest {
   @ViewChild(CustomFilter, { static: false })
   customFilter: CustomFilter;
 
   filter: ClrDatagridFilterInterface<number>;
   open: boolean = false;
+
+  clrDgFilterOpenChangeFn = ($event: boolean) => {};
 }

--- a/src/clr-angular/data/datagrid/datagrid-filter.ts
+++ b/src/clr-angular/data/datagrid/datagrid-filter.ts
@@ -45,7 +45,7 @@ import { isPlatformBrowser } from '@angular/common';
               #anchor
               clrPopoverAnchor
               clrPopoverOpenCloseButton
-              [class.datagrid-filter-open]="open" 
+              [class.datagrid-filter-open]="open"
               [class.datagrid-filtered]="active">
           <clr-icon [attr.shape]="active ? 'filter-grid-circle': 'filter-grid'" class="is-solid"></clr-icon>
       </button>
@@ -63,7 +63,6 @@ import { isPlatformBrowser } from '@angular/common';
           <ng-content></ng-content>
       </div>
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ClrDatagridFilter<T = any> extends DatagridFilterRegistrar<T, ClrDatagridFilterInterface<T>>
   implements CustomFilter, OnDestroy {
@@ -94,19 +93,22 @@ export class ClrDatagridFilter<T = any> extends DatagridFilterRegistrar<T, ClrDa
     content: ClrAlignment.END,
   };
 
+  private _open: boolean = false;
   public get open() {
-    return this.smartToggleService.open;
+    return this._open;
   }
 
   @Input('clrDgFilterOpen')
   public set open(open: boolean) {
-    const boolOpen = !!open;
-    if (boolOpen !== this.open) {
-      this.smartToggleService.open = !!open;
-      this.openChange.emit(!!open);
-      if (!boolOpen && isPlatformBrowser(this.platformId)) {
+    open = !!open;
+    if (this.open !== open) {
+      this.smartToggleService.open = open;
+      this.openChange.emit(open);
+      if (!open && isPlatformBrowser(this.platformId)) {
         this.anchor.nativeElement.focus();
       }
+      // keep track of the state
+      this._open = open;
     }
   }
 

--- a/src/dev/src/app/datagrid/filtering/filtering.html
+++ b/src/dev/src/app/datagrid/filtering/filtering.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -49,7 +49,7 @@
   <clr-dg-column>Pokemon</clr-dg-column>
   <clr-dg-column>
     Favorite color
-    <clr-dg-filter [clrDgFilter]="colorFilter">
+    <clr-dg-filter (clrDgFilterOpenChange)="dgFilterChange($event)" [clrDgFilter]="colorFilter">
       <clr-datagrid-color-filter-demo #colorFilter class="color-filter">
       </clr-datagrid-color-filter-demo>
     </clr-dg-filter>

--- a/src/dev/src/app/datagrid/filtering/filtering.ts
+++ b/src/dev/src/app/datagrid/filtering/filtering.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -21,5 +21,9 @@ export class DatagridFilteringDemo {
     inventory.size = 10;
     inventory.reset();
     this.users = inventory.all;
+  }
+
+  dgFilterChange($event: boolean) {
+    console.log('clrDgFilterOpenChange is fired', $event);
   }
 }


### PR DESCRIPTION
`clrDgFilterOpenChange` was not called when `open` is toggle between `true|false`

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3804 

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This change has to be added to `v2` branch as well. The original bug is from there.

Close #3804 