### PR TITLE
fix: changing rgba() to use rgb values

### DIFF
--- a/src/clr-angular/button/_properties.buttons.scss
+++ b/src/clr-angular/button/_properties.buttons.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -149,13 +149,13 @@
       --clr-btn-inverse-color: var(--clr-color-neutral-0);
       --clr-btn-inverse-border-color: var(--clr-color-neutral-0);
       --clr-btn-inverse-bg-color: transparent;
-      --clr-btn-inverse-hover-bg-color: rgba($clr-color-neutral-0, 0.15);
+      --clr-btn-inverse-hover-bg-color: rgba(255, 255, 255, 0.15);
       --clr-btn-inverse-hover-color: var(--clr-color-neutral-0);
-      --clr-btn-inverse-box-shadow-color: rgba($clr-color-neutral-1000, 0.25);
+      --clr-btn-inverse-box-shadow-color: rgba(0, 0, 0, 0.25);
       --clr-btn-inverse-disabled-color: var(--clr-color-neutral-0);
       --clr-btn-inverse-disabled-bg-color: var(--clr-btn-inverse-bg-color);
       --clr-btn-inverse-disabled-border-color: var(--clr-color-neutral-0);
-      --clr-btn-inverse-checked-bg-color: rgba($clr-color-neutral-0, 0.15);
+      --clr-btn-inverse-checked-bg-color: rgba(255, 255, 255, 0.15);
       --clr-btn-inverse-checked-color: var(--clr-color-neutral-0);
 
       // For theme-able icon button color

--- a/src/clr-angular/button/_variables.buttons.scss
+++ b/src/clr-angular/button/_variables.buttons.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -533,13 +533,13 @@ $clr-btn-link-checked-color: $clr-color-action-800 !default;
 $clr-btn-inverse-color: $clr-color-neutral-0 !default;
 $clr-btn-inverse-border-color: $clr-color-neutral-0 !default;
 $clr-btn-inverse-bg-color: transparent !default;
-$clr-btn-inverse-hover-bg-color: rgba($clr-color-neutral-0, 0.15) !default;
+$clr-btn-inverse-hover-bg-color: rgba(255, 255, 255, 0.15) !default;
 $clr-btn-inverse-hover-color: $clr-color-neutral-0 !default;
-$clr-btn-inverse-box-shadow-color: rgba($clr-color-neutral-1000, 0.25) !default;
+$clr-btn-inverse-box-shadow-color: rgba(0, 0, 0, 0.25) !default;
 $clr-btn-inverse-disabled-color: $clr-color-neutral-0 !default;
 $clr-btn-inverse-disabled-bg-color: $clr-btn-inverse-bg-color !default;
 $clr-btn-inverse-disabled-border-color: $clr-color-neutral-0 !default;
-$clr-btn-inverse-checked-bg-color: rgba($clr-color-neutral-0, 0.15) !default;
+$clr-btn-inverse-checked-bg-color: rgba(255, 255, 255, 0.15) !default;
 $clr-btn-inverse-checked-color: $clr-color-neutral-0 !default;
 
 @function lookupFromInverseButtonColors($property: null) {

--- a/src/clr-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clr-angular/data/datagrid/_datagrid.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -7,7 +7,7 @@
 }
 
 @mixin clr-datagrid-popover-shadows {
-  $fallbackShadowColor: rgba($clr-color-neutral-600, 0.25);
+  $fallbackShadowColor: rgba(140, 140, 140, 0.25);
   // IE/OldEdge
   box-shadow: 0 $clr_baselineRem_1px $clr_baselineRem_3px $fallbackShadowColor;
   box-shadow: 0 $clr_baselineRem_1px $clr_baselineRem_3px
@@ -914,7 +914,7 @@
 
         .exceeded-max {
           // TODO: CSS property here?
-          border-right: $clr-global-borderwidth dotted rgba($clr-color-danger-700, 0.3);
+          border-right: $clr-global-borderwidth dotted rgba(219, 33, 0, 0.3);
         }
       }
 

--- a/src/clr-angular/data/datagrid/_properties.datagrid.scss
+++ b/src/clr-angular/data/datagrid/_properties.datagrid.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -25,7 +25,7 @@
       --clr-datagrid-action-popover-hover-color: var(--clr-color-neutral-200);
       --clr-datagrid-row-selected: var(--clr-color-neutral-1000);
       --clr-datagrid-loading-background: #{$clr-datagrid-loading-background};
-      --clr-datagrid-popovers-box-shadow-color: rgba($clr-color-neutral-600, 0.25);
+      --clr-datagrid-popovers-box-shadow-color: rgba(140, 140, 140, 0.25);
 
       --clr-datagrid-column-switch-header-font-color: var(--clr-color-neutral-500);
       --clr-datagrid-column-switch-header-font-hover-color: var(--clr-color-action-600);

--- a/src/clr-angular/layout/nav/_header.clarity.scss
+++ b/src/clr-angular/layout/nav/_header.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -165,7 +165,7 @@
       }
 
       &.active {
-        background: rgba($clr-color-neutral-0, 0.15);
+        background: rgba(255, 255, 255, 0.15);
         opacity: 1;
       }
 

--- a/src/clr-angular/utils/variables/_variables.global.scss
+++ b/src/clr-angular/utils/variables/_variables.global.scss
@@ -253,7 +253,7 @@ $clr-close-color--hover: $clr-color-neutral-1000 !default;
 $clr-close-color--hover-opacity: 0.5 !default;
 
 // Box Shadow
-$clr-popover-box-shadow-color: rgba($clr-color-neutral-600, 0.25) !default;
+$clr-popover-box-shadow-color: rgba(140, 140, 140, 0.25) !default;
 
 // All z-indexes should come from here, to have a centralized file to reorganize them if needed
 $clr-layers: (

--- a/src/clr-core/button/button.element.scss
+++ b/src/clr-core/button/button.element.scss
@@ -159,7 +159,7 @@
 }
 
 :host([status='inverse']) {
-  --box-shadow-color: rgba($cds-token-color-neutral-1000, 0.25);
+  --box-shadow-color: rgba(0, 0, 0, 0.25);
   --border-color: #{$cds-token-color-neutral-0};
   --background: transparent;
   --color: #{$cds-token-color-neutral-0};


### PR DESCRIPTION
• this is a bit of a sledgehammer to force rgb values in to rgba() functions
• SASS is working in some instances but not others – likely due to custom properties
• this should fix a problem VMware teams were having from trying to pull our CSS in to their LESS builds
• this should be considered a stopgap for now as much of this SASS/CSS will be replaced by core in the long term

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [x] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4441 

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
