### PR TITLE
chore: enable more applitools tests

### DIFF
--- a/cypress/integration/accordion.js
+++ b/cypress/integration/accordion.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { checkEyes, setup } from '../util';
+
+const test = 'Accordion';
+
+export function AccordionSpec() {
+  describe(test, () => {
+    beforeEach(() => {
+      setup(test);
+    });
+
+    it('default', () => {
+      cy.visit('/accordion');
+      checkEyes('default');
+    });
+  });
+}

--- a/cypress/integration/badge.js
+++ b/cypress/integration/badge.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { checkEyes, setup } from '../util';
+
+const test = 'Badge';
+
+export function BadgeSpec() {
+  describe(test, () => {
+    beforeEach(() => {
+      setup(test);
+    });
+
+    it('color-options', () => {
+      cy.visit('/badges/color-options');
+      checkEyes('color-options');
+    });
+
+    it('status', () => {
+      cy.visit('/badges/status');
+      checkEyes('status');
+    });
+  });
+}

--- a/cypress/integration/checkbox.js
+++ b/cypress/integration/checkbox.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { checkEyes, setup } from '../util';
+
+const test = 'Checkbox';
+
+export function CheckboxSpec() {
+  describe(test, () => {
+    beforeEach(() => {
+      setup(test);
+    });
+
+    it('default', () => {
+      cy.visit('/checkboxes');
+      checkEyes('default');
+    });
+  });
+}

--- a/cypress/integration/image.js
+++ b/cypress/integration/image.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { checkEyes, setup } from '../util';
+
+const test = 'Image';
+
+export function ImageSpec() {
+  describe(test, () => {
+    beforeEach(() => {
+      setup(test);
+    });
+
+    it('default', () => {
+      cy.visit('/image');
+      checkEyes('default');
+    });
+  });
+}

--- a/cypress/integration/input.js
+++ b/cypress/integration/input.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { checkEyes, setup } from '../util';
+
+const test = 'Input';
+
+export function InputSpec() {
+  describe(test, () => {
+    beforeEach(() => {
+      setup(test);
+    });
+
+    it('default', () => {
+      cy.visit('/input');
+      checkEyes('default');
+    });
+  });
+}

--- a/cypress/integration/login.js
+++ b/cypress/integration/login.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { checkEyes, setup } from '../util';
+
+const test = 'Login';
+
+export function LoginSpec() {
+  describe(test, () => {
+    beforeEach(() => {
+      setup(test);
+    });
+
+    it('default', () => {
+      cy.visit('/login');
+      checkEyes('default');
+    });
+  });
+}

--- a/cypress/integration/password.js
+++ b/cypress/integration/password.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { checkEyes, setup } from '../util';
+
+const test = 'Password';
+
+export function PasswordSpec() {
+  describe(test, () => {
+    beforeEach(() => {
+      setup(test);
+    });
+
+    it('default', () => {
+      cy.visit('/password');
+      checkEyes('default');
+    });
+  });
+}

--- a/cypress/integration/radio.js
+++ b/cypress/integration/radio.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { checkEyes, setup } from '../util';
+
+const test = 'Radio';
+
+export function RadioSpec() {
+  describe(test, () => {
+    beforeEach(() => {
+      setup(test);
+    });
+
+    it('default', () => {
+      cy.visit('/radio');
+      checkEyes('default');
+    });
+  });
+}

--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -4,23 +4,68 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
+import { AccordionSpec } from './accordion';
+import { BadgeSpec } from './badge';
 import { ButtonSpecs } from './buttons';
-import { CheckboxesSpec } from './checkboxes';
+import { CheckboxSpec } from './checkbox';
 import { ColorSpec } from './color';
 import { DatagridSpec } from './datagrid';
+import { ImageSpec } from './image';
+import { InputSpec } from './input';
 import { ListsSpec } from './lists';
-import { TogglesSpec } from './toggles';
+import { LoginSpec } from './login';
+import { PasswordSpec } from './password';
+import { RadioSpec } from './radio';
 import { SelectSpec } from './select';
+import { SpinnerSpec } from './spinner';
+import { StepperSpec } from './stepper';
+import { TabsSpec } from './tabs';
+import { TextareaSpec } from './textarea';
+import { TimelineSpec } from './timeline';
+import { ToggleSpec } from './toggle';
 
 // Organized this way to make one batch for all of the tests in Applitools,
 // otherwise it treats each file as a different batch and makes it hard to
 // see a single run as one unit.
 describe(`Clarity - ${Cypress.env('CLARITY_THEME')}`, () => {
-  // ButtonSpecs();
-  CheckboxesSpec();
+  AccordionSpec();
+  // AlertSpec(); // Need to simplify tests
+  // BadgeSpec(); // Need to simplify tests
+  // ButtonSpec(); // Need to simplify tests
+  // ButtonGroupSpec(); // Need to simplify tests
+  // CardSpec(); // Need to simplify tests
+  CheckboxSpec();
   ColorSpec();
-  // DatagridSpec();
-  // ListsSpec();
-  TogglesSpec();
+  // DatagridSpec(); // Tests still have changes between runs
+  // DatepickerSpec(); // Need to simplify tests
+  // DropdownSpec(); // Need to simplify tests
+  // FormSpec(); // Need to simplify tests
+  // GridSpec(); // Need to simplify tests
+  // IconSpec(); // Need to simplify tests
+  ImageSpec();
+  InputSpec();
+  // LabelSpec(); // Need to simplify tests
+  // LayoutSpec(); // Need to simplify tests
+  // ListSpec(); // Need to simplify tests
+  LoginSpec();
+  // ModalSpec(); // Need to simplify tests
+  // NavigationSpec(); // Need to simplify tests
+  PasswordSpec();
+  // ProgressBarSpec(); // Need to simplify tests
+  RadioSpec();
   SelectSpec();
+  // SignpostSpec(); // Need to simplify tests
+  // SpinnerSpec(); // Need to simplify tests
+  // StackViewSpec(); // Need to simplify tests
+  StepperSpec();
+  // TableSpec(); // Need to simplify tests
+  // TabsSpec(); // Need to simplify tests
+  TextareaSpec();
+  TimelineSpec();
+  ToggleSpec();
+  // TooltipSpec(); // Need to simplify tests
+  // TreeViewSpec(); // Need to simplify tests
+  // TypographySpec(); // Need to simplify tests
+  // VerticalNavSpec(); // Need to simplify tests
+  // WizardSpec(); // Need to simplify tests
 });

--- a/cypress/integration/spinner.js
+++ b/cypress/integration/spinner.js
@@ -6,17 +6,22 @@
 
 import { checkEyes, setup } from '../util';
 
-const test = 'Checkboxes';
+const test = 'Spinner';
 
-export function CheckboxesSpec() {
+export function SpinnerSpec() {
   describe(test, () => {
     beforeEach(() => {
       setup(test);
     });
 
-    it('default', () => {
-      cy.visit('/checkboxes');
-      checkEyes('default');
+    it('types', () => {
+      cy.visit('/spinners/spinner-types');
+      checkEyes('types');
+    });
+
+    it('sizes', () => {
+      cy.visit('/spinners/spinner-sizes');
+      checkEyes('sizes');
     });
   });
 }

--- a/cypress/integration/stepper.js
+++ b/cypress/integration/stepper.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { checkEyes, setup } from '../util';
+
+const test = 'Stepper';
+
+export function StepperSpec() {
+  describe(test, () => {
+    beforeEach(() => {
+      setup(test);
+    });
+
+    it('default', () => {
+      cy.visit('/stepper');
+      checkEyes('default');
+    });
+  });
+}

--- a/cypress/integration/tabs.js
+++ b/cypress/integration/tabs.js
@@ -6,17 +6,22 @@
 
 import { checkEyes, setup } from '../util';
 
-const test = 'Toggles';
+const test = 'Tabs';
 
-export function TogglesSpec() {
+export function TabsSpec() {
   describe(test, () => {
     beforeEach(() => {
       setup(test);
     });
 
-    it('default', () => {
-      cy.visit('/toggles');
-      checkEyes('default');
+    it('static', () => {
+      cy.visit('/tabs/static');
+      checkEyes('static');
+    });
+
+    it('angular', () => {
+      cy.visit('/tabs/angular');
+      checkEyes('angular');
     });
   });
 }

--- a/cypress/integration/textarea.js
+++ b/cypress/integration/textarea.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { checkEyes, setup } from '../util';
+
+const test = 'Textarea';
+
+export function TextareaSpec() {
+  describe(test, () => {
+    beforeEach(() => {
+      setup(test);
+    });
+
+    it('default', () => {
+      cy.visit('/textarea');
+      checkEyes('default');
+    });
+  });
+}

--- a/cypress/integration/timeline.js
+++ b/cypress/integration/timeline.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { checkEyes, setup } from '../util';
+
+const test = 'Timeline';
+
+export function TimelineSpec() {
+  describe(test, () => {
+    beforeEach(() => {
+      setup(test);
+    });
+
+    it('default', () => {
+      cy.visit('/timeline');
+      checkEyes('default');
+    });
+  });
+}

--- a/cypress/integration/toggle.js
+++ b/cypress/integration/toggle.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { checkEyes, setup } from '../util';
+
+const test = 'Toggle';
+
+export function ToggleSpec() {
+  describe(test, () => {
+    beforeEach(() => {
+      setup(test);
+    });
+
+    it('default', () => {
+      cy.visit('/toggles');
+      checkEyes('default');
+    });
+  });
+}

--- a/gemini/tests/set1/accordion.js
+++ b/gemini/tests/set1/accordion.js
@@ -1,6 +1,7 @@
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 
+// @TODO COVERED BY APPLITOOLS, REMOVE
 gemini.suite('accordion', child => {
   child
     .setUrl('/accordion')

--- a/gemini/tests/set1/badges.js
+++ b/gemini/tests/set1/badges.js
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 var WAIT_TIME = 5000;
 
+// @TODO COVERED BY APPLITOOLS, REMOVE
 gemini.suite('badges', child => {
   gemini.suite('color-options', child => {
     child

--- a/gemini/tests/set1/checkboxes.js
+++ b/gemini/tests/set1/checkboxes.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -7,6 +7,7 @@
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 
+// @TODO COVERED BY APPLITOOLS, REMOVE
 gemini.suite('checkboxes', child => {
   child
     .setUrl('/checkboxes')

--- a/gemini/tests/set1/color.js
+++ b/gemini/tests/set1/color.js
@@ -7,6 +7,7 @@
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 
+// @TODO COVERED BY APPLITOOLS, REMOVE
 gemini.suite('color', child => {
   gemini.suite('color-palette', child => {
     child

--- a/gemini/tests/set3/images.js
+++ b/gemini/tests/set3/images.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -7,6 +7,7 @@
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 
+// @TODO COVERED BY APPLITOOLS, REMOVE
 gemini.suite('images', child => {
   child
     .setUrl('/images')

--- a/gemini/tests/set3/input.js
+++ b/gemini/tests/set3/input.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -7,6 +7,7 @@
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 
+// @TODO COVERED BY APPLITOOLS, REMOVE
 gemini.suite('input', child => {
   child
     .setUrl('/input')

--- a/gemini/tests/set3/login.js
+++ b/gemini/tests/set3/login.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -7,6 +7,7 @@
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 
+// @TODO COVERED BY APPLITOOLS, REMOVE
 gemini.suite('login', child => {
   gemini.suite('layout', child => {
     child

--- a/gemini/tests/set3/password.js
+++ b/gemini/tests/set3/password.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -7,6 +7,7 @@
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 
+// @TODO COVERED BY APPLITOOLS, REMOVE
 gemini.suite('password', child => {
   child
     .setUrl('/password')

--- a/gemini/tests/set3/radios.js
+++ b/gemini/tests/set3/radios.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -7,6 +7,7 @@
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 
+// @TODO COVERED BY APPLITOOLS, REMOVE
 gemini.suite('radios', child => {
   child
     .setUrl('/radios')

--- a/gemini/tests/set3/selects.js
+++ b/gemini/tests/set3/selects.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -7,6 +7,7 @@
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 
+// @TODO COVERED BY APPLITOOLS, REMOVE
 gemini.suite('selects', child => {
   child
     .setUrl('/selects')

--- a/gemini/tests/set3/spinners.js
+++ b/gemini/tests/set3/spinners.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -7,6 +7,7 @@
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 
+// @TODO COVERED BY APPLITOOLS, REMOVE
 gemini.suite('spinners', child => {
   // gemini.suite('spinner-types', (child) => {
   //     child.setUrl('/spinners/spinner-types')

--- a/gemini/tests/set4/stepper.js
+++ b/gemini/tests/set4/stepper.js
@@ -1,6 +1,7 @@
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 
+// @TODO COVERED BY APPLITOOLS, REMOVE
 gemini.suite('stepper', child => {
   child
     .setUrl('/stepper')

--- a/gemini/tests/set4/tabs.js
+++ b/gemini/tests/set4/tabs.js
@@ -7,6 +7,7 @@
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 
+// @TODO COVERED BY APPLITOOLS, REMOVE
 gemini.suite('tabs', child => {
   gemini.suite('static', child => {
     child

--- a/gemini/tests/set4/textarea.js
+++ b/gemini/tests/set4/textarea.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -7,6 +7,7 @@
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 
+// @TODO COVERED BY APPLITOOLS, REMOVE
 gemini.suite('textarea', child => {
   child
     .setUrl('/textarea')

--- a/gemini/tests/set4/timeline.js
+++ b/gemini/tests/set4/timeline.js
@@ -7,6 +7,7 @@
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 
+// @TODO COVERED BY APPLITOOLS, REMOVE
 gemini.suite('timeline', child => {
   child
     .setUrl('/timeline')

--- a/gemini/tests/set4/toggles.js
+++ b/gemini/tests/set4/toggles.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -7,6 +7,7 @@
 var WAIT_TIME = 5000;
 var WAIT_LOAD_TIME = 1000;
 
+// @TODO COVERED BY APPLITOOLS, REMOVE
 gemini.suite('toggles', child => {
   child
     .setUrl('/toggles')


### PR DESCRIPTION
This enables the easy demos that don't require a lot of cleanup to start using Applitools for testing. Approximately half of the gemini tests are now in Applitools.

After this, we'll have to do some rework. Buttons for example are over a dozen pages with very little on them, we should consolidate.

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [x] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
