### PR TITLE
feat(form): support a generic control container

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -36,7 +36,12 @@
                 "output": "/assets"
               }
             ],
-            "styles": ["src/clr-angular/main.scss", "src/clr-icons/clr-icons.scss", "src/dev/src/styles.scss"],
+            "styles": [
+              "src/clr-angular/main.scss",
+              "src/clr-icons/clr-icons.scss",
+              "src/dev/src/styles.scss",
+              "node_modules/@ng-select/ng-select/themes/default.theme.css"
+            ],
             "scripts": [
               "node_modules/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js",
               "node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"

--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -45,6 +45,22 @@ export declare const CLR_VERTICAL_NAV_DIRECTIVES: Type<any>[];
 
 export declare const CLR_WIZARD_DIRECTIVES: any[];
 
+export declare abstract class ClrAbstractContainer implements DynamicWrapper, OnDestroy {
+    _dynamic: boolean;
+    control: NgControl;
+    protected controlClassService: ControlClassService;
+    protected ifErrorService: IfErrorService;
+    invalid: boolean;
+    label: ClrLabel;
+    protected layoutService: LayoutService;
+    protected ngControlService: NgControlService;
+    protected subscriptions: Subscription[];
+    constructor(ifErrorService: IfErrorService, layoutService: LayoutService, controlClassService: ControlClassService, ngControlService: NgControlService);
+    addGrid(): boolean;
+    controlClass(): string;
+    ngOnDestroy(): void;
+}
+
 export declare class ClrAccordion implements OnInit, OnChanges, AfterViewInit, OnDestroy {
     multiPanel: boolean;
     panels: QueryList<ClrAccordionPanel>;
@@ -234,17 +250,9 @@ export declare class ClrCheckbox extends WrappedFormControl<ClrCheckboxWrapper> 
     ngOnInit(): void;
 }
 
-export declare class ClrCheckboxContainer implements OnDestroy {
+export declare class ClrCheckboxContainer extends ClrAbstractContainer {
     set clrInline(value: boolean | string);
     get clrInline(): boolean | string;
-    control: NgControl;
-    invalid: boolean;
-    label: ClrLabel;
-    constructor(ifErrorService: IfErrorService, layoutService: LayoutService, controlClassService: ControlClassService, ngControlService: NgControlService);
-    addGrid(): boolean;
-    controlClass(): string;
-    ngOnDestroy(): void;
-    ngOnInit(): void;
 }
 
 export declare class ClrCheckboxModule {
@@ -266,6 +274,14 @@ export declare class ClrCommonStringsService extends CommonStringsServiceInterna
 }
 
 export declare class ClrConditionalModule {
+}
+
+export declare class ClrControl extends WrappedFormControl<ClrControlContainer> {
+    protected index: number;
+    constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef);
+}
+
+export declare class ClrControlContainer extends ClrAbstractContainer {
 }
 
 export declare class ClrControlError implements AfterViewInit {
@@ -623,16 +639,9 @@ export declare class ClrDatalist implements AfterContentInit {
     ngOnDestroy(): void;
 }
 
-export declare class ClrDatalistContainer implements DynamicWrapper {
-    _dynamic: boolean;
-    control: NgControl;
+export declare class ClrDatalistContainer extends ClrAbstractContainer {
     focus: boolean;
-    invalid: boolean;
-    label: ClrLabel;
-    constructor(controlClassService: ControlClassService, layoutService: LayoutService, ifErrorService: IfErrorService, focusService: FocusService, ngControlService: NgControlService);
-    addGrid(): boolean;
-    controlClass(): string;
-    ngOnDestroy(): void;
+    constructor(controlClassService: ControlClassService, layoutService: LayoutService, ifErrorService: IfErrorService, ngControlService: NgControlService, focusService: FocusService);
 }
 
 export declare class ClrDatalistInput extends WrappedFormControl<ClrDatalistContainer> implements AfterContentInit {
@@ -943,15 +952,7 @@ export declare class ClrInput extends WrappedFormControl<ClrInputContainer> {
     constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef);
 }
 
-export declare class ClrInputContainer implements DynamicWrapper, OnDestroy {
-    _dynamic: boolean;
-    control: NgControl;
-    invalid: boolean;
-    label: ClrLabel;
-    constructor(ifErrorService: IfErrorService, layoutService: LayoutService, controlClassService: ControlClassService, ngControlService: NgControlService);
-    addGrid(): boolean;
-    controlClass(): string;
-    ngOnDestroy(): void;
+export declare class ClrInputContainer extends ClrAbstractContainer {
 }
 
 export declare class ClrInputModule {
@@ -1082,21 +1083,14 @@ export declare class ClrPassword extends WrappedFormControl<ClrPasswordContainer
     triggerValidation(): void;
 }
 
-export declare class ClrPasswordContainer implements DynamicWrapper, OnDestroy {
-    _dynamic: boolean;
+export declare class ClrPasswordContainer extends ClrAbstractContainer {
     set clrToggle(state: boolean);
     get clrToggle(): boolean;
     commonStrings: ClrCommonStringsService;
-    control: NgControl;
     focus: boolean;
     focusService: FocusService;
-    invalid: boolean;
-    label: ClrLabel;
     show: boolean;
-    constructor(ifErrorService: IfErrorService, layoutService: LayoutService, controlClassService: ControlClassService, focusService: FocusService, ngControlService: NgControlService, toggleService: BehaviorSubject<boolean>, commonStrings: ClrCommonStringsService);
-    addGrid(): boolean;
-    controlClass(): string;
-    ngOnDestroy(): void;
+    constructor(ifErrorService: IfErrorService, layoutService: LayoutService, controlClassService: ControlClassService, ngControlService: NgControlService, focusService: FocusService, toggleService: BehaviorSubject<boolean>, commonStrings: ClrCommonStringsService);
     toggle(): void;
 }
 
@@ -1209,16 +1203,9 @@ export declare class ClrRadio extends WrappedFormControl<ClrRadioWrapper> {
     constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef);
 }
 
-export declare class ClrRadioContainer implements OnDestroy {
+export declare class ClrRadioContainer extends ClrAbstractContainer {
     set clrInline(value: boolean | string);
     get clrInline(): boolean | string;
-    control: NgControl;
-    invalid: boolean;
-    label: ClrLabel;
-    constructor(ifErrorService: IfErrorService, layoutService: LayoutService, controlClassService: ControlClassService, ngControlService: NgControlService);
-    addGrid(): boolean;
-    controlClass(): string;
-    ngOnDestroy(): void;
 }
 
 export declare class ClrRadioModule {
@@ -1234,18 +1221,11 @@ export declare class ClrRange extends WrappedFormControl<ClrRangeContainer> {
     constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef);
 }
 
-export declare class ClrRangeContainer implements DynamicWrapper, OnDestroy {
-    _dynamic: boolean;
-    control: NgControl;
+export declare class ClrRangeContainer extends ClrAbstractContainer {
     set hasProgress(val: boolean);
     get hasProgress(): boolean;
-    invalid: boolean;
-    label: ClrLabel;
     constructor(ifErrorService: IfErrorService, layoutService: LayoutService, controlClassService: ControlClassService, ngControlService: NgControlService, renderer: Renderer2, idService: ControlIdService);
-    addGrid(): boolean;
-    controlClass(): string;
     getRangeProgressFillWidth(): string;
-    ngOnDestroy(): void;
 }
 
 export declare class ClrRangeModule {
@@ -1269,16 +1249,9 @@ export declare class ClrSelect extends WrappedFormControl<ClrSelectContainer> {
     constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef);
 }
 
-export declare class ClrSelectContainer implements DynamicWrapper, OnDestroy {
-    _dynamic: boolean;
-    control: NgControl;
-    invalid: boolean;
-    label: ClrLabel;
+export declare class ClrSelectContainer extends ClrAbstractContainer {
     multiple: SelectMultipleControlValueAccessor;
-    constructor(ifErrorService: IfErrorService, layoutService: LayoutService, controlClassService: ControlClassService, ngControlService: NgControlService);
-    addGrid(): boolean;
-    controlClass(): string;
-    ngOnDestroy(): void;
+    ngOnInit(): void;
     wrapperClass(): "clr-multiselect-wrapper" | "clr-select-wrapper";
 }
 
@@ -1518,15 +1491,7 @@ export declare class ClrTextarea extends WrappedFormControl<ClrTextareaContainer
     constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef);
 }
 
-export declare class ClrTextareaContainer implements DynamicWrapper, OnDestroy {
-    _dynamic: boolean;
-    control: NgControl;
-    invalid: boolean;
-    label: ClrLabel;
-    constructor(ifErrorService: IfErrorService, layoutService: LayoutService, controlClassService: ControlClassService, ngControlService: NgControlService);
-    addGrid(): boolean;
-    controlClass(): string;
-    ngOnDestroy(): void;
+export declare class ClrTextareaContainer extends ClrAbstractContainer {
 }
 
 export declare class ClrTextareaModule {
@@ -1944,3 +1909,22 @@ export declare const TOGGLE_SERVICE_PROVIDER: {
 };
 
 export declare function ToggleServiceFactory(): BehaviorSubject<boolean>;
+
+export declare class WrappedFormControl<W extends DynamicWrapper> implements OnInit, OnDestroy {
+    _id: string;
+    protected controlIdService: ControlIdService;
+    protected el: ElementRef<any>;
+    get id(): string;
+    set id(value: string);
+    protected index: number;
+    protected ngControlService: NgControlService;
+    protected renderer: Renderer2;
+    protected subscriptions: Subscription[];
+    protected vcr: ViewContainerRef;
+    protected wrapperType: Type<W>;
+    constructor(vcr: ViewContainerRef, wrapperType: Type<W>, injector: Injector, ngControl: NgControl, renderer: Renderer2, el: ElementRef);
+    protected getProviderFromContainer<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T): T;
+    ngOnDestroy(): void;
+    ngOnInit(): void;
+    triggerValidation(): void;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8239,6 +8239,15 @@
         }
       }
     },
+    "@ng-select/ng-select": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@ng-select/ng-select/-/ng-select-3.7.2.tgz",
+      "integrity": "sha512-hbus2lRIJVPYm8g/z1b8T/iGpYaRQZpzGvfYzdeteguhQOly8pkC8gsSRCLVBv5wyJzDAuOKsKmHKdzakdRisA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "@ngtools/webpack": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-9.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "@babel/runtime": "^7.4.5",
     "@commitlint/cli": "8.0.0",
     "@commitlint/config-conventional": "8.0.0",
+    "@ng-select/ng-select": "3.7.2",
     "@storybook/addon-a11y": "6.0.0-alpha.0",
     "@storybook/addon-actions": "6.0.0-alpha.0",
     "@storybook/addon-cssresources": "6.0.0-alpha.0",

--- a/src/clr-angular/forms/checkbox/checkbox-container.ts
+++ b/src/clr-angular/forms/checkbox/checkbox-container.ts
@@ -4,15 +4,12 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, ContentChild, Input, OnDestroy, Optional } from '@angular/core';
-import { Subscription } from 'rxjs';
-import { NgControl } from '@angular/forms';
+import { Component, Input } from '@angular/core';
 
 import { IfErrorService } from '../common/if-error/if-error.service';
-import { ClrLabel } from '../common/label';
 import { ControlClassService } from '../common/providers/control-class.service';
-import { LayoutService } from '../common/providers/layout.service';
 import { NgControlService } from '../common/providers/ng-control.service';
+import { ClrAbstractContainer } from '../common/abstract-container';
 
 @Component({
   selector: 'clr-checkbox-container,clr-toggle-container',
@@ -35,12 +32,8 @@ import { NgControlService } from '../common/providers/ng-control.service';
   },
   providers: [NgControlService, ControlClassService, IfErrorService],
 })
-export class ClrCheckboxContainer implements OnDestroy {
-  private subscriptions: Subscription[] = [];
-  invalid = false;
-  @ContentChild(ClrLabel) label: ClrLabel;
+export class ClrCheckboxContainer extends ClrAbstractContainer {
   private inline = false;
-  control: NgControl;
   // private formGroup: AbstractControl;
 
   /*
@@ -59,62 +52,5 @@ export class ClrCheckboxContainer implements OnDestroy {
   }
   get clrInline() {
     return this.inline;
-  }
-
-  // @TODO Solve for group validation, which doesn't work now with ngModelGroup
-  // Blocked by https://github.com/angular/angular/issues/20268
-  // @Input()
-  // set clrFormGroup(value: FormGroup) {
-  //   this.formGroup = value;
-  // }
-
-  // @Input()
-  // set clrFormArray(value: FormArray) {
-  //   this.formGroup = value;
-  // }
-
-  constructor(
-    private ifErrorService: IfErrorService,
-    @Optional() private layoutService: LayoutService,
-    private controlClassService: ControlClassService,
-    private ngControlService: NgControlService
-  ) {
-    this.subscriptions.push(
-      this.ngControlService.controlChanges.subscribe(control => {
-        this.control = control;
-      })
-    );
-  }
-
-  ngOnInit() {
-    // @TODO put a solution in for form group validation
-    // if (!this.formGroup) {
-    this.subscriptions.push(
-      this.ifErrorService.statusChanges.subscribe(invalid => {
-        this.invalid = invalid;
-      })
-    );
-    // } else {
-    //   // Because ngModel does this, we have to delay a tick to get the result
-    //   Promise.resolve().then(() => {
-    //     this.subscriptions.push(
-    //       this.formGroup.statusChanges.subscribe(() => {
-    //         this.invalid = this.formGroup.invalid;
-    //       })
-    //     );
-    //   });
-    // }
-  }
-
-  controlClass() {
-    return this.controlClassService.controlClass(this.invalid, this.addGrid(), this.inline ? 'clr-control-inline' : '');
-  }
-
-  addGrid() {
-    return this.layoutService && !this.layoutService.isVertical();
-  }
-
-  ngOnDestroy() {
-    this.subscriptions.map(sub => sub.unsubscribe());
   }
 }

--- a/src/clr-angular/forms/common/abstract-container.ts
+++ b/src/clr-angular/forms/common/abstract-container.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { ContentChild, Directive, OnDestroy, Optional } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { NgControl } from '@angular/forms';
+
+import { IfErrorService } from './if-error/if-error.service';
+import { NgControlService } from './providers/ng-control.service';
+import { LayoutService } from './providers/layout.service';
+import { DynamicWrapper } from '../../utils/host-wrapping/dynamic-wrapper';
+import { ClrLabel } from './label';
+import { ControlClassService } from './providers/control-class.service';
+
+@Directive()
+export abstract class ClrAbstractContainer implements DynamicWrapper, OnDestroy {
+  protected subscriptions: Subscription[] = [];
+  invalid = false;
+  _dynamic = false;
+  @ContentChild(ClrLabel, { static: false })
+  label: ClrLabel;
+  control: NgControl;
+
+  constructor(
+    protected ifErrorService: IfErrorService,
+    @Optional() protected layoutService: LayoutService,
+    protected controlClassService: ControlClassService,
+    protected ngControlService: NgControlService
+  ) {
+    this.subscriptions.push(
+      this.ifErrorService.statusChanges.subscribe(invalid => {
+        this.invalid = invalid;
+      })
+    );
+    this.subscriptions.push(
+      this.ngControlService.controlChanges.subscribe(control => {
+        this.control = control;
+      })
+    );
+  }
+
+  controlClass() {
+    return this.controlClassService.controlClass(this.invalid, this.addGrid());
+  }
+
+  addGrid() {
+    return this.layoutService && !this.layoutService.isVertical();
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.map(sub => sub.unsubscribe());
+  }
+}

--- a/src/clr-angular/forms/common/all.spec.ts
+++ b/src/clr-angular/forms/common/all.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -17,11 +17,13 @@ import ControlIdServiceSpecs from './providers/control-id.service.spec';
 import LayoutServiceSpecs from './providers/layout.service.spec';
 import NgControlServiceSpecs from './providers/ng-control.service.spec';
 import WrappedControlSpecs from './wrapped-control.spec';
+import ControlContainerSpecs from './control-container.spec';
 
 describe('Forms common utilities', function() {
   ControlClassServiceSpecs();
   ControlIdServiceSpecs();
   ControlStatusServiceSpecs();
+  ControlContainerSpecs();
   NgControlServiceSpecs();
   LayoutServiceSpecs();
   LayoutSpecs();

--- a/src/clr-angular/forms/common/common.module.ts
+++ b/src/clr-angular/forms/common/common.module.ts
@@ -1,11 +1,12 @@
 /**
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { ClrIconModule } from '../../icon/icon.module';
 
 import { ClrControlError } from './error';
 import { ClrControlHelper } from './helper';
@@ -13,10 +14,31 @@ import { ClrIfError } from './if-error/if-error';
 import { ClrLabel } from './label';
 import { ClrForm } from './form';
 import { ClrLayout } from './layout';
+import { ClrControlContainer } from './control-container';
+import { ClrControl } from './control';
 
 @NgModule({
-  imports: [CommonModule],
-  declarations: [ClrLabel, ClrControlError, ClrControlHelper, ClrIfError, ClrForm, ClrLayout],
-  exports: [ClrLabel, ClrControlError, ClrControlHelper, ClrIfError, ClrForm, ClrLayout],
+  imports: [CommonModule, ClrIconModule],
+  declarations: [
+    ClrLabel,
+    ClrControlError,
+    ClrControlHelper,
+    ClrIfError,
+    ClrForm,
+    ClrLayout,
+    ClrControlContainer,
+    ClrControl,
+  ],
+  exports: [
+    ClrLabel,
+    ClrControlError,
+    ClrControlHelper,
+    ClrIfError,
+    ClrForm,
+    ClrLayout,
+    ClrControlContainer,
+    ClrControl,
+  ],
+  entryComponents: [ClrControlContainer],
 })
 export class ClrCommonFormsModule {}

--- a/src/clr-angular/forms/common/control-container.spec.ts
+++ b/src/clr-angular/forms/common/control-container.spec.ts
@@ -6,19 +6,19 @@
 import { Component } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 
-import { ClrInput } from './input';
-import { ClrInputContainer } from './input-container';
+import { ClrControlContainer } from './control-container';
+import { ClrControl } from './control';
 
-import { TemplateDrivenSpec, ReactiveSpec, ContainerNoLabelSpec } from '../tests/container.spec';
+import { ContainerNoLabelSpec, ReactiveSpec, TemplateDrivenSpec } from '../tests/container.spec';
 
 @Component({
   template: `
-    <clr-input-container>
-        <input name="model" clrInput required [(ngModel)]="model" [disabled]="disabled" />
+    <clr-control-container>
+        <input name="model" clrControl required [(ngModel)]="model" [disabled]="disabled" />
         <label>Hello World</label>
         <clr-control-helper>Helper text</clr-control-helper>
         <clr-control-error>Must be at least 5 characters</clr-control-error>
-    </clr-input-container>
+    </clr-control-container>
     `,
 })
 class SimpleTest {
@@ -28,9 +28,9 @@ class SimpleTest {
 
 @Component({
   template: `
-  <clr-input-container>
-    <input clrInput name="model" [(ngModel)]="model" />
-  </clr-input-container>`,
+  <clr-control-container>
+    <input clrControl name="model" [(ngModel)]="model" />
+  </clr-control-container>`,
 })
 class NoLabelTest {
   model;
@@ -39,12 +39,12 @@ class NoLabelTest {
 @Component({
   template: `
   <form [formGroup]="form">
-    <clr-input-container>
-      <input clrInput formControlName="model" />
+    <clr-control-container>
+      <input clrControl formControlName="model" />
       <label>Hello World</label>
       <clr-control-helper>Helper text</clr-control-helper>
       <clr-control-error>Must be at least 5 characters</clr-control-error>
-    </clr-input-container>
+    </clr-control-container>
   </form>`,
 })
 class ReactiveTest {
@@ -55,9 +55,9 @@ class ReactiveTest {
 }
 
 export default function(): void {
-  describe('ClrInputContainer', () => {
-    ContainerNoLabelSpec(ClrInputContainer, ClrInput, NoLabelTest);
-    TemplateDrivenSpec(ClrInputContainer, ClrInput, SimpleTest, '.clr-input-wrapper [clrInput]');
-    ReactiveSpec(ClrInputContainer, ClrInput, ReactiveTest, '.clr-input-wrapper [clrInput]');
+  describe('ClrControlContainer', () => {
+    ContainerNoLabelSpec(ClrControlContainer, ClrControl, NoLabelTest);
+    TemplateDrivenSpec(ClrControlContainer, ClrControl, SimpleTest, '.clr-input-wrapper [clrControl]');
+    ReactiveSpec(ClrControlContainer, ClrControl, ReactiveTest, '.clr-input-wrapper [clrControl]');
   });
 }

--- a/src/clr-angular/forms/common/control-container.ts
+++ b/src/clr-angular/forms/common/control-container.ts
@@ -6,20 +6,20 @@
 
 import { Component } from '@angular/core';
 
-import { IfErrorService } from '../common/if-error/if-error.service';
-import { NgControlService } from '../common/providers/ng-control.service';
-import { ControlIdService } from '../common/providers/control-id.service';
-import { ControlClassService } from '../common/providers/control-class.service';
 import { ClrAbstractContainer } from '../common/abstract-container';
+import { IfErrorService } from './if-error/if-error.service';
+import { NgControlService } from './providers/ng-control.service';
+import { ControlIdService } from './providers/control-id.service';
+import { ControlClassService } from './providers/control-class.service';
 
 @Component({
-  selector: 'clr-input-container',
+  selector: 'clr-control-container',
   template: `
         <ng-content select="label"></ng-content>
         <label *ngIf="!label && addGrid()"></label>
         <div class="clr-control-container" [ngClass]="controlClass()">
             <div class="clr-input-wrapper">
-                <ng-content select="[clrInput]"></ng-content>
+                <ng-content></ng-content>
                 <clr-icon *ngIf="invalid" class="clr-validate-icon" shape="exclamation-circle" aria-hidden="true"></clr-icon>
             </div>
             <ng-content select="clr-control-helper" *ngIf="!invalid"></ng-content>
@@ -33,4 +33,4 @@ import { ClrAbstractContainer } from '../common/abstract-container';
   },
   providers: [IfErrorService, NgControlService, ControlIdService, ControlClassService],
 })
-export class ClrInputContainer extends ClrAbstractContainer {}
+export class ClrControlContainer extends ClrAbstractContainer {}

--- a/src/clr-angular/forms/common/control.spec.ts
+++ b/src/clr-angular/forms/common/control.spec.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import { Component } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+
+import { TemplateDrivenSpec, ControlStandaloneSpec, ReactiveSpec } from '../tests/control.spec';
+import { ClrControlContainer } from './control-container';
+import { ClrControl } from './control';
+
+@Component({
+  template: `
+       <input type="text" clrControl />
+    `,
+})
+class StandaloneUseTest {}
+
+@Component({
+  template: `
+       <input clrControl name="model" class="test-class" [(ngModel)]="model" />
+    `,
+})
+class TemplateDrivenTest {
+  model;
+}
+
+@Component({
+  template: `
+    <div [formGroup]="example">
+       <input clrControl name="model" class="test-class" formControlName="model" />
+    </div>
+    `,
+})
+class ReactiveTest {
+  example = new FormGroup({
+    model: new FormControl('', Validators.required),
+  });
+}
+
+export default function(): void {
+  describe('Input directive', () => {
+    ControlStandaloneSpec(StandaloneUseTest);
+    TemplateDrivenSpec(ClrControlContainer, ClrControl, TemplateDrivenTest, 'clr-input');
+    ReactiveSpec(ClrControlContainer, ClrControl, ReactiveTest, 'clr-input');
+  });
+}

--- a/src/clr-angular/forms/common/control.ts
+++ b/src/clr-angular/forms/common/control.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import { Directive, ElementRef, Injector, Optional, Renderer2, Self, ViewContainerRef } from '@angular/core';
+import { WrappedFormControl } from './wrapped-control';
+import { ClrControlContainer } from './control-container';
+import { NgControl } from '@angular/forms';
+
+@Directive({ selector: '[clrControl]', host: { '[class.clr-input]': 'true' } })
+export class ClrControl extends WrappedFormControl<ClrControlContainer> {
+  protected index = 1;
+
+  constructor(
+    vcr: ViewContainerRef,
+    injector: Injector,
+    @Self()
+    @Optional()
+    control: NgControl,
+    renderer: Renderer2,
+    el: ElementRef
+  ) {
+    super(vcr, ClrControlContainer, injector, control, renderer, el);
+  }
+}

--- a/src/clr-angular/forms/common/index.ts
+++ b/src/clr-angular/forms/common/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -10,4 +10,8 @@ export * from './form';
 export * from './helper';
 export * from './label';
 export * from './layout';
+export * from './abstract-container';
+export * from './control';
+export * from './control-container';
+export * from './wrapped-control';
 export * from './common.module';

--- a/src/clr-angular/forms/datalist/datalist-container.ts
+++ b/src/clr-angular/forms/datalist/datalist-container.ts
@@ -4,18 +4,15 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, ContentChild } from '@angular/core';
+import { Component, Optional } from '@angular/core';
 import { ControlClassService } from '../common/providers/control-class.service';
 import { LayoutService } from '../common/providers/layout.service';
-import { DynamicWrapper } from '../../utils/host-wrapping/dynamic-wrapper';
 import { ControlIdService } from '../common/providers/control-id.service';
 import { FocusService } from '../common/providers/focus.service';
 import { IfErrorService } from '../common/if-error/if-error.service';
 import { NgControlService } from '../common/providers/ng-control.service';
-import { NgControl } from '@angular/forms';
-import { Subscription } from 'rxjs';
-import { ClrLabel } from '../common/label';
 import { DatalistIdService } from './providers/datalist-id.service';
+import { ClrAbstractContainer } from '../common/abstract-container';
 
 @Component({
   selector: 'clr-datalist-container',
@@ -49,38 +46,18 @@ import { DatalistIdService } from './providers/datalist-id.service';
     DatalistIdService,
   ],
 })
-export class ClrDatalistContainer implements DynamicWrapper {
-  private subscriptions: Subscription[] = [];
-  _dynamic: boolean = false;
-  invalid: boolean = false;
+export class ClrDatalistContainer extends ClrAbstractContainer {
   focus: boolean = false;
-  control: NgControl;
 
   constructor(
-    private controlClassService: ControlClassService,
-    private layoutService: LayoutService,
-    private ifErrorService: IfErrorService,
-    private focusService: FocusService,
-    private ngControlService: NgControlService
+    controlClassService: ControlClassService,
+    @Optional() layoutService: LayoutService,
+    ifErrorService: IfErrorService,
+    ngControlService: NgControlService,
+    private focusService: FocusService
   ) {
-    this.subscriptions.push(
-      this.ifErrorService.statusChanges.subscribe(invalid => (this.invalid = invalid)),
-      this.focusService.focusChange.subscribe(state => (this.focus = state)),
-      this.ngControlService.controlChanges.subscribe(control => (this.control = control))
-    );
-  }
+    super(ifErrorService, layoutService, controlClassService, ngControlService);
 
-  @ContentChild(ClrLabel) label: ClrLabel;
-
-  controlClass() {
-    return this.controlClassService.controlClass(this.invalid, this.addGrid());
-  }
-
-  addGrid() {
-    return this.layoutService && !this.layoutService.isVertical();
-  }
-
-  ngOnDestroy() {
-    this.subscriptions.map(sub => sub.unsubscribe());
+    this.subscriptions.push(this.focusService.focusChange.subscribe(state => (this.focus = state)));
   }
 }

--- a/src/clr-angular/forms/radio/radio-container.ts
+++ b/src/clr-angular/forms/radio/radio-container.ts
@@ -4,15 +4,12 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, ContentChild, Input, OnDestroy, Optional } from '@angular/core';
-import { NgControl } from '@angular/forms';
-import { Subscription } from 'rxjs';
+import { Component, Input } from '@angular/core';
 
 import { IfErrorService } from '../common/if-error/if-error.service';
-import { ClrLabel } from '../common/label';
 import { ControlClassService } from '../common/providers/control-class.service';
-import { LayoutService } from '../common/providers/layout.service';
 import { NgControlService } from '../common/providers/ng-control.service';
+import { ClrAbstractContainer } from '../common/abstract-container';
 
 @Component({
   selector: 'clr-radio-container',
@@ -35,12 +32,8 @@ import { NgControlService } from '../common/providers/ng-control.service';
   },
   providers: [NgControlService, ControlClassService, IfErrorService],
 })
-export class ClrRadioContainer implements OnDestroy {
-  private subscriptions: Subscription[] = [];
-  invalid = false;
-  @ContentChild(ClrLabel) label: ClrLabel;
+export class ClrRadioContainer extends ClrAbstractContainer {
   private inline = false;
-  control: NgControl;
 
   /*
    * Here we want to support the following cases
@@ -58,35 +51,5 @@ export class ClrRadioContainer implements OnDestroy {
   }
   get clrInline() {
     return this.inline;
-  }
-
-  constructor(
-    private ifErrorService: IfErrorService,
-    @Optional() private layoutService: LayoutService,
-    private controlClassService: ControlClassService,
-    private ngControlService: NgControlService
-  ) {
-    this.subscriptions.push(
-      this.ifErrorService.statusChanges.subscribe(invalid => {
-        this.invalid = invalid;
-      })
-    );
-    this.subscriptions.push(
-      this.ngControlService.controlChanges.subscribe(control => {
-        this.control = control;
-      })
-    );
-  }
-
-  controlClass() {
-    return this.controlClassService.controlClass(this.invalid, this.addGrid(), this.inline ? 'clr-control-inline' : '');
-  }
-
-  addGrid() {
-    return this.layoutService && !this.layoutService.isVertical();
-  }
-
-  ngOnDestroy() {
-    this.subscriptions.map(sub => sub.unsubscribe());
   }
 }

--- a/src/clr-angular/forms/range/range-container.ts
+++ b/src/clr-angular/forms/range/range-container.ts
@@ -4,17 +4,14 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, ContentChild, OnDestroy, Optional, Input, Renderer2 } from '@angular/core';
-import { Subscription } from 'rxjs';
-import { NgControl } from '@angular/forms';
+import { Component, Input, Optional, Renderer2 } from '@angular/core';
 
 import { IfErrorService } from '../common/if-error/if-error.service';
 import { NgControlService } from '../common/providers/ng-control.service';
 import { LayoutService } from '../common/providers/layout.service';
-import { DynamicWrapper } from '../../utils/host-wrapping/dynamic-wrapper';
 import { ControlIdService } from '../common/providers/control-id.service';
-import { ClrLabel } from '../common/label';
 import { ControlClassService } from '../common/providers/control-class.service';
+import { ClrAbstractContainer } from '../common/abstract-container';
 
 @Component({
   selector: 'clr-range-container',
@@ -42,13 +39,7 @@ import { ControlClassService } from '../common/providers/control-class.service';
   },
   providers: [IfErrorService, NgControlService, ControlIdService, ControlClassService],
 })
-export class ClrRangeContainer implements DynamicWrapper, OnDestroy {
-  private subscriptions: Subscription[] = [];
-  invalid = false;
-  _dynamic = false;
-  @ContentChild(ClrLabel) label: ClrLabel;
-  control: NgControl;
-
+export class ClrRangeContainer extends ClrAbstractContainer {
   private _hasProgress: boolean = false;
 
   @Input('clrRangeHasProgress')
@@ -64,23 +55,14 @@ export class ClrRangeContainer implements DynamicWrapper, OnDestroy {
   }
 
   constructor(
-    private ifErrorService: IfErrorService,
-    @Optional() private layoutService: LayoutService,
-    private controlClassService: ControlClassService,
-    private ngControlService: NgControlService,
+    ifErrorService: IfErrorService,
+    @Optional() layoutService: LayoutService,
+    controlClassService: ControlClassService,
+    ngControlService: NgControlService,
     private renderer: Renderer2,
     private idService: ControlIdService
   ) {
-    this.subscriptions.push(
-      this.ifErrorService.statusChanges.subscribe(invalid => {
-        this.invalid = invalid;
-      })
-    );
-    this.subscriptions.push(
-      this.ngControlService.controlChanges.subscribe(control => {
-        this.control = control;
-      })
-    );
+    super(ifErrorService, layoutService, controlClassService, ngControlService);
   }
 
   getRangeProgressFillWidth(): string {
@@ -99,17 +81,5 @@ export class ClrRangeContainer implements DynamicWrapper, OnDestroy {
     const valueAsPercent = (inputValue - inputMinValue) * 100 / (inputMaxValue - inputMinValue);
 
     return valueAsPercent * inputWidth / 100 + 'px';
-  }
-
-  controlClass() {
-    return this.controlClassService.controlClass(this.invalid, this.addGrid());
-  }
-
-  addGrid() {
-    return this.layoutService && !this.layoutService.isVertical();
-  }
-
-  ngOnDestroy() {
-    this.subscriptions.map(sub => sub.unsubscribe());
   }
 }

--- a/src/clr-angular/forms/select/select-container.ts
+++ b/src/clr-angular/forms/select/select-container.ts
@@ -4,21 +4,18 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, ContentChild, OnDestroy, Optional } from '@angular/core';
-import { SelectMultipleControlValueAccessor, NgControl } from '@angular/forms';
-import { Subscription } from 'rxjs';
+import { Component, ContentChild } from '@angular/core';
+import { SelectMultipleControlValueAccessor } from '@angular/forms';
 
 import { IfErrorService } from '../common/if-error/if-error.service';
 import { NgControlService } from '../common/providers/ng-control.service';
-import { LayoutService } from '../common/providers/layout.service';
-import { DynamicWrapper } from '../../utils/host-wrapping/dynamic-wrapper';
 import { ControlIdService } from '../common/providers/control-id.service';
-import { ClrLabel } from '../common/label';
 import { ControlClassService } from '../common/providers/control-class.service';
+import { ClrAbstractContainer } from '../common/abstract-container';
 
 @Component({
   selector: 'clr-select-container',
-  template: `    
+  template: `
         <ng-content select="label"></ng-content>
         <label *ngIf="!label && addGrid()"></label>
         <div class="clr-control-container" [ngClass]="controlClass()">
@@ -38,26 +35,12 @@ import { ControlClassService } from '../common/providers/control-class.service';
   },
   providers: [IfErrorService, NgControlService, ControlIdService, ControlClassService],
 })
-export class ClrSelectContainer implements DynamicWrapper, OnDestroy {
-  private subscriptions: Subscription[] = [];
-  invalid = false;
-  _dynamic = false;
-  @ContentChild(ClrLabel) label: ClrLabel;
-  @ContentChild(SelectMultipleControlValueAccessor) multiple: SelectMultipleControlValueAccessor;
+export class ClrSelectContainer extends ClrAbstractContainer {
+  @ContentChild(SelectMultipleControlValueAccessor, { static: false })
+  multiple: SelectMultipleControlValueAccessor;
   private multi = false;
-  control: NgControl;
 
-  constructor(
-    private ifErrorService: IfErrorService,
-    @Optional() private layoutService: LayoutService,
-    private controlClassService: ControlClassService,
-    private ngControlService: NgControlService
-  ) {
-    this.subscriptions.push(
-      this.ifErrorService.statusChanges.subscribe(invalid => {
-        this.invalid = invalid;
-      })
-    );
+  ngOnInit() {
     this.subscriptions.push(
       this.ngControlService.controlChanges.subscribe(control => {
         if (control) {
@@ -70,17 +53,5 @@ export class ClrSelectContainer implements DynamicWrapper, OnDestroy {
 
   wrapperClass() {
     return this.multi ? 'clr-multiselect-wrapper' : 'clr-select-wrapper';
-  }
-
-  controlClass() {
-    return this.controlClassService.controlClass(this.invalid, this.addGrid());
-  }
-
-  addGrid() {
-    return this.layoutService && !this.layoutService.isVertical();
-  }
-
-  ngOnDestroy() {
-    this.subscriptions.map(sub => sub.unsubscribe());
   }
 }

--- a/src/clr-angular/forms/textarea/textarea-container.ts
+++ b/src/clr-angular/forms/textarea/textarea-container.ts
@@ -4,17 +4,13 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, ContentChild, OnDestroy, Optional } from '@angular/core';
-import { Subscription } from 'rxjs';
-import { NgControl } from '@angular/forms';
+import { Component } from '@angular/core';
 
 import { IfErrorService } from '../common/if-error/if-error.service';
 import { NgControlService } from '../common/providers/ng-control.service';
-import { LayoutService } from '../common/providers/layout.service';
-import { DynamicWrapper } from '../../utils/host-wrapping/dynamic-wrapper';
 import { ControlIdService } from '../common/providers/control-id.service';
-import { ClrLabel } from '../common/label';
 import { ControlClassService } from '../common/providers/control-class.service';
+import { ClrAbstractContainer } from '../common/abstract-container';
 
 @Component({
   selector: 'clr-textarea-container',
@@ -37,40 +33,4 @@ import { ControlClassService } from '../common/providers/control-class.service';
   },
   providers: [IfErrorService, NgControlService, ControlIdService, ControlClassService],
 })
-export class ClrTextareaContainer implements DynamicWrapper, OnDestroy {
-  private subscriptions: Subscription[] = [];
-  invalid = false;
-  _dynamic = false;
-  @ContentChild(ClrLabel) label: ClrLabel;
-  control: NgControl;
-
-  constructor(
-    private ifErrorService: IfErrorService,
-    @Optional() private layoutService: LayoutService,
-    private controlClassService: ControlClassService,
-    private ngControlService: NgControlService
-  ) {
-    this.subscriptions.push(
-      this.ifErrorService.statusChanges.subscribe(invalid => {
-        this.invalid = invalid;
-      })
-    );
-    this.subscriptions.push(
-      this.ngControlService.controlChanges.subscribe(control => {
-        this.control = control;
-      })
-    );
-  }
-
-  controlClass() {
-    return this.controlClassService.controlClass(this.invalid, this.addGrid());
-  }
-
-  addGrid() {
-    return this.layoutService && !this.layoutService.isVertical();
-  }
-
-  ngOnDestroy() {
-    this.subscriptions.map(sub => sub.unsubscribe());
-  }
-}
+export class ClrTextareaContainer extends ClrAbstractContainer {}

--- a/src/dev/src/app/forms/forms.demo.module.ts
+++ b/src/dev/src/app/forms/forms.demo.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -35,9 +35,11 @@ import { FormsResetDemo } from './reset/reset';
 import { FormsA11yDemo } from './a11y/a11y';
 import { FormsLayoutHorizontalAngularGridDemo } from './layout-angular/layout-horizontal-angular-grid';
 import { FormsLayoutCompactAngularGridDemo } from './layout-angular/layout-compact-angular-grid';
+import { FormsGenericContainerDemo } from './generic-container/generic-container';
+import { NgSelectModule } from '@ng-select/ng-select';
 
 @NgModule({
-  imports: [CommonModule, FormsModule, ReactiveFormsModule, ClarityModule, ROUTING],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, ClarityModule, NgSelectModule, ROUTING],
   declarations: [
     FormsDemo,
     FormsInputGroupDemo,
@@ -63,6 +65,7 @@ import { FormsLayoutCompactAngularGridDemo } from './layout-angular/layout-compa
     FormsReactiveDemo,
     FormsResetDemo,
     FormsA11yDemo,
+    FormsGenericContainerDemo,
   ],
   exports: [
     FormsDemo,
@@ -87,6 +90,7 @@ import { FormsLayoutCompactAngularGridDemo } from './layout-angular/layout-compa
     FormsReactiveDemo,
     FormsResetDemo,
     FormsA11yDemo,
+    FormsGenericContainerDemo,
   ],
 })
 export class FormsDemoModule {}

--- a/src/dev/src/app/forms/forms.demo.routing.ts
+++ b/src/dev/src/app/forms/forms.demo.routing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -30,6 +30,7 @@ import { FormsResetDemo } from './reset/reset';
 import { FormsA11yDemo } from './a11y/a11y';
 import { FormsLayoutCompactAngularGridDemo } from './layout-angular/layout-compact-angular-grid';
 import { FormsLayoutHorizontalAngularGridDemo } from './layout-angular/layout-horizontal-angular-grid';
+import { FormsGenericContainerDemo } from './generic-container/generic-container';
 
 const ROUTES: Routes = [
   {
@@ -60,6 +61,7 @@ const ROUTES: Routes = [
       { path: 'reactive', component: FormsReactiveDemo },
       { path: 'reset', component: FormsResetDemo },
       { path: 'a11y', component: FormsA11yDemo },
+      { path: 'generic-container', component: FormsGenericContainerDemo },
     ],
   },
 ];

--- a/src/dev/src/app/forms/forms.demo.ts
+++ b/src/dev/src/app/forms/forms.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -34,6 +34,7 @@ import { Component } from '@angular/core';
             <li><a [routerLink]="['./reactive']">Reactive</a></li>
             <li><a [routerLink]="['./reset']">Reset</a></li>
             <li><a [routerLink]="['./a11y']">a11y</a></li>
+            <li><a [routerLink]="['./generic-container']">Generic Container</a></li>
         </ul>
         <router-outlet></router-outlet>
     `,

--- a/src/dev/src/app/forms/generic-container/generic-container.html
+++ b/src/dev/src/app/forms/generic-container/generic-container.html
@@ -1,0 +1,70 @@
+<!--
+  ~ Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<h2>Generic Container</h2>
+
+<h3>Template Driven</h3>
+
+<form clrForm #form="ngForm" (submit)="submit()">
+  <input clrControl placeholder="Basic text" name="basic" [(ngModel)]="model.basic" />
+
+  <clr-control-container>
+    <input clrControl placeholder="Basic text" name="basic" [(ngModel)]="model.container" />
+  </clr-control-container>
+
+  <clr-control-container>
+    <label>Required</label>
+    <input clrControl placeholder="Input control" name="required" [(ngModel)]="model.required" pattern="asdfasdf" required minlength="5"
+    />
+    <clr-control-helper>Helper text</clr-control-helper>
+    <clr-control-error *clrIfError="'required'">This is a required field</clr-control-error>
+    <clr-control-error *clrIfError="'minlength'">Must be at least 5 characters</clr-control-error>
+    <clr-control-error *clrIfError="'pattern'">It must match 'asdfasdf'</clr-control-error>
+  </clr-control-container>
+
+  <clr-control-container>
+    <label>Ng Select 2</label>
+    <ng-select clrControl [multiple]="true" name="cars" [(ngModel)]="model.cars" required>
+      <ng-option *ngFor="let car of cars" [value]="car.id">{{car.name}}</ng-option>
+      <ng-option [value]="'custom'">Custom</ng-option>
+    </ng-select>
+    <clr-control-helper>Helper text</clr-control-helper>
+    <clr-control-error *clrIfError="'required'">This is a required field</clr-control-error>
+  </clr-control-container>
+
+  <button class="btn btn-primary" type="submit" [disabled]="form.invalid">Submit</button>
+</form>
+
+<h3>Reactive</h3>
+
+<form clrForm [formGroup]="reactiveModel" (submit)="submit()">
+  <input clrControl placeholder="Basic text" formControlName="basic" />
+
+  <clr-control-container>
+    <input clrControl placeholder="Basic text" formControlName="container" />
+  </clr-control-container>
+
+  <clr-control-container>
+    <label>Required</label>
+    <input clrControl placeholder="Input control" formControlName="required" />
+    <clr-control-helper>Helper text</clr-control-helper>
+    <clr-control-error *clrIfError="'required'">This is a required field</clr-control-error>
+    <clr-control-error *clrIfError="'minlength'">Must be at least 5 characters</clr-control-error>
+    <clr-control-error *clrIfError="'pattern'">It must match 'asdfasdf'</clr-control-error>
+  </clr-control-container>
+
+  <clr-control-container>
+    <label>Ng Select 2</label>
+    <ng-select clrControl [multiple]="true" formControlName="cars">
+      <ng-option *ngFor="let car of cars" [value]="car.id">{{car.name}}</ng-option>
+      <ng-option [value]="'custom'">Custom</ng-option>
+    </ng-select>
+    <clr-control-helper>Helper text</clr-control-helper>
+    <clr-control-error *clrIfError="'required'">This is a required field</clr-control-error>
+  </clr-control-container>
+
+  <button class="btn btn-primary" type="submit" [disabled]="form.invalid">Submit</button>
+</form>

--- a/src/dev/src/app/forms/generic-container/generic-container.ts
+++ b/src/dev/src/app/forms/generic-container/generic-container.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import '@clr/icons/shapes/social-shapes';
+import '@clr/icons/shapes/essential-shapes';
+import { Component } from '@angular/core';
+import { FormBuilder, FormControl, Validators } from '@angular/forms';
+
+@Component({ templateUrl: './generic-container.html' })
+export class FormsGenericContainerDemo {
+  constructor(private fb: FormBuilder) {}
+
+  model = {
+    basic: '',
+    container: '',
+    required: '',
+    cars: [3],
+  };
+
+  cars = [
+    { id: 1, name: 'Volvo' },
+    { id: 2, name: 'Saab', disabled: true },
+    { id: 3, name: 'Opel' },
+    { id: 4, name: 'Audi' },
+  ];
+
+  reactiveModel = this.fb.group({
+    basic: new FormControl(),
+    container: new FormControl(),
+    required: new FormControl('', [Validators.required, Validators.minLength(5), Validators.pattern(/asdfasdf/)]),
+    cars: new FormControl([3], [Validators.required]),
+  });
+
+  submit() {
+    console.log(this);
+  }
+}

--- a/src/website/src/app/documentation/demos/forms/forms.demo.html
+++ b/src/website/src/app/documentation/demos/forms/forms.demo.html
@@ -1,7 +1,7 @@
 <clr-doc-wrapper [ng]="ng" [ui]="ui" [title]="title" [newLayout]="newLayout">
     <article>
         <h5 class="component-summary" id="a-form-is-a-structured-layout-of-related-input-components">
-            Forms are a grouping of input controls that allow a user to submit information to your application.    
+            Forms are a grouping of input controls that allow a user to submit information to your application.
         </h5>
 
         <div id="top">
@@ -245,9 +245,9 @@
             <clr-code-snippet [clrCode]="ngValidate" clrLanguage="typescript"></clr-code-snippet>
 
             <h4>Layout with grid</h4>
-            
+
             <p>You can use the <code class="clr-code">clrLabelSize</code> directive to configure the label width for an entire form. This is useful for <code class="clr-code">horizontal</code> and compact layouts, but doesn't apply when you are using <code class="clr-code">vertical</code> layout. It will accept a number between 1-12 to calculate the width according to our grid, and the controls will adopt the remaining size. For example if you pass <code class="clr-code">clrLabelSize="4"</code> it will size the controls to use 8 grid columns for a total of 12 columns.</p>
-            
+
             <clr-code-snippet [clrCode]="ngLabelSize"></clr-code-snippet>
 
             <h4>Overriding column widths</h4>
@@ -262,6 +262,28 @@
 
             <clr-code-snippet [clrCode]="ngReactiveTs" clrLanguage="typescript"></clr-code-snippet>
             <clr-code-snippet [clrCode]="ngReactiveHtml"></clr-code-snippet>
+
+
+            <h4>Custom and non-Clarity Controls</h4>
+            <p>Applications often have form controls that are not supported by Clarity directly. To make these controls work nicely with Clarity, you can wrap them in a generic control container. Regardless if you make your own form controls or import a third party control, the generic container should help make your controls more consistent. The only requirement is that the form control works with Angular forms (Reactive or Template-Driven).</p>
+            <p>The basic process is to wrap the form control in the <code class="clr-code">clr-control-container</code> component, and then apply the <code class="clr-code">clrControl</code> directive to the form control itself.</p>
+            <div class="alert alert-info">
+              <div class="alert-items">
+                <div class="alert-item static">
+                  <div class="alert-icon-wrapper">
+                    <clr-icon class="alert-icon" shape="info-circle"></clr-icon>
+                  </div>
+                  <span class="alert-text">
+                      It is likely that you'll have to write some CSS rules to make the custom controls fit and look correct within the generic control container. Use specific selectors to avoid changing the default form control behaviors in other parts of the application!
+                    </span>
+                </div>
+              </div>
+            </div>
+
+            <clr-code-snippet [clrCode]="ngGenericTs" clrLanguage="typescript"></clr-code-snippet>
+            <clr-code-snippet [clrCode]="ngGenericHtml"></clr-code-snippet>
+
+
 
 
             <h2 id="forms-code-samples">Forms with CSS</h2>

--- a/src/website/src/app/documentation/demos/forms/forms.demo.ts
+++ b/src/website/src/app/documentation/demos/forms/forms.demo.ts
@@ -25,6 +25,8 @@ const NgOptional = require('raw-loader!./ng/optional.html');
 const NgReset = require('!raw-loader!./ng/reset.txt');
 const NgValidate = require('!raw-loader!./ng/validate.txt');
 const NgLabelSize = require('!raw-loader!./ng/label-size.html');
+const NgGenericTs = require('!raw-loader!./ng/generic.txt');
+const NgGenericHtml = require('!raw-loader!./ng/generic.html');
 
 @Component({
   selector: 'clr-forms-demo',
@@ -58,4 +60,6 @@ export class FormsDemo extends ClarityDocComponent {
   ngReset: any = NgReset;
   ngValidate: any = NgValidate;
   ngLabelSize: any = NgLabelSize;
+  ngGenericTs: any = NgGenericTs;
+  ngGenericHtml: any = NgGenericHtml;
 }

--- a/src/website/src/app/documentation/demos/forms/ng/generic.html
+++ b/src/website/src/app/documentation/demos/forms/ng/generic.html
@@ -1,0 +1,56 @@
+<!-- Template Driven Example -->
+<form clrForm>
+  <clr-control-container>
+    <input clrControl placeholder="Basic text" name="basic" [(ngModel)]="model.container" />
+  </clr-control-container>
+
+  <clr-control-container>
+    <label>Required</label>
+    <input clrControl placeholder="Input control" name="required" [(ngModel)]="model.required" pattern="asdfasdf" required minlength="5"
+    />
+    <clr-control-helper>Helper text</clr-control-helper>
+    <clr-control-error *clrIfError="'required'">This is a required field</clr-control-error>
+    <clr-control-error *clrIfError="'minlength'">Must be at least 5 characters</clr-control-error>
+    <clr-control-error *clrIfError="'pattern'">It must match 'asdfasdf'</clr-control-error>
+  </clr-control-container>
+
+  <clr-control-container>
+    <label>Ng Select 2</label>
+    <ng-select clrControl [multiple]="true" name="cars" [(ngModel)]="model.cars" required>
+      <ng-option *ngFor="let car of cars" [value]="car.id">{{car.name}}</ng-option>
+      <ng-option [value]="'custom'">Custom</ng-option>
+    </ng-select>
+    <clr-control-helper>Helper text</clr-control-helper>
+    <clr-control-error *clrIfError="'required'">This is a required field</clr-control-error>
+  </clr-control-container>
+
+  <button class="btn btn-primary" type="submit">Submit</button>
+</form>
+
+<!-- Reactive Example -->
+<form clrForm [formGroup]="reactiveModel">
+  <clr-control-container>
+    <input clrControl placeholder="Basic text" formControlName="container" />
+  </clr-control-container>
+
+  <clr-control-container>
+    <label>Required</label>
+    <input clrControl placeholder="Input control" formControlName="required" />
+    <clr-control-helper>Helper text</clr-control-helper>
+    <clr-control-error *clrIfError="'required'">This is a required field</clr-control-error>
+    <clr-control-error *clrIfError="'minlength'">Must be at least 5 characters</clr-control-error>
+    <clr-control-error *clrIfError="'pattern'">It must match 'asdfasdf'</clr-control-error>
+  </clr-control-container>
+
+  <clr-control-container>
+    <label>Ng Select 2</label>
+    <ng-select clrControl [multiple]="true" formControlName="cars">
+      <ng-option *ngFor="let car of cars" [value]="car.id">{{car.name}}</ng-option>
+      <ng-option [value]="'custom'">Custom</ng-option>
+    </ng-select>
+    <clr-control-helper>Helper text</clr-control-helper>
+    <clr-control-error *clrIfError="'required'">This is a required field</clr-control-error>
+  </clr-control-container>
+
+  <button class="btn btn-primary" type="submit">Submit</button>
+</form>

--- a/src/website/src/app/documentation/demos/forms/ng/generic.txt
+++ b/src/website/src/app/documentation/demos/forms/ng/generic.txt
@@ -1,0 +1,28 @@
+import { Component } from '@angular/core';
+import {FormBuilder, FormControl, Validators} from "@angular/forms";
+
+@Component({ templateUrl: './generic-container.html' })
+export class FormsGenericContainerDemo {
+  constructor(private fb: FormBuilder) {}
+
+  cars = [
+    { id: 1, name: 'Volvo' },
+    { id: 2, name: 'Saab', disabled: true },
+    { id: 3, name: 'Opel' },
+    { id: 4, name: 'Audi' },
+  ];
+
+  model = {
+    basic: '',
+    container: '',
+    required: '',
+    cars: [3]
+  };
+
+  reactiveModel = this.fb.group({
+    basic: new FormControl(),
+    container: new FormControl(),
+    required: new FormControl('', [Validators.required, Validators.minLength(5), Validators.pattern(/asdfasdf/)]),
+    cars: new FormControl([3], [Validators.required]),
+  });
+}

--- a/src/website/src/app/utils/code-snippet.ts
+++ b/src/website/src/app/utils/code-snippet.ts
@@ -10,10 +10,10 @@ import { CodeHighlight } from './code-highlight';
   selector: 'clr-code-snippet',
   template: `
         <ng-container *ngIf="!disablePrism">
-            <pre><code [clr-code-highlight]="'language-'+language">{{code.trim()}}</code></pre>
+            <pre><code [clr-code-highlight]="'language-'+language">{{code.default.trim()}}</code></pre>
         </ng-container>
         <ng-container *ngIf="disablePrism">
-            <pre><code class="clr-code">{{code.trim()}}</code></pre>
+            <pre><code class="clr-code">{{code.default.trim()}}</code></pre>
         </ng-container>
     `,
   styles: [
@@ -28,7 +28,7 @@ import { CodeHighlight } from './code-highlight';
 export class CodeSnippet implements AfterViewInit {
   @ViewChild(CodeHighlight) codeHighlight: CodeHighlight;
 
-  @Input('clrCode') public code: string;
+  @Input('clrCode') public code: { default: string };
   @Input('clrLanguage') public language: string = 'html';
   @Input('clrDisablePrism') public disablePrism: boolean = false;
 


### PR DESCRIPTION
This implements a new `clr-control-container` component and `clrControl` directive for wrapping potentially any form control to work with Clarity forms. Any controls must implement FormControlAccessor to properly wire up with the forms logic, but it works for internal or third party components.

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (formatting, local variables)
* [x] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

closes: #2886 

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
