### PR TITLE
fix(date-picker): prevent calling for focus, when date-picker is closed

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -549,7 +549,7 @@ export interface ClrDatagridStringFilterInterface<T> {
 export declare class ClrDataModule {
 }
 
-export declare class ClrDateContainer implements DynamicWrapper, OnDestroy {
+export declare class ClrDateContainer implements DynamicWrapper, OnDestroy, AfterViewInit {
     _dynamic: boolean;
     actionButton: ElementRef;
     commonStrings: ClrCommonStringsService;
@@ -561,8 +561,8 @@ export declare class ClrDateContainer implements DynamicWrapper, OnDestroy {
     position: PopoverPosition;
     constructor(_toggleService: ClrPopoverToggleService, _dateNavigationService: DateNavigationService, _datepickerEnabledService: DatepickerEnabledService, dateFormControlService: DateFormControlService, commonStrings: ClrCommonStringsService, ifErrorService: IfErrorService, focusService: FocusService, controlClassService: ControlClassService, layoutService: LayoutService, ngControlService: NgControlService);
     addGrid(): boolean;
-    close(): void;
     controlClass(): string;
+    ngAfterViewInit(): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
     toggleDatepicker(event: MouseEvent): void;

--- a/src/clr-angular/forms/datepicker/date-container.spec.ts
+++ b/src/clr-angular/forms/datepicker/date-container.spec.ts
@@ -73,18 +73,25 @@ export default function() {
         context.detectChanges();
       });
 
-      it('returns focus to the toggle button when closed with the escape key', () => {
+      it('should returns focus to calendar when we close it', () => {
         const actionButton: HTMLButtonElement = context.clarityElement.querySelector('.clr-input-group-icon-action');
         const actionButtonSpy = spyOn(actionButton, 'focus');
-        expect(actionButtonSpy.calls.count()).toBe(0);
-        actionButton.click();
+        toggleService.open = true;
         context.detectChanges();
+        toggleService.open = false;
+        context.detectChanges();
+        expect(actionButtonSpy.calls.count()).toBe(1);
+      });
+
+      it('should not call focus when date-picker is not visible', () => {
+        const actionButton: HTMLButtonElement = context.clarityElement.querySelector('.clr-input-group-icon-action');
+        const actionButtonSpy = spyOn(actionButton, 'focus');
         const event = new KeyboardEvent('keyup', {
           key: 'Escape',
         });
         document.body.dispatchEvent(event);
         context.detectChanges();
-        expect(actionButtonSpy.calls.count()).toBe(1);
+        expect(actionButtonSpy.calls.count()).toBe(0);
       });
 
       it('applies the clr-form-control class', () => {

--- a/src/clr-angular/forms/datepicker/date-container.ts
+++ b/src/clr-angular/forms/datepicker/date-container.ts
@@ -8,7 +8,7 @@ import {
   OnDestroy,
   Optional,
   ContentChild,
-  HostListener,
+  AfterViewInit,
   ViewChild,
   ElementRef,
   Input,
@@ -81,7 +81,7 @@ import { PopoverPosition } from '../../popover/common/popover-positions';
     '[class.clr-row]': 'addGrid()',
   },
 })
-export class ClrDateContainer implements DynamicWrapper, OnDestroy {
+export class ClrDateContainer implements DynamicWrapper, OnDestroy, AfterViewInit {
   _dynamic: boolean = false;
   invalid = false;
   focus = false;
@@ -111,13 +111,6 @@ export class ClrDateContainer implements DynamicWrapper, OnDestroy {
     private ngControlService: NgControlService
   ) {
     this.subscriptions.push(
-      this._toggleService.openChange.subscribe(open => {
-        if (open) {
-          this.initializeCalendar();
-        }
-      })
-    );
-    this.subscriptions.push(
       this.focusService.focusChange.subscribe(state => {
         this.focus = state;
       })
@@ -129,15 +122,22 @@ export class ClrDateContainer implements DynamicWrapper, OnDestroy {
     );
   }
 
-  @HostListener('body:keyup.escape')
-  close(): void {
-    this.toggleButton.nativeElement.focus();
-  }
-
   ngOnInit() {
     this.subscriptions.push(
       this.ifErrorService.statusChanges.subscribe(invalid => {
         this.invalid = invalid;
+      })
+    );
+  }
+
+  ngAfterViewInit(): void {
+    this.subscriptions.push(
+      this._toggleService.openChange.subscribe(open => {
+        if (open) {
+          this.initializeCalendar();
+        } else {
+          this.toggleButton.nativeElement.focus();
+        }
       })
     );
   }


### PR DESCRIPTION
Prevent from calling focus on date picker when the calendar is not open (depend on ifOpenService)

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4060 

## What is the new behavior?

track ifOpenService state and prevent requesting for focus.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Close #4060