### PR TITLE
fix(schematics): ng add was not resolving Angular version 

### DIFF
--- a/src/schematics/src/add/index.ts
+++ b/src/schematics/src/add/index.ts
@@ -74,15 +74,15 @@ function updateJsonFile(path: string, callback: (a: any) => any) {
 // Checks if a version of Angular is compatible with current or next
 function getVersion(ngVersion: string, clrVersion: string) {
   const diff = 6; // Number disparity between Angular and Clarity, this works as long as we stay in sync with versioning
-  const version1 = Number.parseInt(ngVersion.split('.')[0]);
-  const version2 = Number.parseInt(clrVersion.split('.')[0]);
+  const version1 = Number.parseInt(ngVersion.split('.')[0].replace(/\D/g, ''));
+  const version2 = Number.parseInt(clrVersion.split('.')[0].replace(/\D/g, ''));
 
   if (version1 - version2 > diff) {
     // If Angular is more than 6 versions ahead, use `next` tag
     return 'next';
   } else {
     // Else, calculate correct Clarity version by subtracting 6 from Angular major
-    return (version1 - diff).toString();
+    return `^${version1 - diff}.0.0`;
   }
 }
 
@@ -151,9 +151,6 @@ export default function(options: ComponentOptions): Rule {
       }
       if (!packages.includes('@clr/icons')) {
         json.dependencies['@clr/icons'] = `${version}`;
-      }
-      if (!packages.includes('@clr/core')) {
-        json.dependencies['@clr/core'] = `${version}`;
       }
       if (!packages.includes('@webcomponents/webcomponentsjs')) {
         json.dependencies['@webcomponents/webcomponentsjs'] = '^2.0.0';


### PR DESCRIPTION
If you used symbols like ^ or ~ in your Angular version, it was throwing `NaN` errors when trying to parse it as an integer. This adds a replace to drop non-digits before parsing.

This also removes installing Core by default.

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

fixes #4444

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
