### PR TITLE
fix(datagrid): datagrid-row add aria-expanded & aria-label on open/close

### DIFF
--- a/src/clr-angular/data/datagrid/datagrid-row.html
+++ b/src/clr-angular/data/datagrid/datagrid-row.html
@@ -59,7 +59,14 @@
         <div *ngIf="globalExpandable.hasExpandableRow"
              class="datagrid-expandable-caret datagrid-fixed-column datagrid-cell" role="gridcell">
           <ng-container *ngIf="expand.expandable">
-            <button (click)="toggleExpand()" *ngIf="!expand.loading" type="button" class="datagrid-expandable-caret-button" [attr.aria-label]="detailService.isOpen ? clrDgDetailCloseLabel : clrDgDetailOpenLabel">
+            <button
+              *ngIf="!expand.loading"
+              (click)="toggleExpand()"
+              type="button"
+              class="datagrid-expandable-caret-button"
+              [attr.aria-expanded]="expand.expanded"
+              [attr.aria-label]="expand.expanded ? clrDgDetailCloseLabel : clrDgDetailOpenLabel"
+              >
               <clr-icon shape="caret"
                         class="datagrid-expandable-caret-icon"
                         [attr.dir]="expand.expanded ? 'down' : 'right'"

--- a/src/clr-angular/data/datagrid/datagrid-row.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-row.spec.ts
@@ -391,6 +391,21 @@ export default function(): void {
       );
 
       it(
+        'expands and collapses change the aria-label text aria-expanded',
+        fakeAsync(function() {
+          const caret = context.clarityElement.querySelector('.datagrid-expandable-caret button');
+          caret.click();
+          flushAnimations();
+          expect(caret.getAttribute('aria-label')).toBe(context.testComponent.clrDgDetailCloseLabel);
+          expect(caret.getAttribute('aria-expanded')).toBe('true');
+          caret.click();
+          flushAnimations();
+          expect(caret.getAttribute('aria-label')).toBe(context.testComponent.clrDgDetailOpenLabel);
+          expect(caret.getAttribute('aria-expanded')).toBe('false');
+        })
+      );
+
+      it(
         'offers 2-way binding on the expanded state of the row',
         fakeAsync(function() {
           context.testComponent.expanded = true;
@@ -478,7 +493,7 @@ class FullTest {
 
 @Component({
   template: `
-        <clr-dg-row [(clrDgExpanded)]="expanded">
+        <clr-dg-row [(clrDgExpanded)]="expanded" [clrDgDetailOpenLabel]="clrDgDetailOpenLabel" [clrDgDetailCloseLabel]="clrDgDetailCloseLabel">
             <clr-dg-cell>Hello world</clr-dg-cell>
             <clr-dg-row-detail *clrIfExpanded>
                 Detail
@@ -487,4 +502,6 @@ class FullTest {
 })
 class ExpandTest {
   expanded = false;
+  clrDgDetailOpenLabel: string = 'Open Me';
+  clrDgDetailCloseLabel: string = 'Close Me';
 }

--- a/src/clr-angular/data/datagrid/datagrid-row.ts
+++ b/src/clr-angular/data/datagrid/datagrid-row.ts
@@ -186,7 +186,7 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
     this._detailCloseLabel = label;
   }
   get clrDgDetailCloseLabel(): string {
-    return this._detailCloseLabel ? this._detailCloseLabel : this.commonStrings.keys.open;
+    return this._detailCloseLabel ? this._detailCloseLabel : this.commonStrings.keys.close;
   }
 
   /*****


### PR DESCRIPTION

* `clrDgDetailCloseLabel` was returning the wrong label for the close button.
* `.datagrid-expandable-caret-button` Element was using the wrong service to track open/closed state and missing `aria-expanded` attribute


## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?
* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?


Issue Number: #4089

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Close #4089 