### PR TITLE
fix: core icon performance and a11y

### DIFF
--- a/docs/core/cwc-icon.md
+++ b/docs/core/cwc-icon.md
@@ -20,7 +20,6 @@ ClarityIcons.addIcons(userIcon);
 |----------|-----------|----------|--------------|--------------------------------------------------|
 | `dir`    | `dir`     | `string` | **required** | Takes a directional value (up\|down\|left\|right) that rotates the icon 90° with the<br />top of the icon pointing in the specified direction. |
 | `flip`   | `flip`    | `string` | **required** | Takes an orientation value (horizontal\|vertical) that reverses the orientation of the<br />icon vertically or horizontally. |
-| `id`     | `id`      | `string` | **required** | If present, determines the id of the icon. Uses a generated unique id otherwise. |
 | `shape`  | `shape`   | `string` |              | Changes the svg glyph displayed in the icon component. Defaults to the 'unknown' icon if<br />the specified icon cannot be found in the icon registry. |
 | `size`   | `size`    | `string` |              | Apply numerical width-height or a t-shirt-sized CSS classname |
 | `title`  | `title`   | `string` | **required** | If present, customizes the aria-label for the icon for accessibility. |

--- a/src/clr-core/icon-shapes/icon.element.spec.ts
+++ b/src/clr-core/icon-shapes/icon.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -14,14 +14,6 @@ const testIcon = renderIcon('test');
 describe('icon element', () => {
   let testElement: HTMLElement;
   let component: CwcIcon;
-  let idcomponent: CwcIcon;
-  let updaterObject: CwcIcon;
-  let updaterValue: string;
-
-  function updateIconSizeMock(obj: CwcIcon, val: string) {
-    updaterObject = obj;
-    updaterValue = val;
-  }
 
   beforeAll(() => {
     ClarityIcons.add({ testing: testIcon });
@@ -30,16 +22,11 @@ describe('icon element', () => {
   beforeEach(async () => {
     testElement = createTestElement();
     testElement.innerHTML = `
-      <cwc-icon class="no-id"></cwc-icon>
-      <cwc-icon id="ohai"></cwc-icon>
+      <cwc-icon></cwc-icon>
     `;
 
-    updaterObject = void 0;
-    updaterValue = void 0;
-
     await waitForComponent('cwc-icon');
-    component = testElement.querySelector<CwcIcon>('cwc-icon.no-id');
-    idcomponent = testElement.querySelector<CwcIcon>('cwc-icon#ohai');
+    component = testElement.querySelector<CwcIcon>('cwc-icon');
   });
 
   afterEach(() => {
@@ -103,43 +90,18 @@ describe('icon element', () => {
     });
   });
 
-  describe('ariaId: ', () => {
-    it('ariaId should return an aria prefixed id for use by labelled by', async () => {
-      // only shape in registry is 'unknown'
-      await componentIsStable(idcomponent);
-      expect(idcomponent.shadowRoot.innerHTML.includes('aria-ohai')).toBe(true);
-    });
-    it('ariaId should default to a defined id', async () => {
+  describe('title and aria label: ', () => {
+    it('should set aria label when a icon title is provided', async () => {
       await componentIsStable(component);
-      expect(component.shadowRoot.innerHTML.includes('aria-undefined')).toBe(false);
-      expect(component.shadowRoot.innerHTML.includes('aria-cwc-icon-0')).toBe(false);
-    });
-  });
+      expect(component.shadowRoot.querySelector('svg').getAttribute('aria-labelledby')).toBe(null);
+      expect(component.shadowRoot.querySelector('span')).toBe(null);
 
-  describe('id: ', () => {
-    it('should set an id if one is not given', async () => {
+      component.title = 'test';
       await componentIsStable(component);
-      const tagNameInId = component.tagName.toLowerCase();
-      expect(component.getAttribute('id')).toContain(tagNameInId);
-      expect(component.shadowRoot.innerHTML.includes('id="aria-' + tagNameInId)).toBe(true);
-      expect(component.shadowRoot.innerHTML.includes('aria-labelledby="aria-' + tagNameInId)).toBe(true);
-    });
 
-    it('should not overwrite id if one is given', async () => {
-      await componentIsStable(idcomponent);
-      const expectedId = 'ohai';
-      expect(idcomponent.shadowRoot.innerHTML.includes('id="aria-' + expectedId)).toBe(true);
-      expect(idcomponent.shadowRoot.innerHTML.includes('aria-labelledby="aria-' + expectedId)).toBe(true);
-      expect(idcomponent.id).toBe(expectedId);
-    });
-
-    it('should update id if it is changed', async () => {
-      const newId = 'kthxbye';
-      await componentIsStable(idcomponent);
-      idcomponent.setAttribute('id', newId);
-      await componentIsStable(idcomponent);
-      expect(idcomponent.shadowRoot.innerHTML.includes('id="aria-' + newId)).toBe(true);
-      expect(idcomponent.shadowRoot.innerHTML.includes('aria-labelledby="aria-' + newId)).toBe(true);
+      const id = component.shadowRoot.querySelector('span').getAttribute('id');
+      expect(id.includes('aria-cwc-icon')).toBe(true);
+      expect(component.shadowRoot.querySelector('svg').getAttribute('aria-labelledby')).toBe(id);
     });
   });
 
@@ -190,22 +152,10 @@ describe('icon element', () => {
     });
   });
 
-  describe('title: ', () => {
-    it('should generate a title consisting of "[shape] icon" in the sr-only element if no title is given', async () => {
-      const shape = 'testing';
-      let srOnlyEl: HTMLElement;
-      await componentIsStable(component);
-      component.setAttribute('shape', shape);
-      await componentIsStable(component);
-      srOnlyEl = component.shadowRoot.querySelector('.sr-only');
-      expect(srOnlyEl.innerHTML).toContain(shape + ' icon');
-    });
-  });
-
   describe('render(): ', () => {
     it('should render icon', async () => {
-      await componentIsStable(idcomponent);
-      const iconHtml = idcomponent.shadowRoot.innerHTML;
+      await componentIsStable(component);
+      const iconHtml = component.shadowRoot.innerHTML;
       const iconHtmlPaths = iconHtml
         .split('<')
         .map((val, index, arry) => {
@@ -214,22 +164,11 @@ describe('icon element', () => {
           }
         })
         .join('<');
-      expect(idcomponent.shadowRoot.innerHTML.includes('aria-' + idcomponent.id)).toBe(true);
-      expect(idcomponent.shadowRoot.innerHTML.includes(iconHtmlPaths)).toBe(true);
+      expect(component.shadowRoot.innerHTML.includes(iconHtmlPaths)).toBe(true);
     });
   });
 
   describe('Behavior: ', () => {
-    it('should reflect changes in id', async () => {
-      await componentIsStable(component);
-      component.id = 'howdy';
-      await componentIsStable(component);
-      expect(component.getAttribute('id')).toEqual(component.id);
-      component.setAttribute('id', 'kthxbye');
-      await componentIsStable(component);
-      expect(component.getAttribute('id')).toEqual(component.id);
-    });
-
     it('should reflect changes in shape', async () => {
       await componentIsStable(component);
       component.shape = 'testing';

--- a/src/clr-core/icon-shapes/utils/icon.svg-helpers.ts
+++ b/src/clr-core/icon-shapes/utils/icon.svg-helpers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -46,7 +46,7 @@ export function getIconSvgOpeningTag(icon: IconShapeCollection) {
   const iconSvgViewboxSize = 36;
   const iconSvgClasses = getIconSvgClasses(icon);
 
-  return `<svg version="1.1" class="${iconSvgClasses}" viewBox="0 0 ${iconSvgViewboxSize} ${iconSvgViewboxSize}" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" focusable="false" role="img">`;
+  return `<svg version="1.1" class="${iconSvgClasses}" viewBox="0 0 ${iconSvgViewboxSize} ${iconSvgViewboxSize}" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" focusable="false" role="img" aria-label="">`;
 }
 
 export function getIconSvgClosingTag(icon: IconShapeCollection): string {

--- a/src/dev-core/src/app/icon-sets/icon-sets.demo.html
+++ b/src/dev-core/src/app/icon-sets/icon-sets.demo.html
@@ -1,133 +1,118 @@
 <style>
-    table.table {
-        width: 100%;
-        max-width: 32rem;
-        margin: 1.2rem 0;
-    }
+  table.table {
+      width: 100%;
+      max-width: 32rem;
+      margin: 1.2rem 0;
+  }
 
-    table.table th,
-    table.table td {
-        text-align: left;
-        line-height: 1.1em;
-    }
+  table.table th,
+  table.table td {
+      text-align: left;
+      line-height: 1.1em;
+  }
 
-    .style-toggles label,
-    p > label {
-        padding-left: 0.9rem;
-    }
-    
-    .style-toggles label:first-child,
-    p > label:first-child {
-        padding-left: 0;
-    }
+  .style-toggles label,
+  p > label {
+      padding-left: 0.9rem;
+  }
+  
+  .style-toggles label:first-child,
+  p > label:first-child {
+      padding-left: 0;
+  }
 
-    .filter-and-toggles {
-        border-bottom: 0.05rem solid #ccc;
-        padding-bottom: 1.2rem;
-        margin-bottom: 1.2rem;
-    }
-    
-    table b {
-        padding-right: 0.6rem;
-    }
-    tr + tr > td {
-        padding-top: 0.6rem;
-    }
+  .filter-and-toggles {
+      border-bottom: 0.05rem solid #ccc;
+      padding-bottom: 1.2rem;
+      margin-bottom: 1.2rem;
+  }
 
-    .style-toggles input {
-        padding-right: 0.4rem;
-    }
+  table b {
+      padding-right: 0.6rem;
+  }
+  tr + tr > td {
+      padding-top: 0.6rem;
+  }
 
-    .dc-icon-set cwc-icon {
-        width: 1.8rem;
-        height: 1.8rem;
-    }
+  .style-toggles input {
+      padding-right: 0.4rem;
+  }
 
-    .dc-icon-box table {
-        margin: 0;
-    }
-    
-    .dc-icon-box table td {
-        text-align: center;
-    }
+  .dc-icon-set cwc-icon {
+      width: 1.8rem;
+      height: 1.8rem;
+  }
 
-    .dc-icon-boxes {
-        padding: 1.2rem 0.4rem 0;
-        margin: 0;
-        background: #f4f4f4;
-    }
+  .dc-icon-boxes {
+      padding: 1.2rem 0.4rem 0;
+      background: #f4f4f4;
+  }
 
-    .dc-icon-boxes.inverse {
-        background: #565656;
-    }
+  .dc-icon-boxes.inverse {
+      background: #565656;
+  }
 
-    .dc-icon-boxes.inverse .dc-icon-name {
-        color: #fff;
-    }
+  .dc-icon-boxes.inverse .dc-icon-name {
+      color: #fff;
+  }
 
-    table tr td.dc-icon-name {
-        padding: 0.2rem 0 1.2rem;
-    }
+  .dc-icon-box {
+      text-align: center;
+  }
+
+  .dc-icon-box p {
+      margin: 0;
+      padding: 0.2rem 0 1.2rem;
+  }
 </style>
 
 <h1>Icon Sets Demo</h1>
 
 <section class="filter-and-toggles" [formGroup]="iconFilterAndToggles">
-    <table class="table">
-        <tbody>
-            <tr>
-                <td>
-                    <label><b>Search:</b><input type="text" placeholder="Enter icon name" formControlName="filterText"></label>
-                </td>
-                <td>
-                    <label>
-                        <b>Show Icon Set:</b>
-                        <select formControlName="currentSet">
-                            <option value="All">All</option>
-                            <option *ngFor="let setName of availableSets" [value]="setName">{{setName}}</option>
-                        </select>
-                    </label>
-                </td>
-            </tr>
-            <tr>
-                <td class="style-toggles" colspan="2">
-                    <label>
-                        <input type="checkbox" formControlName="isSolid">
-                        Solid
-                    </label>
-                    <label>
-                        <input type="checkbox" formControlName="isInverse">
-                        Inverse
-                    </label>
-                </td>
-            </tr>
-        </tbody>
-    </table>
-    <p>
-        <label><b>Decoration:</b></label>
-        <label><input type="radio" value="none" formControlName="decoration"> None</label>
-        <label><input type="radio" value="alerted" formControlName="decoration"> Alerted</label>
-        <label><input type="radio" value="badged" formControlName="decoration"> Badged</label>
-    </p>
+  <table class="table">
+      <tbody>
+          <tr>
+              <td>
+                  <label><b>Search:</b><input type="text" placeholder="Enter icon name" formControlName="filterText"></label>
+              </td>
+              <td>
+                  <label>
+                      <b>Show Icon Set:</b>
+                      <select formControlName="currentSet">
+                          <option value="All">All</option>
+                          <option *ngFor="let setName of availableSets" [value]="setName">{{setName}}</option>
+                      </select>
+                  </label>
+              </td>
+          </tr>
+          <tr>
+              <td class="style-toggles" colspan="2">
+                  <label>
+                      <input type="checkbox" formControlName="isSolid">
+                      Solid
+                  </label>
+                  <label>
+                      <input type="checkbox" formControlName="isInverse">
+                      Inverse
+                  </label>
+              </td>
+          </tr>
+      </tbody>
+  </table>
+  <p>
+      <label><b>Decoration:</b></label>
+      <label><input type="radio" value="none" formControlName="decoration"> None</label>
+      <label><input type="radio" value="alerted" formControlName="decoration"> Alerted</label>
+      <label><input type="radio" value="badged" formControlName="decoration"> Badged</label>
+  </p>
 </section>
 
-<section *ngFor="let iconSet of visibleIconSets" id="dev-core-icon-set-core" class="dc-icon-set">
-    <h2>{{iconSet}} Set</h2>
-    <div [ngClass]="iconRowClassnames">
-        <ng-container *ngFor="let iconName of iconIndex[iconSet]">
-            <div class="dc-icon-box clr-col-2" *ngIf="showIcon(iconName)">
-                <table class="table">
-                    <tbody>
-                        <tr>
-                            <td><cwc-icon [shape]="iconName" [ngClass]="iconClassnames"></cwc-icon></td>
-                        </tr>
-                        <tr>
-                            <td class="dc-icon-name">{{iconName}}</td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-        </ng-container>
-    </div>
+<section *ngFor="let iconSet of visibleIconSets" class="dc-icon-set">
+  <h2>{{iconSet}} Set</h2>
+  <div class="clr-row dc-icon-boxes" [ngClass]="{ 'inverse': isInverse }">
+      <div *ngFor="let iconName of iconIndex[iconSet]" class="dc-icon-box clr-col-2" [hidden]="!showIcon(iconName)">
+          <cwc-icon [shape]="iconName" [ngClass]="iconClassnames"></cwc-icon>
+          <p class="dc-icon-name">{{iconName}}</p>
+      </div>
+  </div>
 </section>
-


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [x] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the new behavior?
### 1. Improved icon demo performance
  - Renders demo page (416 icons) around ~630-750ms compared to 1.1s - 1.2s on docs icon demo page built in prod mode on 2018 macbook pro.
  - Remove use of getters and replace with form value changes observable. This prevents recalculation for each icon during each change detection cycle.
  - Load icons immediately and create index object inline to prevent multiple renders/change detection cycles when angular component is created.
  - Use CSS to show and hide icons to prevent large amount of components being created/destroyed when filtering/searching
  - Remove table layout to reduce number of DOM nodes improving render times

### 2. Improved icon element render performance
  - Single cwc-icon uses ~0.64ms of JS execution time vs current clr-icon at ~1.5ms (2018 macbook pro)
  - remove unnecessary id reflection, ids for a11y labeling are internal and unique so syncing was not needed for a11y
  - only write to svg and create SR label if title is set
  - default svg template to have `role="img"` instead of writing on creation
  - remove unnecessary `<div>` wrapper to reduce DOM elements

### 3. Fix a11y behavior with screen readers.
  - Icons default decorative images unless otherwise set with `title`. When set with title a SR only message will be rendered with title value. Icon should be described by the context of usage such as text within a button or a `aria-label` on a button. Only if icon is represented as stand alone content is the `title` needed. https://clarity.design/icons/accessibility 

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
