### PR TITLE
fix(alert): fix alert-text width for IE11

### DIFF
--- a/packages/angular/projects/clr-angular/src/emphasis/alert/_alert.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/emphasis/alert/_alert.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -329,7 +329,7 @@
 
     .alert-item > span,
     .alert-text {
-      flex: 0 1 auto;
+      flex: 0 1 100%; // IE11 needs 100% here.
     }
 
     .alert-icon-wrapper {


### PR DESCRIPTION
This change fixes #4548. IE11 doesn't calculate the correct height of .alert-text.

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

IE11 has an issue calculating the height of long multiline content for global alerts when flex-basis is set to auto. 

Issue Number: #4548

`.alert-text` elements set a percentage for other device size screens. This PR updates the default to be 100% 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
