### PR TITLE
var $clr_baselineRem_-1px

### DIFF
--- a/src/clr-core/styles/variables/_variables.global.scss
+++ b/src/clr-core/styles/variables/_variables.global.scss
@@ -44,7 +44,7 @@ $clr_baselineRem_10: convertBaselineToBase20(240); // 240px
 $clr_baselineRem_15: convertBaselineToBase20(360); // 360px
 
 // Pixel-based utilities
-$clr_baselineRem_-1px: -convertBaselineToBase20(1);
+$clr_baselineRem_-1px: -1 *convertBaselineToBase20(1);
 $clr_baselineRem_0_5px: convertBaselineToBase20(0.5); // used by cwc-tag to depress the tag .5px when user clicks
 $clr_baselineRem_1px: convertBaselineToBase20(1);
 $clr_baselineRem_2px: convertBaselineToBase20(2);


### PR DESCRIPTION
var $clr_baselineRem_-1px not working.

in css it -convertBaselineToBase20(1) must be -0.05rem.

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [x] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
