### PR TITLE
core: fix badge and tag to re-use same custom properties for its variations

### DIFF
--- a/docs/core/cwc-badge.md
+++ b/docs/core/cwc-badge.md
@@ -25,25 +25,7 @@ import '@clr/core/badge';
 
 ## CSS Custom Properties
 
-| Property                          |
-|-----------------------------------|
-| `--clr-badge-blue-bg-color`       |
-| `--clr-badge-blue-color`          |
-| `--clr-badge-danger-bg-color`     |
-| `--clr-badge-danger-color`        |
-| `--clr-badge-font-color-dark`     |
-| `--clr-badge-font-color-light`    |
-| `--clr-badge-gray-bg-color`       |
-| `--clr-badge-gray-color`          |
-| `--clr-badge-info-bg-color`       |
-| `--clr-badge-info-color`          |
-| `--clr-badge-light-blue-bg-color` |
-| `--clr-badge-light-blue-color`    |
-| `--clr-badge-orange-bg-color`     |
-| `--clr-badge-orange-color`        |
-| `--clr-badge-purple-bg-color`     |
-| `--clr-badge-purple-color`        |
-| `--clr-badge-success-bg-color`    |
-| `--clr-badge-success-color`       |
-| `--clr-badge-warning-bg-color`    |
-| `--clr-badge-warning-color`       |
+| Property                       |
+|--------------------------------|
+| `--clr-badge-background-color` |
+| `--clr-badge-color`            |

--- a/docs/core/cwc-tag.md
+++ b/docs/core/cwc-tag.md
@@ -25,35 +25,12 @@ import '@clr/core/tag';
 
 ## CSS Custom Properties
 
-| Property                         |
-|----------------------------------|
-| `--clr-tag-bg-hover-color`       |
-| `--clr-tag-blue-bg-color`        |
-| `--clr-tag-blue-color`           |
-| `--clr-tag-border-radius`        |
-| `--clr-tag-danger-bg-color`      |
-| `--clr-tag-danger-border-color`  |
-| `--clr-tag-danger-font-color`    |
-| `--clr-tag-default-border-color` |
-| `--clr-tag-font-color-dark`      |
-| `--clr-tag-font-color-light`     |
-| `--clr-tag-font-size`            |
-| `--clr-tag-font-weight`          |
-| `--clr-tag-gray-bg-color`        |
-| `--clr-tag-gray-color`           |
-| `--clr-tag-info-bg-color`        |
-| `--clr-tag-info-border-color`    |
-| `--clr-tag-info-font-color`      |
-| `--clr-tag-letter-spacing`       |
-| `--clr-tag-light-blue-bg-color`  |
-| `--clr-tag-light-blue-color`     |
-| `--clr-tag-orange-bg-color`      |
-| `--clr-tag-orange-color`         |
-| `--clr-tag-purple-bg-color`      |
-| `--clr-tag-purple-color`         |
-| `--clr-tag-success-bg-color`     |
-| `--clr-tag-success-border-color` |
-| `--clr-tag-success-font-color`   |
-| `--clr-tag-warning-bg-color`     |
-| `--clr-tag-warning-border-color` |
-| `--clr-tag-warning-font-color`   |
+| Property                   |
+|----------------------------|
+| `--clr-tag-bg-color`       |
+| `--clr-tag-bg-hover-color` |
+| `--clr-tag-border-color`   |
+| `--clr-tag-border-radius`  |
+| `--clr-tag-font-size`      |
+| `--clr-tag-font-weight`    |
+| `--clr-tag-letter-spacing` |

--- a/src/clr-angular/emphasis/_properties.label.scss
+++ b/src/clr-angular/emphasis/_properties.label.scss
@@ -24,6 +24,7 @@
       // Usage: ./_labels.clarity.scss
       --clr-label-bg-hover-color: var(--clr-color-neutral-200);
 
+      // START: deprecated for removal in 4.0
       --clr-label-gray-bg-color: var(--clr-color-neutral-600);
       --clr-label-gray-color: var(--clr-label-font-color-light);
 
@@ -54,6 +55,7 @@
       --clr-label-danger-bg-color: var(--clr-color-danger-100);
       --clr-label-danger-font-color: var(--clr-color-danger-900);
       --clr-label-danger-border-color: var(--clr-color-danger-200);
+      // END: deprecated for removal in 4.0
     }
   }
 }

--- a/src/clr-core/badge/_properties.scss
+++ b/src/clr-core/badge/_properties.scss
@@ -4,10 +4,12 @@
 
 @include exports('badge.properties') {
   @if $clr-use-custom-properties == true {
-    :root {
-      --clr-badge-font-color-light: var(--clr-color-neutral-0);
-      --clr-badge-font-color-dark: var(--clr-color-neutral-1000);
+    :root,
+    :host {
+      --clr-badge-background-color: var(--clr-color-neutral-600);
+      --clr-badge-color: var(--clr-color-on-neutral-600);
 
+      // START: deprecated for removal in 4.0
       --clr-badge-info-bg-color: var(--clr-color-action-600);
       --clr-badge-info-color: var(--clr-color-neutral-0);
       --clr-badge-success-bg-color: var(--clr-color-success-700);
@@ -27,6 +29,7 @@
       --clr-badge-orange-color: var(--clr-badge-font-color-dark);
       --clr-badge-light-blue-bg-color: var(--clr-color-action-300);
       --clr-badge-light-blue-color: var(--clr-badge-font-color-dark);
+      // END: deprecated for removal in 4.0
     }
   }
 }

--- a/src/clr-core/badge/badge.element.scss
+++ b/src/clr-core/badge/badge.element.scss
@@ -1,177 +1,5 @@
 @import './../styles/utils/core-component';
-@import './variables';
 @import './properties';
-
-@function getBadgeCssVarName($type: gray, $prop: color) {
-  @return #{'clr-badge-' + $type + '-' + $prop};
-}
-
-@function getBadgeColor($type: gray, $property: color, $var-type: 'sass-var') {
-  @if $var-type == 'css-var' {
-    @return getBadgeCssVarName($type, $property);
-  }
-
-  @if $type == gray {
-    @return lookupGrayBadgeColor($property);
-  }
-
-  @if $type == purple {
-    @return lookupPurpleBadgeColor($property);
-  }
-
-  @if $type == blue {
-    @return lookupBlueBadgeColor($property);
-  }
-
-  @if $type == orange {
-    @return lookupOrangeBadgeColor($property);
-  }
-
-  @if $type == light-blue {
-    @return lookupLightBlueBadgeColor($property);
-  }
-
-  @if $type == success {
-    @return lookupSuccessBadgeColor($property);
-  }
-
-  @if $type == warning {
-    @return lookupWarningBadgeColor($property);
-  }
-
-  @if $type == danger {
-    @return lookupDangerBadgeColor($property);
-  }
-
-  @if $type == info {
-    @return lookupInfoBadgeColor($property);
-  }
-
-  @return null;
-}
-
-@function lookupGrayBadgeColor($property: color) {
-  @if $property == color {
-    @return $clr-badge-gray-color;
-  }
-
-  @if $property == bg-color {
-    @return $clr-badge-gray-bg-color;
-  }
-
-  @return null;
-}
-
-@function lookupPurpleBadgeColor($property: color) {
-  @if $property == color {
-    @return $clr-badge-purple-color;
-  }
-
-  @if $property == bg-color {
-    @return $clr-badge-purple-bg-color;
-  }
-
-  @return null;
-}
-
-@function lookupBlueBadgeColor($property: color) {
-  @if $property == color {
-    @return $clr-badge-blue-color;
-  }
-
-  @if $property == bg-color {
-    @return $clr-badge-blue-bg-color;
-  }
-
-  @return null;
-}
-
-@function lookupOrangeBadgeColor($property: color) {
-  @if $property == color {
-    @return $clr-badge-orange-color;
-  }
-
-  @if $property == bg-color {
-    @return $clr-badge-orange-bg-color;
-  }
-
-  @return null;
-}
-
-@function lookupLightBlueBadgeColor($property: color) {
-  @if $property == color {
-    @return $clr-badge-light-blue-color;
-  }
-
-  @if $property == bg-color {
-    @return $clr-badge-light-blue-bg-color;
-  }
-
-  @return null;
-}
-
-@function lookupInfoBadgeColor($property: color) {
-  @if $property == color {
-    @return $clr-badge-info-color;
-  }
-
-  @if $property == bg-color {
-    @return $clr-badge-info-bg-color;
-  }
-
-  @return null;
-}
-
-@function lookupSuccessBadgeColor($property: color) {
-  @if $property == color {
-    @return $clr-badge-success-color;
-  }
-
-  @if $property == bg-color {
-    @return $clr-badge-success-bg-color;
-  }
-
-  @return null;
-}
-
-@function lookupWarningBadgeColor($property: color) {
-  @if $property == color {
-    @return $clr-badge-warning-color;
-  }
-
-  @if $property == bg-color {
-    @return $clr-badge-warning-bg-color;
-  }
-
-  @return null;
-}
-
-@function lookupDangerBadgeColor($property: color) {
-  @if $property == color {
-    @return $clr-badge-danger-color;
-  }
-
-  @if $property == bg-color {
-    @return $clr-badge-danger-bg-color;
-  }
-
-  @return null;
-}
-
-@mixin generateBadgeStyles($color: gray, $alias: 1) {
-  :host([color='#{'' + $color}']),
-  :host([alias='#{'' + $alias}']) {
-    @include css-var(background, getBadgeColor($color, bg-color, 'css-var'), getBadgeColor($color, bg-color));
-    @include css-var(color, getBadgeColor($color, color, 'css-var'), getBadgeColor($color, color));
-  }
-}
-
-@mixin generateStatusBadgeStyles($status: info) {
-  :host([status='#{'' + $status}']) {
-    @include css-var(background, getBadgeColor($status, bg-color, 'css-var'), getBadgeColor($status, bg-color));
-    @include css-var(color, getBadgeColor($status, color, 'css-var'), getBadgeColor($status, color));
-  }
-}
 
 :host {
   display: inline-flex;
@@ -179,7 +7,6 @@
   align-items: center;
   justify-content: center;
   min-width: $clr_baselineRem_0_625;
-  background: getLabelColor(gray, bg-color);
   height: $clr_baselineRem_0_625;
   line-height: normal;
   border-radius: $clr_baselineRem_0_416;
@@ -188,19 +15,56 @@
   margin-right: $clr_baselineRem_0_25;
   white-space: nowrap;
   text-align: center;
-  @include css-var(color, clr-badge-font-color-light, $clr-badge-font-color-light);
 
-  &:host(:visited) {
-    @include css-var(color, clr-badge-font-color-light, $clr-badge-font-color-light);
-  }
+  background-color: var(--clr-badge-background-color);
+  color: var(--clr-badge-color);
 }
 
-@include generateBadgeStyles(gray, 1);
-@include generateBadgeStyles(purple, 2);
-@include generateBadgeStyles(blue, 3);
-@include generateBadgeStyles(orange, 4);
-@include generateBadgeStyles(light-blue, 5);
-@include generateStatusBadgeStyles(info);
-@include generateStatusBadgeStyles(success);
-@include generateStatusBadgeStyles(danger);
-@include generateStatusBadgeStyles(warning);
+:host(:visited) {
+  --clr-badge-color: var(--clr-color-on-neutral-600);
+}
+
+:host([color='gray']) {
+  --clr-badge-background-color: var(--clr-color-neutral-600);
+  --clr-badge-color: var(--clr-color-on-neutral-600);
+}
+
+:host([color='purple']) {
+  --clr-badge-background-color: var(--clr-color-secondary-action-500);
+  --clr-badge-color: var(--clr-color-on-secondary-action-500);
+}
+
+:host([color='blue']) {
+  --clr-badge-background-color: var(--clr-color-secondary-action-800);
+  --clr-badge-color: var(--clr-color-on-secondary-action-800);
+}
+
+:host([color='orange']) {
+  --clr-badge-background-color: var(--clr-color-warning-500);
+  --clr-badge-color: var(--clr-color-on-warning-500);
+}
+
+:host([color='light-blue']) {
+  --clr-badge-background-color: var(--clr-color-action-300);
+  --clr-badge-color: var(-clr-color-on-action-300);
+}
+
+:host([status='info']) {
+  --clr-badge-background-color: var(--clr-color-action-600);
+  --clr-badge-color: var(--clr-color-on-action-600);
+}
+
+:host([status='success']) {
+  --clr-badge-background-color: var(--clr-color-success-700);
+  --clr-badge-color: var(--clr-color-on-success-700);
+}
+
+:host([status='warning']) {
+  --clr-badge-background-color: var(--clr-color-warning-300);
+  --clr-badge-color: var(--clr-color-on-warning-300);
+}
+
+:host([status='danger']) {
+  --clr-badge-background-color: var(--clr-color-danger-800);
+  --clr-badge-color: var(--clr-color-on-danger-800);
+}

--- a/src/clr-core/badge/badge.element.ts
+++ b/src/clr-core/badge/badge.element.ts
@@ -23,26 +23,10 @@ import { styles } from './badge.element.css';
  * @beta 3.0
  * @element cwc-badge
  * @slot default - Content slot for inside the badge
- * @cssprop --clr-badge-font-color-light
- * @cssprop --clr-badge-font-color-dark
- * @cssprop --clr-badge-info-bg-color
- * @cssprop --clr-badge-info-color
- * @cssprop --clr-badge-success-bg-color
- * @cssprop --clr-badge-success-color
- * @cssprop --clr-badge-warning-bg-color
- * @cssprop --clr-badge-warning-color
- * @cssprop --clr-badge-danger-bg-color
- * @cssprop --clr-badge-danger-color
- * @cssprop --clr-badge-gray-bg-color
- * @cssprop --clr-badge-gray-color
- * @cssprop --clr-badge-purple-bg-color
- * @cssprop --clr-badge-purple-color
- * @cssprop --clr-badge-blue-bg-color
- * @cssprop --clr-badge-blue-color
- * @cssprop --clr-badge-orange-bg-color
- * @cssprop --clr-badge-orange-color
- * @cssprop --clr-badge-light-blue-bg-color
- * @cssprop --clr-badge-light-blue-color
+ * @attr {String} color - Sets the color of the badge from a predefined list of choices <br/> (`gray`, `purple`, `blue`, `orange`, `light-blue`)
+ * @attr {String} status - Sets the color of the badge from a predefined list of statuses <br/> (`info`, `success`, `warning`, `danger`)
+ * @cssprop --clr-badge-background-color
+ * @cssprop --clr-badge-color
  */
 // @dynamic
 export class CwcBadge extends LitElement {

--- a/src/clr-core/button/_properties.scss
+++ b/src/clr-core/button/_properties.scss
@@ -4,7 +4,8 @@
 
 @include exports('button.properties') {
   @if $clr-use-custom-properties == true {
-    :root {
+    :root,
+    :host {
       // Spacing
       --clr-btn-vertical-margin: #{$clr-btn-vertical-margin};
       --clr-btn-horizontal-margin: #{$clr-btn-horizontal-margin};

--- a/src/clr-core/tag/_properties.scss
+++ b/src/clr-core/tag/_properties.scss
@@ -4,15 +4,21 @@
 
 @include exports('tag.properties') {
   @if $clr-use-custom-properties == true {
-    :root {
+    :root,
+    :host {
       --clr-tag-font-color-light: var(--clr-color-neutral-700);
       --clr-tag-font-color-dark: var(--clr-color-neutral-1000);
-      --clr-tag-default-border-color: var(--clr-color-neutral-600);
+      --clr-tag-border-color: var(--clr-color-neutral-600);
+
       --clr-tag-font-size: #{$clr-p7-font-size};
       --clr-tag-font-weight: #{$clr-p7-font-weight};
       --clr-tag-letter-spacing: #{$clr-p7-letter-spacing};
       --clr-tag-border-radius: #{$clr_baselineRem_0_5};
+      --clr-tag-bg-color: none;
       --clr-tag-bg-hover-color: var(--clr-color-neutral-200);
+
+      // START: deprecated for removal in 4.0
+      --clr-tag-default-border-color: var(--clr-color-neutral-600);
       --clr-tag-gray-bg-color: var(--clr-color-neutral-600);
       --clr-tag-gray-color: var(--clr-tag-font-color-light);
       --clr-tag-purple-bg-color: var(--clr-color-secondary-action-500);
@@ -35,6 +41,7 @@
       --clr-tag-danger-bg-color: var(--clr-color-danger-100);
       --clr-tag-danger-font-color: var(--clr-color-danger-900);
       --clr-tag-danger-border-color: var(--clr-color-danger-200);
+      // END: deprecated for removal in 4.0
     }
   }
 }

--- a/src/clr-core/tag/tag.element.scss
+++ b/src/clr-core/tag/tag.element.scss
@@ -1,56 +1,7 @@
 @import './../styles/utils/core-component';
-@import './../badge/variables';
 @import './../badge/properties';
 @import './variables';
 @import './properties';
-
-@mixin generateTagStyles($color: gray, $alias: 1) {
-  $sassVarBgColor: getLabelColor($color, bg-color);
-  $cssVarBgColor: getLabelColor($color, bg-color, 'css-var');
-  $sassVarTextColor: getLabelColor($color, color);
-  $cssVarTextColor: getLabelColor($color, color, 'css-var');
-
-  :host([color='#{'' + $color}']),
-  :host([alias='#{'' + $alias}']) {
-    border: $clr-label-borderwidth solid;
-    @include css-var(border-color, $cssVarBgColor, $sassVarBgColor);
-
-    // style for clickable tag
-    &:host(:not([readonly])) {
-      &:host(:hover),
-      &:host(:active) {
-        text-decoration: none;
-        @include css-var(background, clr-tag-bg-hover-color, $clr-label-bg-hover-color);
-        cursor: pointer;
-      }
-
-      &:host(:active) {
-        // OldEdge/IE
-        box-shadow: 0 $clr-label-borderwidth 0 0 $sassVarBgColor inset;
-        box-shadow: 0 $clr-label-borderwidth 0 0 var(css-variablize-string($cssVarBgColor), $sassVarBgColor) inset;
-        transform: translateY($clr_baselineRem_0_5px);
-      }
-    }
-  }
-
-  :host([color='#{'' + $color}']) ::slotted(cwc-badge) {
-    @include css-var(background, getBadgeColor($color, bg-color, 'css-var'), getBadgeColor($color, bg-color));
-    @include css-var(color, getBadgeColor($color, color, 'css-var'), getBadgeColor($color, color));
-  }
-}
-
-@mixin generateStatusTagStyles($status: info) {
-  :host([status='#{'' + $status}']) {
-    @include css-var(background, getLabelColor($status, bg-color, 'css-var'), getLabelColor($status, bg-color));
-    @include css-var(color, getLabelColor($status, color, 'css-var'), getLabelColor($status, color));
-    border: $clr-label-borderwidth solid;
-    @include css-var(
-      border-color,
-      getLabelColor($status, border-color, 'css-var'),
-      getLabelColor($status, border-color)
-    );
-  }
-}
 
 :host {
   //default
@@ -71,10 +22,13 @@
   height: $clr_baselineRem_0_875;
   margin: 0 $clr_baselineRem_0_25 0 0;
   white-space: nowrap;
-  @include css-var(color, clr-tag-font-color-light, $clr-label-font-color-light);
+
+  background-color: var(--clr-tag-bg-color);
+  border-color: var(--clr-tag-border-color);
+  color: var(--clr-tag-color);
 
   &:host(:visited) {
-    @include css-var(color, clr-tag-font-color-light, $clr-label-font-color-light);
+    --clr-tag-color: var(--clr-color-on-neutral-600);
   }
 
   &:host(:focus),
@@ -87,15 +41,15 @@
   &:host(:not([readonly])) {
     &:host(:hover),
     &:host(:active) {
-      @include css-var(background, clr-tag-bg-hover-color, $clr-label-bg-hover-color);
+      text-decoration: none;
+      background-color: var(--clr-tag-background-hover-color);
+      cursor: pointer;
     }
 
     &:host(:active) {
-      $mySassShadow: getLabelColor(gray, bg-color);
       // OldEdge/IE
-      box-shadow: 0 $clr_baselineRem_1px 0 0 getLabelColor(gray, bg-color) inset;
-      box-shadow: 0 $clr_baselineRem_1px 0 0
-        var(css-variablize-string(getLabelColor(gray, bg-color, 'css-var')), $mySassShadow) inset;
+      box-shadow: 0 $clr_baselineRem_1px 0 0 var(--clr-tag-bg-color) inset;
+      box-shadow: 0 $clr-label-borderwidth 0 0 var(--clr-tag-bg-color) inset;
       transform: translateY($clr_baselineRem_0_5px);
     }
   }
@@ -105,16 +59,78 @@
   }
 }
 
-@include generateTagStyles(gray, 1);
-@include generateTagStyles(purple, 2);
-@include generateTagStyles(blue, 3);
-@include generateTagStyles(orange, 4);
-@include generateTagStyles(light-blue, 5);
+:host([color='gray']) {
+  --clr-tag-border-color: var(--clr-color-neutral-600);
 
-@include generateStatusTagStyles(info);
-@include generateStatusTagStyles(success);
-@include generateStatusTagStyles(warning);
-@include generateStatusTagStyles(danger);
+  ::slotted(cwc-badge) {
+    --clr-badge-background-color: var(--clr-color-neutral-600);
+    --clr-badge-color: var(--clr-color-on-neutral-600);
+  }
+}
+
+:host([color='purple']) {
+  --clr-tag-border-color: var(--clr-color-secondary-action-500);
+
+  ::slotted(cwc-badge) {
+    --clr-badge-background-color: var(--clr-color-secondary-action-500);
+    --clr-badge-color: var(--clr-color-on-secondary-action-500);
+  }
+}
+
+:host([color='blue']) {
+  --clr-tag-border-color: var(--clr-color-action-800);
+
+  ::slotted(cwc-badge) {
+    --clr-badge-background-color: var(--clr-color-secondary-action-800);
+    --clr-badge-color: var(--clr-color-on-secondary-action-800);
+  }
+}
+
+:host([color='orange']) {
+  --clr-tag-border-color: var(--clr-color-warning-500);
+
+  ::slotted(cwc-badge) {
+    --clr-badge-background-color: var(--clr-color-warning-500);
+    --clr-badge-color: var(--clr-color-on-warning-500);
+  }
+}
+
+:host([color='light-blue']) {
+  --clr-tag-border-color: var(--clr-color-action-300);
+
+  ::slotted(cwc-badge) {
+    --clr-badge-background-color: var(--clr-color-action-300);
+    --clr-badge-color: var(--clr-color-on-action-300);
+  }
+}
+
+:host([status='info']) {
+  --clr-tag-bg-color: var(--clr-color-action-50);
+  --clr-tag-background-hover-color: var(--clr-color-action-100);
+  --clr-tag-border-color: var(--clr-color-action-400);
+  --clr-tag-color: var(--clr-color-action-800);
+}
+
+:host([status='success']) {
+  --clr-tag-bg-color: var(--clr-color-success-50);
+  --clr-tag-background-hover-color: var(--clr-color-success-100);
+  --clr-tag-color: var(--clr-color-success-800);
+  --clr-tag-border-color: var(--clr-color-success-400);
+}
+
+:host([status='warning']) {
+  --clr-tag-bg-color: var(--clr-color-warning-100);
+  --clr-tag-background-hover-color: var(--clr-color-warning-200);
+  --clr-tag-color: var(--clr-color-neutral-900);
+  --clr-tag-border-color: var(--clr-color-warning-300);
+}
+
+:host([status='danger']) {
+  --clr-tag-bg-color: var(--clr-color-danger-100);
+  --clr-tag-background-hover-color: var(--clr-color-danger-200);
+  --clr-tag-color: var(--clr-color-danger-900);
+  --clr-tag-border-color: var(--clr-color-danger-200);
+}
 
 @include fixForFirefox() {
   :host {

--- a/src/clr-core/tag/tag.element.ts
+++ b/src/clr-core/tag/tag.element.ts
@@ -23,36 +23,15 @@ import { styles } from './tag.element.css';
  * @beta 3.0
  * @element cwc-tag
  * @slot default - Content slot for inside the tag
- * @cssprop --clr-tag-font-color-light
- * @cssprop --clr-tag-font-color-dark
- * @cssprop --clr-tag-default-border-color
+ * @attr {String} color - Sets the color of the tag (and badge if present) from a predefined list of choices <br/> (`gray`, `purple`, `blue`, `orange`, `light-blue`)
+ * @attr {String} status - Sets the color of the tag (and badge if present) from a predefined list of statuses <br/> (`info`, `success`, `warning`, `danger`)
+ * @cssprop --clr-tag-border-color
  * @cssprop --clr-tag-font-size
  * @cssprop --clr-tag-font-weight
  * @cssprop --clr-tag-letter-spacing
  * @cssprop --clr-tag-border-radius
+ * @cssprop --clr-tag-bg-color
  * @cssprop --clr-tag-bg-hover-color
- * @cssprop --clr-tag-gray-bg-color
- * @cssprop --clr-tag-gray-color
- * @cssprop --clr-tag-purple-bg-color
- * @cssprop --clr-tag-purple-color
- * @cssprop --clr-tag-blue-bg-color
- * @cssprop --clr-tag-blue-color
- * @cssprop --clr-tag-orange-bg-color
- * @cssprop --clr-tag-orange-color
- * @cssprop --clr-tag-light-blue-bg-color
- * @cssprop --clr-tag-light-blue-color
- * @cssprop --clr-tag-info-bg-color
- * @cssprop --clr-tag-info-font-color
- * @cssprop --clr-tag-info-border-color
- * @cssprop --clr-tag-success-bg-color
- * @cssprop --clr-tag-success-font-color
- * @cssprop --clr-tag-success-border-color
- * @cssprop --clr-tag-warning-bg-color
- * @cssprop --clr-tag-warning-font-color
- * @cssprop --clr-tag-warning-border-color
- * @cssprop --clr-tag-danger-bg-color
- * @cssprop --clr-tag-danger-font-color
- * @cssprop --clr-tag-danger-border-color
  */
 // @dynamic
 export class CwcTag extends CwcBaseButton {

--- a/src/dev-core/src/app/badge/badge.demo.html
+++ b/src/dev-core/src/app/badge/badge.demo.html
@@ -1,14 +1,11 @@
 <h1>Color Options</h1>
+<cwc-badge>5</cwc-badge>
 <cwc-badge color="gray">1</cwc-badge>
 <cwc-badge color="purple">1</cwc-badge>
 <cwc-badge color="blue">15</cwc-badge>
 <cwc-badge color="orange">2</cwc-badge>
 <cwc-badge color="light-blue">3</cwc-badge>
-<cwc-badge alias="1">12</cwc-badge>
-<cwc-badge alias="2">90</cwc-badge>
-<cwc-badge alias="3">51</cwc-badge>
-<cwc-badge alias="4">25</cwc-badge>
-<cwc-badge alias="5">32</cwc-badge>
+<cwc-badge class='app-custom'>23</cwc-badge>
 
 <h1>Status</h1>
 <cwc-badge status="info">2</cwc-badge>

--- a/src/dev-core/src/app/badge/badge.demo.scss
+++ b/src/dev-core/src/app/badge/badge.demo.scss
@@ -1,0 +1,4 @@
+cwc-badge.app-custom {
+  --clr-badge-background-color: darkblue;
+  --clr-badge-color: snow;
+}

--- a/src/dev-core/src/app/badge/badge.demo.ts
+++ b/src/dev-core/src/app/badge/badge.demo.ts
@@ -8,6 +8,7 @@ import '@clr/core/badge';
 
 @Component({
   selector: 'app-badge-demo',
+  styleUrls: ['./badge.demo.scss'],
   templateUrl: './badge.demo.html',
 })
 export class BadgeDemoComponent {

--- a/src/dev-core/src/app/tag/tag.demo.html
+++ b/src/dev-core/src/app/tag/tag.demo.html
@@ -4,11 +4,12 @@
 <cwc-tag readonly color="blue">Palo Alto</cwc-tag>
 <cwc-tag readonly color="orange">San Francisco</cwc-tag>
 <cwc-tag readonly color="light-blue">Seattle</cwc-tag>
-<cwc-tag readonly alias="1">Austin</cwc-tag>
-<cwc-tag readonly alias="2">New York</cwc-tag>
-<cwc-tag readonly alias="3">Palo Alto</cwc-tag>
-<cwc-tag readonly alias="4">San Francisco</cwc-tag>
-<cwc-tag readonly alias="5">Seattle</cwc-tag>
+
+<h1>Status</h1>
+<cwc-tag readonly status="info">Info</cwc-tag>
+<cwc-tag readonly status="success">Success</cwc-tag>
+<cwc-tag readonly status="warning">Warning</cwc-tag>
+<cwc-tag readonly status="danger">Danger</cwc-tag>
 
 <h1>Clickable</h1>
 <cwc-tag color="gray">Austin</cwc-tag>
@@ -16,17 +17,10 @@
 <cwc-tag color="blue">Palo Alto</cwc-tag>
 <cwc-tag color="orange">San Francisco</cwc-tag>
 <cwc-tag color="light-blue">Seattle</cwc-tag>
-<cwc-tag alias="1">Austin</cwc-tag>
-<cwc-tag alias="2">New York</cwc-tag>
-<cwc-tag alias="3">Palo Alto</cwc-tag>
-<cwc-tag alias="4">San Francisco</cwc-tag>
-<cwc-tag alias="5">Seattle</cwc-tag>
-
-<h1>Status (Not clickable)</h1>
-<cwc-tag readonly status="info">Info</cwc-tag>
-<cwc-tag readonly status="success">Success</cwc-tag>
-<cwc-tag readonly status="warning">Warning</cwc-tag>
-<cwc-tag readonly status="danger">Danger</cwc-tag>
+<cwc-tag status="info">Info</cwc-tag>
+<cwc-tag status="success">Success</cwc-tag>
+<cwc-tag status="warning">Warning</cwc-tag>
+<cwc-tag status="danger">Danger</cwc-tag>
 
 <h1>With badges</h1>
 <cwc-tag readonly color="gray">Austin <cwc-badge>1</cwc-badge></cwc-tag>


### PR DESCRIPTION

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [x] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Instead of using specific variable names like 

Issue Number: N/A

## What is the new behavior?

Instead of using specialized css variables like `--clr-badge-gray-bg-color`, opt to reuse the generic variable name `--clr-badge-bg-color`. This allows an override for the variation like:
```
:host([attr='value']) {
  --clr-badge-bg-color: <custom background color>;
  --clr-badge-color: <custom color>;
}
```
## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
