### PR TITLE
feat: update the limit of header-max-length from 72 to 100 characters

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -45,5 +45,6 @@ module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'scope-enum': [2, 'always', scopes],
+    'header-max-length': [2, 'always', 100],
   },
 };


### PR DESCRIPTION
I'm getting super often this error:

```
✖   header must not be longer than 72 characters, current length is 74 [header-max-length]
```
Visible in the case when I use one of the long `scopes` like `date-picker`, `progress-bar` and so on.

So in the case of: 
```
feat(date-picker):<space><commit-message>
```
 I'm losing 19 characters from the commit message just for tagging. And including one input or output name, there are no characters left to do a meaningful sentence. And the messages become a bit cryptic just to get inside the limitation. 

I don't suggest to go and try to fill the how 100 character limit, but having some additional characters could be handy.

Also, there is similar open PR for this change inside the [commitlint](https://github.com/conventional-changelog/commitlint/issues/303)

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [x] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [x] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
