### PR TITLE
fix(a11y): prevent clr-control-error from announcing unwanted messages

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -303,8 +303,9 @@ export declare class ClrControlContainer extends ClrAbstractContainer {
 }
 
 export declare class ClrControlError implements AfterViewInit {
+    controlClassService: ControlClassService;
     controlIdService: ControlIdService;
-    constructor(controlIdService: ControlIdService, ariaLiveService: ClrAriaLiveService, el: ElementRef);
+    constructor(controlIdService: ControlIdService, controlClassService: ControlClassService, ariaLiveService: ClrAriaLiveService, el: ElementRef);
     ngAfterViewInit(): void;
 }
 

--- a/src/clr-angular/forms/common/error.ts
+++ b/src/clr-angular/forms/common/error.ts
@@ -7,6 +7,7 @@
 import { Component, Optional, ElementRef, AfterViewInit } from '@angular/core';
 import { ControlIdService } from './providers/control-id.service';
 import { ClrAriaLiveService } from '../../utils/a11y/aria-live.service';
+import { ControlClassService } from './providers/control-class.service';
 
 @Component({
   providers: [ClrAriaLiveService],
@@ -22,12 +23,28 @@ import { ClrAriaLiveService } from '../../utils/a11y/aria-live.service';
 export class ClrControlError implements AfterViewInit {
   constructor(
     @Optional() public controlIdService: ControlIdService,
+    @Optional() public controlClassService: ControlClassService,
     private ariaLiveService: ClrAriaLiveService,
     private el: ElementRef
   ) {}
 
+  /** @deprecated since 3.0, remove in 4.0 - ariaLiveService */
   ngAfterViewInit() {
-    /** @deprecated since 3.0, remove in 4.0 */
-    this.ariaLiveService.announce(this.el.nativeElement);
+    /**
+     * The way we render elements inside the `clr-control-container make this
+     * component announce itself without been visible on the screen.
+     *
+     * The check below try to guess is clr-controll-error used in some of the
+     * cases mention above and prevent us from announcing without the need of that.
+     *
+     * This change won't create breaking change - but will make aria live announcment
+     * work only when the component is used outside forms or some of the components.
+     *
+     * This is temporary solution - until better is found.
+     *
+     */
+    if (this.controlClassService === null) {
+      this.ariaLiveService.announce(this.el.nativeElement);
+    }
   }
 }


### PR DESCRIPTION
Inside `clr-control-container` we have this inside the template.

```html
 <ng-content select="clr-control-error" *ngIf="invalid"></ng-content>
```

That will trigger the announcement inside the `clr-control-error` and when voice-over is turn on - the user will hear all possible error without seeing them on the screen. 

The reason is that Angular will render the `clr-control-error` and hide it from the view, but will trigger all of its lifecycles and with that trigger the aria-live announcement. This also prevents `clr-control-error` to be destroyed until the parent component is alive - so when there is a new error or the error is visible - no announcement will be made.

The fix below is only hiding the issue until a better solution is found. But with the plans of deprecation and moving aria-live outside of the scope of Angular components - this won't be an issue in the next major release. 

## PR Type

What kind of change does this PR introduce?

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4387

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Other information

Close: #4387 