### PR TITLE
fix: don't update view after opening and immediately closing a popover

### DIFF
--- a/packages/angular/projects/clr-angular/src/utils/popover/popover-content.spec.ts
+++ b/packages/angular/projects/clr-angular/src/utils/popover/popover-content.spec.ts
@@ -167,6 +167,15 @@ export default function (): void {
         expect(testElement.style.top).toMatch(/\d+px/);
         expect(testElement.style.left).toMatch(/\d+px/);
       });
+
+      it('does not fail when the popup view is immediately destroyed', fakeAsync(function (this: Context) {
+        this.testComponent.openState = true;
+        this.fixture.detectChanges();
+        this.testComponent.openState = false;
+        this.fixture.detectChanges();
+
+        expect(tick).not.toThrowAnyError();
+      }));
     });
   });
 }

--- a/packages/angular/projects/clr-angular/src/utils/popover/popover-content.ts
+++ b/packages/angular/projects/clr-angular/src/utils/popover/popover-content.ts
@@ -75,14 +75,18 @@ export class ClrPopoverContent implements AfterContentChecked, OnDestroy {
         this.shouldRealign = true;
         // Avoid flickering on initialization, caused by the asynchronous nature of the
         // check-collector pattern.
-        this.renderer.setStyle(this.view.rootNodes[0], 'opacity', '0');
+        if (this.view) {
+          this.renderer.setStyle(this.view.rootNodes[0], 'opacity', '0');
+        }
       }),
       // Here we collect subsequent synchronously received content-check events and only take action
       // at the end of the cycle. See below for details on the check-collector pattern.
       this.checkCollector.pipe(debounceTime(0)).subscribe(() => {
         this.alignContent();
         this.shouldRealign = false;
-        this.renderer.setStyle(this.view.rootNodes[0], 'opacity', '1');
+        if (this.view) {
+          this.renderer.setStyle(this.view.rootNodes[0], 'opacity', '1');
+        }
       })
     );
   }


### PR DESCRIPTION
Close: #4430

Signed-off-by: Bram Meerten <bram.mee@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?
When opening and closing a popover synchronously, the following error is thrown:
```TypeError: Cannot read property 'rootNodes' of undefined```

Issue Number: #4430

## What is the new behavior?
When handling the content-check events in the ClrPopoverContent, make sure view is still defined before updating the renderer style.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
