### PR TITLE
fix: cleaning up stray sass variables

### DIFF
--- a/packages/angular/projects/clr-angular/src/button/_properties.buttons.scss
+++ b/packages/angular/projects/clr-angular/src/button/_properties.buttons.scss
@@ -159,7 +159,7 @@
       --clr-btn-inverse-checked-color: var(--clr-color-neutral-0);
 
       // For theme-able icon button color
-      --clr-btn-icon-disabled-color: var(--clr-btn-default-disabled-color, $clr-btn-default-disabled-color);
+      --clr-btn-icon-disabled-color: var(--clr-btn-default-disabled-color, #{$clr-btn-default-disabled-color});
 
       // Button groups
       --clr-btn-group-focus-outline: #{$clr-btn-group-focus-outline};

--- a/packages/angular/projects/clr-angular/src/forms/styles/_properties.forms.scss
+++ b/packages/angular/projects/clr-angular/src/forms/styles/_properties.forms.scss
@@ -44,7 +44,7 @@
       --clr-forms-select-multiple-background-color: var(--clr-forms-textarea-background-color);
       --clr-forms-select-multiple-border-color: var(--clr-color-neutral-400);
       --clr-forms-select-multiple-option-color: var(--clr-forms-text-color);
-      --clr-forms-select-multiple-error-focus-color: lighten($clr-forms-invalid-color, 30%);
+      --clr-forms-select-multiple-error-focus-color: #{lighten($clr-forms-invalid-color, 30%)};
 
       // Checkbox
       --clr-forms-checkbox-label-color: var(--clr-forms-text-color);

--- a/packages/angular/projects/clr-angular/src/layout/_properties.login.scss
+++ b/packages/angular/projects/clr-angular/src/layout/_properties.login.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -19,7 +19,7 @@
       --clr-login-subtitle-font-family: var(--clr-h3-font-family);
 
       --clr-login-background-color: var(--clr-global-app-background);
-      --clr-login-background: #{$clr-login-background};
+      --clr-login-background: url('data:image/svg+xml;charset=utf8,#{$clr-login-background}');
 
       --clr-login-error-background-color: var(--clr-color-danger-800);
       --clr-login-error-border-radius: var(--clr-global-borderradius);


### PR DESCRIPTION
• sass variable keys were being passed as values into css custom properties
• this cleans those up so the actual values make it into the generated CSS

Fixes: #4526

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] clarity.design website / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4526 

## What is the new behavior?

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This needs to be backported to v3.