### PR TITLE
fix: add aria-selected to selected tree node link

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -1696,7 +1696,8 @@ export declare class ClrTreeNode<T> implements OnInit, OnDestroy {
 }
 
 export declare class ClrTreeNodeLink {
-    constructor(el: ElementRef);
+    routerLinkActive: RouterLinkActive;
+    constructor(el: ElementRef, routerLinkActive: RouterLinkActive);
     activate(): void;
 }
 

--- a/src/clr-angular/data/tree-view/tree-node-link.ts
+++ b/src/clr-angular/data/tree-view/tree-node-link.ts
@@ -1,16 +1,18 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Directive, ElementRef } from '@angular/core';
+import { Directive, ElementRef, Optional } from '@angular/core';
+import { RouterLinkActive } from '@angular/router';
 
 @Directive({
   selector: '.clr-treenode-link',
+  host: { '[attr.aria-selected]': 'routerLinkActive?.isActive' },
 })
 export class ClrTreeNodeLink {
-  constructor(private el: ElementRef) {}
+  constructor(private el: ElementRef, @Optional() public routerLinkActive: RouterLinkActive) {}
 
   activate() {
     if (this.el.nativeElement && this.el.nativeElement.click) {

--- a/src/dev/src/app/tree-view/tree-node-routing/tree-node-routing-abbey-road.ts
+++ b/src/dev/src/app/tree-view/tree-node-routing/tree-node-routing-abbey-road.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -7,6 +7,7 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'clr-tree-node-routing-abbey-road-demo',
+  styles: ['h4 { margin-top: 0}'],
   template: `
         <!--Credit https://en.wikipedia.org/wiki/Abbey_Road-->
         <h4>Abbey Road (1969)</h4>

--- a/src/dev/src/app/tree-view/tree-node-routing/tree-node-routing-revolver.ts
+++ b/src/dev/src/app/tree-view/tree-node-routing/tree-node-routing-revolver.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -7,6 +7,7 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'clr-tree-node-routing-revolver-demo',
+  styles: ['h4 { margin-top: 0}'],
   template: `
         <!--Credit https://en.wikipedia.org/wiki/Revolver_(Beatles_album)-->
         <h4>Revolver (1966)</h4>

--- a/src/dev/src/app/tree-view/tree-node-routing/tree-node-routing-rubber-soul.ts
+++ b/src/dev/src/app/tree-view/tree-node-routing/tree-node-routing-rubber-soul.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -7,6 +7,7 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'clr-tree-node-routing-rubber-soul-demo',
+  styles: ['h4 { margin-top: 0}'],
   template: `
         <!--Credit https://en.wikipedia.org/wiki/Rubber_Soul-->
         <h4>Rubber Soul (1965)</h4>

--- a/src/website/src/app/documentation/demos/tree-view/tree-node-routing/tree-node-routing.html
+++ b/src/website/src/app/documentation/demos/tree-view/tree-node-routing/tree-node-routing.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -7,36 +7,27 @@
     <div class="clr-col-12 clr-col-md-4">
         <clr-tree>
             <clr-tree-node [clrExpanded]="true">
-                The Beatles
-                <clr-tree-node>
-                    <button
-                            (click)="showPane(0)"
-                            class="clr-treenode-link"
-                            [class.active]="pane === 0">Abbey Road
-                    </button>
-                </clr-tree-node>
-    
-                <clr-tree-node>
-                    <button
-                            (click)="showPane(1)"
-                            class="clr-treenode-link"
-                            [class.active]="pane === 1">Revolver
-                    </button>
-                </clr-tree-node>
-    
-                <clr-tree-node>
-                    <button
-                            (click)="showPane(2)"
-                            class="clr-treenode-link"
-                            [class.active]="pane === 2">Rubber Soul
-                    </button>
-                </clr-tree-node>
+              The Beatles
+              <clr-tree-node>
+                  <a [routerLink]="['./album1']"
+                    class="clr-treenode-link"
+                    routerLinkActive="active">Abbey Road</a>
+              </clr-tree-node>
+              <clr-tree-node>
+                  <a [routerLink]="['./album2']"
+                    class="clr-treenode-link"
+                    routerLinkActive="active">Revolver</a>
+              </clr-tree-node>
+              <clr-tree-node>
+                  <a [routerLink]="['./album3']"
+                    class="clr-treenode-link"
+                    routerLinkActive="active">Rubber Soul</a>
+              </clr-tree-node>
             </clr-tree-node>
-        </clr-tree>
+          </clr-tree>
     </div>
     <div class="clr-col-12 clr-col-md-8 example-outlet">
-        <h4 style="margin-top: 0">{{content[pane].title}}</h4>
-        <p>{{content[pane].content}}</p>
+        <router-outlet></router-outlet>
     </div>
 </div>
 

--- a/src/website/src/app/documentation/demos/tree-view/tree-view-dynamic/tree-view-dynamic.html
+++ b/src/website/src/app/documentation/demos/tree-view/tree-view-dynamic/tree-view-dynamic.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -13,7 +13,8 @@
                     <button
                             (click)="openFile(directory.name, file.name)"
                             class="clr-treenode-link"
-                            [class.active]="file.active">
+                            [class.active]="file.active"
+                            [attr.aria-selected]="file.active">
                         <clr-icon [attr.shape]="file.icon"></clr-icon>
                         {{file.name}}
                     </button>

--- a/src/website/src/app/documentation/demos/tree-view/tree-view-dynamic/tree-view-dynamic.ts
+++ b/src/website/src/app/documentation/demos/tree-view/tree-view-dynamic/tree-view-dynamic.ts
@@ -14,7 +14,8 @@ const EXAMPLE_HTML = `
           <button
                   (click)="openFile(directory.name, file.name)"
                   class="clr-treenode-link"
-                  [class.active]="file.active">
+                  [class.active]="file.active"
+                  [attr.aria-selected]="file.active">
               <clr-icon [attr.shape]="file.icon"></clr-icon>
               {{file.name}}
           </button>

--- a/src/website/src/app/documentation/demos/tree-view/tree-view.demo.module.ts
+++ b/src/website/src/app/documentation/demos/tree-view/tree-view.demo.module.ts
@@ -1,36 +1,48 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
 import { ClarityModule } from '@clr/angular';
-
+import { UtilsModule } from '../../../utils/utils.module';
+import { DocWrapperModule } from '../_doc-wrapper/doc-wrapper.module';
+import { TreeBasicDMDemo } from './basic-tree-DM/tree-basic-DM';
 import { TreeBasicDemo } from './basic-tree/tree-basic';
 import { BooleanSelectionTreeDemo } from './boolean-selection-tree/boolean-selection-tree';
-import { TreeViewDynamicDemo } from './tree-view-dynamic/tree-view-dynamic';
-import { LazyLoadingTreeDemo } from './lazy-loading-tree/lazy-loading-tree';
 import { TreeNodeLabelChangeOnExpandDemo } from './label-change-on-expand/label-change-on-expand';
-import { SelectionTreeDemo } from './selection-tree/selection-tree';
-import { TreeNodeRoutingDemo } from './tree-node-routing/tree-node-routing';
-import { SmallSelectionTreeDemo } from './small-selection-tree/small-selection-tree';
-import { TreeBasicDMDemo } from './basic-tree-DM/tree-basic-DM';
-import { RecursiveTreeDemo } from './recursive-tree/recursive-tree';
-import { LazyLoadingSelectionTreeDemo } from './lazy-loading-selection-tree/lazy-loading-selection-tree';
-import { GroceryItemsComponent } from './lazy-loading-selection-tree/grocery-items';
 import { LazyLoadingRecursiveTreeDemo } from './lazy-loading-recursive-tree/lazy-loading-recursive-tree';
-
+import { GroceryItemsComponent } from './lazy-loading-selection-tree/grocery-items';
+import { LazyLoadingSelectionTreeDemo } from './lazy-loading-selection-tree/lazy-loading-selection-tree';
+import { LazyLoadingTreeDemo } from './lazy-loading-tree/lazy-loading-tree';
+import { RecursiveTreeDemo } from './recursive-tree/recursive-tree';
+import { SelectionTreeDemo } from './selection-tree/selection-tree';
+import { SmallSelectionTreeDemo } from './small-selection-tree/small-selection-tree';
+import { TreeNodeRoutingDemo } from './tree-node-routing/tree-node-routing';
+import { TreeViewDynamicDemo } from './tree-view-dynamic/tree-view-dynamic';
 import { TreeViewDemo } from './tree-view.demo';
-import { RouterModule } from '@angular/router';
-import { DocWrapperModule } from '../_doc-wrapper/doc-wrapper.module';
-import { UtilsModule } from '../../../utils/utils.module';
+import { TreeNodeRoutingAbbeyRoadDemo } from '../../../../../../dev/src/app/tree-view/tree-node-routing/tree-node-routing-abbey-road';
+import { TreeNodeRoutingRevolverDemo } from '../../../../../../dev/src/app/tree-view/tree-node-routing/tree-node-routing-revolver';
+import { TreeNodeRoutingRubberSoulDemo } from '../../../../../../dev/src/app/tree-view/tree-node-routing/tree-node-routing-rubber-soul';
 
 @NgModule({
   imports: [
     CommonModule,
     ClarityModule,
-    RouterModule.forChild([{ path: '', component: TreeViewDemo }]),
+    RouterModule.forChild([
+      {
+        path: '',
+        component: TreeViewDemo,
+        children: [
+          { path: '', redirectTo: 'album1', pathMatch: 'full' },
+          { path: 'album1', component: TreeNodeRoutingAbbeyRoadDemo },
+          { path: 'album2', component: TreeNodeRoutingRevolverDemo },
+          { path: 'album3', component: TreeNodeRoutingRubberSoulDemo },
+        ],
+      },
+    ]),
     DocWrapperModule,
     UtilsModule,
   ],

--- a/src/website/src/app/documentation/demos/tree-view/tree-view.demo.scss
+++ b/src/website/src/app/documentation/demos/tree-view/tree-view.demo.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -25,4 +25,10 @@
   height: $clr_baselineRem_20;
   overflow-y: auto;
   overflow-x: hidden;
+}
+
+.example-outlet {
+  h4 {
+    margin-top: 0;
+  }
 }


### PR DESCRIPTION
Signed-off-by: stsogoo <stsogoo@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

The PR adds `aria-selected` attribute and sets its value depending on whether the tree node-link belongs to the currently activated page or not. There are two types of node links: one that depends on `RouterLinkActive` and the other one doesn't. If it depends on `RouterLinkActive`, tree-node-link automatically handles `aria-selected`. If it doesn't, a user needs to manually set `aria-selected` which is reflected in the document.

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/vmware/clarity/issues/3571

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
