### PR TITLE
feat(dnd): add clrDragStartDelay input property to clrDraggable

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -828,10 +828,7 @@ export declare class ClrDragAndDropModule {
 export declare class ClrDragEvent<T> {
     dragDataTransfer: T;
     dragPosition: DragPointPosition;
-    dropPointPosition: {
-        pageX: number;
-        pageY: number;
-    };
+    dropPointPosition: DragPointPosition;
     group: string | string[];
     constructor(dragEvent: DragEventInterface<T>);
 }
@@ -842,6 +839,7 @@ export declare class ClrDraggable<T> implements AfterContentInit, OnDestroy {
     dragEndEmitter: EventEmitter<ClrDragEvent<T>>;
     dragMoveEmitter: EventEmitter<ClrDragEvent<T>>;
     dragOn: boolean;
+    set dragStartDelay(value: number);
     dragStartEmitter: EventEmitter<ClrDragEvent<T>>;
     set group(value: string | string[]);
     constructor(el: ElementRef, dragEventListener: DragEventListenerService<T>, dragHandleRegistrar: DragHandleRegistrarService<T>, viewContainerRef: ViewContainerRef, cfr: ComponentFactoryResolver, injector: Injector, draggableSnapshot: DraggableSnapshotService<T>, globalDragMode: GlobalDragModeService);

--- a/src/clr-angular/utils/drag-and-drop/drag-and-drop-integrated.spec.ts
+++ b/src/clr-angular/utils/drag-and-drop/drag-and-drop-integrated.spec.ts
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { Component, ElementRef } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
@@ -52,67 +52,112 @@ export default function(): void {
         expect(dragEvent.dragDataTransfer).toEqual(MOCK_DATA_PAYLOAD);
       };
 
-      it('should emit event with proper properties on dragStart', function() {
-        emulateDragEvent('mousedown', 0, 0, draggable.nativeElement);
-        emulateDragEvent('mousemove', 10, 20);
-        checkStaticProps(testComponent.dragStartEvent);
-        expect(testComponent.dragStartEvent.dragPosition).toEqual({ pageX: 10, pageY: 20, moveX: 10, moveY: 20 });
-        expect(testComponent.dragStartEvent.dropPointPosition).toBeUndefined();
-      });
+      it(
+        'should emit event with proper properties on dragStart',
+        fakeAsync(function() {
+          emulateDragEvent('mousedown', 10, 20, draggable.nativeElement);
+          tick();
+          checkStaticProps(testComponent.dragStartEvent);
+          expect(testComponent.dragStartEvent.dragPosition).toEqual({ pageX: 10, pageY: 20, moveX: 0, moveY: 0 });
+          expect(testComponent.dragStartEvent.dropPointPosition).toBeUndefined();
+        })
+      );
 
-      it('should emit event with proper properties on dragMove', function() {
-        emulateDragEvent('mousedown', 0, 0, draggable.nativeElement);
-        emulateDragEvent('mousemove', 10, 20);
-        emulateDragEvent('mousemove', 100, 200);
-        checkStaticProps(testComponent.dragMoveEvent);
-        expect(testComponent.dragMoveEvent.dragPosition).toEqual({ pageX: 100, pageY: 200, moveX: 100, moveY: 200 });
+      it(
+        'should emit event with proper properties on dragMove',
+        fakeAsync(function() {
+          emulateDragEvent('mousedown', 10, 20, draggable.nativeElement);
+          tick();
+          emulateDragEvent('mousemove', 100, 200);
+          checkStaticProps(testComponent.dragMoveEvent);
+          expect(testComponent.dragMoveEvent.dragPosition).toEqual({ pageX: 100, pageY: 200, moveX: 90, moveY: 180 });
 
-        // offsetX = dragStart.pageX - draggable.pageX
-        // offsetY = dragStart.pageY - draggable.pageY
-        // dropPointPosition.pageX =  dragMove.pageX + draggable.width/2 - offsetX
-        // dropPointPosition.pageY =  dragMove.pageY + draggable.height/2 - offsetY
-        expect(testComponent.dragMoveEvent.dropPointPosition).toEqual({ pageX: 140, pageY: 205 });
-      });
+          // offsetX = dragStart.pageX - draggable.pageX
+          // offsetY = dragStart.pageY - draggable.pageY
+          // dropPointPosition.pageX =  dragMove.pageX + draggable.width/2 - offsetX
+          // dropPointPosition.pageY =  dragMove.pageY + draggable.height/2 - offsetY
+          expect(testComponent.dragMoveEvent.dropPointPosition).toEqual({ pageX: 140, pageY: 205 });
+        })
+      );
 
-      it('should emit event with proper properties on dragEnter', function() {
-        emulateDragEvent('mousedown', 0, 0, draggable.nativeElement);
-        emulateDragEvent('mousemove', 10, 20);
-        emulateDragEvent('mousemove', 500, 300);
-        checkStaticProps(testComponent.dragEnterEvent);
-        expect(testComponent.dragEnterEvent.dragPosition).toEqual({ pageX: 500, pageY: 300, moveX: 500, moveY: 300 });
-        expect(testComponent.dragEnterEvent.dropPointPosition).toEqual({ pageX: 540, pageY: 305 });
-      });
+      it(
+        'should emit event with proper properties on dragEnter',
+        fakeAsync(function() {
+          emulateDragEvent('mousedown', 10, 20, draggable.nativeElement);
+          tick();
+          emulateDragEvent('mousemove', 500, 300);
+          checkStaticProps(testComponent.dragEnterEvent);
+          expect(testComponent.dragEnterEvent.dragPosition).toEqual({ pageX: 500, pageY: 300, moveX: 490, moveY: 280 });
+          expect(testComponent.dragEnterEvent.dropPointPosition).toEqual({ pageX: 540, pageY: 305 });
+        })
+      );
 
-      it('should emit event with proper properties on dragLeave', function() {
-        emulateDragEvent('mousedown', 0, 0, draggable.nativeElement);
-        emulateDragEvent('mousemove', 10, 20);
-        emulateDragEvent('mousemove', 500, 300);
-        emulateDragEvent('mousemove', 100, 200);
-        checkStaticProps(testComponent.dragLeaveEvent);
-        expect(testComponent.dragLeaveEvent.dragPosition).toEqual({ pageX: 100, pageY: 200, moveX: 100, moveY: 200 });
-        expect(testComponent.dragLeaveEvent.dropPointPosition).toEqual({ pageX: 140, pageY: 205 });
-      });
+      it(
+        'should emit event with proper properties on dragLeave',
+        fakeAsync(function() {
+          emulateDragEvent('mousedown', 10, 20, draggable.nativeElement);
+          tick();
+          emulateDragEvent('mousemove', 500, 300);
+          emulateDragEvent('mousemove', 100, 200);
+          checkStaticProps(testComponent.dragLeaveEvent);
+          expect(testComponent.dragLeaveEvent.dragPosition).toEqual({ pageX: 100, pageY: 200, moveX: 90, moveY: 180 });
+          expect(testComponent.dragLeaveEvent.dropPointPosition).toEqual({ pageX: 140, pageY: 205 });
+        })
+      );
 
-      it('should emit event with proper properties on dragEnd', function() {
-        emulateDragEvent('mousedown', 0, 0, draggable.nativeElement);
-        emulateDragEvent('mousemove', 10, 20);
-        emulateDragEvent('mousemove', 500, 300);
-        emulateDragEvent('mousemove', 100, 200);
-        emulateDragEvent('mouseup', 100, 200);
-        checkStaticProps(testComponent.dragEndEvent);
-        expect(testComponent.dragEndEvent.dragPosition).toEqual({ pageX: 100, pageY: 200, moveX: 100, moveY: 200 });
-        expect(testComponent.dragEndEvent.dropPointPosition).toEqual({ pageX: 140, pageY: 205 });
-      });
+      it(
+        'should emit event with proper properties on dragEnd',
+        fakeAsync(function() {
+          emulateDragEvent('mousedown', 10, 20, draggable.nativeElement);
+          tick();
+          emulateDragEvent('mousemove', 500, 300);
+          emulateDragEvent('mousemove', 100, 200);
+          emulateDragEvent('mouseup', 100, 200);
+          checkStaticProps(testComponent.dragEndEvent);
+          expect(testComponent.dragEndEvent.dragPosition).toEqual({ pageX: 100, pageY: 200, moveX: 90, moveY: 180 });
+          expect(testComponent.dragEndEvent.dropPointPosition).toEqual({ pageX: 140, pageY: 205 });
+        })
+      );
 
-      it('should emit event with proper properties on drop', function() {
-        emulateDragEvent('mousedown', 0, 0, draggable.nativeElement);
-        emulateDragEvent('mousemove', 10, 20);
-        emulateDragEvent('mousemove', 500, 300);
-        emulateDragEvent('mouseup', 500, 300);
-        checkStaticProps(testComponent.dropEvent);
-        expect(testComponent.dropEvent.dragPosition).toEqual({ pageX: 500, pageY: 300, moveX: 500, moveY: 300 });
-        expect(testComponent.dropEvent.dropPointPosition).toEqual({ pageX: 540, pageY: 305 });
-      });
+      it(
+        'should emit event with proper properties on drop',
+        fakeAsync(function() {
+          emulateDragEvent('mousedown', 10, 20, draggable.nativeElement);
+          tick();
+          emulateDragEvent('mousemove', 500, 300);
+          emulateDragEvent('mouseup', 500, 300);
+          checkStaticProps(testComponent.dropEvent);
+          expect(testComponent.dropEvent.dragPosition).toEqual({ pageX: 500, pageY: 300, moveX: 490, moveY: 280 });
+          expect(testComponent.dropEvent.dropPointPosition).toEqual({ pageX: 540, pageY: 305 });
+        })
+      );
+
+      it(
+        'should delay dragStart event if clrDragStartDelay is provided',
+        fakeAsync(function() {
+          testComponent.dragStartDelay = 1000;
+          fixture.detectChanges();
+          emulateDragEvent('mousedown', 10, 20, draggable.nativeElement);
+          tick(500);
+          expect(testComponent.dragStartEvent).toBeUndefined();
+          tick(500);
+          expect(testComponent.dragStartEvent).not.toBeUndefined();
+          checkStaticProps(testComponent.dragStartEvent);
+        })
+      );
+
+      it(
+        'should cancel the entire drag process if mousemove during clrDragStartDelay',
+        fakeAsync(function() {
+          testComponent.dragStartDelay = 1000;
+          fixture.detectChanges();
+          emulateDragEvent('mousedown', 10, 20, draggable.nativeElement);
+          tick(500);
+          emulateDragEvent('mousemove', 20, 30);
+          tick(500);
+          expect(testComponent.dragStartEvent).toBeUndefined();
+        })
+      );
     });
 
     describe('View', function() {
@@ -122,86 +167,110 @@ export default function(): void {
         expect(testElement.querySelectorAll('clr-draggable-ghost').length).toBe(0);
       });
 
-      it('should add being-dragged class to draggable being dragged', function() {
-        emulateDragEvent('mousedown', 0, 0, draggable.nativeElement);
-        emulateDragEvent('mousemove', 10, 20);
-        fixture.detectChanges();
-        const draggableQueries = testElement.querySelectorAll('.being-dragged');
-        expect(draggableQueries.length).toBe(1, `Only one draggable should have the "being-dragged" class at a time.`);
-        expect(draggableQueries[0]).toBe(draggable.nativeElement);
-      });
+      it(
+        'should add being-dragged class to draggable being dragged',
+        fakeAsync(function() {
+          emulateDragEvent('mousedown', 0, 0, draggable.nativeElement);
+          tick();
+          fixture.detectChanges();
+          const draggableQueries = testElement.querySelectorAll('.being-dragged');
+          expect(draggableQueries.length).toBe(
+            1,
+            `Only one draggable should have the "being-dragged" class at a time.`
+          );
+          expect(draggableQueries[0]).toBe(draggable.nativeElement);
+        })
+      );
 
-      it('should show ghost next to proper draggable on dragStart', function() {
-        emulateDragEvent('mousedown', 0, 0, draggable.nativeElement);
-        emulateDragEvent('mousemove', 10, 20);
-        fixture.detectChanges();
-        const draggableQueries = testElement.querySelectorAll('.being-dragged');
-        expect(draggableQueries[0].nextElementSibling.tagName).toBe('CLR-DRAGGABLE-GHOST');
-        expect(draggableQueries[0].nextElementSibling.classList.contains('draggable-ghost')).toBeTruthy();
-      });
+      it(
+        'should show ghost next to proper draggable on dragStart',
+        fakeAsync(function() {
+          emulateDragEvent('mousedown', 0, 0, draggable.nativeElement);
+          tick();
+          fixture.detectChanges();
+          const draggableQueries = testElement.querySelectorAll('.being-dragged');
+          expect(draggableQueries[0].nextElementSibling.tagName).toBe('CLR-DRAGGABLE-GHOST');
+          expect(draggableQueries[0].nextElementSibling.classList.contains('draggable-ghost')).toBeTruthy();
+        })
+      );
 
-      it('should add draggable-match to all droppables with matching group', function() {
-        emulateDragEvent('mousedown', 0, 0, draggable.nativeElement);
-        emulateDragEvent('mousemove', 10, 20);
-        fixture.detectChanges();
-        const matchingDroppablesQueries = testElement.querySelectorAll('.draggable-match');
-        expect(matchingDroppablesQueries.length).toBe(2);
+      it(
+        'should add draggable-match to all droppables with matching group',
+        fakeAsync(function() {
+          emulateDragEvent('mousedown', 0, 0, draggable.nativeElement);
+          tick();
+          fixture.detectChanges();
+          const matchingDroppablesQueries = testElement.querySelectorAll('.draggable-match');
+          expect(matchingDroppablesQueries.length).toBe(2);
 
-        const overDroppablesQueries = testElement.querySelectorAll('.draggable-over');
-        expect(overDroppablesQueries.length).toBe(0);
-      });
+          const overDroppablesQueries = testElement.querySelectorAll('.draggable-over');
+          expect(overDroppablesQueries.length).toBe(0);
+        })
+      );
 
-      it('should add draggable-over to proper droppable on dragEnter', function() {
-        emulateDragEvent('mousedown', 0, 0, draggable.nativeElement);
-        emulateDragEvent('mousemove', 10, 20);
-        emulateDragEvent('mousemove', 500, 300);
-        fixture.detectChanges();
+      it(
+        'should add draggable-over to proper droppable on dragEnter',
+        fakeAsync(function() {
+          emulateDragEvent('mousedown', 0, 0, draggable.nativeElement);
+          tick();
+          emulateDragEvent('mousemove', 500, 300);
+          fixture.detectChanges();
 
-        const matchingDroppablesQueries = testElement.querySelectorAll('.draggable-match');
-        expect(matchingDroppablesQueries.length).toBe(2);
+          const matchingDroppablesQueries = testElement.querySelectorAll('.draggable-match');
+          expect(matchingDroppablesQueries.length).toBe(2);
 
-        const overDroppablesQueries = testElement.querySelectorAll('.draggable-over');
-        expect(overDroppablesQueries.length).toBe(1);
-      });
+          const overDroppablesQueries = testElement.querySelectorAll('.draggable-over');
+          expect(overDroppablesQueries.length).toBe(1);
+        })
+      );
 
-      it('should remove draggable-over to on dragLeave', function() {
-        emulateDragEvent('mousedown', 0, 0, draggable.nativeElement);
-        emulateDragEvent('mousemove', 10, 20);
-        emulateDragEvent('mousemove', 500, 300);
-        emulateDragEvent('mousemove', 100, 200);
-        fixture.detectChanges();
+      it(
+        'should remove draggable-over to on dragLeave',
+        fakeAsync(function() {
+          emulateDragEvent('mousedown', 0, 0, draggable.nativeElement);
+          tick();
+          emulateDragEvent('mousemove', 500, 300);
+          emulateDragEvent('mousemove', 100, 200);
+          fixture.detectChanges();
 
-        const matchingDroppablesQueries = testElement.querySelectorAll('.draggable-match');
-        expect(matchingDroppablesQueries.length).toBe(2);
+          const matchingDroppablesQueries = testElement.querySelectorAll('.draggable-match');
+          expect(matchingDroppablesQueries.length).toBe(2);
 
-        const overDroppablesQueries = testElement.querySelectorAll('.draggable-over');
-        expect(overDroppablesQueries.length).toBe(0);
-      });
+          const overDroppablesQueries = testElement.querySelectorAll('.draggable-over');
+          expect(overDroppablesQueries.length).toBe(0);
+        })
+      );
 
-      it('should have no droppables with draggable-over and draggable-match class on dragEnd', function() {
-        emulateDragEvent('mousedown', 0, 0, draggable.nativeElement);
-        emulateDragEvent('mousemove', 10, 20);
-        emulateDragEvent('mousemove', 500, 300);
-        emulateDragEvent('mousemove', 100, 200);
-        emulateDragEvent('mouseup', 100, 200);
-        fixture.detectChanges();
+      it(
+        'should have no droppables with draggable-over and draggable-match class on dragEnd',
+        fakeAsync(function() {
+          emulateDragEvent('mousedown', 0, 0, draggable.nativeElement);
+          tick();
+          emulateDragEvent('mousemove', 500, 300);
+          emulateDragEvent('mousemove', 100, 200);
+          emulateDragEvent('mouseup', 100, 200);
+          fixture.detectChanges();
 
-        const matchingDroppablesQueries = testElement.querySelectorAll('.draggable-match');
-        expect(matchingDroppablesQueries.length).toBe(0);
+          const matchingDroppablesQueries = testElement.querySelectorAll('.draggable-match');
+          expect(matchingDroppablesQueries.length).toBe(0);
 
-        const overDroppablesQueries = testElement.querySelectorAll('.draggable-over');
-        expect(overDroppablesQueries.length).toBe(0);
-      });
+          const overDroppablesQueries = testElement.querySelectorAll('.draggable-over');
+          expect(overDroppablesQueries.length).toBe(0);
+        })
+      );
 
-      it('should add dropped class to ghost on successful drop event', function() {
-        emulateDragEvent('mousedown', 0, 0, draggable.nativeElement);
-        emulateDragEvent('mousemove', 10, 20);
-        const ghost = testElement.querySelector('.draggable-ghost');
-        emulateDragEvent('mousemove', 500, 300);
-        expect(ghost.classList.contains('dropped')).toBeFalsy();
-        emulateDragEvent('mouseup', 500, 300);
-        expect(ghost.classList.contains('dropped')).toBeTruthy();
-      });
+      it(
+        'should add dropped class to ghost on successful drop event',
+        fakeAsync(function() {
+          emulateDragEvent('mousedown', 0, 0, draggable.nativeElement);
+          tick();
+          const ghost = testElement.querySelector('.draggable-ghost');
+          emulateDragEvent('mousemove', 500, 300);
+          expect(ghost.classList.contains('dropped')).toBeFalsy();
+          emulateDragEvent('mouseup', 500, 300);
+          expect(ghost.classList.contains('dropped')).toBeTruthy();
+        })
+      );
     });
   });
 }
@@ -225,7 +294,9 @@ export default function(): void {
             }
         `,
   ],
-  template: `<button clrDraggable>draggable button</button><div class="draggable-test-state" clrGroup="draggable-1" [clrDraggable]="mockDataPayload">draggable div</div>
+  template: `
+        <button clrDraggable>draggable button</button>
+        <div class="draggable-test-state" clrGroup="draggable-1" [clrDraggable]="mockDataPayload" [clrDragStartDelay]="dragStartDelay">draggable div</div>
         <div clrDroppable clrGroup="draggable-0"></div>        
         <div class="droppable-test-state" clrDroppable 
                     [clrGroup]="['draggable-1', 'draggable-2']"
@@ -240,6 +311,7 @@ export default function(): void {
 })
 class WithDraggableTest {
   public mockDataPayload = MOCK_DATA_PAYLOAD;
+  public dragStartDelay: number;
   public dragStartEvent: any;
   public dragMoveEvent: any;
   public dragEndEvent: any;

--- a/src/clr-angular/utils/drag-and-drop/drag-event.ts
+++ b/src/clr-angular/utils/drag-and-drop/drag-event.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -11,7 +11,7 @@ export class ClrDragEvent<T> {
   public dragPosition: DragPointPosition;
   public group: string | string[];
   public dragDataTransfer: T;
-  public dropPointPosition: { pageX: number; pageY: number };
+  public dropPointPosition: DragPointPosition;
 
   constructor(dragEvent: DragEventInterface<T>) {
     this.dragPosition = dragEvent.dragPosition;

--- a/src/clr-angular/utils/drag-and-drop/draggable-ghost.spec.ts
+++ b/src/clr-angular/utils/drag-and-drop/draggable-ghost.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -7,11 +7,9 @@ import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-
 import { DomAdapter } from '../dom-adapter/dom-adapter';
-
-import { ClrDraggableGhost } from './index';
 import { ClrDragAndDropModule } from './drag-and-drop.module';
+import { ClrDraggableGhost } from './draggable-ghost';
 import { DragEventListenerService } from './providers/drag-event-listener.service';
 import { MOCK_DRAG_EVENT_LISTENER_PROVIDER } from './providers/drag-event-listener.service.mock';
 import { DraggableSnapshotService } from './providers/draggable-snapshot.service';
@@ -57,7 +55,9 @@ export default function(): void {
       });
 
       it('should appear on the first drag move event', function() {
+        this.dragEventListener.dragStartPosition = { pageX: 0, pageY: 0 };
         const mockDragMoveEvent = { dragPosition: { pageX: 33, pageY: 44 } };
+
         this.dragEventListener.dragMoved.next(mockDragMoveEvent);
 
         expect(this.ghostElement.style.left).toBe(`${mockDragMoveEvent.dragPosition.pageX}px`);
@@ -66,6 +66,7 @@ export default function(): void {
       });
 
       it('should be dragged from mouse position on page', function() {
+        this.dragEventListener.dragStartPosition = { pageX: 0, pageY: 0 };
         const mockDragMoveEvent1 = { dragPosition: { pageX: 120, pageY: 60 } };
         const mockDragMoveEvent2 = { dragPosition: { pageX: 180, pageY: 120 } };
 

--- a/src/clr-angular/utils/drag-and-drop/draggable-ghost.ts
+++ b/src/clr-angular/utils/drag-and-drop/draggable-ghost.ts
@@ -82,7 +82,10 @@ export class ClrDraggableGhost<T> implements OnDestroy {
               `${this.draggableSnapshot.clientRect.left}px`
             );
           } else {
-            this.animateToOnLeave(`${event.dragPosition.pageY}px`, `${event.dragPosition.pageX}px`);
+            this.animateToOnLeave(
+              `${this.dragEventListener.dragStartPosition.pageY}px`,
+              `${this.dragEventListener.dragStartPosition.pageY}px`
+            );
           }
           isAnimationConfigured = true;
         }

--- a/src/clr-angular/utils/drag-and-drop/draggable/draggable.spec.ts
+++ b/src/clr-angular/utils/drag-and-drop/draggable/draggable.spec.ts
@@ -71,6 +71,12 @@ export default function(): void {
       expect(this.draggable.nativeElement.classList.contains('draggable')).toBeTruthy();
     });
 
+    it('should pass drag start delay to dragListener', function() {
+      this.testComponent.dragStartDelay = 123;
+      this.fixture.detectChanges();
+      expect(this.dragEventListener.dragStartDelay).toBe(123);
+    });
+
     it('should emit event on drag start', function() {
       this.dragEventListener.dragStarted.next(mockDragStartEventInt);
       expect(this.testComponent.dragStartEvent).toEqual(mockDragStartEventExt);
@@ -154,10 +160,12 @@ export default function(): void {
 }
 
 @Component({
-  template: `<div clrDraggable (clrDragStart)="dragStartEvent=$event;" (clrDragMove)="dragMoveEvent=$event;" (clrDragEnd)="dragEndEvent=$event;">Test</div>`,
+  template: `<div clrDraggable [clrDragStartDelay]="dragStartDelay" (clrDragStart)="dragStartEvent=$event;" (clrDragMove)="dragMoveEvent=$event;" (clrDragEnd)="dragEndEvent=$event;">Test</div>`,
 })
 class BasicDraggableTest {
   dragStartEvent: ClrDragEvent<any>;
   dragMoveEvent: ClrDragEvent<any>;
   dragEndEvent: ClrDragEvent<any>;
+
+  dragStartDelay: number;
 }

--- a/src/clr-angular/utils/drag-and-drop/draggable/draggable.ts
+++ b/src/clr-angular/utils/drag-and-drop/draggable/draggable.ts
@@ -72,6 +72,15 @@ export class ClrDraggable<T> implements AfterContentInit, OnDestroy {
     this.dragEventListener.group = value;
   }
 
+  @Input('clrDragStartDelay')
+  set dragStartDelay(value: number) {
+    if (typeof value === 'number') {
+      this.dragEventListener.dragStartDelay = value;
+    } else if (typeof value === 'string') {
+      this.dragEventListener.dragStartDelay = parseInt(value, 10) || 0;
+    }
+  }
+
   private createDefaultGhost(event: DragEventInterface<T>) {
     this.draggableSnapshot.capture(this.draggableEl, event);
     // NOTE: The default ghost element will appear

--- a/src/clr-angular/utils/drag-and-drop/droppable/droppable.spec.ts
+++ b/src/clr-angular/utils/drag-and-drop/droppable/droppable.spec.ts
@@ -9,7 +9,7 @@ import { By } from '@angular/platform-browser';
 
 import { ClrDragEvent } from '../drag-event';
 import { generateDragPosition } from '../helpers.spec';
-import { DragEventInterface, DragEventType } from '../interfaces/drag-event.interface';
+import { DragEventInterface, DragEventType, DragPointPosition } from '../interfaces/drag-event.interface';
 import { ClrDropToleranceInterface } from '../interfaces/drop-tolerance.interface';
 import { DragAndDropEventBusService } from '../providers/drag-and-drop-event-bus.service';
 import { MOCK_DRAG_DROP_EVENT_BUS } from '../providers/drag-and-drop-event-bus.service.mock';
@@ -34,7 +34,7 @@ export default function(): void {
     mockDragEndEventExt = new ClrDragEvent(mockDragEndEventInt);
   });
 
-  const decorateEventWithDropPosition = (event, dropPointPosition: { pageX: number; pageY: number }) => {
+  const decorateEventWithDropPosition = (event, dropPointPosition: DragPointPosition) => {
     event.dropPointPosition = dropPointPosition;
   };
 

--- a/src/clr-angular/utils/drag-and-drop/droppable/droppable.ts
+++ b/src/clr-angular/utils/drag-and-drop/droppable/droppable.ts
@@ -8,7 +8,7 @@ import { Subscription } from 'rxjs';
 
 import { DomAdapter } from '../../dom-adapter/dom-adapter';
 import { ClrDragEvent } from '../drag-event';
-import { DragEventInterface, DragEventType } from '../interfaces/drag-event.interface';
+import { DragEventInterface, DragEventType, DragPointPosition } from '../interfaces/drag-event.interface';
 import { ClrDropToleranceInterface } from '../interfaces/drop-tolerance.interface';
 import { DragAndDropEventBusService } from '../providers/drag-and-drop-event-bus.service';
 
@@ -131,7 +131,7 @@ export class ClrDroppable<T> implements OnInit, OnDestroy {
     }
   }
 
-  private isInDropArea(point: { pageX: number; pageY: number }): boolean {
+  private isInDropArea(point: DragPointPosition): boolean {
     if (!point) {
       return false;
     }

--- a/src/clr-angular/utils/drag-and-drop/helpers.spec.ts
+++ b/src/clr-angular/utils/drag-and-drop/helpers.spec.ts
@@ -14,8 +14,8 @@ export const generateDragPosition = (
     return {
       pageX: startPosition[0],
       pageY: startPosition[1],
-      moveX: startPosition[0],
-      moveY: startPosition[1],
+      moveX: 0,
+      moveY: 0,
     };
   }
   return {

--- a/src/clr-angular/utils/drag-and-drop/interfaces/drag-event.interface.ts
+++ b/src/clr-angular/utils/drag-and-drop/interfaces/drag-event.interface.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -15,8 +15,8 @@ export enum DragEventType {
 export interface DragPointPosition {
   pageX: number;
   pageY: number;
-  moveX: number;
-  moveY: number;
+  moveX?: number;
+  moveY?: number;
 }
 
 export interface DragEventInterface<T> {
@@ -27,5 +27,5 @@ export interface DragEventInterface<T> {
   dragDataTransfer?: T;
   // For default ghosts, this dropPointPosition denotes the center point of the ghost element.
   // This center point is used to determine whether the ghost is over droppable elements or not.
-  dropPointPosition?: { pageX: number; pageY: number };
+  dropPointPosition?: DragPointPosition;
 }

--- a/src/clr-angular/utils/drag-and-drop/providers/drag-event-listener.service.mock.ts
+++ b/src/clr-angular/utils/drag-and-drop/providers/drag-event-listener.service.mock.ts
@@ -6,6 +6,7 @@
 import { Subject } from 'rxjs';
 import { DragEventListenerService } from './drag-event-listener.service';
 import { Injectable } from '@angular/core';
+import { DragPointPosition } from '../interfaces/drag-event.interface';
 
 // This mock service is necessary because the real service uses Renderer2 and attaches complex event listeners.
 // This class mocks that as setting ".hasListener" to true
@@ -17,6 +18,7 @@ export class MockDragEventListener {
   public dragStarted: Subject<any> = new Subject<any>();
   public dragMoved: Subject<any> = new Subject<any>();
   public dragEnded: Subject<any> = new Subject<any>();
+  public dragStartPosition: DragPointPosition;
 
   public attachDragListeners(draggableEl: any) {
     this.draggableEl = draggableEl;

--- a/src/dev/src/app/drag-and-drop/basic-draggable.demo.html
+++ b/src/dev/src/app/drag-and-drop/basic-draggable.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -8,6 +8,15 @@
 
 <div class="clr-example">
     <button class="btn btn-primary" clrDraggable>draggable</button>
+</div>
+
+
+<h4>Delayed Drag Start</h4>
+
+<p>Hold your pointer down for at least 500ms to trigger drag start</p>
+
+<div class="clr-example">
+    <button class="btn btn-primary" clrDraggable [clrDragStartDelay]="500">draggable</button>
 </div>
 
 <h4>Draggable cards</h4>

--- a/src/dev/src/app/drag-and-drop/draggable-handle.demo.html
+++ b/src/dev/src/app/drag-and-drop/draggable-handle.demo.html
@@ -1,10 +1,15 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
 
 <h4>Draggable cards with a handle</h4>
+
+<p>
+    It's recommended to use a handle if your draggable contains native interactive elements so that
+    we can prevent their default interactive behaviors from getting mixed with the draggable's interactivity.
+</p>
 
 <div class="clr-example">
     <div class="clr-row">
@@ -15,6 +20,11 @@
                     <p class="card-text">
                         Lorem ipsum dolor sit amet consectetur adipisicing elit. Qui eum distinctio fuga sapiente enim tenetur et saepe veniam eligendi!
                         Doloribus ipsa vel eveniet rerum incidunt voluptates dolor? Non, porro modi!
+
+                        <clr-input-container>
+                            <label>My name</label>
+                            <input clrInput placeholder="Fill me in" name="name"/>
+                        </clr-input-container>
                     </p>
                 </div>
                 <div class="card-footer">
@@ -30,6 +40,11 @@
                         Lorem ipsum dolor, sit amet consectetur adipisicing elit. Quasi aspernatur incidunt maxime doloribus, temporibus tempore
                         iure reiciendis, facilis nihil atque corrupti neque! Doloribus, quod praesentium ratione accusamus
                         sapiente omnis neque!
+
+                        <clr-input-container>
+                            <label>My name</label>
+                            <input clrInput placeholder="Fill me in" name="name"/>
+                        </clr-input-container>
                     </p>
                 </div>
                 <div class="card-footer">
@@ -39,3 +54,5 @@
         </div>
     </div>
 </div>
+
+


### PR DESCRIPTION
Signed-off-by: stsogoo <stsogoo@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

This PR introduces `clrDragStartDelay` input to `clrDraggable` directive. The input defines the hold duration for initiating the drag start event.

Example: 
```html
<button class="btn btn-primary" clrDraggable [clrDragStartDelay]="500">draggable</button>
```

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
