### PR TITLE
fix(date-picker): correctly compare min/max date limits

### DIFF
--- a/src/clr-angular/forms/datepicker/model/calendar-view.model.spec.ts
+++ b/src/clr-angular/forms/datepicker/model/calendar-view.model.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -135,12 +135,12 @@ export default function(): void {
         // iterate all the week arrays
         for (const day of view) {
           // iterate all of the days
-          if (day.dayModel.toDate() < dateRange.minDate.toDate()) {
-            expect(day.isDisabled).toBe(true); // if the date is less than the minDate should be  disabled
-          } else if (day.dayModel.toDate() > dateRange.maxDate.toDate()) {
-            expect(day.isDisabled).toBe(true); // if the date is above the max date it should be disabled
+          if (day.dayModel.toComparisonString() < dateRange.minDate.toComparisonString()) {
+            expect(day.isDisabled).toBe(true, `Expected ${day.dayModel.toDateString()} to be disabled`); // if the date is less than the minDate should be  disabled
+          } else if (day.dayModel.toComparisonString() > dateRange.maxDate.toComparisonString()) {
+            expect(day.isDisabled).toBe(true, `Expected ${day.dayModel.toDateString()} to be disabled`); // if the date is above the max date it should be disabled
           } else {
-            expect(day.isDisabled).toBe(false); // otherwise, the date should not be disabled
+            expect(day.isDisabled).toBe(false, `Expected ${day.dayModel.toDateString()} to be enabled`); // otherwise, the date should not be disabled
           }
         }
       }

--- a/src/clr-angular/forms/datepicker/model/calendar-view.model.ts
+++ b/src/clr-angular/forms/datepicker/model/calendar-view.model.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -84,9 +84,9 @@ export class CalendarViewModel {
 
   private isDateExcluded(date: DayModel) {
     const { minDate, maxDate }: DateRange = this.excludedDates;
-    const from = new Date(minDate.year, minDate.month - 1, minDate.date);
-    const to = new Date(maxDate.year, maxDate.month - 1, maxDate.date);
-    const today = new Date(date.year, date.month - 1, date.date);
+    const from = minDate.toComparisonString();
+    const to = maxDate.toComparisonString();
+    const today = date.toComparisonString();
 
     return !(today >= from && today <= to);
   }

--- a/src/clr-angular/forms/datepicker/model/day.model.spec.ts
+++ b/src/clr-angular/forms/datepicker/model/day.model.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -71,6 +71,12 @@ export default function(): void {
     it('provides a toDateString method that returns the local date string', () => {
       const testString = dayModel1.toDateString();
       expect(testString).toEqual('1/1/2018');
+    });
+
+    it('provides a toComparisonString method to compare dates', () => {
+      const testString = dayModel1.toComparisonString();
+      // Remember, months are 0 indexed
+      expect(testString).toEqual('20180001');
     });
   });
 }

--- a/src/clr-angular/forms/datepicker/model/day.model.ts
+++ b/src/clr-angular/forms/datepicker/model/day.model.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -37,6 +37,14 @@ export class DayModel {
    */
   clone(): DayModel {
     return new DayModel(this.year, this.month, this.date);
+  }
+
+  toComparisonString(): string {
+    return `${this.year}${this.pad(this.month)}${this.pad(this.date)}`;
+  }
+
+  private pad(num: number): string {
+    return num < 10 ? `0${num}` : `${num}`;
   }
 
   public toDateString(): string {

--- a/src/dev/src/app/datepicker/datepicker-min-max.html
+++ b/src/dev/src/app/datepicker/datepicker-min-max.html
@@ -1,5 +1,5 @@
 <!--
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
 -->
@@ -8,8 +8,17 @@
   <h6>Min/Max Dates</h6>
   <p></p>
   <clr-date-container>
+    <label>Date</label>
     <input type="date" [(ngModel)]="model" clrDate [min]="minDate" [max]="maxDate">
   </clr-date-container>
+  <clr-input-container>
+    <label>Min Date</label>
+    <input type="text" [(ngModel)]="minDate" clrInput>
+  </clr-input-container>
+  <clr-input-container>
+    <label>Max Date</label>
+    <input type="text" [(ngModel)]="maxDate" clrInput>
+  </clr-input-container>
 </div>
 
 <button class="btn" (click)="toggleMinDate()">{{ minDate ? 'Remove' : 'Add'}} Min</button>

--- a/src/dev/src/app/datepicker/datepicker-min-max.ts
+++ b/src/dev/src/app/datepicker/datepicker-min-max.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -11,9 +11,9 @@ import { Component } from '@angular/core';
   styleUrls: ['./datepicker.demo.scss'],
 })
 export class DatepickerMinMaxDemo {
-  minDate: string = '2019-11-17';
-  maxDate: string = '2019-11-19';
-  model;
+  minDate: string = '2017-04-01';
+  maxDate: string = '2017-04-30';
+  model = '04/15/2017';
 
   toggleMaxDate() {
     if (this.minDate) {


### PR DESCRIPTION
The day models were being converted to Date objects and then compared, which caused some potential issues with timezones in comparisons. This converts the comparisons to YYYYMMDD strings instead to do comparisons, which avoids timezones.

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

The dates are compared as date objects, which can cause some timezone drift and enable/disbable dates on the edges incorrectly.

closes #4144

## What is the new behavior?

The dates are converted to YYYYMMDD strings and compared to remove date drift.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
