### PR TITLE
docs: Fix node imports for manual library installation on Getting Started page

### DIFF
--- a/src/website/src/app/documentation/get-started/get-started.component.ts
+++ b/src/website/src/app/documentation/get-started/get-started.component.ts
@@ -36,14 +36,14 @@ const HTML_IMPORTS = `
 
 const NODE_IMPORTS = `
 "styles": [
-      "../node_modules/@clr/icons/clr-icons.min.css",
-      "../node_modules/@clr/ui/clr-ui.min.css",
+      "node_modules/@clr/icons/clr-icons.min.css",
+      "node_modules/@clr/ui/clr-ui.min.css",
       ... any other styles
 ],
 "scripts": [
   ... any existing scripts
-  "../node_modules/@webcomponents/custom-elements/custom-elements.min.js",
-  "../node_modules/@clr/icons/clr-icons.min.js"
+  "node_modules/@webcomponents/custom-elements/custom-elements.min.js",
+  "node_modules/@clr/icons/clr-icons.min.js"
 ]
 `;
 


### PR DESCRIPTION
PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

Corrects the node imports section when following the manual library installation steps on the Getting Started page to match what is is done when performing the installation with the Angular CLI.

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

The wrong paths are listed for the node module imports section.

Issue Number: #4047

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
