### PR TITLE
fix: add missing ng-content for row cells

### DIFF
--- a/src/clr-angular/data/datagrid/datagrid-row.html
+++ b/src/clr-angular/data/datagrid/datagrid-row.html
@@ -91,6 +91,7 @@
     <div class="datagrid-row-scrollable" [ngClass]="{'is-replaced': replaced && expanded}">
       <div class="datagrid-scrolling-cells">
         <ng-container #scrollableCells></ng-container>
+        <ng-content select="clr-dg-cell"></ng-content>
       </div>
       <!-- details here when replace, re-visit when sticky container is used for pinned cells -->
       <ng-template *ngIf="replaced && !expand.loading"

--- a/src/clr-angular/data/datagrid/datagrid-row.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-row.spec.ts
@@ -456,6 +456,19 @@ export default function(): void {
         })
       );
 
+      it(
+        'retains its own cells when row detail gets toggled',
+        fakeAsync(function() {
+          expect(context.clarityElement.querySelectorAll('clr-dg-cell').length).toBe(1);
+          context.testComponent.removeRowDetail = true;
+          context.detectChanges();
+          expect(context.clarityElement.querySelectorAll('clr-dg-cell').length).toBe(1);
+          context.testComponent.removeRowDetail = false;
+          context.detectChanges();
+          expect(context.clarityElement.querySelectorAll('clr-dg-cell').length).toBe(1);
+        })
+      );
+
       function flushAnimations() {
         context.detectChanges();
         tick();
@@ -492,13 +505,16 @@ class FullTest {
   template: `
         <clr-dg-row [(clrDgExpanded)]="expanded" [clrDgDetailOpenLabel]="clrDgDetailOpenLabel" [clrDgDetailCloseLabel]="clrDgDetailCloseLabel">
             <clr-dg-cell>Hello world</clr-dg-cell>
-            <clr-dg-row-detail *clrIfExpanded>
+            <ng-container ngProjectAs="clr-dg-row-detail" *ngIf="!removeRowDetail">
+              <clr-dg-row-detail *clrIfExpanded>
                 Detail
             </clr-dg-row-detail>
+            </ng-container>
         </clr-dg-row>`,
 })
 class ExpandTest {
   expanded = false;
   clrDgDetailOpenLabel: string = 'Open Me';
   clrDgDetailCloseLabel: string = 'Close Me';
+  removeRowDetail = false;
 }

--- a/src/clr-angular/data/datagrid/datagrid-row.ts
+++ b/src/clr-angular/data/datagrid/datagrid-row.ts
@@ -199,7 +199,9 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
   ngAfterContentInit() {
     this.dgCells.changes.subscribe(() => {
       this.dgCells.forEach(cell => {
-        this._scrollableCells.insert(cell._view);
+        if (!cell._view.destroyed) {
+          this._scrollableCells.insert(cell._view);
+        }
       });
     });
   }


### PR DESCRIPTION
Signed-off-by: stsogoo <stsogoo@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

Depending on `clr-dg-row-detail`'s presence, we project row cells in different view containers. When `clr-dg-row-detail` gets toggled, Datagrid row tries to transfer cells between those two view containers. But because we don't have `ng-content`, we lose the cells. This PR adds that necessary `ng-content` in the datagrid row so that it could still retain its cells.

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4466 

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
