### PR TITLE
fix: adding .js extension to exported *.css.js file

### DIFF
--- a/src/clr-core/common/index.ts
+++ b/src/clr-core/common/index.ts
@@ -24,4 +24,4 @@ export * from './mixins/css-helpers';
 export * from './mixins/unique-id';
 export * from './mixins/apply-mixins';
 export * from './interfaces';
-export { styles as baseStyles } from './base/base.element.css';
+export { styles as baseStyles } from './base/base.element.css.js';


### PR DESCRIPTION
• this was throwing off some versions/configurations of Jest
• the module loader was looking for a CSS file

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We have to export the base element styles. These are generated `*.css.js` styles.

Some configs/implementations of Jest don't try to look for `*css.js`. They stop looking at `*.css`.

Issue Number: N/A

## What is the new behavior?

I added the full path. This is the only Clarity issue I've been able to find that impedes Jest configuration. Every other issue in #4094 and #4196 are (thus far) solvable by properly configuring an application.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
