### PR TITLE
fix: cleaning up stray sass variables - v3 backport

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -110,14 +110,14 @@ export declare class ClrAlert implements OnInit, OnDestroy, AfterViewInit {
     get alertClass(): string;
     set alertIconShape(value: string);
     alertTexts: QueryList<ElementRef>;
-    get alertType(): string;
     set alertType(val: string);
+    get alertType(): string;
     get ariaLive(): ClrAriaLivePoliteness;
     assertive: boolean;
     closable: boolean;
     clrCloseButtonAriaLabel: string;
-    get hidden(): boolean;
     set hidden(value: boolean);
+    get hidden(): boolean;
     isAppLevel: boolean;
     isSmall: boolean;
     off: boolean;
@@ -160,8 +160,8 @@ export declare class ClrAlertsPager implements OnInit, OnDestroy {
     set currentAlert(alert: ClrAlert);
     get currentAlert(): ClrAlert;
     currentAlertChange: EventEmitter<ClrAlert>;
-    get currentAlertIndex(): number;
     set currentAlertIndex(index: number);
+    get currentAlertIndex(): number;
     currentAlertIndexChange: EventEmitter<number>;
     multiAlertService: MultiAlertService;
     constructor(multiAlertService: MultiAlertService, commonStrings: ClrCommonStringsService);
@@ -203,10 +203,10 @@ export declare class ClrButton implements LoadingListener {
     buttonInGroupService: ButtonInGroupService;
     get classNames(): string;
     set classNames(value: string);
-    set disabled(value: any);
     get disabled(): any;
-    set id(value: string);
+    set disabled(value: any);
     get id(): string;
+    set id(value: string);
     get inMenu(): boolean;
     set inMenu(value: boolean);
     loading: boolean;
@@ -227,8 +227,8 @@ export declare class ClrButtonGroup {
     commonStrings: ClrCommonStringsService;
     inlineButtons: ClrButton[];
     menuButtons: ClrButton[];
-    set menuPosition(pos: string);
     get menuPosition(): string;
+    set menuPosition(pos: string);
     get open(): boolean;
     popoverId: string;
     popoverPosition: ClrPopoverPosition;
@@ -425,8 +425,8 @@ export declare class ClrDatagridActionBar {
 
 export declare class ClrDatagridActionOverflow implements OnDestroy {
     commonStrings: ClrCommonStringsService;
-    set open(open: boolean);
     get open(): boolean;
+    set open(open: boolean);
     openChange: EventEmitter<boolean>;
     popoverId: string;
     smartPosition: ClrPopoverPosition;
@@ -449,10 +449,10 @@ export declare class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<
     set colType(value: 'string' | 'number');
     commonStrings: ClrCommonStringsService;
     customFilter: boolean;
-    set field(field: string);
     get field(): string;
-    set filterValue(newValue: string | [number, number]);
+    set field(field: string);
     get filterValue(): string | [number, number];
+    set filterValue(newValue: string | [number, number]);
     filterValueChange: EventEmitter<any>;
     set projectedFilter(custom: any);
     showSeparator: boolean;
@@ -618,10 +618,10 @@ export declare class ClrDatagridPagination implements OnDestroy, OnInit {
     set lastPage(last: number);
     get middlePages(): number[];
     page: Page;
-    set pageSize(size: number);
     get pageSize(): number;
-    set totalItems(total: number);
+    set pageSize(size: number);
     get totalItems(): number;
+    set totalItems(total: number);
     constructor(page: Page, commonStrings: ClrCommonStringsService, detailService: DetailService);
     next(): void;
     ngOnDestroy(): void;
@@ -642,12 +642,12 @@ export declare class ClrDatagridRow<T = any> implements AfterContentInit, AfterV
     _stickyCells: ViewContainerRef;
     get _view(): any;
     checkboxId: string;
-    get clrDgDetailCloseLabel(): string;
     set clrDgDetailCloseLabel(label: string);
-    get clrDgDetailOpenLabel(): string;
+    get clrDgDetailCloseLabel(): string;
     set clrDgDetailOpenLabel(label: string);
-    get clrDgSelectable(): boolean;
+    get clrDgDetailOpenLabel(): string;
     set clrDgSelectable(value: boolean);
+    get clrDgSelectable(): boolean;
     commonStrings: ClrCommonStringsService;
     detailButton: any;
     detailService: DetailService;
@@ -665,8 +665,8 @@ export declare class ClrDatagridRow<T = any> implements AfterContentInit, AfterV
     radioId: string;
     replaced: any;
     rowActionService: RowActionService;
-    set selected(value: boolean);
     get selected(): boolean;
+    set selected(value: boolean);
     selectedChanged: EventEmitter<boolean>;
     selection: Selection<T>;
     constructor(selection: Selection<T>, rowActionService: RowActionService, globalExpandable: ExpandableRowsCount, expand: DatagridIfExpandService, detailService: DetailService, displayMode: DisplayModeService, vcr: ViewContainerRef, renderer: Renderer2, el: ElementRef, commonStrings: ClrCommonStringsService);
@@ -877,10 +877,10 @@ export declare class ClrDropdown implements OnDestroy {
 export declare class ClrDropdownItem implements AfterViewInit {
     set disabled(value: boolean | string);
     get disabled(): boolean | string;
-    get disabledDeprecated(): boolean | string;
     set disabledDeprecated(value: boolean | string);
-    get dropdownItemId(): string;
+    get disabledDeprecated(): boolean | string;
     set dropdownItemId(value: string);
+    get dropdownItemId(): string;
     setByDeprecatedDisabled: boolean;
     constructor(dropdown: ClrDropdown, el: ElementRef<HTMLElement>, _dropdownService: RootDropdownService, renderer: Renderer2, focusableItem: FocusableItem);
     ngAfterViewInit(): void;
@@ -1018,8 +1018,8 @@ export declare class ClrIfError {
 }
 
 export declare class ClrIfExpanded implements OnInit, OnDestroy {
-    set expanded(value: boolean);
     get expanded(): boolean;
+    set expanded(value: boolean);
     expandedChange: EventEmitter<boolean>;
     constructor(template: TemplateRef<any>, container: ViewContainerRef, el: ElementRef, renderer: Renderer2, expand: IfExpandService);
     ngOnDestroy(): void;
@@ -1201,10 +1201,10 @@ export declare class ClrPopoverContent implements AfterContentChecked, OnDestroy
 }
 
 export declare class ClrPopoverEventsService implements OnDestroy {
-    get anchorButtonRef(): ElementRef;
     set anchorButtonRef(ref: ElementRef);
-    get closeButtonRef(): ElementRef;
+    get anchorButtonRef(): ElementRef;
     set closeButtonRef(ref: ElementRef);
+    get closeButtonRef(): ElementRef;
     set contentRef(host: ElementRef);
     get contentRef(): ElementRef;
     ignoredEvent: any;
@@ -1243,8 +1243,8 @@ export declare class ClrPopoverPositionService {
 }
 
 export declare class ClrPopoverToggleService {
-    get open(): boolean;
     set open(value: boolean);
+    get open(): boolean;
     get openChange(): Observable<boolean>;
     set openEvent(event: Event);
     get openEvent(): Event;
@@ -1278,8 +1278,8 @@ export declare class ClrProgressBar {
     off: boolean;
     get progressClass(): boolean;
     get successClass(): boolean;
-    set value(value: number);
     get value(): number;
+    set value(value: number);
     constructor(ariaLiveService: ClrAriaLiveService);
     displayAriaLive(): boolean;
 }
@@ -1366,8 +1366,8 @@ export declare class ClrSignpost {
 
 export declare class ClrSignpostContent extends AbstractPopover implements OnDestroy {
     commonStrings: ClrCommonStringsService;
-    set position(position: string);
     get position(): string;
+    set position(position: string);
     signpostContentId: string;
     constructor(injector: Injector, parentHost: ElementRef, commonStrings: ClrCommonStringsService, signpostContentId: string, signpostIdService: SignpostIdService, signpostFocusManager: SignpostFocusManager, platformId: Object, document: any);
     close(): void;
@@ -1500,8 +1500,8 @@ export declare class ClrStepperPanel extends ClrAccordionPanel implements OnInit
     commonStrings: ClrCommonStringsService;
     get formGroup(): import("@angular/forms").FormGroup;
     headerButton: ElementRef;
-    set id(_value: string);
     get id(): string;
+    set id(_value: string);
     isAccordion: boolean;
     constructor(platformId: Object, commonStrings: ClrCommonStringsService, formGroupName: FormGroupName, ngModelGroup: NgModelGroup, stepperService: StepperService, ifExpandService: IfExpandService, id: string);
     ngOnDestroy(): void;
@@ -1523,8 +1523,8 @@ export declare class ClrTabContent implements OnDestroy {
     get ariaLabelledBy(): string;
     id: number;
     ifActiveService: IfActiveService;
-    set tabContentId(id: string);
     get tabContentId(): string;
+    set tabContentId(id: string);
     constructor(ifActiveService: IfActiveService, id: number, ariaService: AriaService, tabsService: TabsService);
     ngOnDestroy(): void;
 }
@@ -1558,8 +1558,8 @@ export declare class ClrTabs implements AfterContentInit, OnDestroy {
     get isCurrentInOverflow(): boolean;
     get isVertical(): boolean;
     keyFocus: ClrKeyFocus;
-    get layout(): TabsLayout;
     set layout(layout: TabsLayout);
+    get layout(): TabsLayout;
     get tabIds(): string;
     get tabLinkDirectives(): ClrTabLink[];
     tabLinkElements: HTMLElement[];
@@ -1639,12 +1639,12 @@ export declare class ClrTooltip {
 }
 
 export declare class ClrTooltipContent extends AbstractPopover {
-    set id(value: string);
     get id(): string;
+    set id(value: string);
     get position(): string;
     set position(position: string);
-    set size(size: string);
     get size(): string;
+    set size(size: string);
     uniqueId: string;
     constructor(injector: Injector, parentHost: ElementRef, uniqueId: string, tooltipIdService: TooltipIdService);
 }
@@ -1679,13 +1679,13 @@ export declare class ClrTreeNode<T> implements OnInit, OnDestroy {
     contentContainerTabindex: number;
     expandService: IfExpandService;
     expandable: boolean | undefined;
-    set expanded(value: boolean);
     get expanded(): boolean;
+    set expanded(value: boolean);
     expandedChange: EventEmitter<boolean>;
     featuresService: TreeFeaturesService<T>;
     nodeId: string;
-    set selected(value: ClrSelectedState | boolean);
     get selected(): ClrSelectedState | boolean;
+    set selected(value: ClrSelectedState | boolean);
     selectedChange: EventEmitter<ClrSelectedState>;
     get treeNodeLink(): ClrTreeNodeLink;
     constructor(nodeId: string, platformId: Object, parent: ClrTreeNode<T>, featuresService: TreeFeaturesService<T>, expandService: IfExpandService, commonStrings: ClrCommonStringsService, focusManager: TreeFocusManagerService<T>, injector: Injector);
@@ -1721,8 +1721,8 @@ export declare class ClrVerticalNav implements OnDestroy {
 
 export declare class ClrVerticalNavGroup implements AfterContentInit, OnDestroy {
     commonStrings: ClrCommonStringsService;
-    set expandAnimationState(value: string);
     get expandAnimationState(): string;
+    set expandAnimationState(value: string);
     get expanded(): boolean;
     set expanded(value: boolean);
     expandedChange: EventEmitter<boolean>;
@@ -1762,8 +1762,8 @@ export declare class ClrWizard implements OnDestroy, AfterContentInit, DoCheck {
     get currentPage(): ClrWizardPage;
     set currentPage(page: ClrWizardPage);
     currentPageChanged: EventEmitter<any>;
-    get disableStepnav(): boolean;
     set disableStepnav(value: boolean);
+    get disableStepnav(): boolean;
     set forceForward(value: boolean);
     get forceForward(): boolean;
     headerActionService: HeaderActionService;
@@ -1779,13 +1779,13 @@ export declare class ClrWizard implements OnDestroy, AfterContentInit, DoCheck {
     pageCollection: PageCollectionService;
     pages: QueryList<ClrWizardPage>;
     size: string;
-    get stopCancel(): boolean;
     set stopCancel(value: boolean);
+    get stopCancel(): boolean;
     get stopModalAnimations(): string;
-    get stopNavigation(): boolean;
     set stopNavigation(value: boolean);
-    get stopNext(): boolean;
+    get stopNavigation(): boolean;
     set stopNext(value: boolean);
+    get stopNext(): boolean;
     wizardFinished: EventEmitter<any>;
     wizardTitle: ElementRef;
     constructor(platformId: Object, navService: WizardNavigationService, pageCollection: PageCollectionService, buttonService: ButtonHubService, headerActionService: HeaderActionService, elementRef: ElementRef, differs: IterableDiffers);
@@ -1857,15 +1857,15 @@ export declare class ClrWizardPage implements OnInit {
     get enabled(): boolean;
     finishButtonClicked: EventEmitter<ClrWizardPage>;
     get hasButtons(): boolean;
-    set hasError(val: boolean);
     get hasError(): boolean;
+    set hasError(val: boolean);
     get hasHeaderActions(): boolean;
     get headerActions(): TemplateRef<any>;
     get id(): string;
     get navTitle(): TemplateRef<any>;
     nextButtonClicked: EventEmitter<ClrWizardPage>;
-    set nextStepDisabled(val: boolean);
     get nextStepDisabled(): boolean;
+    set nextStepDisabled(val: boolean);
     nextStepDisabledChange: EventEmitter<boolean>;
     onCommit: EventEmitter<string>;
     onLoad: EventEmitter<string>;
@@ -1876,8 +1876,8 @@ export declare class ClrWizardPage implements OnInit {
     preventDefault: boolean;
     previousButtonClicked: EventEmitter<ClrWizardPage>;
     get previousCompleted(): boolean;
-    set previousStepDisabled(val: boolean);
     get previousStepDisabled(): boolean;
+    set previousStepDisabled(val: boolean);
     previousStepDisabledChange: EventEmitter<boolean>;
     primaryButtonClicked: EventEmitter<string>;
     get readyToComplete(): boolean;
@@ -1885,8 +1885,8 @@ export declare class ClrWizardPage implements OnInit {
     get stopCancel(): boolean;
     set stopCancel(val: boolean);
     stopCancelChange: EventEmitter<boolean>;
-    set stopNext(val: boolean);
     get stopNext(): boolean;
+    set stopNext(val: boolean);
     get title(): TemplateRef<any>;
     constructor(navService: WizardNavigationService, pageCollection: PageCollectionService, buttonService: ButtonHubService);
     makeCurrent(): void;
@@ -1960,11 +1960,11 @@ export declare class DatagridNumericFilter<T = any> extends DatagridFilterRegist
     set customNumericFilter(value: ClrDatagridNumericFilterInterface<T> | RegisteredFilter<T, DatagridNumericFilterImpl<T>>);
     filterContainer: ClrDatagridFilter<T>;
     filterValueChange: EventEmitter<any>;
-    set high(high: number | string);
     get high(): number | string;
+    set high(high: number | string);
     input: ElementRef;
-    set low(low: number | string);
     get low(): number | string;
+    set low(low: number | string);
     open: boolean;
     get value(): [number, number];
     set value(values: [number, number]);
@@ -1999,8 +1999,8 @@ export declare class DatagridStringFilter<T = any> extends DatagridFilterRegistr
     filterValueChange: EventEmitter<any>;
     input: ElementRef;
     open: boolean;
-    set value(value: string);
     get value(): string;
+    set value(value: string);
     constructor(filters: FiltersProvider<T>, domAdapter: DomAdapter, smartToggleService: ClrPopoverToggleService);
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
@@ -2054,8 +2054,8 @@ export declare class WrappedFormControl<W extends DynamicWrapper> implements OnI
     _id: string;
     protected controlIdService: ControlIdService;
     protected el: ElementRef<any>;
-    set id(value: string);
     get id(): string;
+    set id(value: string);
     protected index: number;
     protected ngControlService: NgControlService;
     protected renderer: Renderer2;

--- a/src/clr-angular/button/_properties.buttons.scss
+++ b/src/clr-angular/button/_properties.buttons.scss
@@ -159,7 +159,7 @@
       --clr-btn-inverse-checked-color: var(--clr-color-neutral-0);
 
       // For theme-able icon button color
-      --clr-btn-icon-disabled-color: var(--clr-btn-default-disabled-color, $clr-btn-default-disabled-color);
+      --clr-btn-icon-disabled-color: var(--clr-btn-default-disabled-color, #{$clr-btn-default-disabled-color});
 
       // Button groups
       --clr-btn-group-focus-outline: #{$clr-btn-group-focus-outline};

--- a/src/clr-angular/forms/styles/_properties.forms.scss
+++ b/src/clr-angular/forms/styles/_properties.forms.scss
@@ -44,7 +44,7 @@
       --clr-forms-select-multiple-background-color: var(--clr-forms-textarea-background-color);
       --clr-forms-select-multiple-border-color: var(--clr-color-neutral-400);
       --clr-forms-select-multiple-option-color: var(--clr-forms-text-color);
-      --clr-forms-select-multiple-error-focus-color: lighten($clr-forms-invalid-color, 30%);
+      --clr-forms-select-multiple-error-focus-color: lighten(#{$clr-forms-invalid-color}, 30%);
 
       // Checkbox
       --clr-forms-checkbox-label-color: var(--clr-forms-text-color);

--- a/src/clr-angular/layout/_properties.login.scss
+++ b/src/clr-angular/layout/_properties.login.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -19,7 +19,7 @@
       --clr-login-subtitle-font-family: var(--clr-h3-font-family);
 
       --clr-login-background-color: var(--clr-global-app-background);
-      --clr-login-background: #{$clr-login-background};
+      --clr-login-background: url('data:image/svg+xml;charset=utf8,#{$clr-login-background}');
 
       --clr-login-error-background-color: var(--clr-color-danger-800);
       --clr-login-error-border-radius: var(--clr-global-borderradius);


### PR DESCRIPTION
• sass variable keys were being passed as values into css custom properties
• this cleans those up so the actual values make it into the generated CSS

Fixes: #4526

Signed-off-by: Scott Mathis <smathis@vmware.com>
