### PR TITLE
feat(icons): update to clr-core icons API

### DIFF
--- a/docs/core/cwc-icon.md
+++ b/docs/core/cwc-icon.md
@@ -18,9 +18,7 @@ ClarityIcons.addIcons(userIcon);
 
 | Property    | Attribute   | Type      | Default      | Description                                      |
 |-------------|-------------|-----------|--------------|--------------------------------------------------|
-| `alert`     | `alert`     | `boolean` | false        | Displays the icon warning symbol (triangle) if `true` |
-| `badge`     | `badge`     | `boolean` | false        | Displays the icon badge symbol (dot) if `true`<br /><br />Use the badgeType property (`badge-type` attribute) if you<br />want a badge to display using a different pre-defined color. |
-| `badgeType` | `badgeType` | `any`     |              | Attribute: `badge-type`<br />Sets the color of the icon badge (dot) from the following predefined.<br />By default, the badge uses the 'danger' color. This property is only used<br />to change the color of the badge. It is not required to show the badge,<br />although it can be used independently to show the badge.<br /><br />The color of the badge can change according to the following<br />list of statuses: 'info', 'success', 'warning', 'danger', 'inverse'<br /><br />Setting the badge to 'null' removes it from the DOM. This is necessary to<br />remove the badge (dot) from the icon if you are using badgeType. |
+| `badge`     | `badge`     | `any`     |              | Attribute: `badge`<br />Sets the color of the icon decoration that appears in the top-right corner<br />of the glyph. The icon decoration is derived from the following predefined types.<br /><br />The color of the badge can change according to the following<br />list of statuses:<br />'info'  -> blue dot<br />'success' -> green dot<br />'warning' -> yellow dot<br />'danger' -> red dot<br />'inherit' -> dot inherits color of full icon glyph<br />'warning-triangle' -> yellow triangle<br />'inherit-triangle' -> triangle inherits color of full icon glyph<br />unrecognized value, empty string, or true -> red dot<br /><br />By default, the badge displays a 'danger' dot (a red-colored dot).<br /><br />Setting the badge to 'null' removes the attribute from the DOM. |
 | `dir`       | `dir`       | `any`     |              |                                                  |
 | `direction` | `direction` | `any`     |              | Takes a directional value (up\|down\|left\|right) that rotates the icon 90° with the<br />top of the icon pointing in the specified direction. |
 | `flip`      | `flip`      | `any`     |              | Takes an orientation value (horizontal\|vertical) that reverses the orientation of the<br />icon vertically or horizontally using the strings: 'horizontal' or 'vertical' |
@@ -33,17 +31,15 @@ ClarityIcons.addIcons(userIcon);
 
 ## CSS Custom Properties
 
-| Property                             |
-|--------------------------------------|
-| `--clr-icon-color-danger`            |
-| `--clr-icon-color-default`           |
-| `--clr-icon-color-highlight`         |
-| `--clr-icon-color-info`              |
-| `--clr-icon-color-inverse`           |
-| `--clr-icon-color-inverse-danger`    |
-| `--clr-icon-color-inverse-highlight` |
-| `--clr-icon-color-inverse-info`      |
-| `--clr-icon-color-inverse-success`   |
-| `--clr-icon-color-inverse-warning`   |
-| `--clr-icon-color-success`           |
-| `--clr-icon-color-warning`           |
+| Property                           |
+|------------------------------------|
+| `--clr-icon-color-danger`          |
+| `--clr-icon-color-default`         |
+| `--clr-icon-color-info`            |
+| `--clr-icon-color-inverse`         |
+| `--clr-icon-color-inverse-danger`  |
+| `--clr-icon-color-inverse-info`    |
+| `--clr-icon-color-inverse-success` |
+| `--clr-icon-color-inverse-warning` |
+| `--clr-icon-color-success`         |
+| `--clr-icon-color-warning`         |

--- a/src/clr-core/icon-shapes/icon.element.scss
+++ b/src/clr-core/icon-shapes/icon.element.scss
@@ -122,11 +122,8 @@ svg {
 }
 
 // DEPRECATED IN 3.0: is-highlight
-:host(.is-highlight),
-:host([status='highlight']) {
-  @include setIconColor(
-    #{'var(--clr-icon-color-highlight, var(--clr-color-action-600,' + $clr-color-action-600 + '))'}
-  );
+:host(.is-highlight) {
+  @include setIconColor(#{'var(--clr-icon-color-info, var(--clr-color-action-600,' + $clr-color-action-600 + '))'});
 }
 
 // INVERSE COLORS
@@ -219,27 +216,27 @@ svg {
   }
 }
 
-// DEPRECATED IN 3.0: has-alert
-:host([class*='has-alert']) .can-alert,
-:host([alert]) .can-alert {
-  .clr-i-outline--alerted {
-    display: block;
-  }
-
-  .clr-i-outline:not(.clr-i-outline--alerted) {
-    display: none;
-  }
-}
-
 // DEPRECATED IN 3.0: has-badge
 :host([class*='has-badge']) .can-badge,
-:host([badge]) .can-badge,
-:host([badge-type]) .can-badge {
+:host([badge]) .can-badge {
   .clr-i-outline--badged {
     display: block;
   }
 
   .clr-i-outline:not(.clr-i-outline--badged) {
+    display: none;
+  }
+}
+
+// DEPRECATED IN 3.0: has-alert
+:host([class*='has-alert']) .can-alert,
+:host([badge$='triangle']) .can-alert {
+  .clr-i-outline--alerted {
+    display: block;
+  }
+
+  .clr-i-outline--badged,
+  .clr-i-outline:not(.clr-i-outline--alerted) {
     display: none;
   }
 }
@@ -270,9 +267,7 @@ svg {
 :host(.is-solid[class*='has-badge']) .can-badge.has-solid,
 :host([solid].has-badge) .can-badge.has-solid,
 :host([badge].is-solid) .can-badge.has-solid,
-:host([badge][solid]) .can-badge.has-solid,
-:host([badge-type].is-solid) .can-badge.has-solid,
-:host([badge-type][solid]) .can-badge.has-solid {
+:host([badge][solid]) .can-badge.has-solid {
   .clr-i-solid--badged {
     display: block;
   }
@@ -287,14 +282,15 @@ svg {
 // DEPRECATED IN 3.0: is-solid, has-alert
 :host(.is-solid[class*='has-alert']) .can-alert.has-solid,
 :host([solid].has-alert) .can-alert.has-solid,
-:host([alert].is-solid) .can-alert.has-solid,
-:host([solid][alert]) .can-alert.has-solid {
+:host([badge$='triangle'].is-solid) .can-alert.has-solid,
+:host([solid][badge$='triangle']) .can-alert.has-solid {
   .clr-i-solid--alerted {
     display: block;
   }
 
   .clr-i-outline,
   .clr-i-outline--alerted,
+  .clr-i-solid--badged,
   .clr-i-solid:not(.clr-i-solid--alerted) {
     display: none;
   }
@@ -304,7 +300,7 @@ svg {
 
 // DEPRECATED IN 3.0: has-badge--success
 :host(.has-badge--success),
-:host([badge-type='success']) {
+:host([badge='success']) {
   .clr-i-badge {
     @include setIconColor(
       #{'var(--clr-icon-color-success, var(--clr-color-success-700,' + $clr-color-success-700 + '))'}
@@ -315,14 +311,14 @@ svg {
 // DEPRECATED IN 3.0: has-badge--danger, has-badge--error
 :host(.has-badge--danger),
 :host(.has-badge--error),
-:host([badge-type='danger']) {
+:host([badge='danger']) {
   .clr-i-badge {
     @include setIconColor(#{'var(--clr-icon-color-danger, var(--clr-color-danger-700,' + $clr-color-danger-700 + '))'});
   }
 }
 
 // there is no .has-badge--warning classname
-:host([badge-type='warning']) {
+:host([badge='warning']) {
   .clr-i-badge {
     @include setIconColor(
       #{'var(--clr-icon-color-warning, var(--clr-color-warning-900,' + $clr-color-warning-900 + '))'}
@@ -330,9 +326,15 @@ svg {
   }
 }
 
+:host([badge='inherit']) {
+  .clr-i-badge {
+    @include setIconColor('inherit');
+  }
+}
+
 // DEPRECATED IN 3.0: has-badge--info
 :host(.has-badge--info),
-:host([badge-type='info']) {
+:host([badge='info']) {
   .clr-i-badge {
     @include setIconColor(#{'var(--clr-icon-color-info, var(--clr-color-action-600,' + $clr-color-action-600 + '))'});
   }
@@ -341,7 +343,7 @@ svg {
 // alert colors
 // DEPRECATED IN 3.0: has-alert
 :host(.has-alert),
-:host([alert]) {
+:host([badge$='triangle']) {
   .clr-i-alert {
     @include setIconColor(
       #{'var(--clr-icon-color-warning, var(--clr-color-warning-800,' + $clr-color-warning-800 + '))'}
@@ -349,38 +351,17 @@ svg {
   }
 }
 
-// inverse + variants
-
-// DEPRECATED IN 3.0: is-highlight, is-inverse
-:host([status='highlight'][inverse]),
-:host([status='highlight'].is-inverse),
-:host([inverse].is-highlight),
-:host(.is-highlight.is-inverse) {
-  @include setIconColor(
-    #{'var(--clr-icon-color-inverse-highlight, var(--clr-color-action-400,' + $clr-color-action-400 + '))'}
-  );
-}
-
-// variant badge colors
-// DEPRECATED IN 3.0: has-badge--success, is-inverse
-:host([badge-type='success'][inverse]),
-:host([inverse].has-badge--success),
-:host([badge-type='success'].is-inverse),
-:host(.has-badge--success.is-inverse) {
-  .clr-i-badge {
-    @include setIconColor(
-      #{'var(--clr-icon-color-inverse-success, var(--clr-color-success-400,' + $clr-color-success-400 + '))'}
-    );
+:host([badge='inherit-triangle']) {
+  .clr-i-alert {
+    @include setIconColor('inherit');
   }
 }
 
-// LEFTOFF: UPDATE ICON-SETS DEMO TO USE NEW CODE; ALSO TEST FOR AND FIX NULL/UNDEFINED IN SIZE/SHAPE SETTERS
+// inverse + variants
 
 // DEPRECATED IN 3.0: has-badge--error, has-badge--danger, is-inverse
 :host([badge][inverse]),
 :host([badge].is-inverse),
-:host([badge-type='danger'][inverse]),
-:host([badge-type='danger'].is-inverse),
 :host(.has-badge--danger[inverse]),
 :host(.has-badge--error[inverse]),
 :host(.has-badge--danger.is-inverse),
@@ -392,8 +373,35 @@ svg {
   }
 }
 
+// DEPRECATED IN 3.0: is-highlight, is-inverse
+:host([inverse].is-highlight),
+:host(.is-highlight.is-inverse) {
+  @include setIconColor(
+    #{'var(--clr-icon-color-inverse-info, var(--clr-color-action-400,' + $clr-color-action-400 + '))'}
+  );
+}
+
+// variant badge colors
+// DEPRECATED IN 3.0: has-badge--success, is-inverse
+:host([badge='success'][inverse]),
+:host([inverse].has-badge--success),
+:host([badge='success'].is-inverse),
+:host(.has-badge--success.is-inverse) {
+  .clr-i-badge {
+    @include setIconColor(
+      #{'var(--clr-icon-color-inverse-success, var(--clr-color-success-400,' + $clr-color-success-400 + '))'}
+    );
+  }
+}
+
+:host([badge='inherit'][inverse]) {
+  .clr-i-badge {
+    @include setIconColor('inherit');
+  }
+}
+
 // there is no has-badge--warning classname
-:host([badge-type='warning'][inverse]) {
+:host([badge='warning'][inverse]) {
   .clr-i-badge {
     @include setIconColor(
       #{'var(--clr-icon-color-inverse-warning, var(--clr-color-warning-500,' + $clr-color-warning-500 + '))'}
@@ -402,9 +410,9 @@ svg {
 }
 
 // DEPRECATED IN 3.0: has-badge--info, is-inverse
-:host([badge-type='info'][inverse]),
+:host([badge='info'][inverse]),
 :host(.has-badge--info[inverse]),
-:host([badge-type='info'].is-inverse),
+:host([badge='info'].is-inverse),
 :host(.has-badge--info.is-inverse) {
   .clr-i-badge {
     @include setIconColor(
@@ -415,13 +423,19 @@ svg {
 
 // alert colors
 // DEPRECATED IN 3.0: has-alert, is-inverse
-:host([alert][inverse]),
+:host([badge$='triangle'][inverse]),
 :host(.has-alert[inverse]),
-:host(.is-inverse[alert]),
+:host(.is-inverse[badge$='triangle']),
 :host(.has-alert.is-inverse) {
   .clr-i-alert {
     @include setIconColor(
       #{'var(--clr-icon-color-inverse-warning, var(--clr-color-warning-500,' + $clr-color-warning-500 + '))'}
     );
+  }
+}
+
+:host([badge='inherit-triangle'][inverse]) {
+  .clr-i-alert {
+    @include setIconColor('inherit');
   }
 }

--- a/src/clr-core/icon-shapes/icon.element.spec.ts
+++ b/src/clr-core/icon-shapes/icon.element.spec.ts
@@ -225,55 +225,34 @@ describe('icon element', () => {
     });
   });
 
-  describe('alert: ', () => {
-    it('should default to false', async () => {
-      await componentIsStable(component);
-      expect(component.hasAttribute('alert')).toBe(false);
-    });
-    it('should update if assigned a new value', async () => {
-      await componentIsStable(component);
-      component.alert = true;
-      await componentIsStable(component);
-      expect(component.hasAttribute('alert')).toBe(true);
-    });
-  });
-
   describe('badge: ', () => {
     it('should default to false', async () => {
       await componentIsStable(component);
-      expect(component.badge).toBe(false);
+      expect(component.badge).toBe(undefined);
       expect(component.hasAttribute('badge')).toBe(false);
     });
     it('should update if assigned a new value', async () => {
       await componentIsStable(component);
-      component.badge = true;
+      component.badge = 'warning';
       await componentIsStable(component);
       expect(component.hasAttribute('badge')).toBe(true);
     });
-  });
-
-  describe('badgeType: ', () => {
-    it('should default to undefined and not be present', async () => {
-      await componentIsStable(component);
-      expect(component.badgeType).toBe(undefined);
-      expect(component.hasAttribute('badge-type')).toBe(false);
-    });
     it('should update if assigned a new value', async () => {
       await componentIsStable(component);
-      component.badgeType = 'info';
+      component.badge = 'info';
       await componentIsStable(component);
-      expect(component.hasAttribute('badge-type')).toBe(true);
+      expect(component.hasAttribute('badge')).toBe(true);
       await componentIsStable(component);
-      expect(component.getAttribute('badge-type')).toEqual('info');
+      expect(component.getAttribute('badge')).toEqual('info');
     });
     it('should be removed if set to null', async () => {
       await componentIsStable(component);
-      component.badgeType = 'danger';
+      component.badge = 'danger';
       await componentIsStable(component);
-      expect(component.hasAttribute('badge-type')).toBe(true);
-      component.badgeType = null;
+      expect(component.hasAttribute('badge')).toBe(true);
+      component.badge = null;
       await componentIsStable(component);
-      expect(component.hasAttribute('badge-type')).toBe(false);
+      expect(component.hasAttribute('badge')).toBe(false);
     });
   });
 

--- a/src/clr-core/icon-shapes/icon.element.ts
+++ b/src/clr-core/icon-shapes/icon.element.ts
@@ -51,13 +51,11 @@ applyMixins(IconMixinClass, [UniqueId, CssHelpers]);
  * @cssprop --clr-icon-color-danger
  * @cssprop --clr-icon-color-warning
  * @cssprop --clr-icon-color-info
- * @cssprop --clr-icon-color-highlight
  * @cssprop --clr-icon-color-inverse
  * @cssprop --clr-icon-color-inverse-success
  * @cssprop --clr-icon-color-inverse-danger
  * @cssprop --clr-icon-color-inverse-warning
  * @cssprop --clr-icon-color-inverse-info
- * @cssprop --clr-icon-color-inverse-highlight
  */
 // @dynamic
 export class CwcIcon extends IconMixinClass {
@@ -149,35 +147,27 @@ export class CwcIcon extends IconMixinClass {
   inverse = false;
 
   /**
-   * Displays the icon warning symbol (triangle) if `true`
-   */
-  @property({ type: Boolean })
-  alert = false;
-
-  /**
-   * Displays the icon badge symbol (dot) if `true`
-   *
-   * Use the badgeType property (`badge-type` attribute) if you
-   * want a badge to display using a different pre-defined color.
-   */
-  @property({ type: Boolean })
-  badge = false;
-
-  /**
-   * Attribute: `badge-type`
-   * Sets the color of the icon badge (dot) from the following predefined.
-   * By default, the badge uses the 'danger' color. This property is only used
-   * to change the color of the badge. It is not required to show the badge,
-   * although it can be used independently to show the badge.
+   * Attribute: `badge`
+   * Sets the color of the icon decoration that appears in the top-right corner
+   * of the glyph. The icon decoration is derived from the following predefined types.
    *
    * The color of the badge can change according to the following
-   * list of statuses: 'info', 'success', 'warning', 'danger', 'inverse'
+   * list of statuses:
+   * 'info'  -> blue dot
+   * 'success' -> green dot
+   * 'warning' -> yellow dot
+   * 'danger' -> red dot
+   * 'inherit' -> dot inherits color of full icon glyph
+   * 'warning-triangle' -> yellow triangle
+   * 'inherit-triangle' -> triangle inherits color of full icon glyph
+   * unrecognized value, empty string, or true -> red dot
    *
-   * Setting the badge to 'null' removes it from the DOM. This is necessary to
-   * remove the badge (dot) from the icon if you are using badgeType.
+   * By default, the badge displays a 'danger' dot (a red-colored dot).
+   *
+   * Setting the badge to 'null' removes the attribute from the DOM.
    */
   @property({ type: String })
-  badgeType: StatusTypes | 'inverse' | null; // [info | warning | danger | success]
+  badge: StatusTypes | 'inherit' | 'warning-triangle' | 'inherit-triangle' | true | null;
 
   @query('svg') private svg: SVGElement;
 

--- a/src/dev-core/src/app/icon-deprecated/icon.demo.html
+++ b/src/dev-core/src/app/icon-deprecated/icon.demo.html
@@ -11,6 +11,11 @@
         line-height: 1.1em;
     }
 
+    .inverse-blackout {
+        background: black;
+        color: #ccc;
+    }
+
     .custom-icon-colors {
         background: black;
         padding: 8px 12px;
@@ -56,7 +61,7 @@
 <h1>Icon Deprecations</h1>
 
 <p>This demo displays the backwards compatible classnames API that is deprecated in 3.0 and will be removed in 4.0.</p>
-<p>This shows that the expected deprecations still work as expected in 3.0.</p>
+<p>This shows that the 3.0 deprecations still work as expected.</p>
 
 <h2>Custom Styling</h2>
 
@@ -145,6 +150,31 @@
     </tbody>
 </table>
 
+<table class="table inverse-blackout">
+    <thead>
+        <tr>
+            <th>outline</th>
+            <th>outline-badged</th>
+            <th>outline-alerted</th>
+            <th>solid</th>
+            <th>solid-badged</th>
+            <th>solid-alerted</th>
+            <th>solid-badged-success</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><cwc-icon size="32" shape="user" class="is-inverse"></cwc-icon></td>
+            <td><cwc-icon size="32" shape="user" class="is-inverse has-badge"></cwc-icon></td>
+            <td><cwc-icon size="32" shape="user" class="is-inverse has-alert"></cwc-icon></td>
+            <td><cwc-icon size="32" shape="user" class="is-inverse is-solid"></cwc-icon></td>
+            <td><cwc-icon size="32" shape="user" class="is-inverse is-solid has-badge"></cwc-icon></td>
+            <td><cwc-icon size="32" shape="user" class="is-inverse is-solid has-alert"></cwc-icon></td>
+            <td><cwc-icon size="32" shape="user" class="is-inverse is-solid has-badge--success"></cwc-icon></td>
+        </tr>
+    </tbody>
+</table>
+
 <h3>Badge Colors</h3>
 
 <table class="table">
@@ -164,6 +194,27 @@
             <td><cwc-icon size="32" shape="user" class="is-solid has-badge--success"></cwc-icon></td>
             <td><cwc-icon size="32" shape="user" class="is-solid has-badge--danger"></cwc-icon></td>
             <td><cwc-icon size="32" shape="user" class="is-solid has-badge--error"></cwc-icon></td>
+        </tr>
+    </tbody>
+</table>
+
+<table class="table inverse-blackout">
+    <thead>
+        <tr>
+            <th>default (danger)</th>
+            <th>info</th>
+            <th>success</th>
+            <th>danger</th>
+            <th>error</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><cwc-icon size="32" shape="user" class="is-inverse has-badge"></cwc-icon></td>
+            <td><cwc-icon size="32" shape="user" class="is-inverse is-solid has-badge--info"></cwc-icon></td>
+            <td><cwc-icon size="32" shape="user" class="is-inverse is-solid has-badge--success"></cwc-icon></td>
+            <td><cwc-icon size="32" shape="user" class="is-inverse is-solid has-badge--danger"></cwc-icon></td>
+            <td><cwc-icon size="32" shape="user" class="is-inverse is-solid has-badge--error"></cwc-icon></td>
         </tr>
     </tbody>
 </table>

--- a/src/dev-core/src/app/icon/icon.demo.html
+++ b/src/dev-core/src/app/icon/icon.demo.html
@@ -11,6 +11,11 @@
         line-height: 1.1em;
     }
 
+    .inverse-blackout {
+        background: black;
+        color: #ccc;
+    }
+    
     .custom-icon-colors {
         background: black;
         padding: 8px 12px;
@@ -64,10 +69,10 @@
         <cwc-icon shape="user" inverse badge></cwc-icon>
     </div>
     <div class="custom-icon-colors">
-        <cwc-icon shape="user" status="danger" badge-type="danger" inverse></cwc-icon>
+        <cwc-icon shape="user" status="danger" badge="danger" inverse></cwc-icon>
     </div>
     <div class="custom-icon-colors custom-icon-colors-2">
-        <cwc-icon shape="user" badge-type="danger"></cwc-icon>
+        <cwc-icon shape="user" badge="danger"></cwc-icon>
     </div>
 </div>
 <p><i>A should be green with a pink badge</i><br>
@@ -199,6 +204,20 @@
             <th>outline</th>
             <th>outline-badged</th>
             <th>outline-alerted</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><cwc-icon size="32" shape="user"></cwc-icon></td>
+            <td><cwc-icon size="32" shape="user" badge></cwc-icon></td>
+            <td><cwc-icon size="32" shape="user" badge="warning-triangle"></cwc-icon></td>
+        </tr>
+    </tbody>
+</table>
+
+<table class="table">
+    <thead>
+        <tr>
             <th>solid</th>
             <th>solid-badged</th>
             <th>solid-alerted</th>
@@ -207,13 +226,10 @@
     </thead>
     <tbody>
         <tr>
-            <td><cwc-icon size="32" shape="user"></cwc-icon></td>
-            <td><cwc-icon size="32" shape="user" badge></cwc-icon></td>
-            <td><cwc-icon size="32" shape="user" alert></cwc-icon></td>
             <td><cwc-icon size="32" shape="user" solid></cwc-icon></td>
             <td><cwc-icon size="32" shape="user" solid badge></cwc-icon></td>
-            <td><cwc-icon size="32" shape="user" solid alert></cwc-icon></td>
-            <td><cwc-icon size="32" shape="user" solid badge-type="success"></cwc-icon></td>
+            <td><cwc-icon size="32" shape="user" solid badge="warning-triangle"></cwc-icon></td>
+            <td><cwc-icon size="32" shape="user" solid badge="success"></cwc-icon></td>
         </tr>
     </tbody>
 </table>
@@ -223,22 +239,53 @@
 <table class="table">
     <thead>
         <tr>
-            <th>default (danger)</th>
+            <th>fallthrough value</th>
+            <th>inherit</th>
             <th>info</th>
             <th>success</th>
             <th>warning</th>
             <th>danger</th>
-            <th>error</th>
+            <th>inherit-triangle</th>
+            <th>warning-triangle</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><cwc-icon size="32" shape="user" badge></cwc-icon></td>
-            <td><cwc-icon size="32" shape="user" solid badge-type="info"></cwc-icon></td>
-            <td><cwc-icon size="32" shape="user" solid badge-type="success"></cwc-icon></td>
-            <td><cwc-icon size="32" shape="user" solid badge-type="warning"></cwc-icon></td>
-            <td><cwc-icon size="32" shape="user" solid badge-type="danger"></cwc-icon></td>
-            <td><cwc-icon size="32" shape="user" solid badge-type="error"></cwc-icon></td>
+            <td><cwc-icon size="32" shape="user" badge="inherit"></cwc-icon></td>
+            <td><cwc-icon size="32" shape="user" badge="info"></cwc-icon></td>
+            <td><cwc-icon size="32" shape="user" badge="success"></cwc-icon></td>
+            <td><cwc-icon size="32" shape="user" badge="warning"></cwc-icon></td>
+            <td><cwc-icon size="32" shape="user" badge="danger"></cwc-icon></td>
+            <td><cwc-icon size="32" shape="user" badge="inherit-triangle"></cwc-icon></td>
+            <td><cwc-icon size="32" shape="user" badge="warning-triangle"></cwc-icon></td>
+        </tr>
+    </tbody>
+</table>
+
+<table class="table inverse-blackout">
+    <thead>
+        <tr>
+            <th>fallthrough value</th>
+            <th>inherit</th>
+            <th>info</th>
+            <th>success</th>
+            <th>warning</th>
+            <th>danger</th>
+            <th>inherit-triangle</th>
+            <th>warning-triangle</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><cwc-icon size="32" inverse shape="user" badge></cwc-icon></td>
+            <td><cwc-icon size="32" inverse shape="user" badge="inherit"></cwc-icon></td>
+            <td><cwc-icon size="32" inverse shape="user" badge="info"></cwc-icon></td>
+            <td><cwc-icon size="32" inverse shape="user" badge="success"></cwc-icon></td>
+            <td><cwc-icon size="32" inverse shape="user" badge="warning"></cwc-icon></td>
+            <td><cwc-icon size="32" inverse shape="user" badge="danger"></cwc-icon></td>
+            <td><cwc-icon size="32" inverse shape="user" badge="inherit-triangle"></cwc-icon></td>
+            <td><cwc-icon size="32" inverse shape="user" badge="warning-triangle"></cwc-icon></td>
         </tr>
     </tbody>
 </table>


### PR DESCRIPTION
• merged badge, alert, and badgeType properties into badge
• replaced alert terminology with a `warning-triangle` status
• this eliminates impossible states introduced by former API
• removed pitched (but not supported by code) inverse state of badges
• replaced inverse badges with `inherit` status
• `inherit` status makes badge same color as rest of icon
• added `inherit-triangle` for a similar feature with alerted icons

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [x] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4235 

## What is the new behavior?

## Does this PR introduce a breaking change?

* [x] Yes
* [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
