### PR TITLE
fix(dropdown): let user overwrite ClrDropdownItem id

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -807,6 +807,8 @@ export declare class ClrDropdownItem implements AfterViewInit {
     get disabled(): boolean | string;
     set disabledDeprecated(value: boolean | string);
     get disabledDeprecated(): boolean | string;
+    set dropdownItemId(value: string);
+    get dropdownItemId(): string;
     setByDeprecatedDisabled: boolean;
     constructor(dropdown: ClrDropdown, el: ElementRef<HTMLElement>, _dropdownService: RootDropdownService, renderer: Renderer2, focusableItem: FocusableItem);
     ngAfterViewInit(): void;

--- a/src/clr-angular/popover/dropdown/dropdown-item.spec.ts
+++ b/src/clr-angular/popover/dropdown/dropdown-item.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -33,6 +33,17 @@ export default function(): void {
     spec(ClrDropdownItem, SimpleTest, null, {
       // Dummy dropdown provider, I don't even need a single property or method on it at the moment.
       providers: [{ provide: ClrDropdown, useValue: {} }, ROOT_DROPDOWN_PROVIDER],
+    });
+
+    it('sets the id to the unique generated id', function(this: Context) {
+      const id = 'myId';
+      this.clarityElement.setAttribute('id', id);
+      this.detectChanges();
+      expect(this.clarityElement.getAttribute('id')).toBe(id);
+    });
+
+    it('should have id by default', function(this: Context) {
+      expect(this.clarityElement.getAttribute('id')).not.toBe(null);
     });
 
     it('adds the menuitem role to the host', function(this: Context) {

--- a/src/clr-angular/popover/dropdown/dropdown-item.ts
+++ b/src/clr-angular/popover/dropdown/dropdown-item.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -18,6 +18,7 @@ import { RootDropdownService } from './providers/dropdown.service';
     '[attr.role]': '"menuitem"',
     '[attr.aria-disabled]': 'disabled',
     '[attr.disabled]': "(disabled && setByDeprecatedDisabled)? '' : null",
+    '[attr.id]': 'dropdownItemId',
   },
   providers: [BASIC_FOCUSABLE_ITEM_PROVIDER],
 })
@@ -55,6 +56,17 @@ export class ClrDropdownItem implements AfterViewInit {
 
   get disabledDeprecated() {
     return this.focusableItem.disabled;
+  }
+
+  /**
+   * Let you overwrite the focusable auto increment id.
+   */
+  @Input('id')
+  set dropdownItemId(value: string) {
+    this.focusableItem.id = value;
+  }
+  get dropdownItemId() {
+    return this.focusableItem.id;
   }
 
   ngAfterViewInit() {

--- a/src/clr-angular/popover/dropdown/providers/dropdown-focus-handler.service.ts
+++ b/src/clr-angular/popover/dropdown/providers/dropdown-focus-handler.service.ts
@@ -83,7 +83,6 @@ export class DropdownFocusHandler implements FocusableItem {
   }
   set trigger(el: HTMLElement) {
     this._trigger = el;
-    this.renderer.setAttribute(el, 'id', this.id);
 
     if (this.parent) {
       this._unlistenFuncs.push(

--- a/src/clr-angular/popover/dropdown/providers/dropdown-focus-handler.spec.ts
+++ b/src/clr-angular/popover/dropdown/providers/dropdown-focus-handler.spec.ts
@@ -77,12 +77,6 @@ export default function(): void {
         expect(this.fixture.debugElement.injector.get(FocusableItem, null)).toBe(this.focusHandler);
       });
 
-      it('sets the id of the trigger to the unique generated id', function(this: TestContext) {
-        const id = this.fixture.debugElement.injector.get(UNIQUE_ID, 'not_found');
-        this.focusHandler.trigger = this.trigger;
-        expect(this.trigger.getAttribute('id')).toBe(id);
-      });
-
       it('toggles open when arrow up or down on the trigger', function(this: TestContext) {
         fakeAsync(function(this: TestContext) {
           expect(this.toggleService.open).toBeFalsy();


### PR DESCRIPTION
Move the code that set the `id` for `ClrDropdownItem` from `DropdownFocusHandler ` into the component. This way we could overwrite the `id` from the outside and keep the same functionality 

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

Currently, the `id` for every dropdown item is set by the focus service. This is making hard to overwrite it from outside. This change is moving this into the component itself to handle it. And the focus service is no longer responsible for setting the id.

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3795 

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Close #3795 