### PR TITLE
fix(datagrid): focus trap no longer steals focus when going outside

### DIFF
--- a/src/clr-angular/data/datagrid/datagrid-detail.ts
+++ b/src/clr-angular/data/datagrid/datagrid-detail.ts
@@ -16,7 +16,7 @@ import { ClrDatagridDetailHeader } from './datagrid-detail-header';
   // We put the *ngIf on the clrFocusTrap so it doesn't always exist on the page
   // have to test for presence of header for aria-describedby because it was causing unit tests to crash
   template: `
-    <div clrFocusTrap class="datagrid-detail-pane-content" *ngIf="detailService.isOpen" role="dialog"
+    <div [clrFocusTrap]="{strict: false}" class="datagrid-detail-pane-content" *ngIf="detailService.isOpen" role="dialog"
          [id]="detailService.id" aria-modal="true" [attr.aria-describedby]="header ? header.titleId : ''">
     <div class="clr-sr-only">{{commonStrings.keys.detailPaneStart}}</div>
       <ng-content></ng-content>


### PR DESCRIPTION
The focus trap is too greedy for the detail pane use case, where we only want to trap focus for keyboard users. This adds a new local option that puts the rebound elements before and after the host and focus traps only when tabbing through the content. If you use a mouse to move focus outside of the Datagrid, it will disable the focus trap entirely.

fixes #3999

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: fixes #3999

## What is the new behavior?

The focus trap now has an optional 'local' mode where it only traps focus while the focus is cycling internally, but once focus is moved outside of the focus trap it disabled the trap. 

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
