### PR TITLE
fix: datepicker input disabled state

### DIFF
--- a/src/clr-angular/forms/datepicker/date-input.spec.ts
+++ b/src/clr-angular/forms/datepicker/date-input.spec.ts
@@ -659,6 +659,18 @@ export default function() {
         dateNavigationService = dateContainerDebugElement.injector.get(DateNavigationService);
       });
 
+      it('when disabled is true there must be attribute attach to the input', () => {
+        fixture.componentInstance.disabled = true;
+        fixture.detectChanges();
+        const datePicker = fixture.nativeElement.querySelector('input');
+        expect(datePicker.getAttribute('disabled')).not.toBeNull();
+
+        // make sure that it won't stay and trick the styles
+        fixture.componentInstance.disabled = false;
+        fixture.detectChanges();
+        expect(datePicker.getAttribute('disabled')).toBeNull();
+      });
+
       it('supports a clrDate Input', () => {
         const date: Date = new Date();
 

--- a/src/clr-angular/forms/datepicker/date-input.spec.ts
+++ b/src/clr-angular/forms/datepicker/date-input.spec.ts
@@ -659,7 +659,7 @@ export default function() {
         dateNavigationService = dateContainerDebugElement.injector.get(DateNavigationService);
       });
 
-      it('when disabled is true there must be attribute attach to the input', () => {
+      it('when disabled is true there must be attribute attached to the input', () => {
         fixture.componentInstance.disabled = true;
         fixture.detectChanges();
         const datePicker = fixture.nativeElement.querySelector('input');
@@ -780,7 +780,7 @@ export default function() {
 
 @Component({
   template: `
-        <input 
+        <input
                 class="test-class clr-col-12 clr-col-md-8"
                 type="date"
                 [min]="minDate"

--- a/src/clr-angular/forms/datepicker/date-input.ts
+++ b/src/clr-angular/forms/datepicker/date-input.ts
@@ -159,11 +159,18 @@ export class ClrDateInput extends WrappedFormControl<ClrDateContainer> implement
     }
   }
 
+  @HostBinding('disabled')
   @Input('disabled')
   set disabled(value: boolean | string) {
     if (this.dateFormControlService) {
       this.dateFormControlService.setDisabled(isBooleanAttributeSet(value));
     }
+  }
+  get disabled() {
+    if (this.dateFormControlService) {
+      return this.dateFormControlService.disabled;
+    }
+    return null;
   }
 
   private usingClarityDatepicker() {

--- a/src/dev/src/app/datepicker/disabled.html
+++ b/src/dev/src/app/datepicker/disabled.html
@@ -31,7 +31,7 @@
 
 <h6>No ClrForm</h6>
 
-<h6>Controll Disabled & Enabled</h6>
+<h6>Control Disabled & Enabled</h6>
 <clr-date-container>
     <label>Disabled Date Picker</label>
     <input type="date" [(clrDate)]="date" [disabled]="disabled" />

--- a/src/dev/src/app/datepicker/disabled.html
+++ b/src/dev/src/app/datepicker/disabled.html
@@ -30,12 +30,19 @@
 </div>
 
 <h6>No ClrForm</h6>
+
+<h6>Controll Disabled & Enabled</h6>
 <clr-date-container>
     <label>Disabled Date Picker</label>
     <input type="date" [(clrDate)]="date" [disabled]="disabled" />
 </clr-date-container>
 
-<h6>Controll Disabled & Enabled</h6>
 <div>
     <button class="btn" (click)="disabled = !disabled">Toggle Disabled</button>
 </div>
+
+<h6>Disabled and will stay that way</h6>
+<clr-date-container>
+    <label>Disabled Date Picker</label>
+    <input type="date" [(clrDate)]="date" disabled />
+</clr-date-container>


### PR DESCRIPTION
Add/Remove the `disabled` attribute to the input field at date-input component.

this way all click-events are disabled and the input won't be editable  

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4228 

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Close #4228 