### PR TITLE
fix: downgrade es2015 code in version tracker

### DIFF
--- a/src/clr-core/common/utils/exists.ts
+++ b/src/clr-core/common/utils/exists.ts
@@ -14,7 +14,13 @@ export const existsIn = curryN(2, (pathToCheck: string[], obj: object): boolean 
   return typeof pathExists !== 'undefined';
 });
 
-export function elementExists(tagName: string, registry = window.customElements): boolean {
+export function elementExists(tagName: string, registry?: { get: (name: string) => {} }): boolean {
+  if (!registry) {
+    registry = window && window.customElements;
+  }
+  if (!registry) {
+    return true; // we don't want to execute further actions because window does not exist
+  }
   return !!registry.get(tagName);
 }
 

--- a/src/clr-core/common/utils/global.spec.ts
+++ b/src/clr-core/common/utils/global.spec.ts
@@ -22,12 +22,12 @@ describe('CDS global', () => {
     });
 
     it('should log a warning if more than one version was detected', () => {
-      spyOn(console, 'warn');
+      const consoleSpy = spyOn(console, 'warn').and.callFake(() => {});
       setupCDSGlobal();
       window.CDS._version.push('1.0.0');
       window.CDS._version.push('2.0.0');
       setupCDSGlobal();
-      expect(console.warn).toHaveBeenCalled();
+      expect(consoleSpy).toHaveBeenCalled();
     });
 
     it('should log all registered elements', () => {
@@ -45,6 +45,19 @@ describe('CDS global', () => {
 
     it('should log user agent', () => {
       expect(window.CDS.getVersion().userAgent.length).toBeTruthy();
+    });
+
+    it('should not store duplicate versions when loading', () => {
+      setupCDSGlobal();
+      window.CDS._version = ['@VERSION'];
+      setupCDSGlobal();
+      expect(window.CDS._version.length).toEqual(1);
+    });
+
+    it('should show loaded version in body attribute', () => {
+      setupCDSGlobal();
+      const attrValue = (document.querySelector('body') as HTMLElement).getAttribute('cds-version');
+      expect(attrValue).toEqual('@VERSION');
     });
   });
 });

--- a/src/clr-core/common/utils/global.ts
+++ b/src/clr-core/common/utils/global.ts
@@ -33,13 +33,11 @@ export function setupCDSGlobal() {
 }
 
 function initializeCDSGlobal() {
-  if (!window.CDS) {
-    window.CDS = {
-      _version: [],
-      _loadedElements: [],
-      getVersion,
-    };
-  }
+  window.CDS = window.CDS || {
+    _version: [],
+    _loadedElements: [],
+    getVersion,
+  };
 }
 
 function getVersion() {
@@ -49,18 +47,21 @@ function getVersion() {
     angularVersion: getAngularVersion(),
     userAgent: navigator.userAgent,
   };
-
   console.log(JSON.stringify(log, null, 2));
   return log;
 }
 
 function getAngularVersion() {
-  const appRoot = document.querySelector('[ng-version]');
+  const appRoot = document && document.querySelector('[ng-version]');
   return appRoot ? appRoot.getAttribute('ng-version') : undefined;
 }
 
 function setRunningVersion() {
-  window.CDS._version = [...new Set([...window.CDS._version, '@VERSION'])];
+  const loadedVersion = '@VERSION';
+  if (window.CDS._version.indexOf(loadedVersion) < 0) {
+    window.CDS._version.push(loadedVersion);
+  }
+
   (document.querySelector('body') as HTMLElement).setAttribute('cds-version', window.CDS._version[0]);
 
   if (window.CDS._version.length > 1) {


### PR DESCRIPTION
• we can't count on having the proper version of typescript, so i got rid of sets
• i added a bunch of guards to over-protect vs. potential SSR breakages
• tested in ngUniversal SSR build; it works

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [x] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4319 

## What is the new behavior?

Stackblitz is strugglin'. They force the code editors to a version of typescript that doesn't support `Set` (or rather compiles Set into broken ES5.

As a result, I'm making our code less awesome so things will work in Stackblitz again. I also ran this through SSR. It works as of ng9.0.0.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
