### PR TITLE
fix(icons): css class collisions in icon error-danger classes

### DIFF
--- a/docs/core/cwc-icon.md
+++ b/docs/core/cwc-icon.md
@@ -30,12 +30,10 @@ ClarityIcons.addIcon(userIcon);
 |--------------------------------------|
 | `--clr-icon-color-danger`            |
 | `--clr-icon-color-default`           |
-| `--clr-icon-color-error`             |
 | `--clr-icon-color-highlight`         |
 | `--clr-icon-color-info`              |
 | `--clr-icon-color-inverse`           |
 | `--clr-icon-color-inverse-danger`    |
-| `--clr-icon-color-inverse-error`     |
 | `--clr-icon-color-inverse-highlight` |
 | `--clr-icon-color-inverse-info`      |
 | `--clr-icon-color-inverse-success`   |

--- a/src/clr-core/icon/icon.element.scss
+++ b/src/clr-core/icon/icon.element.scss
@@ -113,10 +113,11 @@ svg {
 }
 
 // DEPRECATED IN 3.0: is-red
+// DEPRECATED IN 3.0: is-error
 :host(.is-red),
 :host(.is-danger),
 :host(.is-error) {
-  @include setIconColor(#{'var(--clr-icon-color-error, var(--clr-color-danger-700,' + $clr-color-danger-700 + '))'});
+  @include setIconColor(#{'var(--clr-icon-color-danger, var(--clr-color-danger-700,' + $clr-color-danger-700 + '))'});
 }
 
 :host(.is-warning) {
@@ -131,15 +132,37 @@ svg {
   @include setIconColor(#{'var(--clr-icon-color-info, var(--clr-color-action-600,' + $clr-color-action-600 + '))'});
 }
 
+:host(.is-highlight) {
+  @include setIconColor(
+    #{'var(--clr-icon-color-highlight, var(--clr-color-action-600,' + $clr-color-action-600 + '))'}
+  );
+}
+
+// INVERSE COLORS
+
 // DEPRECATED IN 3.0: is-white
 :host(.is-white),
 :host(.is-inverse) {
   @include setIconColor(#{'var(--clr-icon-color-inverse, var(--clr-color-neutral-0,' + $clr-color-neutral-0 + '))'});
 }
 
-:host(.is-highlight) {
+:host(.is-inverse.is-success) {
   @include setIconColor(
-    #{'var(--clr-icon-color-highlight, var(--clr-color-action-600,' + $clr-color-action-600 + '))'}
+    #{'var(--clr-icon-color-inverse-success, var(--clr-color-success-400,' + $clr-color-success-400 + '))'}
+  );
+}
+
+// DEPRECATED IN 3.0: is-error
+:host(.is-inverse.is-error),
+:host(.is-inverse.is-danger) {
+  @include setIconColor(
+    #{'var(--clr-icon-color-inverse-danger, var(--clr-color-danger-700,' + $clr-color-danger-700 + '))'}
+  );
+}
+
+:host(.is-inverse.is-warning) {
+  @include setIconColor(
+    #{'var(--clr-icon-color-inverse-warning, var(--clr-color-warning-500,' + $clr-color-warning-500 + '))'}
   );
 }
 
@@ -262,9 +285,10 @@ svg {
   }
 }
 
+:host(.has-badge--danger),
 :host(.has-badge--error) {
   .clr-i-badge {
-    @include setIconColor(#{'var(--clr-icon-color-error, var(--clr-color-danger-700,' + $clr-color-danger-700 + '))'});
+    @include setIconColor(#{'var(--clr-icon-color-danger, var(--clr-color-danger-700,' + $clr-color-danger-700 + '))'});
   }
 }
 
@@ -300,10 +324,12 @@ svg {
   }
 }
 
+// DEPRECATED IN 3.0: has-badge--error
+:host(.has-badge--danger.is-inverse),
 :host(.has-badge--error.is-inverse) {
   .clr-i-badge {
     @include setIconColor(
-      #{'var(--clr-icon-color-inverse-error, var(--clr-color-danger-500,' + $clr-color-danger-500 + '))'}
+      #{'var(--clr-icon-color-inverse-danger, var(--clr-color-danger-500,' + $clr-color-danger-500 + '))'}
     );
   }
 }

--- a/src/clr-core/icon/icon.element.ts
+++ b/src/clr-core/icon/icon.element.ts
@@ -51,14 +51,12 @@ applyMixins(IconMixinClass, [UniqueId, CssHelpers]);
  * @cssprop --clr-icon-color-success
  * @cssprop --clr-icon-color-danger
  * @cssprop --clr-icon-color-warning
- * @cssprop --clr-icon-color-error
  * @cssprop --clr-icon-color-info
  * @cssprop --clr-icon-color-highlight
  * @cssprop --clr-icon-color-inverse
  * @cssprop --clr-icon-color-inverse-success
  * @cssprop --clr-icon-color-inverse-danger
  * @cssprop --clr-icon-color-inverse-warning
- * @cssprop --clr-icon-color-inverse-error
  * @cssprop --clr-icon-color-inverse-info
  * @cssprop --clr-icon-color-inverse-highlight
  */

--- a/src/dev-core/src/app/icon/icon.demo.html
+++ b/src/dev-core/src/app/icon/icon.demo.html
@@ -10,11 +10,69 @@
         text-align: center;
         line-height: 1.1em;
     }
+
+    .custom-icon-colors {
+        background: black;
+        padding: 8px 12px;
+        border-radius: 3px;
+        display: inline-block;
+        margin-left: 12px;
+        position: relative;
+    }
+
+    .custom-icon-colors::before {
+        content: 'B';
+        font-size: 14px;
+        position: absolute;
+        display: block;
+        top: 0;
+        left: 4px;
+        color: white
+    }
+
+    .custom-icon-colors:first-child:before {
+        content: 'A';
+    }
+
+    .custom-icon-colors:last-child:before {
+        content: 'C';
+        color: inherit;
+    }
+
+    .custom-icon-colors-2 {
+        background: #eee;
+    }
+
+    .custom-icon-colors cwc-icon {
+        --clr-icon-color-danger: yellow;
+        --clr-icon-color-inverse: limegreen;
+        --clr-icon-color-inverse-danger: fuchsia;
+
+        height: 36px;
+        width: 36px;
+    }
 </style>
 
 <h1>Icon Demo</h1>
 
 <p><cwc-icon id="ohai"></cwc-icon></p>
+
+<h2>Custom Styling</h2>
+
+<div class="clr-row">
+    <div class="custom-icon-colors">
+        <cwc-icon shape="user" class="has-badge--danger is-inverse"></cwc-icon>
+    </div>
+    <div class="custom-icon-colors">
+        <cwc-icon shape="user" class="is-danger has-badge--danger is-inverse"></cwc-icon>
+    </div>
+    <div class="custom-icon-colors custom-icon-colors-2">
+        <cwc-icon shape="user" class="has-badge--danger"></cwc-icon>
+    </div>
+</div>
+<p><i>A should be green with a pink badge</i><br>
+<i>B should be all pink</i><br>
+<i>C should be default gray with a yellow badge</i></p>
 
 <h2>Icon Sizing</h2>
 


### PR DESCRIPTION
• got rid of "error" colors
• deprecated CSS classnames that use "error"
• fixed issues with inverse colors not being applied
• fixed issue where 'danger' colors were coming from 'error' variables
• added demo of custom styling icons with CSS to verify changes

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

### Before

![Screen Shot 2019-12-18 at 2 51 31 PM](https://user-images.githubusercontent.com/2728359/71125689-1397dd80-21ad-11ea-8e12-2b33f766e373.png)

### After

![Screen Shot 2019-12-18 at 2 45 33 PM](https://user-images.githubusercontent.com/2728359/71125710-1b578200-21ad-11ea-9db4-a862206bec26.png)

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [x] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
