### PR TITLE
docs(signpost): updates i18n strings in documentation

### DIFF
--- a/src/website/src/app/documentation/demos/i18n/i18n.demo.ts
+++ b/src/website/src/app/documentation/demos/i18n/i18n.demo.ts
@@ -128,5 +128,9 @@ export class I18nDemo extends ClarityDocComponent {
       role:
         'Applies the expanded/collapsed state to an aria-expanded attribute for screen readers whenever vertical nav group buttons are expanded/collapsed',
     },
+    {
+      key: 'signpostToggle',
+      role: 'Applies the aria-label value to the signpost trigger.',
+    },
   ];
 }


### PR DESCRIPTION
Adds signpostToggle and a description to the i18n docs page
closes #4095

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?
Adds `signpostToggle` to common strings. 
<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?
signpostToggle common string was minning
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4095

## What is the new behavior?
Docs are updated. 

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
