### PR TITLE
fix(a11y): type error on focus initialization

### DIFF
--- a/src/clr-angular/utils/focus/key-focus/key-focus.spec.ts
+++ b/src/clr-angular/utils/focus/key-focus/key-focus.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -16,7 +16,7 @@ import { KeyCodes } from '@clr/core/common';
     <div *ngIf="open" clrKeyFocus [clrDirection]="direction" [clrFocusOnLoad]="focusOnLoad" (clrFocusChange)="changed = true">
       <button clrKeyFocusItem>Button 1</button>
       <button clrKeyFocusItem>Button 2</button>
-      <button clrKeyFocusItem>Button 3</button>
+      <button *ngIf="showLast" clrKeyFocusItem>Button 3</button>
     </div>
   `,
 })
@@ -27,18 +27,22 @@ class TestComponent {
   changed: boolean = false;
   direction: string = 'vertical';
   focusOnLoad = true;
+  showLast: boolean = true;
 }
 
 @Component({
   template: `
-    <div [clrKeyFocus]="buttons">
+    <div [clrKeyFocus]="buttons" [clrFocusOnLoad]="focusOnLoad">
       <button>Button 1</button>
       <button>Button 2</button>
+      <button *ngIf="showLast">Button 3</button>
     </div>
   `,
 })
 class DOMTestComponent {
   buttons: any;
+  focusOnLoad: boolean = true;
+  showLast: boolean = true;
 }
 
 let fixture: ComponentFixture<any>;
@@ -118,6 +122,15 @@ describe('KeyFocus directive', () => {
       expect(clarityDirective.current).toBe(0);
       keyPress(KeyCodes.ArrowUp);
       expect(clarityDirective.current).toBe(0);
+    });
+    it('current value updates, when elements are being removed', () => {
+      openMenu();
+      expect(clarityDirective.current).toBe(0);
+      keyPress(KeyCodes.End);
+      expect(clarityDirective.current).toBe(2);
+      component.showLast = false;
+      fixture.detectChanges();
+      expect(clarityDirective.current).toBe(1);
     });
   });
 
@@ -280,7 +293,19 @@ describe('KeyFocus directive', () => {
       // An example of this is the Tabs component.
       domComponent.buttons = Array.from(fixture.nativeElement.querySelectorAll('button'));
       fixture.detectChanges();
-      expect(clarityDirective.focusableItems.length).toBe(2);
+      expect(clarityDirective.focusableItems.length).toBe(3);
+    });
+    it('focus updates, when elements are being removed', () => {
+      domComponent.buttons = Array.from(fixture.nativeElement.querySelectorAll('button'));
+      fixture.detectChanges();
+      expect(document.activeElement.textContent).toBe('Button 1');
+      keyPress(KeyCodes.End);
+      expect(document.activeElement.textContent).toBe('Button 3');
+      domComponent.showLast = false;
+      fixture.detectChanges();
+      domComponent.buttons = Array.from(fixture.nativeElement.querySelectorAll('button'));
+      fixture.detectChanges();
+      expect(document.activeElement.textContent).toBe('Button 2');
     });
   });
 });

--- a/src/clr-angular/utils/focus/key-focus/key-focus.ts
+++ b/src/clr-angular/utils/focus/key-focus/key-focus.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -107,10 +107,6 @@ export class ClrKeyFocus {
   }
 
   private get currentItem() {
-    if (this._current >= this.focusableItems.length) {
-      return null;
-    }
-
     return this.focusableItems[this._current];
   }
 
@@ -125,20 +121,25 @@ export class ClrKeyFocus {
   private initializeFocus() {
     if (this.focusableItems && this.focusableItems.length) {
       this.focusableItems.forEach(i => (i.tabIndex = -1));
-      this.currentItem.tabIndex = 0;
-    }
 
-    if (this.focusOnLoad) {
-      this.currentItem.focus();
-      this.focusChange.next();
+      // It is possible that the focus was on an element, whose index is no longer available.
+      // This can happen when some of the focusable elements are being removed.
+      // In such cases, the new focus is initialized on the last focusable element.
+      if (this._current >= this.focusableItems.length) {
+        this._current = this.focusableItems.length - 1;
+      }
+      this.currentItem.tabIndex = 0;
+
+      if (this.focusOnLoad) {
+        this.currentItem.focus();
+        this.focusChange.next();
+      }
     }
   }
 
   private listenForItemUpdates() {
     return this.clrKeyFocusItems.changes.subscribe(() => {
-      this.focusableItems.forEach(item => (item.tabIndex = -1));
-      this._current = 0;
-      this.currentItem.tabIndex = 0;
+      this.initializeFocus();
     });
   }
 


### PR DESCRIPTION
The key-focus component does not handle properly the focus initialization, when some of the focusable elements are being removed.
In case the focus was on an element, whose index is no longer available, the component throws a type error.
This change handles the case by initializing the focus on the last focusable element.

Signed-off-by: Zdravko Popov <zpopov@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?
https://stackblitz.com/edit/clarity-dark-theme-v2-zushxr?file=src%2Fapp%2Fapp.component.ts

![TypeError](https://user-images.githubusercontent.com/26929093/74756774-c9e77400-527d-11ea-88b1-3807435915c4.png)

Issue Number: N/A

## What is the new behavior?
The focus is initialized on the last focusable element.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
This bug was introduced with the addition of the key-focus component.
For this reason, the fix needs to be back-ported to v2 and v1 branches.