### PR TITLE
fix(date-picker): set disabled state without the need of clrForm

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -588,6 +588,7 @@ export declare class ClrDateContainer implements DynamicWrapper, OnDestroy, Afte
     focus: boolean;
     invalid: boolean;
     readonly isEnabled: boolean;
+    readonly isInputDateDisabled: boolean;
     label: ClrLabel;
     position: PopoverPosition;
     constructor(_toggleService: ClrPopoverToggleService, _dateNavigationService: DateNavigationService, _datepickerEnabledService: DatepickerEnabledService, dateFormControlService: DateFormControlService, commonStrings: ClrCommonStringsService, ifErrorService: IfErrorService, focusService: FocusService, controlClassService: ControlClassService, layoutService: LayoutService, ngControlService: NgControlService);
@@ -603,6 +604,7 @@ export declare class ClrDateInput extends WrappedFormControl<ClrDateContainer> i
     protected control: NgControl;
     date: Date;
     dateChange: EventEmitter<Date>;
+    disabled: boolean | string;
     protected el: ElementRef;
     protected index: number;
     readonly inputType: string;

--- a/src/clr-angular/forms/datepicker/date-container.spec.ts
+++ b/src/clr-angular/forms/datepicker/date-container.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -143,6 +143,12 @@ export default function() {
           expect(context.clarityElement.className).toContain('clr-form-control-disabled');
         });
       }));
+
+      it('should set disabled state when dateFormControlService.disabled is true', () => {
+        dateFormControlService.disabled = true;
+        context.detectChanges();
+        expect(context.clarityElement.className).toContain('clr-form-control-disabled');
+      });
 
       it('has an accessible title on the calendar toggle button', () => {
         const toggleButton: HTMLButtonElement = context.clarityElement.querySelector('.clr-input-group-icon-action');

--- a/src/clr-angular/forms/datepicker/date-container.ts
+++ b/src/clr-angular/forms/datepicker/date-container.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -48,7 +48,7 @@ import { PopoverPosition } from '../../popover/common/popover-positions';
                     class="clr-input-group-icon-action"
                     [attr.title]="commonStrings.keys.datepickerToggle"
                     [attr.aria-label]="commonStrings.keys.datepickerToggle"
-                    [disabled]="control?.disabled"
+                    [disabled]="isInputDateDisabled"
                     (click)="toggleDatepicker($event)"
                     *ngIf="isEnabled">
               <clr-icon shape="calendar"></clr-icon>
@@ -76,7 +76,7 @@ import { PopoverPosition } from '../../popover/common/popover-positions';
     ClrCommonStringsService,
   ],
   host: {
-    '[class.clr-form-control-disabled]': 'control?.disabled',
+    '[class.clr-form-control-disabled]': 'isInputDateDisabled',
     '[class.clr-form-control]': 'true',
     '[class.clr-row]': 'addGrid()',
   },
@@ -161,6 +161,16 @@ export class ClrDateContainer implements DynamicWrapper, OnDestroy, AfterViewIni
    */
   get isEnabled(): boolean {
     return this._datepickerEnabledService.isEnabled;
+  }
+
+  /**
+   * Return if Datepicker is diabled or not as Form Control
+   */
+  get isInputDateDisabled(): boolean {
+    /* clrForm wrapper or without clrForm */
+    return (
+      (this.control && this.control.disabled) || (this.dateFormControlService && this.dateFormControlService.disabled)
+    );
   }
 
   /**

--- a/src/clr-angular/forms/datepicker/date-input.ts
+++ b/src/clr-angular/forms/datepicker/date-input.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -38,6 +38,7 @@ import { DateNavigationService } from './providers/date-navigation.service';
 import { DatepickerEnabledService } from './providers/datepicker-enabled.service';
 import { DatepickerFocusService } from './providers/datepicker-focus.service';
 import { datesAreEqual } from './utils/date-utils';
+import { isBooleanAttributeSet } from '../../utils/component/is-boolean-attribute-set';
 
 // There are four ways the datepicker value is set
 // 1. Value set by user typing into text input as a string ex: '01/28/2015'
@@ -156,6 +157,11 @@ export class ClrDateInput extends WrappedFormControl<ClrDateContainer> implement
     } else {
       this.emitDateOutput(null);
     }
+  }
+
+  @Input('disabled')
+  set disabled(value: boolean | string) {
+    this.dateFormControlService.setDisabled(isBooleanAttributeSet(value));
   }
 
   private usingClarityDatepicker() {

--- a/src/clr-angular/forms/datepicker/providers/date-form-control.service.ts
+++ b/src/clr-angular/forms/datepicker/providers/date-form-control.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -10,6 +10,7 @@ import { Observable, Subject } from 'rxjs';
 @Injectable()
 export class DateFormControlService {
   private _touchedChange: Subject<void> = new Subject<void>();
+  public disabled;
 
   get touchedChange(): Observable<void> {
     return this._touchedChange.asObservable();
@@ -27,5 +28,10 @@ export class DateFormControlService {
 
   markAsDirty(): void {
     this._dirtyChange.next();
+  }
+
+  // friendly wrapper
+  setDisabled(state: boolean) {
+    this.disabled = state;
   }
 }

--- a/src/dev/src/app/datepicker/disabled.html
+++ b/src/dev/src/app/datepicker/disabled.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -29,6 +29,13 @@
     </div>
 </div>
 
+<h6>No ClrForm</h6>
+<clr-date-container>
+    <label>Disabled Date Picker</label>
+    <input type="date" [(clrDate)]="date" [disabled]="disabled" />
+</clr-date-container>
+
+<h6>Controll Disabled & Enabled</h6>
 <div>
     <button class="btn" (click)="disabled = !disabled">Toggle Disabled</button>
 </div>

--- a/src/dev/src/app/datepicker/disabled.ts
+++ b/src/dev/src/app/datepicker/disabled.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -11,5 +11,6 @@ import { Component } from '@angular/core';
 })
 export class DisabledDemo {
   model: string = '';
+  date = new Date();
   disabled = true;
 }


### PR DESCRIPTION
Handle when the `date-picker` container is not inside `clrForm` wrapper.

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4016 

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Close: #4016 

Target branch is v3 - must be merged into master/v2/v1(not sure for v1)