### PR TITLE
fix: migrate buttons to use design tokens

### DIFF
--- a/src/clr-core/button/button.element.scss
+++ b/src/clr-core/button/button.element.scss
@@ -1,163 +1,192 @@
-@import './../styles/mixins/utils';
+// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
 
-// TODO: progress spinner CSS deprecated, will be replaced by cds-progress
+@import './../styles/tokens/generated/index';
+@import './../styles/mixins/utils';
+@import './../styles/mixins/mixins';
+
+// TODO: progress spinner CSS deprecated, will be replaced by cds-circular-progress
 @import './../../clr-angular/progress/spinner/variables.spinner';
 @import './../../clr-angular/image/icons.clarity';
 @import './../../clr-angular/progress/spinner/spinner.clarity';
 
 :host {
-  --box-shadow-color: var(--clr-color-action-500, #{$clr-color-action-500});
-  --border-radius: #{$clr_baselineRem_3px};
-  --border-color: var(--clr-color-action-600, #{$clr-color-action-600});
-  --color: var(--clr-color-neutral-0, #{$clr-color-neutral-0});
-  --background: var(--clr-color-action-600, #{$clr-color-action-600});
+  --box-shadow-color: #{$cds-token-color-action-900};
+
+  --border-radius: #{$cds-token-global-border-radius};
+  --border-width: #{$cds-token-global-border-width};
+  --border-color: #{$cds-token-color-action-600};
+  --background: #{$cds-token-color-action-600};
+
+  --color: #{$cds-token-color-neutral-0};
+  --font-size: #{$cds-token-space-size-6};
+  --font-weight: #{$cds-token-typography-font-weight-semibold};
+  --font-family: #{$cds-token-typography-font-family};
+  --text-transform: uppercase;
+  --letter-spacing: 0.12em;
+
+  --padding: #{$cds-token-layout-space-sm};
+  --height: calc(#{$cds-token-space-size-11} + #{$cds-token-space-size-1});
+
   display: inline-block;
 }
 
 .private-host {
-  --font-size: #{$clr_baselineRem_0_5};
-  --line-height: 1.7rem;
-  --letter-spacing: 0.12em;
-  --padding: 0 #{$clr_baselineRem_0_5};
-
+  -webkit-appearance: none !important;
+  align-items: center;
   background: var(--background);
-  color: var(--color);
   border-color: var(--border-color);
   border-radius: var(--border-radius);
-  border-width: $clr-global-borderwidth;
-  font-size: var(--font-size);
-  font-weight: 500;
-  line-height: var(--line-height);
-  letter-spacing: var(--letter-spacing);
-  padding: var(--padding);
-  user-select: none;
-  display: block;
-  -webkit-appearance: none !important;
+  border-style: solid;
+  border-width: var(--border-width);
+  color: var(--color);
   cursor: pointer;
-  min-width: $clr_baselineRem_3;
+  display: inline-flex;
+  font-family: var(--font-family);
+  font-size: var(--font-size);
+  font-weight: var(--font-weight);
+  height: var(--height);
+  justify-content: center;
+  letter-spacing: var(--letter-spacing);
+  line-height: 1em;
+  // TODO: following is a fix for Firefox cutting off right edge of buttons. remove when no longer needed.
+  margin-right: #{$cds-token-space-size-1};
+  min-width: #{$cds-token-space-size-13};
+  overflow: visible;
+  padding: var(--padding);
+  position: relative;
   text-align: center;
   text-decoration: none;
-  text-transform: uppercase;
+  text-overflow: ellipsis;
+  text-transform: var(--text-transform);
+  transform: translateZ(0px); // for chrome rendering bug
+  user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: visible;
-  border-style: solid;
-  position: relative;
-  transform: translateZ(0px); // for chrome rendering bug
-}
 
-:host(:hover) {
-  --background: var(--clr-color-action-800, #{$clr-color-action-800});
-}
+  &:active {
+    box-shadow: 0 #{$cds-token-space-size-1} 0 0 var(--box-shadow-color) inset;
+  }
 
-:host(:active) .private-host {
-  box-shadow: 0 $clr_baselineRem_1px 0 0 var(--box-shadow-color) inset;
-}
+  & > span {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: var(--font-size);
 
-:host([is-anchor]) {
-  .private-host {
-    padding: 0;
+    & > span {
+      @include line-height-eraser(0em);
+    }
   }
 }
 
+:host(:active) .private-host {
+  box-shadow: 0 #{$cds-token-space-size-1} 0 0 var(--box-shadow-color) inset;
+}
+
+:host(:hover) {
+  --background: #{$cds-token-color-action-800};
+}
+
 ::slotted {
-  line-height: var(--line-height);
+  line-height: 1em;
   color: inherit;
 }
 
 ::slotted(a) {
-  padding: 0 #{$clr_baselineRem_0_5};
   text-decoration: none !important;
   display: block;
   height: 100%;
   color: inherit;
-  line-height: var(--line-height);
 }
 
 ::slotted(cds-icon) {
+  $icon-overage-nudge: calc(#{$cds-token-space-size-2} * -1);
+
   --color: inherit;
+
+  @include equilateral(calc(#{$cds-token-space-size-6} + #{$cds-token-space-size-4}));
+  margin-top: $icon-overage-nudge;
+  margin-left: $icon-overage-nudge;
 }
 
 :host([action='outline']) {
   --background: transparent;
-  --color: var(--clr-color-action-600, #{$clr-color-action-600});
+  --color: #{$cds-token-color-action-600};
 
   .private-host:hover {
-    --background: var(--clr-color-action-50, #{$clr-color-action-50});
+    --background: #{$cds-token-color-action-50};
   }
 }
 
 :host([status='success']) {
-  --box-shadow-color: var(clr-color-success-900, #{$clr-color-success-900});
-  --border-color: var(--clr-color-success-700, #{$clr-color-success-700});
-  --background: var(--clr-color-success-700, #{$clr-color-success-700});
+  --box-shadow-color: #{$cds-token-color-success-900};
+  --border-color: #{$cds-token-color-success-700};
+  --background: #{$cds-token-color-success-700};
 
   .private-host:hover {
-    --background: var(--clr-color-success-800, #{$clr-color-success-800});
+    --background: #{$cds-token-color-success-800};
   }
 }
 
 :host([status='success'][action='outline']) {
   --background: transparent;
-  --color: var(--clr-color-success-700, #{$clr-color-success-700});
+  --color: #{$cds-token-color-success-700};
 
   .private-host:hover {
-    --background: var(--clr-color-success-50, #{$clr-color-success-50});
+    --background: #{$cds-token-color-success-50};
   }
 }
 
 :host([status='danger']) {
-  --box-shadow-color: var(--clr-color-danger-900, #{$clr-color-danger-900});
-  --border-color: var(--clr-color-danger-700, #{$clr-color-danger-700});
-  --background: var(--clr-color-danger-700, #{$clr-color-danger-700});
+  --box-shadow-color: #{$cds-token-color-danger-900};
+  --border-color: #{$cds-token-color-danger-700};
+  --background: #{$cds-token-color-danger-700};
 
   .private-host:hover {
-    --background: var(--clr-color-danger-800, #{$clr-color-danger-800});
+    --background: #{$cds-token-color-danger-800};
   }
 }
 
 :host([status='danger'][action='outline']) {
   --background: transparent;
-  --color: var(--clr-color-danger-700, #{$clr-color-danger-700});
+  --color: #{$cds-token-color-danger-700};
 
   .private-host:hover {
-    --background: var(--clr-color-danger-50, #{$clr-color-danger-50});
+    --background: #{$cds-token-color-danger-50};
   }
 }
 
 :host([status='inverse']) {
-  --box-shadow-color: rgba(var(--clr-color-neutral-1000, $clr-color-neutral-1000), 0.25);
-  --border-color: var(--clr-color-neutral-0, #{$clr-color-neutral-0});
+  --box-shadow-color: rgba($cds-token-color-neutral-1000, 0.25);
+  --border-color: #{$cds-token-color-neutral-0};
   --background: transparent;
-  --color: var(--clr-color-neutral-0, #{$clr-color-neutral-0});
+  --color: #{$cds-token-color-neutral-0};
 }
 
 :host([action='flat']) {
   --background: transparent;
   --border-color: transparent;
-  --color: var(--clr-color-action-600, #{$clr-color-action-600});
+  --color: #{$cds-token-color-action-600};
 
   .private-host {
-    margin-right: 0;
     box-shadow: none;
   }
 }
 
 :host([action='flat']) .private-host:hover {
   --background: transparent;
-  --color: var(--clr-color-action-800, #{$clr-color-action-800});
+  --color: #{$cds-token-color-action-600};
 }
 
 :host([size='sm']) .private-host {
-  --line-height: #{$clr_baselineRem_1 - $clr_baselineRem_1px};
   --letter-spacing: 0.073em;
-  --font-size: #{$clr_baselineRem_0_458};
-  --padding: #{0 $clr_baselineRem_0_5};
+  --padding: #{$cds-token-layout-space-xs} #{$cds-token-layout-space-sm};
+  --height: calc(#{$cds-token-space-size-9} + #{$cds-token-space-size-1});
 
   .spinner {
-    @include min-equilateral($clr_baselineRem_0_5416);
-    margin-bottom: -0.05rem;
+    @include min-equilateral(#{$cds-token-space-size-6});
   }
 }
 
@@ -167,9 +196,9 @@
 
 :host([disabled]),
 :host([disabled]) .private-host {
-  --color: var(--clr-color-neutral-700, #{$clr-color-neutral-700}) !important;
-  --background: hsl(0, 0%, 80%) !important;
-  --border-color: var(--clr-color-neutral-700, #{$clr-color-neutral-700}) !important;
+  --color: #{$cds-token-color-neutral-700} !important;
+  --background: #{$cds-token-color-neutral-400} !important;
+  --border-color: #{$cds-token-color-neutral-700} !important;
   outline: 0;
 }
 
@@ -189,10 +218,6 @@
 
 :host([status='inverse'][disabled]) {
   --background: transparent;
-  --color: var(--clr-color-neutral-0, #{$clr-color-neutral-0});
-  --border-color: var(--clr-color-neutral-0, #{$clr-color-neutral-0});
-}
-
-.spinner {
-  margin-bottom: -0.1rem;
+  --color: #{$cds-token-color-neutral-0};
+  --border-color: #{$cds-token-color-neutral-0};
 }

--- a/src/clr-core/button/button.element.ts
+++ b/src/clr-core/button/button.element.ts
@@ -4,8 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { baseStyles, property, registerElementSafely } from '@clr/core/common';
-import { CdsBaseButton, getElementWidth } from '@clr/core/common';
+import { baseStyles, CdsBaseButton, getElementWidth, property, registerElementSafely } from '@clr/core/common';
 import { html, query } from 'lit-element';
 import { styles } from './button.element.css.js';
 
@@ -33,12 +32,19 @@ const iconSpinner = html`<span class="spinner spinner-inline"></span>`;
  *
  * @element cds-button
  * @slot default - Content slot for inside the button
- * @cssprop --box-shadow-color
+ * @cssprop --background
+ * @cssprop --border-color
  * @cssprop --border-radius
  * @cssprop --border-width
- * @cssprop --border-color
+ * @cssprop --box-shadow-color
  * @cssprop --color
- * @cssprop --background
+ * @cssprop --font-family
+ * @cssprop --font-size
+ * @cssprop --font-weight
+ * @cssprop --height
+ * @cssprop --letter-spacing
+ * @cssprop --padding
+ * @cssprop --text-transform
  */
 // @dynamic
 export class CdsButton extends CdsBaseButton {
@@ -96,12 +102,13 @@ export class CdsButton extends CdsBaseButton {
     super.update(props);
   }
 
+  // nested span tags allow for line-height erasers on the innermost span and flex-based centering on the outermost span
   render() {
     return html`
     <div class="private-host">
       ${this.loadingState === ClrLoadingState.LOADING ? iconSpinner : ''}
       ${this.loadingState === ClrLoadingState.SUCCESS ? iconSpinnerCheck : ''}
-      ${this.loadingState === ClrLoadingState.DEFAULT ? html`<slot></slot>` : ''}
+      ${this.loadingState === ClrLoadingState.DEFAULT ? html`<span><span><slot></slot></span></span>` : ''}
       ${this.hiddenButtonTemplate}
     </div>
     `;

--- a/src/clr-core/button/button.stories.ts
+++ b/src/clr-core/button/button.stories.ts
@@ -61,6 +61,13 @@ export const API = () => {
   const borderColor = color('--border-color', undefined, cssGroup);
   const borderWidth = text('--border-width', undefined, cssGroup);
   const borderRadius = text('--border-radius', undefined, cssGroup);
+  const fontSize = text('--font-size', undefined, cssGroup);
+  const fontWeight = text('--font-weight', undefined, cssGroup);
+  const fontFamily = text('--font-family', undefined, cssGroup);
+  const textTransform = text('--text-transform', undefined, cssGroup);
+  const letterSpacing = text('--letter-spacing', undefined, cssGroup);
+  const padding = text('--padding', undefined, cssGroup);
+  const height = text('--height', undefined, cssGroup);
 
   return html`
     <cds-demo ?inverse=${buttonStatus === 'inverse'} inline-block>
@@ -73,6 +80,13 @@ export const API = () => {
             '--border-color': borderColor,
             '--border-width': borderWidth,
             '--border-radius': borderRadius,
+            '--font-size': fontSize,
+            '--font-weight': fontWeight,
+            '--font-family': fontFamily,
+            '--text-transform': textTransform,
+            '--letter-spacing': letterSpacing,
+            '--padding': padding,
+            '--height': height,
           })}
       </style>
       <cds-button
@@ -84,18 +98,20 @@ export const API = () => {
         @click=${action('click')}>
         ${size === 'icon' ? html`<cds-icon></cds-icon>` : slot}
       </cds-button>
-        </cds-demo>
+    </cds-demo>
   `;
 };
 
 export const form = () => {
   return html`
-    <form @submit="${(e: Event) => {
+    <form cds-layout="vertical gap:sm" @submit="${(e: Event) => {
       e.preventDefault();
       action('submit')(e);
     }}">
-      <label for="name">Name</label><br />
-      <input id="name" /><br />
+      <div cds-layout="vertical gap:xs">
+        <label for="name" cds-text="caption">Name</label>
+        <input id="name" />
+      </div>
       <cds-button type="submit">submit</cds-button>
     </form>
   `;
@@ -103,101 +119,122 @@ export const form = () => {
 
 export const actions = () => {
   return html`
-    <cds-button>solid</cds-button>
-    <cds-button action="outline">outline</cds-button>
-    <cds-button action="flat">link</cds-button>
+    <div cds-layout="horizontal gap:xs">
+      <cds-button>solid</cds-button>
+      <cds-button action="outline">outline</cds-button>
+      <cds-button action="flat">link</cds-button>
+    </div>
   `;
 };
 
 export const status = () => {
   return html`
-    <cds-button>primary</cds-button>
-    <cds-button status="success">success</cds-button>
-    <cds-button status="danger">danger</cds-button>
-    <cds-button status="danger" disabled>disabled</cds-button>
-  `;
+    <div cds-layout="horizontal gap:xs">
+      <cds-button>primary</cds-button>
+      <cds-button status="success">success</cds-button>
+      <cds-button status="danger">danger</cds-button>
+      <cds-button status="danger" disabled>disabled</cds-button>
+    </div>
+`;
 };
 
 export const statusOutline = () => {
   return html`
-    <cds-button action="outline">primary</cds-button>
-    <cds-button action="outline" status="success">success</cds-button>
-    <cds-button action="outline" status="danger">danger</cds-button>
-    <cds-button action="outline" disabled>disabled</cds-button>
-  `;
+    <div cds-layout="horizontal gap:xs">
+      <cds-button action="outline">primary</cds-button>
+      <cds-button action="outline" status="success">success</cds-button>
+      <cds-button action="outline" status="danger">danger</cds-button>
+      <cds-button action="outline" disabled>disabled</cds-button>
+    </div>
+`;
 };
 
 export const iconSolid = () => {
   return html`
-    <cds-button aria-label="user account" size="icon"><cds-icon shape="user"></cds-icon></cds-button>
-    <cds-button aria-label="user account" disabled size="icon"><cds-icon shape="user"></cds-icon></cds-button>
-    <cds-button aria-label="user account" status="success" size="icon"><cds-icon shape="user"></cds-icon></cds-button>
-    <cds-button aria-label="user account" status="danger" size="icon"><cds-icon shape="user"></cds-icon></cds-button>
+    <div cds-layout="horizontal gap:xs">
+      <cds-button aria-label="user account" size="icon"><cds-icon shape="user"></cds-icon></cds-button>
+      <cds-button aria-label="user account" disabled size="icon"><cds-icon shape="user"></cds-icon></cds-button>
+      <cds-button aria-label="user account" status="success" size="icon"><cds-icon shape="user"></cds-icon></cds-button>
+      <cds-button aria-label="user account" status="danger" size="icon"><cds-icon shape="user"></cds-icon></cds-button>
+    </div>
   `;
 };
 
 export const iconOutline = () => {
   return html`
-    <cds-button aria-label="user account" action="outline" size="icon"><cds-icon shape="user"></cds-icon></cds-button>
-    <cds-button aria-label="user account" action="outline" disabled size="icon"><cds-icon shape="user"></cds-icon></cds-button>
-    <cds-button aria-label="user account" action="outline" status="success" size="icon"><cds-icon shape="user"></cds-icon></cds-button>
-    <cds-button aria-label="user account" action="outline" status="danger" size="icon"><cds-icon shape="user"></cds-icon></cds-button>
+    <div cds-layout="horizontal gap:xs">
+      <cds-button aria-label="user account" action="outline" size="icon"><cds-icon shape="user"></cds-icon></cds-button>
+      <cds-button aria-label="user account" action="outline" disabled size="icon"><cds-icon shape="user"></cds-icon></cds-button>
+      <cds-button aria-label="user account" action="outline" status="success" size="icon"><cds-icon shape="user"></cds-icon></cds-button>
+      <cds-button aria-label="user account" action="outline" status="danger" size="icon"><cds-icon shape="user"></cds-icon></cds-button>
+    </div>
   `;
 };
 
 export const iconWithText = () => {
   return html`
-    <cds-button><cds-icon shape="user"></cds-icon> user account</cds-button>
-    <cds-button action="outline"><cds-icon shape="user"></cds-icon> user account</cds-button>
-    <cds-button action="flat"><cds-icon shape="user"></cds-icon> user account</cds-button>
+    <div cds-layout="horizontal gap:xs">
+      <cds-button><cds-icon shape="user"></cds-icon> user account</cds-button>
+      <cds-button action="outline"><cds-icon shape="user"></cds-icon> user account</cds-button>
+      <cds-button action="flat"><cds-icon shape="user"></cds-icon> user account</cds-button>
+    </div>
   `;
 };
 
 export const links = () => {
   return html`
-    <cds-button>
-      <a href="#">link</a>
-    </cds-button>
+    <div cds-layout="horizontal gap:xs">
+      <cds-button>
+        <a href="#">link</a>
+      </cds-button>
 
-    <cds-button>
-      <a href="#">this is a long link</a>
-    </cds-button>
+      <cds-button>
+        <a href="#">this is a long link</a>
+      </cds-button>
 
-    <cds-button size="sm">
-      <a href="#">small link</a>
-    </cds-button>
-    <br />
-    <cds-button action="outline">
-      <a href="#">link</a>
-    </cds-button>
+      <cds-button size="sm">
+        <a href="#">small link</a>
+      </cds-button>
+      <br />
+      <cds-button action="outline">
+        <a href="#">link</a>
+      </cds-button>
 
-    <cds-button action="outline">
-      <a href="#">this is a long link</a>
-    </cds-button>
+      <cds-button action="outline">
+        <a href="#">this is a long link</a>
+      </cds-button>
 
-    <cds-button action="outline" size="sm">
-      <a href="#">small link</a>
-    </cds-button>
+      <cds-button action="outline" size="sm">
+        <a href="#">small link</a>
+      </cds-button>
+    </div>
   `;
 };
 
 export const sizes = () => {
   return html`
-    <cds-button>default</cds-button>
-    <cds-button size="sm">small</cds-button>
-    <cds-button aria-label="user account" size="icon"><cds-icon shape="user"></cds-icon></cds-button>
-    <br />
-    <cds-button action="outline">default</cds-button>
-    <cds-button action="outline" size="sm">small</cds-button>
-    <cds-button action="outline" aria-label="user account" size="icon"><cds-icon shape="user"></cds-icon></cds-button>
+    <div cds-layout="vertical gap:sm">
+      <div cds-layout="horizontal align-items:bottom gap:xs">
+        <cds-button>default</cds-button>
+        <cds-button size="sm">small</cds-button>
+        <cds-button aria-label="user account" size="icon"><cds-icon shape="user"></cds-icon></cds-button>
+      </div>
+      <div cds-layout="horizontal align-items:bottom gap:xs">
+        <cds-button action="outline">default</cds-button>
+        <cds-button action="outline" size="sm">small</cds-button>
+        <cds-button action="outline" aria-label="user account" size="icon"><cds-icon shape="user"></cds-icon></cds-button>
+      </div>
+    </div>
   `;
 };
 
 export const loading = () => {
   return html`
-    <cds-button .loadingState="${ClrLoadingState.LOADING}">solid</cds-button>
-    <cds-button action="outline" .loadingState="${ClrLoadingState.LOADING}">outline</cds-button>
-    <cds-button size="sm" .loadingState="${ClrLoadingState.LOADING}">small</cds-button>
+    <div cds-layout="horizontal gap:xs align-items:bottom">
+      <cds-button .loadingState="${ClrLoadingState.LOADING}">solid</cds-button>
+      <cds-button action="outline" .loadingState="${ClrLoadingState.LOADING}">outline</cds-button>
+      <cds-button size="sm" .loadingState="${ClrLoadingState.LOADING}">small</cds-button>
+    </div>
   `;
 };
 
@@ -206,11 +243,25 @@ export const customStyles = () => {
     <style>
       .btn-branding {
         --background: #a447bb;
-        --border-color: #a447bb;
+        --border-color: #74178b;
+        --border-width: 0.15rem;
+        --border-radius: 0.4rem;
+        --text-transform: capitalize;
+        --padding-vertical: 0.9rem;
+        --padding-horizontal: 1rem;
+        --font-size: 0.9rem;
+        --font-weight: bolder;
+        --font-family: 'Courier New', monospace;
+        --height: 2.4rem;
       }
 
       .btn-branding:hover {
-        --background: #9136a8;
+        --background: #74178b;
+      }
+
+      .btn-branding:active {
+        --border-color: #44005b;
+        --box-shadow-color: #44005b;
       }
     </style>
     <cds-button class="btn-branding">button</cds-button>

--- a/src/clr-core/common/base/base.element.scss
+++ b/src/clr-core/common/base/base.element.scss
@@ -14,6 +14,7 @@ $clr-use-custom-properties: true;
 :host {
   font-family: inherit;
   contain: content; // https://developer.mozilla.org/en-US/docs/Web/CSS/contain
+  -webkit-appearance: none !important;
 }
 
 slot {

--- a/src/clr-core/common/utils/dom.spec.ts
+++ b/src/clr-core/common/utils/dom.spec.ts
@@ -24,6 +24,10 @@ describe('Functional Helper: ', () => {
     it('returns the width of an element', () => {
       expect(getElementWidth(testElement)).toEqual(elementWidth);
     });
+
+    it('returns an empty string if passed junk', () => {
+      expect(getElementWidth(null)).toEqual('');
+    });
   });
 
   describe('getElementWidthUnless() ', () => {

--- a/src/clr-core/common/utils/dom.ts
+++ b/src/clr-core/common/utils/dom.ts
@@ -5,7 +5,10 @@
  */
 
 export function getElementWidth(element: HTMLElement, unit = 'px') {
-  return element.getBoundingClientRect ? element.getBoundingClientRect().width + unit : '';
+  if (element) {
+    return element.getBoundingClientRect ? element.getBoundingClientRect().width + unit : '';
+  }
+  return '';
 }
 
 export function getElementWidthUnless(element: HTMLElement, unless: boolean) {

--- a/src/clr-core/styles/mixins/_mixins.scss
+++ b/src/clr-core/styles/mixins/_mixins.scss
@@ -187,39 +187,44 @@ $opp-directions: (
 
 // line-height erasers
 
-@function getLineHeightGap($line-height-value: 1.2em, $line-height-token: null) {
+@function getLineHeightGap($line-height-value: 1.2, $line-height-token: null) {
   @if ($line-height-token == null) or ($line-height-value < 1) {
     @return 0;
   }
   @return calc((#{$line-height-token} - 1em) / 2);
 }
 
-@function pullUp($line-height-gap: 1.2em, $font-top-gap: 0.147em) {
-  @return calc((#{$font-top-gap} + #{$line-height-gap}) * -1);
+@function pullUp($line-height-gap: 1.2em, $font-top-gap: 0.1475em, $pull-nudge: 0.037em) {
+  @return calc(((#{$font-top-gap} + #{$line-height-gap}) * -1) + #{$pull-nudge});
 }
 
 @function pushDown(
   $line-height-gap: 0.6em,
-  $font-top-gap: 0.147em,
-  $font-ascender-height: 0.17,
-  $font-x-height: 0.517
+  $font-top-gap: 0.1475em,
+  $font-ascender-height: 0.1703,
+  $font-x-height: 0.517,
+  $push-nudge: 0.044em
 ) {
-  @return calc(((1em - #{$font-top-gap} - #{$font-ascender-height} - #{$font-x-height}) + #{$line-height-gap}) * -1);
+  @return calc(
+    (((1em - #{$font-top-gap} - #{$font-ascender-height} - #{$font-x-height}) + #{$line-height-gap}) * -1) - #{$push-nudge}
+  );
 }
 
 // default are for metropolis/clarity-city
 @mixin line-height-eraser(
   $line-height-gap-em: 0.6em,
-  $font-top-gap-em: 0.147em,
-  $font-ascender-height-em: 0.17em,
-  $font-x-height-em: 0.517em
+  $font-top-gap-em: 0.1475em,
+  $font-ascender-height-em: 0.1703em,
+  $font-x-height-em: 0.517em,
+  $pull-nudge: 0.037em,
+  $push-nudge: 0.044em
 ) {
   &::before {
     content: '';
     display: block;
     height: 0;
     width: 0;
-    margin-bottom: pullUp($line-height-gap-em, $font-top-gap-em);
+    margin-bottom: pullUp($line-height-gap-em, $font-top-gap-em, $pull-nudge);
   }
 
   &::after {
@@ -227,7 +232,13 @@ $opp-directions: (
     display: block;
     height: 0;
     width: 0;
-    margin-top: pushDown($line-height-gap-em, $font-top-gap-em, $font-ascender-height-em, $font-x-height-em);
+    margin-top: pushDown(
+      $line-height-gap-em,
+      $font-top-gap-em,
+      $font-ascender-height-em,
+      $font-x-height-em,
+      $push-nudge
+    );
   }
 }
 

--- a/src/clr-core/styles/tokens/tokens.yml
+++ b/src/clr-core/styles/tokens/tokens.yml
@@ -9,6 +9,14 @@ props:
     type: 'number'
     category: 'global'
     private: true
+  - name: border-radius
+    value: '3px'
+    type: 'px'
+    category: 'global'
+  - name: border-width
+    value: '1px'
+    type: 'px'
+    category: 'global'
 
   # Space
   - name: 'size-0'
@@ -44,15 +52,27 @@ props:
     type: 'px'
     category: 'space'
   - name: 'size-8'
-    value: '24px'
+    value: '18px'
     type: 'px'
     category: 'space'
   - name: 'size-9'
-    value: '32px'
+    value: '24px'
     type: 'px'
     category: 'space'
   - name: 'size-10'
+    value: '32px'
+    type: 'px'
+    category: 'space'
+  - name: 'size-11'
+    value: '36px'
+    type: 'px'
+    category: 'space'
+  - name: 'size-12'
     value: '48px'
+    type: 'px'
+    category: 'space'
+  - name: 'size-13'
+    value: '72px'
     type: 'px'
     category: 'space'
   - name: xs
@@ -121,11 +141,11 @@ props:
 
   # font settings for line height erasers
   - name: font-top-gap-height 
-    value: '0.147em'
+    value: '0.1475em'
     type: 'em'
     category: 'global'
   - name: font-ascender-height
-    value: '0.17em'
+    value: '0.1703em'
     type: 'em'
     category: 'global'
   - name: font-x-height

--- a/src/clr-core/styles/typography/_typography.scss
+++ b/src/clr-core/styles/typography/_typography.scss
@@ -299,7 +299,13 @@
 
 [cds-text*='body'] {
   $lh-gap: getLineHeightGap($cds-token-typography-body-line-height-static, $cds-token-typography-body-line-height);
-  @include LHE($lh-gap);
+  @include line-height-eraser(
+    $lh-gap,
+    $cds-token-global-font-top-gap-height,
+    $cds-token-global-font-ascender-height,
+    $cds-token-global-font-x-height,
+    0.1em
+  );
 }
 
 [cds-text*='message'] {


### PR DESCRIPTION
• per discussion, not using layouts here but tokens
• this is to preserve ease of atomically re-styling the buttons with custom props
• fixed inset box shadows on active states – was not working
• applied new layouts to all buttons demos
• fixed a very precise sizing issue with line height erasers
• had to use precise sizings and paddings for buttons though; it's voodoo math at the moment but the existing equations are missing a variable somehow
• i believe the combination of a LHE inside of a "button" is throwing off the LHEs
• f-fox was applying `-webkit-appearance: button` to the `cds-button` b/c it has an attribute of `type="button"` or `type="submit"`
• we should be careful in the future not to use common HTML attribute names
• we should consider changing this attr/prop to not be `type`

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [x] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

See notes above...

Issue Number: #4410 

## What is the new behavior?

See notes above...

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
