### PR TITLE
docs(vertical-nav): Consistent Jigglypuff story character

### DIFF
--- a/src/website/src/app/documentation/demos/vertical-nav/basic-nav/basic-nav.html
+++ b/src/website/src/app/documentation/demos/vertical-nav/basic-nav/basic-nav.html
@@ -27,7 +27,7 @@
                 <a clrVerticalNavLink href="javascript://">Raichu</a>
             </clr-vertical-nav>
             <div class="content-area">
-                <h2>Jiggypuff</h2>
+                <h2>Jigglypuff</h2>
                 <p>
                     Jigglypuff is a round, pink ball with pointed ears and large, blue eyes. It has rubbery,
                     balloon-like skin and small, stubby arms and somewhat long feet. On top of its head is a curled tuft


### PR DESCRIPTION
The `H2` element had a typo in Jigglypuff (as Jiggypuff). This corrects it to Jigglypuff.

Closes: #4216

Signed-off-by: Bruce McMoran <mcmoranbjr@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [na] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [na] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

The `H2` element contains Jiggypuff as a typo of the character name Jigglypuff in the vertical nav example. See https://v2.clarity.design/vertical-nav/basic-structure/project-pokemon

Issue Number: #4216 

## What is the new behavior?

Display Jigglypuff in the `H2` element for the vertical nav example https://v2.clarity.design/vertical-nav/basic-structure/project-pokemon

## Does this PR introduce a breaking change?

* [ ] Yes
* [x ] No

## Other information
