### PR TITLE
fix(datagrid): adds a11y attributes to datagrid filter button

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -389,6 +389,7 @@ export declare class ClrDatagridDetailHeader {
 export declare class ClrDatagridFilter<T = any> extends DatagridFilterRegistrar<T, ClrDatagridFilterInterface<T>> implements CustomFilter, OnDestroy {
     readonly active: boolean;
     anchor: ElementRef;
+    ariaExpanded: boolean;
     commonStrings: ClrCommonStringsService;
     customFilter: ClrDatagridFilterInterface<T> | RegisteredFilter<T, ClrDatagridFilterInterface<T>>;
     open: boolean;

--- a/src/clr-angular/data/datagrid/datagrid-filter.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-filter.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -20,6 +20,12 @@ import { ClrPopoverEventsService } from '../../utils/popover/providers/popover-e
 
 class MockRenderer {
   listen() {}
+}
+
+function cleanPopoverDOM(component) {
+  const popoverContent = document.querySelectorAll('.clr-popover-content');
+  popoverContent.forEach(content => document.body.removeChild(content));
+  component.ngOnDestroy();
 }
 
 export default function(): void {
@@ -45,9 +51,7 @@ export default function(): void {
       });
 
       afterEach(function() {
-        const popoverContent = document.querySelectorAll('.clr-popover-content');
-        popoverContent.forEach(content => document.body.removeChild(content));
-        component.ngOnDestroy();
+        cleanPopoverDOM(component);
       });
 
       it('registers to the FiltersProvider provider', function() {
@@ -132,6 +136,34 @@ export default function(): void {
           },
         ]);
         context.testComponent.filter = filter;
+      });
+
+      afterEach(function() {
+        cleanPopoverDOM(context.clarityDirective);
+      });
+
+      it('correctly associates the popover content with the aria-controls value', function() {
+        const toggle: HTMLButtonElement = context.clarityElement.querySelector('.datagrid-filter-toggle');
+        toggle.click();
+        context.detectChanges();
+        const popover: HTMLDivElement = document.querySelector('.datagrid-filter');
+        expect(toggle.getAttribute('aria-controls')).toEqual(popover.getAttribute('id'));
+      });
+
+      it('correctly updates the aria-expanded state', function() {
+        const toggle: HTMLButtonElement = context.clarityElement.querySelector('.datagrid-filter-toggle');
+        expect(toggle.getAttribute('aria-expanded')).toBe('false');
+        toggle.click();
+        context.detectChanges();
+        expect(toggle.getAttribute('aria-expanded')).toBe('true');
+      });
+
+      it('has a button with the correct common string for datagridFilterAriaLabel', function() {
+        const toggle: HTMLButtonElement = context.clarityElement.querySelector('.datagrid-filter-toggle');
+        const commonStrings: ClrCommonStringsService = context.fixture.debugElement.injector.get(
+          ClrCommonStringsService
+        );
+        expect(toggle.getAttribute('aria-label')).toBe(commonStrings.keys.datagridFilterAriaLabel);
       });
 
       it('projects content into the dropdown', function() {

--- a/src/clr-angular/data/datagrid/datagrid-filter.ts
+++ b/src/clr-angular/data/datagrid/datagrid-filter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -43,6 +43,9 @@ import { isPlatformBrowser } from '@angular/common';
       <button class="datagrid-filter-toggle"
               type="button"
               #anchor
+              [attr.aria-label]="commonStrings.keys.datagridFilterAriaLabel"
+              [attr.aria-expanded]="ariaExpanded"
+              [attr.aria-controls]="popoverId"
               clrPopoverAnchor
               clrPopoverOpenCloseButton
               [class.datagrid-filter-open]="open"
@@ -67,6 +70,8 @@ import { isPlatformBrowser } from '@angular/common';
 export class ClrDatagridFilter<T = any> extends DatagridFilterRegistrar<T, ClrDatagridFilterInterface<T>>
   implements CustomFilter, OnDestroy {
   private subs: Subscription[] = [];
+  public ariaExpanded: boolean = false;
+
   constructor(
     _filters: FiltersProvider<T>,
     public commonStrings: ClrCommonStringsService,
@@ -78,6 +83,7 @@ export class ClrDatagridFilter<T = any> extends DatagridFilterRegistrar<T, ClrDa
     this.subs.push(
       smartToggleService.openChange.subscribe(change => {
         this.open = change;
+        this.ariaExpanded = change;
       })
     );
   }

--- a/src/clr-core/common/services/common-strings.default.ts
+++ b/src/clr-core/common/services/common-strings.default.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -48,6 +48,7 @@ export const commonStringsDefault: ClrCommonStrings = {
   singleSelectionAriaLabel: 'Single selection header',
   singleActionableAriaLabel: 'Single actionable header',
   detailExpandableAriaLabel: 'Toggle more row content',
+  datagridFilterAriaLabel: 'Toggle column filter',
   // Alert
   alertCloseButtonAriaLabel: 'Close alert',
   // Date Picker

--- a/src/clr-core/common/services/common-strings.interface.ts
+++ b/src/clr-core/common/services/common-strings.interface.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -116,6 +116,11 @@ export interface ClrCommonStrings {
    * Datagrid numeric filter: max
    */
   maxValue?: string;
+  /**
+   * Datagrid filter toggle button
+   */
+  datagridFilterAriaLabel?: string;
+
   /**
    * Modal start of content
    */


### PR DESCRIPTION
In the conversion to the new popover utility a11y attributes were missed. This adds: aria-label, aria-expanded and aria-controls
to the datagrid filter button. This change closes #3985.

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?
Datagrid filter buttons were missing aria-label, aria-controls and aria-expanded attributes on the toggle button. 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3985

## What is the new behavior?
Datagrid filter buttons have aria-label, aria-controls and aria-expanded attributes on the toggle button. 

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
