### PR TITLE
fix: fix heading typography changes, add inline

### DIFF
--- a/src/clr-core/styles/typography/_typography.scss
+++ b/src/clr-core/styles/typography/_typography.scss
@@ -16,6 +16,7 @@
 }
 
 [cds-text] {
+  font-family: $cds-token-typography-font-family;
   margin-top: 0;
   margin-bottom: 0;
   width: 100%;
@@ -25,9 +26,13 @@
 [cds-text*='heading'],
 [cds-text*='title'],
 [cds-text*='section'],
-[cds-text*='subsection'],
-[cds-text*='h'] {
+[cds-text*='subsection'] {
   font-family: $cds-token-typography-header-font-family;
+}
+
+[cds-text*='inline'] {
+  width: auto !important;
+  display: inline-block !important;
 }
 
 // LEGACY FONT STYLES
@@ -36,6 +41,7 @@
   $lh-gap: getLineHeightGap($cds-token-typography-h0-line-height-static, $cds-token-typography-h0-line-height);
   @include LHE($lh-gap);
 
+  font-family: $cds-token-typography-header-font-family;
   font-size: $cds-token-typography-h0-font-size;
   font-weight: $cds-token-typography-h0-font-weight;
   color: $cds-token-typography-h0-color;
@@ -47,6 +53,7 @@
   $lh-gap: getLineHeightGap($cds-token-typography-h1-line-height-static, $cds-token-typography-h1-line-height);
   @include LHE($lh-gap);
 
+  font-family: $cds-token-typography-header-font-family;
   font-size: $cds-token-typography-h1-font-size;
   font-weight: $cds-token-typography-h1-font-weight;
   color: $cds-token-typography-h1-color;
@@ -58,6 +65,7 @@
   $lh-gap: getLineHeightGap($cds-token-typography-h2-line-height-static, $cds-token-typography-h2-line-height);
   @include LHE($lh-gap);
 
+  font-family: $cds-token-typography-header-font-family;
   font-size: $cds-token-typography-h2-font-size;
   font-weight: $cds-token-typography-h2-font-weight;
   color: $cds-token-typography-h2-color;
@@ -69,6 +77,7 @@
   $lh-gap: getLineHeightGap($cds-token-typography-h3-line-height-static, $cds-token-typography-h3-line-height);
   @include LHE($lh-gap);
 
+  font-family: $cds-token-typography-header-font-family;
   font-size: $cds-token-typography-h3-font-size;
   font-weight: $cds-token-typography-h3-font-weight;
   color: $cds-token-typography-h3-color;
@@ -80,6 +89,7 @@
   $lh-gap: getLineHeightGap($cds-token-typography-h4-line-height-static, $cds-token-typography-h4-line-height);
   @include LHE($lh-gap);
 
+  font-family: $cds-token-typography-header-font-family;
   font-size: $cds-token-typography-h4-font-size;
   font-weight: $cds-token-typography-h4-font-weight;
   color: $cds-token-typography-h4-color;
@@ -91,6 +101,7 @@
   $lh-gap: getLineHeightGap($cds-token-typography-h5-line-height-static, $cds-token-typography-h5-line-height);
   @include LHE($lh-gap);
 
+  font-family: $cds-token-typography-header-font-family;
   font-size: $cds-token-typography-h5-font-size;
   font-weight: $cds-token-typography-h5-font-weight;
   color: $cds-token-typography-h5-color;
@@ -102,6 +113,7 @@
   $lh-gap: getLineHeightGap($cds-token-typography-h6-line-height-static, $cds-token-typography-h6-line-height);
   @include LHE($lh-gap);
 
+  font-family: $cds-token-typography-header-font-family;
   font-size: $cds-token-typography-h6-font-size;
   font-weight: $cds-token-typography-h6-font-weight;
   color: $cds-token-typography-h6-color;
@@ -278,7 +290,6 @@
 }
 
 [cds-text*='body'] {
-  font-family: $cds-token-typography-font-family;
   color: $cds-token-typography-body-color;
   font-weight: $cds-token-typography-body-font-weight;
   font-size: $cds-token-typography-body-font-size;

--- a/src/clr-core/styles/typography/typography.stories.mdx
+++ b/src/clr-core/styles/typography/typography.stories.mdx
@@ -60,6 +60,11 @@ create consistent and coherent experiences.
   <Story id="experimental-typography-stories--weights" />
 </Preview>
 
+## Inline
+<Preview>
+  <Story id="experimental-typography-stories--inline" />
+</Preview>
+
 ## Position
 <Preview>
   <Story id="experimental-typography-stories--position" />

--- a/src/clr-core/styles/typography/typography.stories.ts
+++ b/src/clr-core/styles/typography/typography.stories.ts
@@ -73,6 +73,18 @@ export const weights = () => {
   `;
 };
 
+export const inline = () => {
+  return html`
+    <cds-demo>
+      <span cds-text="display inline">We</span>
+      <span cds-text="body inline"> should </span>
+      <span cds-text="title inline"> all </span>
+      <span cds-text="caption inline"> be </span>
+      <span cds-text="section inline"> inline!</span>
+    </cds-demo>
+  `;
+};
+
 export const position = () => {
   return html`
     <cds-demo cds-layout="vertical gap:md">


### PR DESCRIPTION
• added "inline" option for cds-text
• h* styles were serendipitously inheriting the correct font-family
• this meant they weren't being styled by the alt header font token
• font family styles were dependent on the cds body text being applied
• that has been fixed as well
• docs added for cds-text="inline"

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
