### PR TITLE
fix: clr-snippet-code sometimes won't render the code

### DIFF
--- a/src/website/src/app/documentation/demos/stepper/angular-stepper-reactive.demo.html
+++ b/src/website/src/app/documentation/demos/stepper/angular-stepper-reactive.demo.html
@@ -68,4 +68,4 @@
 
 <clr-code-snippet [clrCode]="templateExample"></clr-code-snippet>
 
-<clr-code-snippet [clrCode]="componentExample"></clr-code-snippet>
+<clr-code-snippet [clrCode]="componentExample" clrLanguage="typescript"></clr-code-snippet>

--- a/src/website/src/app/documentation/demos/stepper/angular-stepper-template.demo.html
+++ b/src/website/src/app/documentation/demos/stepper/angular-stepper-template.demo.html
@@ -64,4 +64,4 @@
 
 <clr-code-snippet [clrCode]="templateExample"></clr-code-snippet>
 
-<clr-code-snippet [clrCode]="componentExample"></clr-code-snippet>
+<clr-code-snippet [clrCode]="componentExample" clrLanguage="typescript"></clr-code-snippet>

--- a/src/website/src/app/utils/code-snippet.ts
+++ b/src/website/src/app/utils/code-snippet.ts
@@ -6,14 +6,21 @@
 import { Component, Input, ViewChild, AfterViewInit } from '@angular/core';
 import { CodeHighlight } from './code-highlight';
 
+/**
+ * Describe ES5/6 module import
+ * let something = require('!raw-loader!/path-to-file')
+ * => { default: <content of path-to-file as string> }
+ */
+type ESModuleImport = { default: string };
+
 @Component({
   selector: 'clr-code-snippet',
   template: `
         <ng-container *ngIf="!disablePrism">
-            <pre><code [clr-code-highlight]="'language-'+language">{{code.default.trim()}}</code></pre>
+            <pre><code [clr-code-highlight]="'language-'+language">{{code}}</code></pre>
         </ng-container>
         <ng-container *ngIf="disablePrism">
-            <pre><code class="clr-code">{{code.default.trim()}}</code></pre>
+            <pre><code class="clr-code">{{code}}</code></pre>
         </ng-container>
     `,
   styles: [
@@ -28,7 +35,32 @@ import { CodeHighlight } from './code-highlight';
 export class CodeSnippet implements AfterViewInit {
   @ViewChild(CodeHighlight) codeHighlight: CodeHighlight;
 
-  @Input('clrCode') public code: { default: string };
+  private _code;
+  @Input('clrCode')
+  set code(code: ESModuleImport) {
+    /**
+     * handle ES5/6 Module imports
+     */
+    if (code && code.default) {
+      this._code = code.default;
+      return;
+    }
+    /**
+     * in case that code is simple string
+     */
+    if (typeof code === 'string') {
+      this._code = code;
+      return;
+    }
+
+    // set to default to string so later code will be render as expected.
+    this._code = '';
+  }
+  get code() {
+    // make sure that there will be no empty new line or space at the end of the string
+    return this._code.trim();
+  }
+
   @Input('clrLanguage') public language: string = 'html';
   @Input('clrDisablePrism') public disablePrism: boolean = false;
 


### PR DESCRIPTION
Some time `clr-snippet-code` will not render the code snippet. This is related to this change 

https://github.com/vmware/clarity/pull/4280/files#diff-5dbf67b916308dc690e7a6ad15467451

Also, resolve this error

https://clarity.design/documentation/stepper

![Screen Shot 2020-02-25 at 5 40 03 PM](https://user-images.githubusercontent.com/204564/75262923-e8a5b780-57f5-11ea-9713-dd05a9c55e25.png)



## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
