### PR TITLE
fix: core - adding block buttons back in, tag fixes

### DIFF
--- a/src/clr-core/badge/badge.element.scss
+++ b/src/clr-core/badge/badge.element.scss
@@ -11,7 +11,7 @@
   --font-weight: #{$cds-token-typography-font-weight-regular};
   --size: #{$cds-token-space-size-7-static - $cds-token-space-size-1-static};
   --padding: calc(#{$cds-token-space-size-3} - var(--border-width));
-  --border-radius: calc((var(--size) / 2) - #{$cds-token-space-size-1});
+  --border-radius: calc(var(--size) / 2);
   display: inline-block;
   text-align: center;
 }

--- a/src/clr-core/button/base-button.element.scss
+++ b/src/clr-core/button/base-button.element.scss
@@ -222,3 +222,7 @@
   --color: #{$cds-token-color-neutral-0};
   --border-color: #{$cds-token-color-neutral-0};
 }
+
+:host([block]) .private-host {
+  width: 100%;
+}

--- a/src/clr-core/button/button.stories.mdx
+++ b/src/clr-core/button/button.stories.mdx
@@ -55,6 +55,12 @@ import '~@clr/core/button';
   <Story id="components-button-stories--sizes" />
 </Preview>
 
+## Block Buttons
+
+<Preview>
+  <Story id="components-button-stories--block" />
+</Preview>
+
 ## Loading States
 
 <Preview>

--- a/src/clr-core/button/button.stories.ts
+++ b/src/clr-core/button/button.stories.ts
@@ -257,6 +257,17 @@ export const sizes = () => {
   `;
 };
 
+export const block = () => {
+  return html`
+    <div cds-layout="vertical gap:xs align:horizontal-stretch">
+      <cds-button block>Default ('md')</cds-button>
+      <cds-button block action="outline">Default ('md')</cds-button>
+      <cds-button block size="sm">Compact ('sm')</cds-button>
+      <cds-button block action="outline" size="sm">Compact ('sm')</cds-button>
+    </div>
+  `;
+};
+
 export const loading = () => {
   return html`
     <div cds-layout="vertical gap:sm">

--- a/src/clr-core/button/icon-button.stories.mdx
+++ b/src/clr-core/button/icon-button.stories.mdx
@@ -47,6 +47,12 @@ ClarityIcons.add(downloadIcon);
   <Story id="components-icon-button-stories--sizes" />
 </Preview>
 
+## Block Icon Buttons
+
+<Preview>
+  <Story id="components-icon-button-stories--block" />
+</Preview>
+
 ## Loading
 
 <Preview>

--- a/src/clr-core/button/icon-button.stories.ts
+++ b/src/clr-core/button/icon-button.stories.ts
@@ -142,6 +142,17 @@ export const sizes = () => {
   `;
 };
 
+export const block = () => {
+  return html`
+    <div cds-layout="vertical gap:xs align:horizontal-stretch">
+      <cds-icon-button block><cds-icon shape="user"></cds-icon></cds-icon-button>
+      <cds-icon-button block action="outline"><cds-icon shape="user"></cds-icon></cds-icon-button>
+      <cds-icon-button block size="sm"><cds-icon shape="user"></cds-icon></cds-icon-button>
+      <cds-icon-button block action="outline" size="sm"><cds-icon shape="user"></cds-icon></cds-icon-button>
+    </div>
+  `;
+};
+
 export const loading = () => {
   return html`
     <div cds-layout="horizontal gap:xs align-items:bottom">

--- a/src/clr-core/tag/tag.element.scss
+++ b/src/clr-core/tag/tag.element.scss
@@ -6,7 +6,7 @@
   --background: none;
   --color: #{$cds-token-color-neutral-600};
   --padding: 0 #{$cds-token-space-size-2};
-  --size: #{$cds-token-space-size-8-static + $cds-token-space-size-2-static + $cds-token-space-size-1-static};
+  --size: #{$cds-token-space-size-8-static + $cds-token-space-size-3-static};
   --font-size: #{($cds-token-space-size-8-static + $cds-token-space-size-2-static) / 2 + $cds-token-space-size-1-static};
   --border-radius: calc(var(--size) / 2);
   --border-color: #{$cds-token-color-neutral-600};
@@ -35,13 +35,21 @@
   .tag-badge,
   .tag-content,
   .tag-close-icon {
-    height: var(--size);
+    height: calc(var(--size) - #{$cds-token-space-size-2});
     display: inline-flex;
     align-items: center;
   }
 
-  .tag-badge,
-  .tag-content {
+  .tag-badge {
+    height: calc(var(--size) - #{$cds-token-space-size-1});
+  }
+
+  ::slotted(cds-badge) {
+    transform: translateY(calc(-1 - #{$cds-token-space-size-2}));
+    --size: #{$cds-token-space-size-7};
+  }
+
+  .tag-badge {
     transform: translateY(calc(-1 * #{$cds-token-space-size-1}));
   }
 
@@ -52,13 +60,11 @@
   .tag-icon {
     overflow: hidden;
     width: calc(var(--size) - (2 * var(--border-width) + (2 * #{$cds-token-space-size-1})));
-    transform: translateY(#{$cds-token-space-size-1});
   }
 
   .tag-close-icon {
     overflow: hidden;
     width: calc(var(--size) - #{$cds-token-space-size-3});
-    transform: translateY(calc(-1.5 * #{$cds-token-space-size-1}));
   }
 
   .tag-icon + .tag-content {
@@ -95,7 +101,8 @@
 }
 
 ::slotted(cds-icon) {
-  @include equilateral(var(--size));
+  @include equilateral(calc(var(--size) - #{$cds-token-space-size-3}));
+  margin-bottom: 1px;
   fill: var(--color);
 }
 

--- a/src/clr-core/tag/tag.stories.ts
+++ b/src/clr-core/tag/tag.stories.ts
@@ -66,29 +66,35 @@ export const API = () => {
 
 export const status = () => {
   return html`
-    <cds-tag readonly status="info">Info</cds-tag>
-    <cds-tag readonly status="success">Success</cds-tag>
-    <cds-tag readonly status="warning">Warning</cds-tag>
-    <cds-tag readonly status="danger">Danger</cds-tag>
+    <div cds-layout="vertical gap:xs">
+      <cds-tag readonly status="info">Info</cds-tag>
+      <cds-tag readonly status="success">Success</cds-tag>
+      <cds-tag readonly status="warning">Warning</cds-tag>
+      <cds-tag readonly status="danger">Danger</cds-tag>
+    </div>
   `;
 };
 
 export const color = () => {
   return html`
-    <cds-tag readonly color="gray">Default</cds-tag>
-    <cds-tag readonly color="purple">Purple</cds-tag>
-    <cds-tag readonly color="blue">Blue</cds-tag>
-    <cds-tag readonly color="orange">Orange</cds-tag>
-    <cds-tag readonly color="light-blue">Light Blue</cds-tag>
+    <div cds-layout="vertical gap:xs">
+      <cds-tag readonly color="gray">Default</cds-tag>
+      <cds-tag readonly color="purple">Purple</cds-tag>
+      <cds-tag readonly color="blue">Blue</cds-tag>
+      <cds-tag readonly color="orange">Orange</cds-tag>
+      <cds-tag readonly color="light-blue">Light Blue</cds-tag>
+    </div>
   `;
 };
 
 export const badgesStatus = () => {
   return html`
-    <cds-tag readonly status="info">Info <cds-badge status="info">1</cds-badge></cds-tag>
-    <cds-tag readonly status="success">Success <cds-badge status="success">2</cds-badge></cds-tag>
-    <cds-tag readonly status="warning">Warning <cds-badge status="warning">3</cds-badge> </cds-tag>
-    <cds-tag readonly status="danger">Danger <cds-badge status="danger">12</cds-badge></cds-tag>
+    <div cds-layout="vertical gap:xs">
+      <cds-tag readonly status="info">Info <cds-badge status="info">1</cds-badge></cds-tag>
+      <cds-tag readonly status="success">Success <cds-badge status="success">2</cds-badge></cds-tag>
+      <cds-tag readonly status="warning">Warning <cds-badge status="warning">3</cds-badge> </cds-tag>
+      <cds-tag readonly status="danger">Danger <cds-badge status="danger">12</cds-badge></cds-tag>
+    </div>
   `;
 };
 
@@ -105,34 +111,36 @@ export const badgesColor = () => {
 
 export const clickable = () => {
   return html`
-    <div>
-      <cds-tag aria-label="Clickable example of a default tag" color="gray">Default</cds-tag>
-      <cds-tag aria-label="Clickable example of a purple tag" color="purple">Purple</cds-tag>
-      <cds-tag aria-label="Clickable example of a blue tag" color="blue">Blue</cds-tag>
-      <cds-tag aria-label="Clickable example of an orange tag" color="orange">Orange</cds-tag>
-      <cds-tag aria-label="Clickable example of a light blue tag" color="light-blue">Light Blue</cds-tag>
-    </div>
-    <div>
-      <cds-tag aria-label="Clickable example of a tag with the info status" status="info">Info <cds-badge status="info">1</cds-badge></cds-tag>
-      <cds-tag aria-label="Clickable example of a tag with the success status" status="success">Success <cds-badge status="success">2</cds-badge></cds-tag>
-      <cds-tag aria-label="Clickable example of a tag with the warning status" status="warning">Warning <cds-badge status="warning">3</cds-badge> </cds-tag>
-      <cds-tag aria-label="Clickable example of a tag with the danger status" status="danger">Danger <cds-badge status="danger">12</cds-badge></cds-tag>
-    </div>
-    <div>
-      <cds-tag aria-label="Clickable example of a default tag with a badge" color="gray">Default <cds-badge>A</cds-badge></cds-tag>
-      <cds-tag aria-label="Clickable example of a purple tag with a badge" color="purple">Purple <cds-badge>B</cds-badge></cds-tag>
-      <cds-tag aria-label="Clickable example of a blue tag with a badge" color="blue">Blue <cds-badge>C</cds-badge></cds-tag>
-      <cds-tag aria-label="Clickable example of an orange tag with a badge" color="orange">Orange <cds-badge>D</cds-badge></cds-tag>
-      <cds-tag aria-label="Clickable example of a light-blue tag with a badge" color="light-blue">Light Blue <cds-badge>E</cds-badge></cds-tag>
-    </div>
-    <div>
-      <cds-tag aria-label="Clickable example of a gray tag with an icon and a badge" color="gray"><cds-icon shape="user"></cds-icon>Default <cds-badge>A</cds-badge></cds-tag>
-      <cds-tag aria-label="Clickable example of a purple tag with an icon and a badge" color="purple"><cds-icon shape="user"></cds-icon>Purple</cds-tag>
-      <cds-tag aria-label="Clickable example of a blue tag with an icon and a badge" color="blue"><cds-icon shape="user"></cds-icon>Blue <cds-badge>B</cds-badge></cds-tag>
-      <cds-tag aria-label="Clickable example of an orange tag with an icon and a badge" color="orange"><cds-icon shape="user"></cds-icon>Orange</cds-tag>
-      <cds-tag aria-label="Clickable example of a light-blue tag with an icon and a badge" color="light-blue"><cds-icon shape="user"></cds-icon>Light Blue <cds-badge>C</cds-badge></cds-tag>
-      <cds-tag aria-label="Clickable example of a tag with an icon and a badge and a status of info" status="info"><cds-icon shape="info-standard"></cds-icon>Info <cds-badge status="info">12,000</cds-badge></cds-tag>
-    <cds-tag aria-label="Clickable example of a tag with an icon and a badge and a status of success" status="success"><cds-icon shape="info-standard"></cds-icon>Success <cds-badge status="success">23+</cds-badge></cds-tag>
+    <div cds-layout="vertical gap:xs">
+      <div cds-layout="horizontal gap:xs">
+        <cds-tag aria-label="Clickable example of a default tag" color="gray">Default</cds-tag>
+        <cds-tag aria-label="Clickable example of a purple tag" color="purple">Purple</cds-tag>
+        <cds-tag aria-label="Clickable example of a blue tag" color="blue">Blue</cds-tag>
+        <cds-tag aria-label="Clickable example of an orange tag" color="orange">Orange</cds-tag>
+        <cds-tag aria-label="Clickable example of a light blue tag" color="light-blue">Light Blue</cds-tag>
+      </div>
+      <div cds-layout="horizontal gap:xs">
+        <cds-tag aria-label="Clickable example of a tag with the info status" status="info">Info <cds-badge status="info">1</cds-badge></cds-tag>
+        <cds-tag aria-label="Clickable example of a tag with the success status" status="success">Success <cds-badge status="success">2</cds-badge></cds-tag>
+        <cds-tag aria-label="Clickable example of a tag with the warning status" status="warning">Warning <cds-badge status="warning">3</cds-badge> </cds-tag>
+        <cds-tag aria-label="Clickable example of a tag with the danger status" status="danger">Danger <cds-badge status="danger">12</cds-badge></cds-tag>
+      </div>
+      <div cds-layout="horizontal gap:xs">
+        <cds-tag aria-label="Clickable example of a default tag with a badge" color="gray">Default <cds-badge>A</cds-badge></cds-tag>
+        <cds-tag aria-label="Clickable example of a purple tag with a badge" color="purple">Purple <cds-badge>B</cds-badge></cds-tag>
+        <cds-tag aria-label="Clickable example of a blue tag with a badge" color="blue">Blue <cds-badge>C</cds-badge></cds-tag>
+        <cds-tag aria-label="Clickable example of an orange tag with a badge" color="orange">Orange <cds-badge>D</cds-badge></cds-tag>
+        <cds-tag aria-label="Clickable example of a light-blue tag with a badge" color="light-blue">Light Blue <cds-badge>E</cds-badge></cds-tag>
+      </div>
+      <div cds-layout="horizontal gap:xs">
+        <cds-tag aria-label="Clickable example of a gray tag with an icon and a badge" color="gray"><cds-icon shape="user"></cds-icon>Default <cds-badge>A</cds-badge></cds-tag>
+        <cds-tag aria-label="Clickable example of a purple tag with an icon and a badge" color="purple"><cds-icon shape="user"></cds-icon>Purple</cds-tag>
+        <cds-tag aria-label="Clickable example of a blue tag with an icon and a badge" color="blue"><cds-icon shape="user"></cds-icon>Blue <cds-badge>B</cds-badge></cds-tag>
+        <cds-tag aria-label="Clickable example of an orange tag with an icon and a badge" color="orange"><cds-icon shape="user"></cds-icon>Orange</cds-tag>
+        <cds-tag aria-label="Clickable example of a light-blue tag with an icon and a badge" color="light-blue"><cds-icon shape="user"></cds-icon>Light Blue <cds-badge>C</cds-badge></cds-tag>
+        <cds-tag aria-label="Clickable example of a tag with an icon and a badge and a status of info" status="info"><cds-icon shape="info-standard"></cds-icon>Info <cds-badge status="info">12,000</cds-badge></cds-tag>
+        <cds-tag aria-label="Clickable example of a tag with an icon and a badge and a status of success" status="success"><cds-icon shape="info-standard"></cds-icon>Success <cds-badge status="success">23+</cds-badge></cds-tag>
+      </div>
     </div>
   `;
 };


### PR DESCRIPTION
• block buttons were left out of the PR earlier this week
• this PR corrects that
• block button stories added for both regular and icon buttons
• working through demos, i noticed the bottom of tags were being cutoff in layouts
• this problem was because some of the content inside of tags were overflowing the component
• these edits fix that problem as well
• a number of nudges were able to be removed as a result

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
