### PR TITLE
feat(build): typescript cleanup

### DIFF
--- a/docs/core/cwc-badge.md
+++ b/docs/core/cwc-badge.md
@@ -14,8 +14,8 @@ import '@clr/core/badge';
 
 | Property | Attribute | Type                                             | Default      | Description                                      |
 |----------|-----------|--------------------------------------------------|--------------|--------------------------------------------------|
-| `color`  | `color`   | `"gray" \| "purple" \| "blue" \| "orange" \| "light-blue"` | **required** | Sets the color of the badge from a predefined list of choices |
-| `status` | `status`  | `"info" \| "success" \| "warning" \| "danger"`   | **required** | Sets the color of the badge from a predefined list of statuses |
+| `color`  | `color`   | `"gray" \| "purple" \| "blue" \| "orange" \| "light-blue"` | **required** | Sets the color of the badge from the following predefined list of choices:<br />'gray', 'purple', 'blue', 'orange', 'light-blue' |
+| `status` | `status`  | `any`                                            |              | Sets the color of the badge from the following predefined list of statuses:<br />'info', 'success', 'warning', 'danger' |
 
 ## Slots
 

--- a/docs/core/cwc-button.md
+++ b/docs/core/cwc-button.md
@@ -12,13 +12,13 @@ import '@clr/core/button';
 
 ## Properties
 
-| Property       | Attribute       | Type                                             | Default      | Description                                      |
-|----------------|-----------------|--------------------------------------------------|--------------|--------------------------------------------------|
-| `action`       | `action`        | `"default" \| "outline" \| "link"`               | **required** | Define the type of action the button triggers    |
-| `icon`         | `icon`          | `""`                                             | **required** | Sets button type for icon                        |
-| `loadingState` | `loading-state` | `ClrLoadingState`                                |              | Changes the button content based on the value passed. The value must be of type `ClrLoadingState` and here are possible states:<br /><br />- `ClrLoadingState.DEFAULT` : shows the content of the button<br /><br />- `ClrLoadingState.LOADING` : disables the button and shows a spinner inside the button<br /><br />- `ClrLoadingState.SUCCESS` : disables the button and shows a check mark inside the button; auto-triggers to change back to DEFAULT state after 1000 ms<br /><br />- `ClrLoadingState.ERROR` : shows the content of the button (in the context of application, this state is usually entered from a LOADING state. the application should show appropriate error message)<br /><br />Defaults to `ClrLoadingState.DEFAULT`. |
-| `size`         | `size`          | `"default" \| "sm"`                              | **required** | Sets the overall height and width of the button based on value |
-| `status`       | `status`        | `"success" \| "warning" \| "danger" \| "default" \| "primary" \| "inverse"` | **required** | Sets the color of the button to match the status |
+| Property       | Attribute       | Type                               | Default      | Description                                      |
+|----------------|-----------------|------------------------------------|--------------|--------------------------------------------------|
+| `action`       | `action`        | `"default" \| "outline" \| "link"` | **required** | Define the type of action the button triggers    |
+| `icon`         | `icon`          | `""`                               | **required** | Sets button type for icon                        |
+| `loadingState` | `loading-state` | `ClrLoadingState`                  |              | Changes the button content based on the value passed. The value must be of type `ClrLoadingState` and here are possible states:<br /><br />- `ClrLoadingState.DEFAULT` : shows the content of the button<br /><br />- `ClrLoadingState.LOADING` : disables the button and shows a spinner inside the button<br /><br />- `ClrLoadingState.SUCCESS` : disables the button and shows a check mark inside the button; auto-triggers to change back to DEFAULT state after 1000 ms<br /><br />- `ClrLoadingState.ERROR` : shows the content of the button (in the context of application, this state is usually entered from a LOADING state. the application should show appropriate error message)<br /><br />Defaults to `ClrLoadingState.DEFAULT`. |
+| `size`         | `size`          | `any`                              |              | Sets the overall height and width of the button based on the following string values:<br />'default', 'sm' |
+| `status`       | `status`        | `any`                              |              | Sets the color of the button to match the following string statuses<br />'default', 'primary', 'inverse', 'success', 'warning', 'danger' |
 
 ## Slots
 

--- a/docs/core/cwc-tag.md
+++ b/docs/core/cwc-tag.md
@@ -12,10 +12,10 @@ import '@clr/core/tag';
 
 ## Properties
 
-| Property | Attribute | Type                                           | Default      | Description                                      |
-|----------|-----------|------------------------------------------------|--------------|--------------------------------------------------|
-| `color`  | `color`   | `"1" \| "2" \| "3" \| "4" \| "5"`              | **required** | Sets the color of the tag (and badge if present) from a predefined list of choices |
-| `status` | `status`  | `"info" \| "success" \| "warning" \| "danger"` | **required** | Sets the color of the tag (and badge if present) from a predefined list of statuses |
+| Property | Attribute | Type                              | Default      | Description                                      |
+|----------|-----------|-----------------------------------|--------------|--------------------------------------------------|
+| `color`  | `color`   | `"1" \| "2" \| "3" \| "4" \| "5"` | **required** | Sets the color of the tag (and badge if present) from a predefined list of choices |
+| `status` | `status`  | `any`                             |              | Sets the color of the tag (and badge if present) from the following predefined list of statuses:<br />'info', 'success', 'warning', 'danger' |
 
 ## Slots
 

--- a/src/clr-core/badge/badge.element.ts
+++ b/src/clr-core/badge/badge.element.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { baseStyles, property, registerElementSafely } from '@clr/core/common';
+import { baseStyles, property, registerElementSafely, StatusTypes } from '@clr/core/common';
 import { html, LitElement } from 'lit-element';
 import { styles } from './badge.element.css';
 
@@ -28,16 +28,22 @@ import { styles } from './badge.element.css';
  */
 // @dynamic
 export class CwcBadge extends LitElement {
-  /** Sets the color of the badge from a predefined list of choices */
+  /** Sets the color of the badge from the following predefined list of choices:
+   *  'gray', 'purple', 'blue', 'orange', 'light-blue'
+   */
   @property({ type: String })
   color: 'gray' | 'purple' | 'blue' | 'orange' | 'light-blue';
 
-  /** Sets the color of the badge from a predefined list of statuses */
+  /** Sets the color of the badge from the following predefined list of statuses:
+   *  'info', 'success', 'warning', 'danger'
+   */
   @property({ type: String })
-  status: 'info' | 'success' | 'warning' | 'danger';
+  status: StatusTypes;
 
   render() {
-    return html`<slot></slot>`;
+    return html`
+      <slot></slot>
+    `;
   }
 
   static get styles() {

--- a/src/clr-core/button/button.element.ts
+++ b/src/clr-core/button/button.element.ts
@@ -7,8 +7,10 @@
 import { baseStyles, property, registerElementSafely } from '@clr/core/common';
 import {
   CwcBaseButton,
+  DefaultSizes,
   getElementWidthUnless,
   getTranslateForChromeRenderingBugUnless,
+  StoplightStatusTypes,
   toggleDisabledAttribute,
 } from '@clr/core/common';
 import { html } from 'lit-element';
@@ -154,13 +156,19 @@ export class CwcButton extends CwcBaseButton {
   @property({ type: String })
   action: 'default' | 'outline' | 'link';
 
-  /** Sets the color of the button to match the status */
+  /**
+   * Sets the color of the button to match the following string statuses
+   * 'default', 'primary', 'inverse', 'success', 'warning', 'danger'
+   */
   @property({ type: String })
-  status: 'default' | 'primary' | 'inverse' | 'success' | 'warning' | 'danger';
+  status: 'default' | 'primary' | 'inverse' | StoplightStatusTypes;
 
-  /** Sets the overall height and width of the button based on value */
+  /**
+   * Sets the overall height and width of the button based on the following string values:
+   * 'default', 'sm'
+   */
   @property({ type: String })
-  size: 'default' | 'sm';
+  size: DefaultSizes;
 
   /** Sets button type for icon */
   @property({ type: String })
@@ -201,19 +209,19 @@ export class CwcButton extends CwcBaseButton {
     switch (this.loadingState) {
       case ClrLoadingState.LOADING:
         return html`
-            <span class="spinner spinner-inline"></span>
-            ${this.hiddenButtonTemplate}
+          <span class="spinner spinner-inline"></span>
+          ${this.hiddenButtonTemplate}
         `;
       case ClrLoadingState.SUCCESS:
         return html`
-            <span class="spinner spinner-inline spinner-check"></span>
-            ${this.hiddenButtonTemplate}
-          `;
+          <span class="spinner spinner-inline spinner-check"></span>
+          ${this.hiddenButtonTemplate}
+        `;
       default:
         return html`
-            <slot></slot>
-            ${this.hiddenButtonTemplate}
-          `;
+          <slot></slot>
+          ${this.hiddenButtonTemplate}
+        `;
     }
   }
 

--- a/src/clr-core/common/index.ts
+++ b/src/clr-core/common/index.ts
@@ -21,4 +21,5 @@ export * from './utils/string';
 export * from './mixins/css-helpers';
 export * from './mixins/unique-id';
 export * from './mixins/apply-mixins';
+export * from './interfaces';
 export { styles as baseStyles } from './base/base.element.css';

--- a/src/clr-core/common/interfaces/index.ts
+++ b/src/clr-core/common/interfaces/index.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+// SIZES
+export type BasicTShirtSizes = 'sm' | 'md' | 'lg' | 'xl';
+
+export type DefaultSizes = 'default' | 'sm';
+
+type ExtraTShirtSizes = 'xs' | 'xxl';
+
+export type TShirtSizes = BasicTShirtSizes | ExtraTShirtSizes;
+
+// STATUSES
+export type StoplightStatusTypes = 'success' | 'warning' | 'danger';
+
+export type StatusTypes = 'info' | StoplightStatusTypes;
+
+// MISC
+export type AriaLivePolitenessSettings = 'off' | 'polite' | 'assertive';

--- a/src/clr-core/tag/tag.element.ts
+++ b/src/clr-core/tag/tag.element.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { baseStyles, CwcBaseButton, property, registerElementSafely } from '@clr/core/common';
+import { baseStyles, CwcBaseButton, property, registerElementSafely, StatusTypes } from '@clr/core/common';
 import { styles } from './tag.element.css';
 
 /**
@@ -32,9 +32,11 @@ import { styles } from './tag.element.css';
  */
 // @dynamic
 export class CwcTag extends CwcBaseButton {
-  /** Sets the color of the tag (and badge if present) from a predefined list of statuses */
+  /** Sets the color of the tag (and badge if present) from the following predefined list of statuses:
+   *  'info', 'success', 'warning', 'danger'
+   */
   @property({ type: String })
-  status: 'info' | 'success' | 'warning' | 'danger';
+  status: StatusTypes;
 
   /** Sets the color of the tag (and badge if present) from a predefined list of choices */
   @property({ type: String })


### PR DESCRIPTION
• added union type for default sizes (default|sm) that we see
in buttons and alerts
• added union types for t-shirt sizes used in modals
• added union types for statuses found in alerts, badges,
tags, and buttons

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
