### PR TITLE
fix(dropdown): adds input setter coercion

### DIFF
--- a/packages/angular/golden/clr-angular.d.ts
+++ b/packages/angular/golden/clr-angular.d.ts
@@ -1046,6 +1046,7 @@ export declare class ClrIfOpen implements OnDestroy {
     constructor(toggleService: ClrPopoverToggleService, template: TemplateRef<any>, container: ViewContainerRef);
     ngOnDestroy(): void;
     updateView(value: boolean): void;
+    static ngAcceptInputType_open: boolean | '';
 }
 
 export declare class ClrInput extends WrappedFormControl<ClrInputContainer> {

--- a/packages/angular/projects/clr-angular/src/utils/conditional/if-open.directive.ts
+++ b/packages/angular/projects/clr-angular/src/utils/conditional/if-open.directive.ts
@@ -21,6 +21,8 @@ import { ClrPopoverToggleService } from '../popover/providers/popover-toggle.ser
  *
  */
 export class ClrIfOpen implements OnDestroy {
+  public static ngAcceptInputType_open: boolean | '';
+
   private subscription: Subscription;
 
   /*********


### PR DESCRIPTION
Adds input setter coercion for the IfOpen directive to enable a usage without a value (`<clr-dropdown-menu *clrIfOpen>`) in projects with strict template checks.
https://angular.io/guide/template-typecheck#input-setter-coercion

Signed-off-by: Tobias Wittwer <t.wittwer95@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

If the IfOpen directive is used like proposed in the docs without a value:  
`<clr-dropdown-menu *clrIfOpen>`  
A type error is thrown in case the consuming project enables [strict template checks](https://angular.io/guide/template-typecheck#strict-mode).  
The reason is the implicit conversion of this construct in:
```
<ng-template [clrIfOpen]="''">
  <clr-dropdown-menu>...</clr-dropdown-menu>
</ng-template>
```

## What is the new behavior?

The input accepts `boolean|''` which is already handled by the existing code, but is not reflected in the typing.
Angular's advice is to use [input setter coercion](https://angular.io/guide/template-typecheck#advice-for-library-authors).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
