### PR TITLE
fix(icons): changing private property on core icon element

### DIFF
--- a/src/clr-core/icon-shapes/icon.element.ts
+++ b/src/clr-core/icon-shapes/icon.element.ts
@@ -87,6 +87,8 @@ export class CdsIcon extends IconMixinClass {
     }
   }
 
+  // TODO: MAKE title A REQUIRED(warn) PROPERTY WHEN THAT IS READY
+
   /** If present, customizes the aria-label for the icon for accessibility. */
   @property({ type: String })
   title: string;
@@ -160,7 +162,7 @@ export class CdsIcon extends IconMixinClass {
 
   @query('svg') private svg: SVGElement;
 
-  private ariaLabel = `aria-${this._idPrefix}${this._uniqueId}`;
+  private idForAriaLabel = 'aria-' + this._idPrefix + this._uniqueId;
 
   firstUpdated() {
     this.updateSVGAriaLabel();
@@ -180,14 +182,14 @@ export class CdsIcon extends IconMixinClass {
   protected render() {
     return html`
       ${unsafeHTML(ClarityIcons.registry[this.shape])}
-      ${this.title ? html`<span id="${this.ariaLabel}" class="clr-sr-only">${this.title}</span>` : ''}
+      ${this.title ? html`<span id="${this.idForAriaLabel}" class="clr-sr-only">${this.title}</span>` : ''}
     `;
   }
 
   private updateSVGAriaLabel() {
     if (this.title) {
       this.svg.removeAttribute('aria-label'); // remove empty label that makes icon decorative by default
-      this.svg.setAttribute('aria-labelledby', this.ariaLabel); // use labelledby for better SR support
+      this.svg.setAttribute('aria-labelledby', this.idForAriaLabel); // use labelledby for better SR support
     } else {
       this.svg.removeAttribute('aria-labelledby');
     }


### PR DESCRIPTION
• renaming `ariaLabel` property on icon.element
• the old naming was causing a collision with some browsers b/c they were expecting it to be a property on the HTMLElement
• we need to be careful about not stomping on the DOM API when naming properties
• needs to be back ported to v3

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [x] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4473 

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
