### PR TITLE
docs: remove clarity happiness survey alert

### DIFF
--- a/src/website/src/app/app.component.html
+++ b/src/website/src/app/app.component.html
@@ -1,15 +1,5 @@
 <clr-main-container>
     <app-skip-link [focusElement]="contentRef.nativeElement"></app-skip-link>
-    <clr-alert *ngIf="showSurvey()" [clrAlertType]="'alert-info'" [clrAlertAppLevel]="true" (clrAlertClosedChange)="trackSurveyAction('close-survey')">
-      <clr-alert-item>
-        <span class="alert-text">
-            Hey there, we’d like to find out how you feel about Clarity! Take a 3 minute survey and tell us what you think!
-        </span>
-        <div class="alert-actions">
-          <a class="btn alert-action" target="_blank" href="https://vmwareuxr.sjc1.qualtrics.com/jfe/form/SV_6lFHAvuxNUALhS5" (click)="trackSurveyAction('start-survey')">Start</a>
-        </div>
-      </clr-alert-item>
-    </clr-alert>
     <clr-header class="header-6">
         <div class="branding">
             <a routerLink="/" class="logo-and-title">

--- a/src/website/src/app/app.component.ts
+++ b/src/website/src/app/app.component.ts
@@ -45,24 +45,6 @@ export class AppComponent implements OnInit {
     });
   }
 
-  trackSurveyAction(eventLabel: string) {
-    if (window.trackSurveyAlert) {
-      window.trackSurveyAlert(eventLabel);
-    }
-
-    // close survey in future visits
-    if (eventLabel === 'close-survey') {
-      const expireDate = new Date();
-      expireDate.setDate(expireDate.getDate() + 60); // set an expire for 60 days
-      const surveyCookie = `closeSurvey=true;expires=${expireDate.toUTCString()}`;
-      document.cookie = surveyCookie;
-    }
-  }
-
-  showSurvey(): boolean {
-    return !document.cookie.includes('closeSurvey=true');
-  }
-
   bodyClasses = [];
 
   updateBodyClasses() {

--- a/src/website/src/index.html
+++ b/src/website/src/index.html
@@ -40,11 +40,6 @@
             window["trackIconSearch"] = function (searchedIcon, numberOfMatches) {
                 ga('send', 'event', 'icon-search', 'input', searchedIcon, numberOfMatches);
             }
-
-
-            window["trackHiringAlert"] = function (eventLabel) {
-                ga('send', 'event', 'clarity-survey', 'click', eventLabel);
-            }
         }
     </script>
 </head>


### PR DESCRIPTION
Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?
Removes the Clarity happiness survey alert from the app shell. 

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [x] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?
There is an alert that opens a new tab to the Clarity survey. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
The alert is gone.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
