### PR TITLE
feat: introduce clr-form-placeholder solid color and set disabled opacity to 0.55

### DIFF
--- a/packages/angular/projects/clr-angular/src/forms/styles/_containers.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/forms/styles/_containers.clarity.scss
@@ -11,7 +11,52 @@
   }
 
   .clr-form-control-disabled {
-    @include css-var(opacity, clr-forms-disabled-opacity, $clr-forms-disabled-opacity, $clr-use-custom-properties);
+    @include css-var(color, clr-forms-text-disabled-color, $clr-forms-text-disabled-color, $clr-use-custom-properties);
+
+    label,
+    .clr-control-label {
+      @include css-var(
+        color,
+        clr-forms-label-disabled-color,
+        $clr-forms-label-disabled-color,
+        $clr-use-custom-properties
+      );
+    }
+
+    .clr-input,
+    .clr-textarea,
+    .clr-select {
+      @include css-var(
+        color,
+        clr-forms-text-disabled-color,
+        $clr-forms-text-disabled-color,
+        $clr-use-custom-properties
+      );
+      @include css-var(
+        border-bottom-color,
+        clr-forms-border-disabled-color,
+        $clr-forms-border-disabled-color,
+        $clr-use-custom-properties
+      );
+    }
+
+    input[type='range']::-webkit-slider-thumb {
+      @include css-var(
+        background-color,
+        clr-forms-border-disabled-color,
+        $clr-forms-border-disabled-color,
+        $clr-use-custom-properties
+      );
+    }
+
+    .clr-subtext {
+      @include css-var(
+        color,
+        cclr-forms-subtext-disabled-color,
+        $clr-forms-subtext-disabled-color,
+        $clr-use-custom-properties
+      );
+    }
   }
 
   .clr-form-control-multi {

--- a/packages/angular/projects/clr-angular/src/forms/styles/_input-group.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/forms/styles/_input-group.clarity.scss
@@ -56,6 +56,7 @@
   }
 
   .clr-form-control-disabled .clr-input-group-icon-action {
+    @include css-var(color, clr-forms-text-disabled-color, $clr-forms-text-disabled-color, $clr-use-custom-properties);
     cursor: not-allowed;
   }
 

--- a/packages/angular/projects/clr-angular/src/forms/styles/_input.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/forms/styles/_input.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -56,5 +56,12 @@
 
   .clr-form-control-multi .clr-input {
     max-width: calc(100% + #{$clr-forms-icon-size});
+  }
+
+  /**
+   Placeholder
+   **/
+  @include input-placeholder-wrapper() {
+    @include css-var(color, clr-forms-placeholder-color, $clr-forms-placeholder-color, $clr-use-custom-properties);
   }
 }

--- a/packages/angular/projects/clr-angular/src/forms/styles/_mixins.forms.scss
+++ b/packages/angular/projects/clr-angular/src/forms/styles/_mixins.forms.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -104,7 +104,7 @@
 }
 
 @mixin disabled-form-fields() {
-  opacity: 0.5;
+  @include css-var(color, clr-forms-text-disabled-color, $clr-forms-text-disabled-color, $clr-use-custom-properties);
   cursor: not-allowed;
 }
 

--- a/packages/angular/projects/clr-angular/src/forms/styles/_properties.forms.scss
+++ b/packages/angular/projects/clr-angular/src/forms/styles/_properties.forms.scss
@@ -15,9 +15,14 @@
       --clr-forms-valid-color: var(--clr-color-success-700);
       --clr-forms-valid-text-color: var(--clr-color-success-900);
       --clr-forms-subtext-color: var(--clr-color-neutral-600);
+      --clr-forms-placeholder-color: var(--clr-color-neutral-600);
       --clr-forms-border-color: var(--clr-color-neutral-500);
       --clr-forms-focused-color: var(--clr-color-action-600);
-      --clr-forms-disabled-opacity: #{$clr-forms-disabled-opacity};
+
+      --clr-forms-subtext-disabled-color: #{$clr-forms-subtext-disabled-color};
+      --clr-forms-border-disabled-color: #{$clr-forms-border-disabled-color};
+      --clr-forms-text-disabled-color: #{$clr-forms-text-disabled-color};
+      --clr-forms-label-disabled-color: #{$clr-forms-label-disabled-color};
 
       // Typographic
       --clr-forms-label-font-weight: var(--clr-font-weight-bold);

--- a/packages/angular/projects/clr-angular/src/forms/styles/_variables.forms.scss
+++ b/packages/angular/projects/clr-angular/src/forms/styles/_variables.forms.scss
@@ -14,9 +14,13 @@ $clr-forms-invalid-color: $clr-color-danger-800 !default;
 $clr-forms-valid-color: $clr-color-success-700 !default;
 $clr-forms-valid-text-color: $clr-color-success-900 !default;
 $clr-forms-subtext-color: $clr-color-neutral-600 !default;
+$clr-forms-placeholder-color: $clr-color-neutral-600 !default;
 $clr-forms-border-color: $clr-color-neutral-500 !default;
 $clr-forms-focused-color: $clr-color-action-600 !default;
-$clr-forms-disabled-opacity: 0.54 !default;
+$clr-forms-subtext-disabled-color: $clr-color-neutral-600 !default;
+$clr-forms-border-disabled-color: $clr-color-neutral-500 !default;
+$clr-forms-text-disabled-color: $clr-color-neutral-500 !default;
+$clr-forms-label-disabled-color: $clr-color-neutral-600 !default;
 
 // Typographic
 $clr-forms-label-font-size: $clr-p2-font-size !default;

--- a/packages/angular/projects/clr-angular/src/utils/_mixins.scss
+++ b/packages/angular/projects/clr-angular/src/utils/_mixins.scss
@@ -184,3 +184,22 @@ $opp-directions: (
     @content;
   }
 }
+
+@mixin input-placeholder-wrapper() {
+  /* _normalize overwrite */
+  ::-webkit-input-placeholder {
+    @content;
+  }
+  /* Internet Explorer 10-11 */
+  :-ms-input-placeholder {
+    @content;
+  }
+  /* Microsoft Edge */
+  ::-ms-input-placeholder {
+    @content;
+  }
+  /* Chrome, Firefox, Opera, Safari 10.1+ */
+  ::placeholder {
+    @content;
+  }
+}

--- a/packages/angular/projects/clr-angular/src/utils/_overwrites.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/utils/_overwrites.clarity.scss
@@ -449,8 +449,13 @@ $clr-forms-invalid-color: null; // $clr-color-danger-800
 $clr-forms-valid-color: null; // $clr-color-success-700
 $clr-forms-valid-text-color: null; // $clr-color-success-900
 $clr-forms-subtext-color: null; // $clr-color-neutral-600
+$clr-forms-placeholder-color: null; // $clr-color-neutral-600
 $clr-forms-border-color: null; // $clr-color-neutral-500
 $clr-forms-focused-color: null; // $clr-color-action-600
+$clr-forms-subtext-disabled-color: null;
+$clr-forms-border-disabled-color: null;
+$clr-forms-text-disabled-color: null;
+$clr-forms-label-disabled-color: null;
 
 // Textarea
 $clr-forms-textarea-background-color: null; // $clr-color-neutral-0

--- a/packages/angular/projects/clr-angular/src/utils/_theme.dark.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/utils/_theme.dark.clarity.scss
@@ -418,8 +418,13 @@ $clr-forms-invalid-color: hsl(3, 90%, 62%);
 $clr-forms-valid-color: hsl(92, 79%, 40%);
 $clr-forms-valid-text-color: hsl(92, 79%, 49%);
 $clr-forms-subtext-color: hsl(203, 16%, 72%);
+$clr-forms-placeholder-color: hsl(203, 16%, 72%);
 $clr-forms-border-color: hsl(203, 16%, 72%);
 $clr-forms-focused-color: hsl(198, 65%, 57%); // Vertical no wrapper, no label
+$clr-forms-subtext-disabled-color: hsl(198, 10%, 46%) !default;
+$clr-forms-border-disabled-color: hsl(198, 10%, 46%) !default;
+$clr-forms-text-disabled-color: hsl(198, 10%, 46%) !default;
+$clr-forms-label-disabled-color: hsl(198, 10%, 46%) !default;
 
 // Textarea
 $clr-forms-textarea-background-color: hsl(201, 30%, 13%);

--- a/packages/angular/projects/dev/src/app/forms/disabled/disabled.html
+++ b/packages/angular/projects/dev/src/app/forms/disabled/disabled.html
@@ -1,0 +1,117 @@
+<!--
+  ~ Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<h2>Disabled</h2>
+
+<button class="btn" (click)="disabled = !disabled">Toggle disabled state</button>
+
+<ng-template #fields>
+  <form clrForm>
+    <clr-input-container>
+      <label>Required</label>
+      <input clrInput [disabled]="disabled" name="input" [(ngModel)]="data.input" placeholder="Input control" />
+      <clr-control-helper>Helper text</clr-control-helper>
+    </clr-input-container>
+
+    <clr-textarea-container>
+      <label>Textarea</label>
+      <textarea clrTextarea [disabled]="disabled" name="textarea" [(ngModel)]="data.textarea"></textarea>
+      <clr-control-helper>Helper text</clr-control-helper>
+    </clr-textarea-container>
+
+    <clr-password-container>
+      <label>Password</label>
+      <input
+        clrPassword
+        [disabled]="disabled"
+        name="password"
+        [(ngModel)]="data.password"
+        placeholder="Password please!"
+      />
+      <clr-control-helper>Helper text</clr-control-helper>
+    </clr-password-container>
+
+    <clr-radio-container>
+      <label>Radio</label>
+      <clr-radio-wrapper>
+        <input type="radio" clrRadio value="option1" [disabled]="disabled" name="radio" [(ngModel)]="data.radio" />
+        <label>Option 1</label>
+      </clr-radio-wrapper>
+      <clr-radio-wrapper>
+        <input type="radio" clrRadio value="option2" [disabled]="disabled" name="radio" [(ngModel)]="data.radio" />
+        <label>Option 2</label>
+      </clr-radio-wrapper>
+      <clr-control-helper>Helper text</clr-control-helper>
+    </clr-radio-container>
+
+    <clr-checkbox-container>
+      <label>Checkbox</label>
+      <clr-checkbox-wrapper>
+        <input
+          type="checkbox"
+          clrCheckbox
+          value="option1"
+          [disabled]="disabled"
+          name="checkbox"
+          [(ngModel)]="data.checkbox"
+        />
+        <label>Option 1</label>
+      </clr-checkbox-wrapper>
+      <clr-checkbox-wrapper>
+        <input
+          type="checkbox"
+          clrCheckbox
+          value="option2"
+          [disabled]="disabled"
+          name="checkbox"
+          [(ngModel)]="data.checkbox"
+        />
+        <label>Option 2</label>
+      </clr-checkbox-wrapper>
+      <clr-control-helper>Helper text</clr-control-helper>
+    </clr-checkbox-container>
+
+    <clr-select-container>
+      <label>Select</label>
+      <select clrSelect [disabled]="disabled" name="select" [(ngModel)]="data.select">
+        <option value="one">One</option>
+        <option value="two">Two</option>
+        <option value="three">Three</option>
+      </select>
+      <clr-control-helper>Helper text</clr-control-helper>
+    </clr-select-container>
+
+    <clr-range-container [clrRangeHasProgress]="true">
+      <label>Range</label>
+      <input type="range" clrRange [disabled]="disabled" name="range" [(ngModel)]="data.range" />
+      <clr-control-helper>Helper text</clr-control-helper>
+    </clr-range-container>
+
+    <clr-datalist-container>
+      <label>Datalist</label>
+      <input clrDatalistInput [disabled]="disabled" name="datalist" [(ngModel)]="data.datalist" />
+      <datalist>
+        <option *ngFor="let item of items" [value]="item"></option>
+      </datalist>
+      <clr-control-helper>Helper text</clr-control-helper>
+    </clr-datalist-container>
+  </form>
+</ng-template>
+
+<h3>Vertical</h3>
+<form clrForm #inputSuccessVertical clrLayout="vertical">
+  <ng-container *ngTemplateOutlet="fields"></ng-container>
+</form>
+
+<h3>Horizontal</h3>
+<form clrForm #inputSuccessHorizontal clrLayout="horizontal">
+  <ng-container *ngTemplateOutlet="fields"></ng-container>
+</form>
+
+<h3>Compact</h3>
+<form clrForm #inputSuccessCompact clrLayout="compact">
+  <ng-container *ngTemplateOutlet="fields"></ng-container>
+</form>

--- a/packages/angular/projects/dev/src/app/forms/disabled/disabled.ts
+++ b/packages/angular/projects/dev/src/app/forms/disabled/disabled.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import { Component } from '@angular/core';
+
+@Component({ templateUrl: './disabled.html' })
+export class FormsDisabledDemo {
+  items: string[] = ['one', 'two'];
+
+  disabled = true;
+
+  data = {
+    input: '',
+    textarea: '',
+    password: '',
+    radio: '',
+    checkbox: '',
+    select: '',
+    range: '',
+    datalist: '',
+  };
+}


### PR DESCRIPTION
Adding a `clr-form-placeholder` SCSS and CSS variable to set the input/textarea/select and every other component placeholder color to a solid one and remove the `opacity` option on it. In addition, change the opacity to all disabled items from 0.54 to 0.55. 

The changes try to improve the accessibility of the colors to be more closely to 3:1 ration - and try to avoid the use of opacity as a form of color shading.

The breaking change from this PR is the change of 0.01 opacity for placeholder color and disabled form elements.

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

* [x] Yes
* [ ] No

## Other information
