### PR TITLE
[NG] Disable checkboxes in tree view

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -1396,6 +1396,8 @@ export declare class ClrTreeNode<T> implements OnInit, OnDestroy {
     _model: TreeNodeModel<T>;
     readonly ariaSelected: boolean;
     commonStrings: ClrCommonStringsService;
+    disabled: boolean;
+    disabledChange: EventEmitter<boolean>;
     expandService: IfExpandService;
     expandable: boolean | undefined;
     expanded: boolean;

--- a/src/clr-angular/data/tree-view/models/tree-node.model.ts
+++ b/src/clr-angular/data/tree-view/models/tree-node.model.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -9,6 +9,9 @@ import { BehaviorSubject } from 'rxjs';
 
 export abstract class TreeNodeModel<T> {
   selected = new BehaviorSubject<ClrSelectedState>(ClrSelectedState.UNSELECTED);
+  disabled = new BehaviorSubject<boolean>(false);
+  // A local condition which is given higher priority than the parent node's 'isSelectionDisabled' policy
+  isDisabledInputSetToTrue: boolean = false;
   model: T | null;
   /*
    * Ideally, I would like to use a polymorphic this type here to ensure homogeneity of the tree, something like:
@@ -30,29 +33,63 @@ export abstract class TreeNodeModel<T> {
   destroy() {
     // Just to be safe
     this.selected.complete();
+    this.disabled.complete();
   }
 
   // Propagate by default when eager, don't propagate in the lazy-loaded tree.
   setSelected(state: ClrSelectedState, propagateUp: boolean, propagateDown: boolean) {
-    if (state === this.selected.value) {
+    if (state === this.selected.value || this.disabled.value) {
       return;
     }
-    this.selected.next(state);
-    if (propagateDown && state !== ClrSelectedState.INDETERMINATE && this.children) {
-      this.children.forEach(child => child.setSelected(state, false, true));
+    if (propagateDown && state !== ClrSelectedState.INDETERMINATE && this.children && this.children.length > 0) {
+      this.children.filter(child => !child.disabled.value).forEach(child => child.setSelected(state, false, true));
+      // If there are any children, then we have to always calculate the selection state from the children after they are set.
+      // This is because, the state sent by parent is not always the state set on children because of the possibility of any
+      // disabled descended nodes persisting their selection states.
+      this._updateSelectionFromChildren();
+    } else {
+      this.selected.next(state);
     }
     if (propagateUp && this.parent) {
       this.parent._updateSelectionFromChildren();
     }
   }
 
-  toggleSelection(propagate: boolean) {
+  setDisabled(value: boolean, propagateUp: boolean, propagateDown: boolean) {
+    if (this.disabled.value === value) {
+      return;
+    }
+    // If selection of the parent is disabled, then this node also has to be disabled
+    const disabledValue = this.parent && this.parent.disabled.value ? true : value;
+    this.disabled.next(disabledValue);
+    // Don't change the disableSelection state of the children for which the clrDisableSelection is set to true
+    if (propagateDown && this.children && this.children.length) {
+      this.children
+        .filter(child => !child.isDisabledInputSetToTrue)
+        .forEach(child => child.setDisabled(this.disabled.value, false, true));
+    }
+    // Parent has to disable itself when all the children are disabled
+    if (propagateUp && this.disabled.value && this.parent) {
+      this.parent._updateDisabledStateFromChildren();
+    }
+  }
+
+  toggleSelection(propagate: boolean, event?: Event) {
     // Both unselected and indeterminate toggle to selected
     const newState =
       this.selected.value === ClrSelectedState.SELECTED ? ClrSelectedState.UNSELECTED : ClrSelectedState.SELECTED;
     // NOTE: we always propagate selection up in this method because it is only called when the user takes an action.
     // It should never be called from lifecycle hooks or app-provided inputs.
     this.setSelected(newState, true, propagate);
+    if (event) {
+      // When a user triggers the click event on checkbox inputs, checkbox has toggled its state from checked to unchecked or vice versa.
+      // And that does not get over written by the equality operations being bound to 'checked' & 'indeterminate' DOM properties in the HTML template.
+      // This is because Angular simply does not update the bindings if they remained the same since the last time the view was checked.
+      // So, they are programatically being set here.
+      const inputElement = event.srcElement as HTMLInputElement;
+      inputElement.checked = this.selected.value === ClrSelectedState.SELECTED;
+      inputElement.indeterminate = this.selected.value === ClrSelectedState.INDETERMINATE;
+    }
   }
 
   private computeSelectionStateFromChildren() {
@@ -97,6 +134,23 @@ export abstract class TreeNodeModel<T> {
     this.selected.next(newState);
     if (this.parent) {
       this.parent._updateSelectionFromChildren();
+    }
+  }
+
+  private get areAllChildrenDisabled(): boolean {
+    return this.children.every(child => child.disabled.value);
+  }
+
+  /*
+  * Internal, but needs to be called by other nodes
+  */
+  _updateDisabledStateFromChildren() {
+    if (!this.areAllChildrenDisabled) {
+      return;
+    }
+    this.disabled.next(true);
+    if (this.parent) {
+      this.parent._updateDisabledStateFromChildren();
     }
   }
 }

--- a/src/clr-angular/data/tree-view/tree-node.html
+++ b/src/clr-angular/data/tree-view/tree-node.html
@@ -20,11 +20,12 @@
   <div class="clr-treenode-spinner-container" *ngIf="expandService.loading || _model.loading">
         <span class="clr-treenode-spinner spinner"></span>
   </div>
-  <div class="clr-checkbox-wrapper clr-treenode-checkbox" *ngIf="featuresService.selectable">
+  <div class="clr-checkbox-wrapper clr-treenode-checkbox" *ngIf="featuresService.selectable"
+    [class.clr-form-control-disabled]="_model.disabled.value">
     <input type="checkbox" id="{{nodeId}}-check" class="clr-checkbox" [attr.aria-labelledby]="nodeId"
            [checked]="_model.selected.value === STATES.SELECTED"
            [indeterminate]="_model.selected.value === STATES.INDETERMINATE"
-           (change)="_model.toggleSelection(featuresService.eager)">
+           (change)="_model.toggleSelection(featuresService.eager, $event)">
     <label for="{{nodeId}}-check" class="clr-control-label"></label>
   </div>
   <div class="clr-treenode-content" [id]="nodeId">

--- a/src/clr-angular/data/tree-view/tree-node.ts
+++ b/src/clr-angular/data/tree-view/tree-node.ts
@@ -82,6 +82,17 @@ export class ClrTreeNode<T> implements OnInit, OnDestroy {
     return !!this.expandService.expandable || (this._model.children && this._model.children.length > 0);
   }
 
+  @Input('clrDisabled')
+  get disabled(): boolean {
+    return this._model.disabled.value;
+  }
+  set disabled(value: boolean) {
+    this._model.isDisabledInputSetToTrue = !!value;
+    this.skipEmitChange = true;
+    this._model.setDisabled(!!value, this.featuresService.eager, this.featuresService.eager);
+    this.skipEmitChange = false;
+  }
+
   @Input('clrSelected')
   get selected(): ClrSelectedState | boolean {
     return this._model.selected.value;
@@ -105,6 +116,8 @@ export class ClrTreeNode<T> implements OnInit, OnDestroy {
   }
 
   @Output('clrSelectedChange') selectedChange = new EventEmitter<ClrSelectedState>(false);
+
+  @Output('clrDisabledChange') disabledChange = new EventEmitter<boolean>(false);
 
   @HostBinding('attr.role')
   get treeNodeRole(): string {
@@ -149,6 +162,9 @@ export class ClrTreeNode<T> implements OnInit, OnDestroy {
       this._model.selected.pipe(filter(() => !this.skipEmitChange)).subscribe(value => this.selectedChange.emit(value))
     );
     this.subscriptions.push(this.expandService.expandChange.subscribe(value => this.expandedChange.emit(value)));
+    this.subscriptions.push(
+      this._model.disabled.pipe(filter(() => !this.skipEmitChange)).subscribe(value => this.disabledChange.emit(value))
+    );
   }
 
   ngOnDestroy() {

--- a/src/clr-angular/forms/styles/_checkbox.clarity.scss
+++ b/src/clr-angular/forms/styles/_checkbox.clarity.scss
@@ -83,7 +83,8 @@
     border-color: $clr-forms-invalid-color;
   }
 
-  .clr-form-control-disabled .clr-checkbox-wrapper {
+  .clr-form-control-disabled .clr-checkbox-wrapper,
+  .clr-treenode-checkbox.clr-form-control-disabled {
     label {
       cursor: not-allowed;
     }

--- a/src/dev/src/app/tree-view/eager-declarative-tree/eager-declarative-tree.html
+++ b/src/dev/src/app/tree-view/eager-declarative-tree/eager-declarative-tree.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -98,6 +98,45 @@
     </clr-tree-node>
     <clr-tree-node>
       D
+    </clr-tree-node>
+  </clr-tree-node>
+</div>
+
+<h4>Selection with Disabled nodes</h4>
+<div class="clr-example example-disabled-nodes">
+  <div>
+    <button class="btn btn-outline" (click)="toggleDisableStateOfNodeA1()">
+      {{ isNodeA1Disabled ? "Enable" : "Disable" }} node A-1
+    </button>
+    <button class="btn btn-outline" (click)="toggleDisableStateOfNodeA23()">
+      {{ isNodeA23Disabled ? "Enable" : "Disable" }} node A-2.3
+    </button>
+  </div>
+  <clr-tree-node [clrSelected]="false">
+    A
+    <clr-tree-node [clrDisabled]="isNodeA1Disabled">
+      A-1
+    </clr-tree-node>
+    <clr-tree-node>
+      A-2
+      <clr-tree-node>
+        A-2.1
+      </clr-tree-node>
+      <clr-tree-node>
+        A-2.2
+      </clr-tree-node>
+      <clr-tree-node [clrDisabled]="isNodeA23Disabled">
+        A-2.3
+        <clr-tree-node>
+          A-2.3.1
+        </clr-tree-node>
+        <clr-tree-node>
+          A-2.3.2
+        </clr-tree-node>
+      </clr-tree-node>
+    </clr-tree-node>
+    <clr-tree-node>
+      A-3
     </clr-tree-node>
   </clr-tree-node>
 </div>

--- a/src/dev/src/app/tree-view/eager-declarative-tree/eager-declarative-tree.ts
+++ b/src/dev/src/app/tree-view/eager-declarative-tree/eager-declarative-tree.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -13,4 +13,15 @@ import { Component } from '@angular/core';
 export class EagerDeclarativeTreeDemo {
   expanded1 = true;
   expanded2 = true;
+
+  isNodeA1Disabled: boolean = false;
+  isNodeA23Disabled: boolean = false;
+
+  toggleDisableStateOfNodeA1() {
+    this.isNodeA1Disabled = !this.isNodeA1Disabled;
+  }
+
+  toggleDisableStateOfNodeA23() {
+    this.isNodeA23Disabled = !this.isNodeA23Disabled;
+  }
 }

--- a/src/dev/src/app/tree-view/eager-recursive-tree/eager-recursive-tree.html
+++ b/src/dev/src/app/tree-view/eager-recursive-tree/eager-recursive-tree.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -35,8 +35,19 @@
     </clr-tree-node>
   </clr-tree>
 </div>
-
 <pre><code>{{singleRootSelected | json}}</code></pre>
+
+<h5>Selection with disabled nodes</h5>
+<p>Selected: {{selectedString(selectedWithDisabledNodes)}}</p>
+<div class="clr-example">
+  <clr-tree>
+    <clr-tree-node *clrRecursiveFor="let node of singleRoot; getChildren: synchronousChildren"
+      [(clrSelected)]="selectedWithDisabledNodes[node.name]" [clrDisabled]="isNodeDisabled(node.name)">
+      {{node.name}}
+    </clr-tree-node>
+  </clr-tree>
+</div>
+<pre><code>{{selectedWithDisabledNodes | json}}</code></pre>
 
 <h4>Multi root, selection</h4>
 <p>

--- a/src/dev/src/app/tree-view/eager-recursive-tree/eager-recursive-tree.ts
+++ b/src/dev/src/app/tree-view/eager-recursive-tree/eager-recursive-tree.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -65,6 +65,7 @@ export class EagerRecursiveTreeDemo {
 
   singleRootSelected: SelectedMap = this.buildDefaultSelected(this.singleRoot);
   multiRootSelected: SelectedMap = this.buildDefaultSelected(this.multiRoot);
+  selectedWithDisabledNodes: SelectedMap = this.buildDefaultSelected(this.singleRoot);
 
   synchronousChildren = node => node.children;
 
@@ -72,5 +73,9 @@ export class EagerRecursiveTreeDemo {
     return Object.keys(selectedMap)
       .filter(key => selectedMap[key] === ClrSelectedState.SELECTED)
       .join(', ');
+  }
+
+  isNodeDisabled(nodeName: string) {
+    return nodeName === 'AA' || nodeName === 'AB';
   }
 }

--- a/src/dev/src/app/tree-view/lazy-declarative-tree/lazy-declarative-tree.html
+++ b/src/dev/src/app/tree-view/lazy-declarative-tree/lazy-declarative-tree.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -53,6 +53,31 @@
   </clr-tree>
 </div>
 
+<h4>Synchronous tree with disabled nodes</h4>
+<p>
+  Selected: {{treeWithDisabledNodes.selected.join(', ')}}
+</p>
+<div class="clr-example">
+  <clr-tree [clrLazy]="true">
+    <clr-tree-node *ngFor="let node of treeWithDisabledNodes.root" [clrSelected]="treeWithDisabledNodes.isSelected(node)"
+      (clrSelectedChange)="treeWithDisabledNodes.select(node, $event)" [clrDisabled]="treeWithDisabledNodes.isDisabled(node)">
+      {{node}}
+      <ng-template clrIfExpanded>
+        <clr-tree-node *ngFor="let child of treeWithDisabledNodes.getChildren(node)" [clrSelected]="treeWithDisabledNodes.isSelected(child)"
+          (clrSelectedChange)="treeWithDisabledNodes.select(child, $event)" [clrDisabled]="treeWithDisabledNodes.isDisabled(child)">
+          {{child}}
+          <ng-template clrIfExpanded>
+            <clr-tree-node *ngFor="let child of treeWithDisabledNodes.getChildren(child)" [clrSelected]="treeWithDisabledNodes.isSelected(child)"
+              (clrSelectedChange)="treeWithDisabledNodes.select(child, $event)" [clrDisabled]="treeWithDisabledNodes.isDisabled(child)">
+              {{child}}
+            </clr-tree-node>
+          </ng-template>
+        </clr-tree-node>
+      </ng-template>
+    </clr-tree-node>
+  </clr-tree>
+</div>
+
 <h4>Asynchronous</h4>
 <p>
   Selected: {{asyncTree.selected.join(', ')}}
@@ -74,6 +99,34 @@
             <clr-tree-node *ngFor="let child of children[child] | async"
                            [clrSelected]="asyncTree.isSelected(child)"
                            (clrSelectedChange)="asyncTree.select(child, $event)">
+              {{child}}
+            </clr-tree-node>
+          </ng-template>
+        </clr-tree-node>
+      </ng-template>
+    </clr-tree-node>
+  </clr-tree>
+</div>
+
+<h4>Asynchronous tree with disabled nodes</h4>
+<p>
+  Selected: {{asyncTreeWithDisabledNodes.selected.join(', ')}}
+</p>
+<div class="clr-example">
+  <clr-tree [clrLazy]="true">
+    <clr-tree-node *ngFor="let node of asyncTreeWithDisabledNodes.root" [clrLoading]="loading[node]"
+      [clrDisabled]="asyncTreeWithDisabledNodes.isDisabled(node)"
+      [clrSelected]="asyncTreeWithDisabledNodes.isSelected(node)" (clrSelectedChange)="asyncTreeWithDisabledNodes.select(node, $event)">
+      {{node}}
+      <ng-template clrIfExpanded (clrIfExpandedChange)="fetchChildren(node, $event)">
+        <clr-tree-node *ngFor="let child of children[node] | async" [clrLoading]="loading[child]"
+          [clrDisabled]="asyncTreeWithDisabledNodes.isDisabled(child)"
+          [clrSelected]="asyncTreeWithDisabledNodes.isSelected(child)" (clrSelectedChange)="asyncTreeWithDisabledNodes.select(child, $event)">
+          {{child}}
+          <ng-template clrIfExpanded (clrIfExpandedChange)="fetchChildren(child, $event)">
+            <clr-tree-node *ngFor="let child of children[child] | async" [clrSelected]="asyncTreeWithDisabledNodes.isSelected(child)"
+              [clrDisabled]="asyncTreeWithDisabledNodes.isDisabled(child)"
+              (clrSelectedChange)="asyncTreeWithDisabledNodes.select(child, $event)">
               {{child}}
             </clr-tree-node>
           </ng-template>

--- a/src/dev/src/app/tree-view/lazy-declarative-tree/lazy-declarative-tree.ts
+++ b/src/dev/src/app/tree-view/lazy-declarative-tree/lazy-declarative-tree.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -17,8 +17,10 @@ import { AsyncInfiniteTree } from '../utils/async-infinite-tree';
 })
 export class LazyDeclarativeTreeDemo {
   tree = new InfiniteTree(9);
+  treeWithDisabledNodes = new InfiniteTree(3, '1.1');
 
   asyncTree = new AsyncInfiniteTree(3, 500);
+  asyncTreeWithDisabledNodes = new AsyncInfiniteTree(3, 500, '1.1');
 
   loading: { [key: string]: boolean } = {};
   children: { [key: string]: Observable<string[]> } = {};

--- a/src/dev/src/app/tree-view/lazy-recursive-tree/lazy-recursive-tree.html
+++ b/src/dev/src/app/tree-view/lazy-recursive-tree/lazy-recursive-tree.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -17,6 +17,20 @@
   </clr-tree>
 </div>
 
+<h4>Synchronous infinite tree with disabled nodes</h4>
+<p>
+  Selected: {{treeWithDisabledNodes.selected.join(', ')}}
+</p>
+<div class="clr-example">
+  <clr-tree [clrLazy]="true">
+    <clr-tree-node *clrRecursiveFor="let node of treeWithDisabledNodes.root; getChildren: synchronousChildren"
+      [clrDisabled]="treeWithDisabledNodes.isDisabled(node)"
+      [clrSelected]="treeWithDisabledNodes.isSelected(node)" (clrSelectedChange)="treeWithDisabledNodes.select(node, $event)">
+      {{node}}
+    </clr-tree-node>
+  </clr-tree>
+</div>
+
 
 <h4>Asynchronous, pre-loading 1 level ahead</h4>
 <p>
@@ -26,6 +40,19 @@
   <clr-tree [clrLazy]="true">
     <clr-tree-node *clrRecursiveFor="let node of asyncTree.root; getChildren: asynchronousChildren"
                    [clrSelected]="asyncTree.isSelected(node)" (clrSelectedChange)="asyncTree.select(node, $event)">
+      {{node}}
+    </clr-tree-node>
+  </clr-tree>
+</div>
+
+<h4>Asynchronous, pre-loading 1 level ahead with disabled nodes</h4>
+<p>
+  Selected: {{asyncTree.selected.join(', ')}}
+</p>
+<div class="clr-example">
+  <clr-tree [clrLazy]="true">
+    <clr-tree-node *clrRecursiveFor="let node of asyncTree.root; getChildren: asynchronousChildren"
+      [clrSelected]="asyncTree.isSelected(node)" (clrSelectedChange)="asyncTree.select(node, $event)">
       {{node}}
     </clr-tree-node>
   </clr-tree>

--- a/src/dev/src/app/tree-view/lazy-recursive-tree/lazy-recursive-tree.ts
+++ b/src/dev/src/app/tree-view/lazy-recursive-tree/lazy-recursive-tree.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -15,6 +15,7 @@ import { AsyncInfiniteTree } from '../utils/async-infinite-tree';
 })
 export class LazyRecursiveTreeDemo {
   tree = new InfiniteTree(3);
+  treeWithDisabledNodes = new InfiniteTree(3, '1.1');
 
   synchronousChildren = (node: string) => this.tree.getChildren(node);
 

--- a/src/dev/src/app/tree-view/utils/async-infinite-tree.ts
+++ b/src/dev/src/app/tree-view/utils/async-infinite-tree.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -11,8 +11,8 @@ import { Observable, timer } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 export class AsyncInfiniteTree {
-  constructor(width: number, latency = 100) {
-    this.tree = new InfiniteTree(width);
+  constructor(width: number, latency = 100, disabledNode?: string) {
+    this.tree = new InfiniteTree(width, disabledNode);
     this.delay = timer(latency);
   }
 
@@ -32,6 +32,10 @@ export class AsyncInfiniteTree {
 
   isSelected(node: string): ClrSelectedState {
     return this.tree.isSelected(node);
+  }
+
+  isDisabled(node): boolean {
+    return this.tree.isDisabled(node);
   }
 
   select(node: string, state: ClrSelectedState): void {

--- a/src/dev/src/app/tree-view/utils/infinite-tree.ts
+++ b/src/dev/src/app/tree-view/utils/infinite-tree.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -7,7 +7,7 @@
 import { ClrSelectedState } from '@clr/angular';
 
 export class InfiniteTree {
-  constructor(width: number) {
+  constructor(width: number, private disabledNode?: string) {
     this.possibleValues = new Array(width).fill(0).map((_, i) => '' + (i + 1));
     this.root = this.possibleValues;
   }
@@ -31,13 +31,19 @@ export class InfiniteTree {
     return ClrSelectedState.UNSELECTED;
   }
 
+  // disabledNode: string = "1.1";
+
+  isDisabled(node: string) {
+    return this.disabledNode && node.startsWith(this.disabledNode);
+  }
+
   // This is demo code to keep it short, without server, and consistent with an infinite tree.
   // I apologize if it's hard to read, but I figured maintenance is not critical since this is neither public
   // nor written to be build upon.
   select(node: string, state: ClrSelectedState) {
     switch (state) {
       case ClrSelectedState.SELECTED:
-        if (this.isSelected(node) !== ClrSelectedState.SELECTED) {
+        if (this.isSelected(node) !== ClrSelectedState.SELECTED && !this.isDisabled(node)) {
           this.selected = this.selected.filter(s => !s.startsWith(node));
           this.selected.push(node);
         }
@@ -50,7 +56,12 @@ export class InfiniteTree {
             const relativePath = node.substring(prefix.length + 1).split('.');
             let soFar = prefix + '.';
             for (const step of relativePath) {
-              this.selected.push(...this.possibleValues.filter(n => n !== step).map(n => soFar + n));
+              this.selected.push(
+                ...this.possibleValues
+                  .filter(n => n !== step)
+                  .map(n => soFar + n)
+                  .filter(n => !this.isDisabled(n))
+              );
               soFar += step + '.';
             }
           }


### PR DESCRIPTION
Add the ability to dynamically disable selection of tree node checkboxes.

closes the issue: https://github.com/vmware/clarity/issues/1458

Signed-off-by: Prudhvi Simhadri <prudhvi.af121@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

* [ ] Bugfix
* [X] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

closes the issue: #1458