### PR TITLE
docs(date-picker): add labels to website demos

### DIFF
--- a/src/website/src/app/documentation/demos/datepicker/demos/datepicker-api.demo.html
+++ b/src/website/src/app/documentation/demos/datepicker/demos/datepicker-api.demo.html
@@ -5,8 +5,9 @@
     <code class="clr-code">input</code> field. Then, place the input inside the
     <code class="clr-code">clr-date-container</code> container element.
 </p>
-<form class="datepicker-demo" clrForm clrLayout="vertical">
+<form class="datepicker-demo" clrForm clrLayout="horizontal">
     <clr-date-container>
+        <label>Basic Demo</label>
         <input type="date" clrDate name="demo" [(ngModel)]="demo">
     </clr-date-container>
 </form>
@@ -37,11 +38,24 @@
 <h5>Only Min</h5>
 <form clrForm clrLayout="vertical">
     <clr-date-container>
-        <input type="date" clrDate name="minDemo" [(ngModel)]="demo" min="2019-11-11">
+        <label>Min date: 2019-11-17</label>
+        <input type="date" clrDate name="minDemo" [(ngModel)]="demo" min="2019-11-17">
     </clr-date-container>
 </form>
 <clr-code-snippet [clrCode]="minExample"></clr-code-snippet>
 <h5>Only Max</h5>
+<form clrForm clrLayout="vertical">
+    <clr-date-container>
+        <label>Max date: 2019-11-19</label>
+        <input type="date" clrDate name="maxDemo" [(ngModel)]="demo" max="2019-11-19">
+    </clr-date-container>
+</form>
 <clr-code-snippet [clrCode]="maxExample"></clr-code-snippet>
 <h5>Min and Max</h5>
+<form clrForm clrLayout="horizontal">
+    <clr-date-container>
+        <label>Min date: 2019-11-17 AND Max date: 2019-11-19</label>
+        <input type="date" clrDate name="minMaxDemo" [(ngModel)]="demo" min="2019-11-17" max="2019-11-19">
+    </clr-date-container>
+</form>
 <clr-code-snippet [clrCode]="minMaxExample"></clr-code-snippet>

--- a/src/website/src/app/documentation/demos/datepicker/demos/datepicker-api.demo.ts
+++ b/src/website/src/app/documentation/demos/datepicker/demos/datepicker-api.demo.ts
@@ -1,34 +1,40 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { Component } from '@angular/core';
 
 const HTML_EXAMPLE = `
-<form clrForm clrLayout="vertical">
-  <clr-date-container>
-    <input type="date" clrDate name="demo" [(ngModel)]="demo">
-  </clr-date-container>
+<form clrForm>
+    <clr-date-container>
+        <label>Basic Demo</label>
+        <input type="date" clrDate name="demo" [(ngModel)]="demo">
+    </clr-date-container>
 </form>
 `;
 
 const MIN_EXAMPLE = `
-<form clrForm clrLayout="vertical">
+<form clrForm>
   <clr-date-container>
-    <input type="date" clrDate name="demo" [(ngModel)]="demo" min="2019-11-11">
+    <label>Min date: 2019-11-17</label>
+    <input type="date" clrDate name="demo" [(ngModel)]="demo" min="2019-11-17">
   </clr-date-container>
 </form>
 `;
 const MAX_EXAMPLE = `
+<form clrForm>
   <clr-date-container>
-    <input type="date" clrDate name="demo" [(ngModel)]="demo" max="2019-11-11">
+    <label>Max date: 2019-11-19</label>
+    <input type="date" clrDate name="demo" [(ngModel)]="demo" max="2019-11-19">
   </clr-date-container>
 </form>
 `;
 const MIN_MAX_EXAMPLE = `
+<form clrForm>
   <clr-date-container>
-    <input type="date" clrDate name="demo" [(ngModel)]="demo" min="2019-11-11" max="2019-12-12">
+    <label>Min date: 2019-11-17 AND Max date: 2019-11-19</label>
+    <input type="date" clrDate name="demo" [(ngModel)]="demo" min="2019-11-17" max="2019-11-19">
   </clr-date-container>
 </form>
 `;

--- a/src/website/src/app/documentation/demos/datepicker/demos/datepicker-date-io.demo.html
+++ b/src/website/src/app/documentation/demos/datepicker/demos/datepicker-date-io.demo.html
@@ -8,6 +8,7 @@
 </clr-alert>
 <form clrForm class="datepicker-demo" clrLayout="vertical">
     <clr-date-container>
+        <label>Date Object</label>
         <input type="date" [(clrDate)]="date">
     </clr-date-container>
 </form>

--- a/src/website/src/app/documentation/demos/datepicker/demos/datepicker-date-io.demo.ts
+++ b/src/website/src/app/documentation/demos/datepicker/demos/datepicker-date-io.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -8,6 +8,7 @@ import { Component } from '@angular/core';
 const HTML_EXAMPLE = `
 <form clrForm clrLayout="vertical">
   <clr-date-container>
+    <label>Date Object</label>
     <input type="date" [(clrDate)]="date">
   </clr-date-container>
 </form>

--- a/src/website/src/app/documentation/demos/datepicker/demos/datepicker-enUS.demo.ts
+++ b/src/website/src/app/documentation/demos/datepicker/demos/datepicker-enUS.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -10,7 +10,10 @@ import { Component } from '@angular/core';
   template: `
         <h5 style="margin-top: 24px">Locale Identifier: en-US</h5>
         <form clrForm clrLayout="vertical">
-            <input type="date" clrDate>
+            <clr-date-container>
+                <label>US locale</label>
+                <input type="date" clrDate>
+            </clr-date-container>
         </form>
         <table class="table">
             <thead>

--- a/src/website/src/app/documentation/demos/datepicker/demos/datepicker-fr.demo.ts
+++ b/src/website/src/app/documentation/demos/datepicker/demos/datepicker-fr.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -10,7 +10,10 @@ import { Component, LOCALE_ID } from '@angular/core';
   template: `
         <h5 style="margin-top: 24px">Locale Idenitifer: fr</h5>
         <form clrForm clrLayout="vertical">
-            <input type="date" clrDate>
+            <clr-date-container>
+                <label>FR Locale</label>
+                <input type="date" clrDate>
+            </clr-date-container>
         </form>
         <table class="table">
             <thead>

--- a/src/website/src/app/documentation/demos/datepicker/demos/datepicker-reactive-forms.html
+++ b/src/website/src/app/documentation/demos/datepicker/demos/datepicker-reactive-forms.html
@@ -1,8 +1,8 @@
 <form clrForm [formGroup]="dateForm" novalidate>
     <h4>Reactive Form Demo</h4>
     <clr-date-container>
-        <label for="dateControl">Date</label>
-        <input id="dateControl" type="date" clrDate formControlName="date"/>
+        <label>Date</label>
+        <input type="date" clrDate formControlName="date"/>
     </clr-date-container>
 </form>
 <pre class="datepicker-output">

--- a/src/website/src/app/documentation/demos/datepicker/demos/datepicker-reactive-forms.ts
+++ b/src/website/src/app/documentation/demos/datepicker/demos/datepicker-reactive-forms.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -10,8 +10,8 @@ const HTML_EXAMPLE = `
 <form clrForm [formGroup]="dateForm" novalidate>
     <h4>Reactive Form Demo</h4>
     <clr-date-container>
-        <label for="dateControl">Date</label>
-        <input id="dateControl" type="date" clrDate formControlName="date"/>
+        <label>Date</label>
+        <input type="date" clrDate formControlName="date"/>
     </clr-date-container>
 </form>
 <pre class="datepicker-output">


### PR DESCRIPTION
This adds labels to the demos to demonstrate proper use of clr-date-containers and labels for accessible forms.
closes #3465

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?
Current datepicker demos and example code show using `clrDate` without a label. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Issue Number: N/A

## What is the new behavior?
This change adds clr-date-container and labels to the datepicker demos. 

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
