### PR TITLE
fix(schematics): set correct version of Clarity during ng add in older Angular projects

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -24,6 +24,7 @@ const scopes = [
   'password',
   'progress-bar',
   'radio',
+  'schematics',
   'select',
   'sidenav',
   'signpost',

--- a/src/schematics/src/add/index.ts
+++ b/src/schematics/src/add/index.ts
@@ -74,12 +74,15 @@ function updateJsonFile(path: string, callback: (a: any) => any) {
 // Checks if a version of Angular is compatible with current or next
 function getVersion(ngVersion: string, clrVersion: string) {
   const diff = 6; // Number disparity between Angular and Clarity, this works as long as we stay in sync with versioning
-  const version1 = ngVersion.split('.');
+  const version1 = Number.parseInt(ngVersion.split('.')[0]);
+  const version2 = Number.parseInt(clrVersion.split('.')[0]);
 
-  if (Number(version1[0]) - diff > 0) {
+  if (version1 - version2 > diff) {
+    // If Angular is more than 6 versions ahead, use `next` tag
     return 'next';
   } else {
-    return clrVersion;
+    // Else, calculate correct Clarity version by subtracting 6 from Angular major
+    return (version1 - diff).toString();
   }
 }
 


### PR DESCRIPTION
If you install Clarity using schematics onto an Angular project that is older than latest, it would incorrectly assign `next` as the tag. This calculates the correct version of Clarity for older Angular versions based on the gap between releases (Angular 9 -> Clarity 3).

fixes #4341

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4341

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
