### PR TITLE
feat(datagrid): add clrDgVisibleItems, get visible items inside the grid

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -293,6 +293,7 @@ export declare class ClrDatagrid<T = any> implements AfterContentInit, AfterView
     selection: Selection<T>;
     singleSelected: T;
     singleSelectedChanged: EventEmitter<T>;
+    visibleItems: EventEmitter<T[]>;
     constructor(organizer: DatagridRenderOrganizer, items: Items<T>, expandableRows: ExpandableRowsCount, selection: Selection<T>, rowActionService: RowActionService, stateProvider: StateProvider<T>, displayMode: DisplayModeService, renderer: Renderer2, detailService: DetailService, datagridId: string, el: ElementRef, page: Page, commonStrings: ClrCommonStringsService);
     dataChanged(): void;
     ngAfterContentInit(): void;

--- a/src/clr-angular/data/datagrid/datagrid.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid.spec.ts
@@ -37,6 +37,7 @@ import { HIDDEN_COLUMN_CLASS } from './render/constants';
       [(clrDgSelected)]="selected"
       [clrDgLoading]="loading"
       (clrDgRefresh)="refresh($event)"
+      (clrDgVisibleItems)="visibleItems($event)"
       >
         <clr-dg-column>
             First
@@ -74,6 +75,11 @@ class FullTest {
     this.nbRefreshed++;
     this.latestState = state;
     this.loading = this.fakeLoad;
+  }
+
+  displayed = [];
+  visibleItems($event) {
+    this.displayed = $event;
   }
 }
 
@@ -491,6 +497,16 @@ export default function(): void {
         context.testComponent.selected = [5];
         context.detectChanges();
         expect(selection.current).toEqual([5]);
+      });
+
+      describe('clrDgVisibleItems', function() {
+        it('should get changes when visible items change', function() {
+          spyOn(context.testComponent, 'visibleItems');
+          expect(context.testComponent.displayed).toEqual(context.testComponent.items);
+          context.testComponent.items = [4, 5, 6];
+          context.detectChanges();
+          expect(context.testComponent.visibleItems).toHaveBeenCalled();
+        });
       });
 
       describe('clrDgRefresh output', function() {

--- a/src/clr-angular/data/datagrid/datagrid.ts
+++ b/src/clr-angular/data/datagrid/datagrid.ts
@@ -90,6 +90,8 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
     this.detailService.id = datagridId;
   }
 
+  @Output('clrDgVisibleItems') visibleItems = new EventEmitter<T[]>();
+
   /* reference to the enum so that template can access */
   public SELECTION_TYPE = SelectionType;
 
@@ -223,6 +225,9 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
       this.items.all = this.rows.map((row: ClrDatagridRow<T>) => row.item);
     }
 
+    // Broadcast for the first time the state of the view.
+    this.visibleItems.emit(this.items.displayed);
+
     this._subscriptions.push(
       this.rows.changes.subscribe(() => {
         if (!this.items.smart) {
@@ -231,6 +236,8 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
         this.rows.forEach(row => {
           this._displayedRows.insert(row._view);
         });
+        // After every change of the view, broadcast the items that are currently visible
+        this.visibleItems.emit(this.items.displayed);
       })
     );
   }

--- a/src/dev/src/app/datagrid/full/full.html
+++ b/src/dev/src/app/datagrid/full/full.html
@@ -61,7 +61,7 @@
         </p>
     </div>
 
-    <clr-datagrid *ngIf="!isServerDriven" [(clrDgSelected)]="selected">
+    <clr-datagrid (clrDgVisibleItems)="visibleItems($event)" *ngIf="!isServerDriven" [(clrDgSelected)]="selected">
         <clr-dg-column>
             <ng-container *clrDgHideableColumn>
                 User ID
@@ -128,7 +128,7 @@
         </clr-dg-footer>
     </clr-datagrid>
 
-    <clr-datagrid *ngIf="isServerDriven" [(clrDgSelected)]="selected"
+    <clr-datagrid (clrDgVisibleItems)="visibleItems($event)" *ngIf="isServerDriven" [(clrDgSelected)]="selected"
                   (clrDgRefresh)="refresh($event)" [clrDgLoading]="loading">
         <clr-dg-column>User ID</clr-dg-column>
         <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>

--- a/src/dev/src/app/datagrid/full/full.ts
+++ b/src/dev/src/app/datagrid/full/full.ts
@@ -70,6 +70,10 @@ export class DatagridFullDemo {
     });
   }
 
+  visibleItems($event) {
+    console.log('Visible Items', $event);
+  }
+
   refresh(state: ClrDatagridStateInterface) {
     if (!this.isServerDriven) {
       return;

--- a/src/website/src/app/documentation/demos/datagrid/binding-properties/binding-properties.html
+++ b/src/website/src/app/documentation/demos/datagrid/binding-properties/binding-properties.html
@@ -27,7 +27,7 @@
     You can see an example of this in the "Wins" column.
 </p>
 
-<clr-datagrid>
+<clr-datagrid (clrDgVisibleItems)="visibleItems($event)">
     <clr-dg-column>User ID</clr-dg-column>
     <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
     <clr-dg-column [clrDgField]="'creation'">Creation date</clr-dg-column>
@@ -73,3 +73,23 @@
         </div>
     </div>
 </div>
+
+<h2>Visible items</h2>
+<p>
+    To get access to the items after filtering, sorting or what will be render inside the <code class="clr-code">ClrDatagrid</code>.
+    There is a Angular Output that could be monitor for those changes. <code class="clr-code">(clrDgVisibleItems)</code>
+</p>
+
+<clr-code-snippet [clrCode]="exampleVisibleItems" clrLanguage="html"></clr-code-snippet>
+<p>The change will be propagated every time when the view of visible items change.</p>
+
+<div class="alert alert-info">
+    <div class="alert-items">
+        <div class="alert-item static">
+            <span class="alert-text">
+                You could see the changes inside the Developer Tools of the Browser.
+            </span>
+        </div>
+    </div>
+</div>
+

--- a/src/website/src/app/documentation/demos/datagrid/binding-properties/binding-properties.ts
+++ b/src/website/src/app/documentation/demos/datagrid/binding-properties/binding-properties.ts
@@ -9,7 +9,7 @@ import { Inventory } from '../inventory/inventory';
 import { User } from '../inventory/user';
 
 const EXAMPLE = `
-<clr-datagrid>
+<clr-datagrid (clrDgVisibleItems)="visibleItems($event)">
     <clr-dg-column>User ID</clr-dg-column>
     <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
     <clr-dg-column [clrDgField]="'creation'">Creation date</clr-dg-column>
@@ -32,6 +32,11 @@ const EXAMPLE = `
 </clr-datagrid>
 `;
 
+const EXAMPLE_VISIBLE_ITEMS = `
+<clr-datagrid (clrDgVisibleItems)="visibleItems($event)">
+   <!-- ...-->
+</clr-datagrid>
+`.trim();
 @Component({
   selector: 'clr-datagrid-binding-properties-demo',
   providers: [Inventory],
@@ -40,11 +45,16 @@ const EXAMPLE = `
 })
 export class DatagridBindingPropertiesDemo {
   example = EXAMPLE;
+  exampleVisibleItems = EXAMPLE_VISIBLE_ITEMS;
   users: User[];
 
   constructor(inventory: Inventory) {
     inventory.size = 10;
     inventory.reset();
     this.users = inventory.all;
+  }
+
+  visibleItems($event) {
+    console.log('Current visible items', $event);
   }
 }


### PR DESCRIPTION
Provide Output to `ClrDatagrid` to monitor the current render item inside the Datagrid.

**NOTE - Those are the only visible items inside the DOM, - NOT INCLUDING PAGED ITEMS**

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #253

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Close: #253