### PR TITLE
docs: fix website detail pane demo from extra pixel in row

### DIFF
--- a/src/website/src/app/documentation/demos/datagrid/detail/detail.html
+++ b/src/website/src/app/documentation/demos/datagrid/detail/detail.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -29,20 +29,39 @@
 <clr-datagrid [(clrDgSelected)]="selected">
     <clr-dg-column>User ID</clr-dg-column>
     <clr-dg-column>Name</clr-dg-column>
-    <clr-dg-column>Creation date</clr-dg-column>
-    <clr-dg-column>Favorite color</clr-dg-column>
 
     <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
         <clr-dg-cell>{{user.id}}</clr-dg-cell>
         <clr-dg-cell>{{user.name}}</clr-dg-cell>
-        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
-        <clr-dg-cell>
-            <span class="color-square" [style.backgroundColor]="user.color"></span>
-        </clr-dg-cell>
     </clr-dg-row>
 
     <clr-dg-detail *clrIfDetail="let detail">
         <clr-dg-detail-header>{{detail.name}}</clr-dg-detail-header>
+        <clr-dg-detail-body>
+            <b>Additional Details</b>
+            <table class="table">
+                <tr>
+                    <th>Property</th>
+                    <th>Value</th>
+                </tr>
+                <tr>
+                    <td>ID</td>
+                    <td>{{detail.id}}</td>
+                </tr>
+                <tr>
+                    <td>Wins</td>
+                    <td>{{detail.wins}}</td>
+                </tr>
+                <tr>
+                    <td>Favorite Color</td>
+                    <td>{{detail.color}} <span class="color-square" [style.backgroundColor]="detail.color"></span></td>
+                </tr>
+                <tr>
+                    <td>Creation</td>
+                    <td>{{detail.creation | date}}</td>
+                </tr>
+            </table>
+        </clr-dg-detail-body>
     </clr-dg-detail>
 
     <clr-dg-footer>
@@ -82,26 +101,39 @@
 <clr-datagrid>
     <clr-dg-column>User ID</clr-dg-column>
     <clr-dg-column>Name</clr-dg-column>
-    <clr-dg-column>Creation date</clr-dg-column>
-    <clr-dg-column>Favorite color</clr-dg-column>
 
     <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
         <clr-dg-cell>{{user.id}}</clr-dg-cell>
         <clr-dg-cell>{{user.name}}</clr-dg-cell>
-        <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
-        <clr-dg-cell>
-            <span class="color-square" [style.backgroundColor]="user.color"></span>
-        </clr-dg-cell>
     </clr-dg-row>
 
     <ng-template [(clrIfDetail)]="state" let-detail>
         <clr-dg-detail>
             <clr-dg-detail-header>{{detail.name}}</clr-dg-detail-header>
             <clr-dg-detail-body>
-                <pre>{{detail | json}}</pre>
-                <pre>{{detail | json}}</pre>
-                <pre>{{detail | json}}</pre>
-                <pre>{{detail | json}}</pre>
+                <b>Additional Details</b>
+                <table class="table">
+                    <tr>
+                        <th>Property</th>
+                        <th>Value</th>
+                    </tr>
+                    <tr>
+                        <td>ID</td>
+                        <td>{{detail.id}}</td>
+                    </tr>
+                    <tr>
+                        <td>Wins</td>
+                        <td>{{detail.wins}}</td>
+                    </tr>
+                    <tr>
+                        <td>Favorite Color</td>
+                        <td>{{detail.color}} <span class="color-square" [style.backgroundColor]="detail.color"></span></td>
+                    </tr>
+                    <tr>
+                        <td>Creation</td>
+                        <td>{{detail.creation | date}}</td>
+                    </tr>
+                </table>
             </clr-dg-detail-body>
         </clr-dg-detail>
     </ng-template>


### PR DESCRIPTION
The detail pane demo had 1px extra from the color column, removed it and have it displaying a nicer table instead for the detail pane.

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
