### PR TITLE
fix(datagrid): update single action close behavior

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -309,6 +309,7 @@ export declare class ClrDatagridActionOverflow implements OnDestroy {
     popoverId: string;
     smartPosition: ClrPopoverPosition;
     constructor(rowActionService: RowActionService, commonStrings: ClrCommonStringsService, platformId: Object, zone: NgZone, smartToggleService: ClrPopoverToggleService, popoverId: string);
+    closeOverflowContent(event: any): void;
     ngOnDestroy(): void;
 }
 

--- a/src/clr-angular/data/datagrid/datagrid-action-overflow.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-action-overflow.spec.ts
@@ -71,16 +71,6 @@ export default function(): void {
       expect(context.clarityDirective.open).toBe(false);
     });
 
-    it("doesn't close the menu when an action menu item container is clicked", function() {
-      toggle.click();
-      context.detectChanges();
-
-      const actionOverflowMenu: HTMLElement = document.querySelector('.clr-popover-content');
-      actionOverflowMenu.click();
-      context.detectChanges();
-      expect(context.clarityDirective.open).toBe(true);
-    });
-
     it('projects menu content when open', function() {
       toggle.click();
       context.detectChanges();

--- a/src/clr-angular/data/datagrid/datagrid-action-overflow.ts
+++ b/src/clr-angular/data/datagrid/datagrid-action-overflow.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -43,6 +43,7 @@ let clrDgActionId = 0;
            [attr.aria-hidden]="!open"
            [attr.id]="popoverId"
            clrFocusTrap
+           (click)="closeOverflowContent($event)"
            *clrPopoverContent="open at smartPosition; outsideClickToClose: true; scrollToClose: true">
           <ng-content></ng-content>
       </div>
@@ -80,6 +81,10 @@ export class ClrDatagridActionOverflow implements OnDestroy {
   ngOnDestroy() {
     this.rowActionService.unregister();
     this.subscriptions.forEach(sub => sub.unsubscribe());
+  }
+
+  closeOverflowContent(event): void {
+    this.smartToggleService.toggleWithEvent(event);
   }
 
   private _open: boolean = false;


### PR DESCRIPTION
This change adds details around adding the clrPopoverCloseButton to items projected into the action overflow menu that also need to be able to close the menu. It also explains that the default behavior is to ignore clicks on projected content.

closes #3796

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?
Adds details for datagrid action overflow menu related to the popover changes to fix clipping issues.

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?
Consumers don't know that by default content projected into the menu will ignore user clicks. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3796

## What is the new behavior?
There is an explanation and demo showing both. The Edit button ignores user clicks but the Delete button will close the menu after user clicks it. 

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
