### PR TITLE
fix(a11y): change how wizard use h1, h2 and h3 tags for accessibility

### DIFF
--- a/src/clr-angular/wizard/_wizard.clarity.scss
+++ b/src/clr-angular/wizard/_wizard.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -311,6 +311,8 @@
       padding-right: $clr-wizard-default-space * 0.5;
       padding-bottom: $clr-wizard-default-space;
       flex: 0 0 auto;
+      font-size: $clr-modal-title-font-size;
+      line-height: $clr-modal-title-line-height;
     }
 
     // normal modal ignores this. wizard needs it so the nav and content

--- a/src/clr-angular/wizard/wizard.html
+++ b/src/clr-angular/wizard/wizard.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -15,11 +15,11 @@
     (clrModalAlternateClose)="modalCancel()">
 
     <nav class="modal-nav clr-wizard-stepnav-wrapper">
-        <h3 class="clr-wizard-title"><ng-content select="clr-wizard-title"></ng-content></h3>
+        <h1 class="clr-wizard-title"><ng-content select="clr-wizard-title"></ng-content></h1>
         <clr-wizard-stepnav></clr-wizard-stepnav>
     </nav>
 
-    <h3 class="modal-title">
+    <h2 class="modal-title">
         <span tabindex="-1" #wizardTitle class="modal-title-text">
             <ng-template [ngTemplateOutlet]="navService.currentPageTitle"></ng-template>
         </span>
@@ -32,7 +32,7 @@
                 <ng-template [ngTemplateOutlet]="navService.currentPage.headerActions"></ng-template>
             </div>
         </div>
-    </h3>
+    </h2>
 
     <div class="modal-body">
         <main clr-wizard-pages-wrapper class="clr-wizard-content">

--- a/src/website/src/styles/global.scss
+++ b/src/website/src/styles/global.scss
@@ -163,7 +163,7 @@ a.btn-primary {
 }
 
 :not(.layout-home) {
-  .content-area section:first-of-type h1 {
+  .content-area section:first-of-type h1 :not(.clr-wizard) {
     margin-top: -1 * $clr_baselineRem_0_25;
   }
 }


### PR DESCRIPTION
Use H1 and H2 tags instead of H3 to provide better accessibility.

**THIS IS BREAKING CHANGE**

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3994 

## What is the new behavior?

## Does this PR introduce a breaking change?

* [x] Yes
* [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Close #3994 