### PR TITLE
fix(button): only toggle overflow when button is in overflow menu

### DIFF
--- a/src/clr-angular/button/button-group/button.spec.ts
+++ b/src/clr-angular/button/button-group/button.spec.ts
@@ -91,6 +91,7 @@ export default function(): void {
     let fixture: ComponentFixture<any>;
     let debugEl: DebugElement;
     let componentInstance: any;
+    let toggleService: ClrPopoverToggleService;
     let buttons: HTMLButtonElement[];
 
     describe('Typescript API', () => {
@@ -104,6 +105,7 @@ export default function(): void {
         fixture = TestBed.createComponent(TestButtonComponent);
         fixture.detectChanges();
         debugEl = fixture.debugElement;
+        toggleService = debugEl.injector.get(ClrPopoverToggleService);
         componentInstance = debugEl.componentInstance;
       });
 
@@ -157,6 +159,15 @@ export default function(): void {
         componentInstance.button1.emitClick();
 
         expect(componentInstance.flag).toBe(false);
+      });
+
+      it('calls toggle service only on buttons in menu', () => {
+        spyOn(toggleService, 'toggleWithEvent');
+        expect(componentInstance.flag).toBe(false);
+        componentInstance.button1.emitClick();
+        expect(toggleService.toggleWithEvent).not.toHaveBeenCalled();
+        componentInstance.button2.emitClick();
+        expect(toggleService.toggleWithEvent).toHaveBeenCalled();
       });
 
       it('implements LoadingListener', () => {

--- a/src/clr-angular/button/button-group/button.ts
+++ b/src/clr-angular/button/button-group/button.ts
@@ -141,7 +141,9 @@ export class ClrButton implements LoadingListener {
   @Output('click') _click: EventEmitter<boolean> = new EventEmitter<boolean>(false);
 
   emitClick($event): void {
-    this.toggleService.toggleWithEvent($event);
+    if (this.inMenu) {
+      this.toggleService.toggleWithEvent($event);
+    }
     this._click.emit(true);
   }
 

--- a/src/website/tsconfig.app.json
+++ b/src/website/tsconfig.app.json
@@ -4,6 +4,7 @@
     "outDir": "../../out-tsc/app",
     "baseUrl": "./",
     "resolveJsonModule": true,
+    "target": "es5",
     "paths": {
       "@clr/angular": ["../clr-angular"],
       "@clr/icons": ["../clr-icons"],


### PR DESCRIPTION
The popover toggle was always being called when any button in a button group was clicked, instead of just those inside of the menu.

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4267

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
