### PR TITLE
fix: add core property decorator with defaults

### DIFF
--- a/docs/CODING_GUIDELINES_CORE.md
+++ b/docs/CODING_GUIDELINES_CORE.md
@@ -140,10 +140,14 @@ adhere to the following guidelines for our Core Web Component codebase.
 * Components should rarely if ever expose public methods as this encourages state.
 
 * Properties should only reflect into attributes if expecting primitive values
-  like `string`, `number`, or `boolean`.
+  like `string`, `number`, or `boolean`. Use the provided `@property` decorator
+  from `@clr/core/common` as this provides the same lit-element decorator with
+  our project defaults.
 
   ```typescript
-  @property({ type: Boolean, reflect: true }) open = false;
+  import { property } from '@clr/core/common';
+
+  @property({ type: Boolean }) open = false;
   ```
 
 * custom events by default should not bubble events to the global document.
@@ -170,7 +174,9 @@ adhere to the following guidelines for our Core Web Component codebase.
   a kebab case attribute.
 
   ```typescript
-  @property({ type: Boolean, reflect: true, attribute: 'loading-state' }) loadingState;
+  import { property } from '@clr/core/common';
+
+  @property({ type: Boolean, attribute: 'loading-state' }) loadingState;
   ```
 
 * If the component needs to render external text or HTML, use the [Slot API](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_templates_and_slots).

--- a/src/clr-core/badge/badge.element.ts
+++ b/src/clr-core/badge/badge.element.ts
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { baseStyles, registerElementSafely } from '@clr/core/common';
-import { html, LitElement, property } from 'lit-element';
+import { baseStyles, property, registerElementSafely } from '@clr/core/common';
+import { html, LitElement } from 'lit-element';
 import { styles } from './badge.element.css';
 
 /**
@@ -29,11 +29,11 @@ import { styles } from './badge.element.css';
 // @dynamic
 export class CwcBadge extends LitElement {
   /** Sets the color of the badge from a predefined list of choices */
-  @property({ type: String, reflect: true })
+  @property({ type: String })
   color: 'gray' | 'purple' | 'blue' | 'orange' | 'light-blue';
 
   /** Sets the color of the badge from a predefined list of statuses */
-  @property({ type: String, reflect: true })
+  @property({ type: String })
   status: 'info' | 'success' | 'warning' | 'danger';
 
   render() {

--- a/src/clr-core/button/button.element.ts
+++ b/src/clr-core/button/button.element.ts
@@ -1,17 +1,17 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { baseStyles, registerElementSafely } from '@clr/core/common';
+import { baseStyles, property, registerElementSafely } from '@clr/core/common';
 import {
   CwcBaseButton,
   getElementWidthUnless,
   getTranslateForChromeRenderingBugUnless,
   toggleDisabledAttribute,
 } from '@clr/core/common';
-import { html, property } from 'lit-element';
+import { html } from 'lit-element';
 import { styles } from './button.element.css';
 
 export enum ClrLoadingState {
@@ -151,19 +151,19 @@ export enum ClrLoadingState {
 // @dynamic
 export class CwcButton extends CwcBaseButton {
   /** Define the type of action the button triggers */
-  @property({ type: String, reflect: true })
+  @property({ type: String })
   action: 'default' | 'outline' | 'link';
 
   /** Sets the color of the button to match the status */
-  @property({ type: String, reflect: true })
+  @property({ type: String })
   status: 'default' | 'primary' | 'inverse' | 'success' | 'warning' | 'danger';
 
   /** Sets the overall height and width of the button based on value */
-  @property({ type: String, reflect: true })
+  @property({ type: String })
   size: 'default' | 'sm';
 
   /** Sets button type for icon */
-  @property({ type: String, reflect: true })
+  @property({ type: String })
   icon: '';
 
   private _loadingState: ClrLoadingState = ClrLoadingState.DEFAULT;
@@ -181,7 +181,7 @@ export class CwcButton extends CwcBaseButton {
    *
    * Defaults to `ClrLoadingState.DEFAULT`.
    */
-  @property({ type: Number, reflect: true, attribute: 'loading-state' })
+  @property({ type: Number, attribute: 'loading-state' })
   set loadingState(state: ClrLoadingState) {
     const oldState = this._loadingState;
     this.updateButtonState(state);

--- a/src/clr-core/common/base/button.base.ts
+++ b/src/clr-core/common/base/button.base.ts
@@ -1,12 +1,13 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { html, LitElement, property, query } from 'lit-element';
+import { html, LitElement, query } from 'lit-element';
 import { ifDefined } from 'lit-html/directives/if-defined';
 
+import { property } from '../decorators/property';
 import { querySlot } from '../decorators/query-slot';
 import { KeyCodes } from './../enums/key-codes';
 import { stopEvent } from './../utils/events';
@@ -16,17 +17,17 @@ export class CwcBaseButton extends LitElement {
   private _disabled: boolean = false;
   protected _previouslyDisabled: boolean = false;
 
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean })
   readonly = false;
-  @property({ type: String, reflect: true })
+  @property({ type: String })
   role = 'button';
-  @property({ type: String, reflect: true })
+  @property({ type: String })
   type: 'button' | 'submit';
-  @property({ type: String, reflect: true })
+  @property({ type: String })
   name = '';
-  @property({ type: String, reflect: true })
+  @property({ type: String })
   value = '';
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean })
   set disabled(value: boolean) {
     // the _previouslyDisabled is used in button.element.ts for loading buttons
     // to keep track of the state it had before being 'disabled' by the component when it's loading

--- a/src/clr-core/common/decorators/property.spec.ts
+++ b/src/clr-core/common/decorators/property.spec.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { getDefaultOptions } from './property';
+
+describe('@property decorator defaults', () => {
+  it('should ignore empty options', () => {
+    expect(getDefaultOptions(undefined as any)).toBe(undefined);
+  });
+
+  it('should allow defaults to be overridden', () => {
+    expect(getDefaultOptions({ type: String, reflect: false }).reflect).toBe(false);
+  });
+
+  it('should reflect properties into attributes for only primitive types', () => {
+    expect(getDefaultOptions({ type: String }).reflect).toBe(true);
+    expect(getDefaultOptions({ type: Number }).reflect).toBe(true);
+    expect(getDefaultOptions({ type: Boolean }).reflect).toBe(true);
+
+    expect(getDefaultOptions({ type: Object }).reflect).toBe(false);
+    expect(getDefaultOptions({ type: Array }).reflect).toBe(false);
+    expect(getDefaultOptions({ type: Date }).reflect).toBe(false);
+  });
+
+  it('should accept boolean attributes with the value of "false"', () => {
+    const booleanConverter: any = getDefaultOptions({ type: Boolean }).converter;
+    expect(booleanConverter.fromAttribute('false')).toBe(false);
+    expect(booleanConverter.fromAttribute('true')).toBe(true);
+    expect(booleanConverter.fromAttribute('')).toBe(true);
+  });
+
+  it('should parse dates from attributes', () => {
+    const dateConverter: any = getDefaultOptions({ type: Date }).converter;
+    const date: Date = dateConverter.fromAttribute('2020-01-02');
+    expect(date.toISOString()).toBe('2020-01-02T00:00:00.000Z');
+  });
+});

--- a/src/clr-core/common/decorators/property.ts
+++ b/src/clr-core/common/decorators/property.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+// tslint:disable-next-line
+import { property as prop } from 'lit-element';
+
+export interface PropertyDeclaration<Type = unknown, TypeHint = unknown> {
+  noAccessor?: boolean;
+  attribute?: boolean | string;
+  type?: TypeHint;
+  reflect?: boolean;
+  converter?:
+    | ((value: string, type?: TypeHint) => Type)
+    | {
+        fromAttribute?(value: string | null, type?: TypeHint): Type;
+        toAttribute?(value: Type, type?: TypeHint): unknown;
+      };
+  hasChanged?(value: Type, oldValue: Type): boolean;
+}
+
+/**
+ * lit-element @property decorator with custom defaults.
+ * https://lit-element.polymer-project.org/guide/properties#property-options
+ *
+ * A property decorator which creates a LitElement property which reflects a
+ * corresponding attribute value. A PropertyDeclaration may optionally be
+ * supplied to configure property features.
+ */
+export function property(options?: PropertyDeclaration<unknown, unknown>) {
+  return prop(getDefaultOptions(options)) as (protoOrDescriptor: {}, name?: string | number | symbol) => any;
+}
+
+/**
+ * https://developers.google.com/web/fundamentals/web-components/best-practices
+ */
+export function getDefaultOptions(options: PropertyDeclaration<unknown, unknown>): PropertyDeclaration {
+  const type = options ? options.type : options;
+
+  switch (type) {
+    case Array:
+      return { reflect: false, ...options };
+    case Object:
+      return { reflect: false, ...options };
+    case String:
+      return { reflect: true, ...options };
+    case Number:
+      return { reflect: true, ...options };
+    case Boolean:
+      return {
+        reflect: true,
+        converter: {
+          // Mimic standard HTML boolean attributes + support "false" attribute values
+          // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes
+          fromAttribute: (value: string) => value !== 'false',
+        },
+        ...options,
+      };
+    case Date: {
+      return {
+        // Parse date strings from attributes but do not reflect back into attribute
+        reflect: false,
+        converter: {
+          fromAttribute: (value: string) => new Date(value),
+        },
+        ...options,
+      };
+    }
+    default:
+      return options;
+  }
+}

--- a/src/clr-core/common/index.ts
+++ b/src/clr-core/common/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -10,6 +10,7 @@ export * from './css-vars/css-vars';
 export * from './utils/dom';
 export * from './utils/register';
 export * from './decorators/query-slot';
+export * from './decorators/property';
 export * from './enums/key-codes';
 export * from './services/common-strings.service';
 export * from './services/common-strings.interface';

--- a/src/clr-core/icon-shapes/icon.element.ts
+++ b/src/clr-core/icon-shapes/icon.element.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -10,10 +10,11 @@ import {
   CssHelpers,
   hasPropertyChanged,
   isNilOrEmpty,
+  property,
   registerElementSafely,
   UniqueId,
 } from '@clr/core/common';
-import { html, LitElement, property } from 'lit-element';
+import { html, LitElement } from 'lit-element';
 import { styles } from './icon.element.css';
 import { ClarityIcons } from './icon.service';
 import { updateIconSizeStyleOrClassnames } from './utils/icon.classnames';
@@ -72,7 +73,7 @@ export class CwcIcon extends IconMixinClass {
    * Changes the svg glyph displayed in the icon component. Defaults to the 'unknown' icon if
    * the specified icon cannot be found in the icon registry.
    */
-  @property({ type: String, reflect: true })
+  @property({ type: String })
   set shape(val: string) {
     if (hasPropertyChanged(val, this._shape)) {
       const oldVal = this._shape;
@@ -86,7 +87,7 @@ export class CwcIcon extends IconMixinClass {
   }
 
   /** Apply numerical width-height or a t-shirt-sized CSS classname */
-  @property({ type: String, reflect: true })
+  @property({ type: String })
   set size(val: string) {
     if (hasPropertyChanged(val, this._size)) {
       const oldVal = this._size;
@@ -97,25 +98,25 @@ export class CwcIcon extends IconMixinClass {
   }
 
   /** If present, customizes the aria-label for the icon for accessibility. */
-  @property({ type: String, reflect: true })
+  @property({ type: String })
   title: string;
 
   /** If present, determines the id of the icon. Uses a generated unique id otherwise. */
-  @property({ type: String, reflect: true })
+  @property({ type: String })
   id: string;
 
   /**
    * Takes a directional value (up|down|left|right) that rotates the icon 90° with the
    * top of the icon pointing in the specified direction.
    */
-  @property({ type: String, reflect: true })
+  @property({ type: String })
   dir: string;
 
   /**
    * Takes an orientation value (horizontal|vertical) that reverses the orientation of the
    * icon vertically or horizontally.
    */
-  @property({ type: String, reflect: true })
+  @property({ type: String })
   flip: string;
 
   firstUpdated() {

--- a/src/clr-core/tag/tag.element.ts
+++ b/src/clr-core/tag/tag.element.ts
@@ -1,11 +1,10 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { baseStyles, CwcBaseButton, registerElementSafely } from '@clr/core/common';
-import { property } from 'lit-element';
+import { baseStyles, CwcBaseButton, property, registerElementSafely } from '@clr/core/common';
 import { styles } from './tag.element.css';
 
 /**
@@ -34,11 +33,11 @@ import { styles } from './tag.element.css';
 // @dynamic
 export class CwcTag extends CwcBaseButton {
   /** Sets the color of the tag (and badge if present) from a predefined list of statuses */
-  @property({ type: String, reflect: true })
+  @property({ type: String })
   status: 'info' | 'success' | 'warning' | 'danger';
 
   /** Sets the color of the tag (and badge if present) from a predefined list of choices */
-  @property({ type: String, reflect: true })
+  @property({ type: String })
   color: '1' | '2' | '3' | '4' | '5';
 
   static get styles() {

--- a/src/clr-core/test-dropdown/test-dropdown.element.ts
+++ b/src/clr-core/test-dropdown/test-dropdown.element.ts
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { CommonStringsService } from '@clr/core';
-import { baseStyles, registerElementSafely } from '@clr/core/common';
-import { html, LitElement, property } from 'lit-element';
+import { baseStyles, property, registerElementSafely } from '@clr/core/common';
+import { html, LitElement } from 'lit-element';
 
 import { styles } from './test-dropdown.element.css';
 

--- a/src/clr-core/tslint.json
+++ b/src/clr-core/tslint.json
@@ -2,7 +2,16 @@
   "extends": "./../../tslint.json",
   "rules": {
     "no-barrel-imports": false,
-    "import-blacklist": [true, "rxjs", "rxjs/operators", "@angular", "@angular/common", "@angular/core", "ramda"],
+    "import-blacklist": [
+      true,
+      { "lit-element": ["property"] },
+      "rxjs",
+      "rxjs/operators",
+      "@angular",
+      "@angular/common",
+      "@angular/core",
+      "ramda"
+    ],
     "ordered-imports": true,
     "member-access": [true, "no-public"],
     "arrow-return-shorthand": true,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?
* [ ] Bugfix
* [ ] Feature
* [x] Code style update (formatting, local variables)
* [x] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the new behavior?
- Adds custom attr parser support for booleans and dates when using `@property`
- New `@property` decorator from `@clr/core/common` is same as lit-html but provides consistent defaults for all components.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

