### PR TITLE
fix: core support slotted layout

### DIFF
--- a/src/clr-core/styles/layout/_type-horizontal.scss
+++ b/src/clr-core/styles/layout/_type-horizontal.scss
@@ -8,8 +8,9 @@
       margin: calc(-1 * #{$sizeValue}) 0 0 calc(-1 * #{$sizeValue});
       width: calc(100% + #{$sizeValue});
 
-      & > * {
-        margin: $sizeValue 0 0 $sizeValue;
+      & > *,
+      &::slotted(*) {
+        margin: $sizeValue 0 0 $sizeValue !important;
       }
     }
   }
@@ -81,13 +82,17 @@
   }
 
   &[cds-layout~='align:stretch'] > *,
-  &[cds-layout~='align:horizontal-stretch'] > * {
-    flex-grow: 1;
+  &[cds-layout~='align:horizontal-stretch'] > *,
+  &[cds-layout~='align:stretch']::slotted(*),
+  &[cds-layout~='align:horizontal-stretch']::slotted(*) {
+    flex-grow: 1 !important;
   }
 
   &[cds-layout~='align:stretch'] > *,
-  &[cds-layout~='align:vertical-stretch'] {
-    align-content: stretch;
+  &[cds-layout~='align:vertical-stretch'],
+  &[cds-layout~='align:stretch']::slotted(*),
+  &[cds-layout~='align:vertical-stretch']::slotted(*) {
+    align-content: stretch !important;
   }
 
   // Align Single Item

--- a/src/clr-core/styles/layout/_type-vertical.scss
+++ b/src/clr-core/styles/layout/_type-vertical.scss
@@ -4,8 +4,11 @@
 
 @mixin generateGaps($breakpoint: null) {
   @each $size, $sizeValue in $cds-layout-sizes {
-    [cds-layout~='vertical'][cds-layout~='gap#{$breakpoint}:#{$size}'] > * {
-      margin-bottom: $sizeValue;
+    [cds-layout~='vertical'][cds-layout~='gap#{$breakpoint}:#{$size}'] {
+      & > *,
+      &::slotted(*) {
+        margin-bottom: $sizeValue !important;
+      }
     }
   }
 }
@@ -25,8 +28,9 @@
   justify-content: flex-start;
   align-items: flex-start;
 
-  & > *:last-child {
-    margin-bottom: 0;
+  & > *:last-child,
+  &::slotted(*:last-child) {
+    margin-bottom: 0 !important;
   }
 
   // Align Items
@@ -73,8 +77,10 @@
   }
 
   &[cds-layout~='align:stretch'] > *,
-  &[cds-layout~='align:vertical-stretch'] > * {
-    flex-grow: 1;
+  &[cds-layout~='align:vertical-stretch'] > *,
+  &[cds-layout~='align:stretch']::slotted(*),
+  &[cds-layout~='align:vertical-stretch']::slotted(*) {
+    flex-grow: 1 !important;
   }
 
   // Align Single Item

--- a/src/clr-core/test-bundles/bundlesize.json
+++ b/src/clr-core/test-bundles/bundlesize.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "./dist/test-bundles/webpack.bundle.js",
-      "maxSize": "25 kB"
+      "maxSize": "25.5 kB"
     }
   ]
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the new behavior?
This change adds support to use the core layout system support for slotted elements in shadow DOM. 

In web component template
```html
<slot cds-layout="vertical gap:md"></slot>
```

Consuming App
```html
<!-- these elements will now be stacked with medium gap -->
<my-element>
  <p>item 1</p>
  <p>item 1</p>
  <p>item 1</p>
</my-element>
```

Consuming App Override
```html
<my-element>
  <div cds-layout="horizontal gap:xs">
    <p>item 1</p>
    <p>item 1</p>
    <p>item 1</p>
  </div>
</my-element>
```

The fix adds a slotted selector that allows us to select slotted elements to apply the gaps to each item. This is needed because we have DOM existing both in light and shadow DOM in this scenario.

In an ideal world we would not need any of these and could use `flex-gap` but its only supported in Firefox.

https://caniuse.com/#feat=flexbox-gap 
https://stackblitz.com/edit/js-2kwqn6?file=style.css 

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
