### PR TITLE
fix(stepper): make sure openFirstPanel is call only once

### DIFF
--- a/src/clr-angular/accordion/stepper/models/stepper.model.spec.ts
+++ b/src/clr-angular/accordion/stepper/models/stepper.model.spec.ts
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+* Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
 * This software is released under MIT license.
 * The full license information can be found in LICENSE in the root directory of this project.
 */
@@ -135,5 +135,38 @@ describe('StepperModel', () => {
   it('should set the specified errors of a step', () => {
     stepper.setPanelsWithErrors([step1Id]);
     expect(stepper.panels[0].status).toBe(AccordionStatus.Error);
+  });
+
+  /**
+   * This test is a bit long, but it's hard to test private property without
+   * going over the flow of the public methods.
+   *
+   * The test must verify that stepperModelInitialize is set to true after the
+   * first run of the main flow and false after reseting the pannels.
+   */
+  it('should prevent calling openFirstPanel multiple times', () => {
+    stepper = new StepperModel();
+    stepper.addPanel(step1Id);
+    stepper.addPanel(step2Id);
+    stepper.addPanel(step3Id);
+    expect(stepper.panels[0].open).toBe(false);
+    stepper.updatePanelOrder([step1Id, step2Id, step3Id]);
+    expect(stepper.panels[0].open).toBe(true);
+
+    // complite the first panel
+    stepper.navigateToNextPanel(step1Id, true);
+    expect(stepper.panels[0].open).toBe(false);
+
+    // Update panels - we must not update the first panel here
+    stepper.updatePanelOrder([step1Id, step2Id, step3Id]);
+    expect(stepper.panels[0].open).toBe(false);
+
+    // reseting the panels will let us go over the code again
+    stepper.resetPanels();
+    stepper.updatePanelOrder([step1Id, step2Id, step3Id]);
+    expect(stepper.panels[0].open).toBe(true);
+    stepper.navigateToNextPanel(step1Id, true);
+    stepper.updatePanelOrder([step1Id, step2Id, step3Id]);
+    expect(stepper.panels[0].open).toBe(false);
   });
 });

--- a/src/clr-angular/accordion/stepper/models/stepper.model.ts
+++ b/src/clr-angular/accordion/stepper/models/stepper.model.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -8,6 +8,8 @@ import { AccordionModel } from '../../models/accordion.model';
 import { AccordionStatus } from '../../enums/accordion-status.enum';
 
 export class StepperModel extends AccordionModel {
+  private stepperModelInitialize: boolean = false;
+
   get allPanelsCompleted(): boolean {
     return this.panels.length && this.getNumberOfIncompletePanels() === 0 && this.getNumberOfOpenPanels() === 0;
   }
@@ -19,7 +21,9 @@ export class StepperModel extends AccordionModel {
 
   updatePanelOrder(ids: string[]) {
     super.updatePanelOrder(ids);
-    this.openFirstPanel();
+    if (this.stepperModelInitialize === false) {
+      this.openFirstPanel();
+    }
   }
 
   togglePanel(panelId: string) {
@@ -54,6 +58,8 @@ export class StepperModel extends AccordionModel {
   }
 
   resetPanels() {
+    /* return stepper to initialize state */
+    this.stepperModelInitialize = false;
     this.panels.forEach(p => this.resetPanel(p.id));
     this.openFirstPanel();
   }
@@ -76,6 +82,7 @@ export class StepperModel extends AccordionModel {
     const firstPanel = this.getFirstPanel();
     this._panels[firstPanel.id].open = true;
     this._panels[firstPanel.id].disabled = true;
+    this.stepperModelInitialize = true;
   }
 
   private completePanel(panelId: string) {

--- a/src/website/src/app/documentation/demos/stepper/angular-stepper-reactive.demo.html
+++ b/src/website/src/app/documentation/demos/stepper/angular-stepper-reactive.demo.html
@@ -5,9 +5,7 @@
 <form clrStepper [formGroup]="form" (ngSubmit)="submit()">
   <clr-stepper-panel formGroupName="name">
     <clr-step-title>Legal Name</clr-step-title>
-    <clr-step-description
-      >Description goes here.</clr-step-description
-    >
+    <clr-step-description>Description goes here.</clr-step-description>
     <clr-step-content *clrIfExpanded>
       <clr-input-container>
         <label>First Name</label>


### PR DESCRIPTION
`StepperModel.openFirstPanel` is called on every `StepperModel.updatePanelOrder()` this is forcing the first panel of the stepper to be open again and again. This change prevents it to be open again. 

You will need to `reset` the stepper before the code for `openFirstPanel` is executable again.


## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4353

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Close #4353