### PR TITLE
fix: tape drive icon html issue

### DIFF
--- a/src/clr-icons/shapes/technology-shapes.ts
+++ b/src/clr-icons/shapes/technology-shapes.ts
@@ -1296,7 +1296,7 @@ export const ClrShapeTapeDrive = clrIconSVG(
 
   <path d="M12.21,23a5,5,0,1,0-5-5A5,5,0,0,0,12.21,23Zm0-7a2,2,0,1,1-2,2A2,2,0,0,1,12.21,16Z" class="clr-i-solid--badged clr-i-solid-path-1--badged"/>
   <path d="M23.79,23a5,5,0,1,0-5-5A5,5,0,0,0,23.79,23Zm0-7a2,2,0,1,1-2,2A2,2,0,0,1,23.79,16Z" class="clr-i-solid--badged clr-i-solid-path-2--badged"/>
-  <path d="M30,13.5V24H6V12H25.51a7.49,7.49,0,0,1-3-6H4A2,2,0,0,0,2,8V28a2,2,0,0,0,2,2H32a2,2,0,0,0,2-2V12.34A7.49,7.49,0,0,1,30,13.5Z"class="clr-i-solid--badged clr-i-solid-path-3--badged"/>
+  <path d="M30,13.5V24H6V12H25.51a7.49,7.49,0,0,1-3-6H4A2,2,0,0,0,2,8V28a2,2,0,0,0,2,2H32a2,2,0,0,0,2-2V12.34A7.49,7.49,0,0,1,30,13.5Z" class="clr-i-solid--badged clr-i-solid-path-3--badged"/>
   <circle cx="30" cy="6" r="5" class="clr-i-solid--badged clr-i-solid-path-4--badged clr-i-badge"/>
 
   <path d="M7.2,18a5,5,0,1,0,5-5A5,5,0,0,0,7.2,18Zm7,0a2,2,0,1,1-2-2A2,2,0,0,1,14.22,18Z" class="clr-i-solid--alerted clr-i-solid-path-1--alerted"/>


### PR DESCRIPTION
• tape drive icon was missing an expected space in front of the classnames attr
• verified that there are no other occurrences of this issue in the codebase

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4451 

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I've verified that this is an issue in v2 as well. So I will need to backport once I get it merged into master.