### PR TITLE
fix: numberic filters type was not applyed on dg-column

### DIFF
--- a/src/clr-angular/data/datagrid/datagrid-column.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -386,6 +386,12 @@ export default function(): void {
         expect(this.context.clarityElement.querySelector('clr-dg-string-filter')).not.toBeNull();
       });
 
+      it('should set number filter when clrDgColType is number', function() {
+        this.context = this.create(ClrDatagridColumn, SimpleNumberFilterTest, DATAGRID_SPEC_PROVIDERS);
+        this.context.detectChanges();
+        expect(this.context.clarityElement.querySelector('clr-dg-numeric-filter')).not.toBeNull();
+      });
+
       it('projects custom filters outside of the title', function() {
         this.context = this.create(ClrDatagridColumn, FilterTest, DATAGRID_SPEC_PROVIDERS);
         expect(this.context.clarityElement.querySelector('.my-filter')).not.toBeNull();
@@ -456,6 +462,17 @@ class SimpleDeprecatedTest {
   field: string;
   sorted = false;
 }
+
+@Component({
+  template: `
+        <clr-dg-column
+                clrDgField="field"
+                clrDgColType="number">
+            1
+        </clr-dg-column>
+    `,
+})
+class SimpleNumberFilterTest {}
 
 @Component({
   template: `

--- a/src/clr-angular/data/datagrid/datagrid-column.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -48,7 +48,7 @@ import { ClrPopoverToggleService } from '../../utils/popover/providers/popover-t
                   *ngIf="field && !customFilter && (colType=='string')"
                   [clrDgStringFilter]="registered"
                   [(clrFilterValue)]="filterValue"></clr-dg-string-filter>
-          
+
           <clr-dg-numeric-filter
                   *ngIf="field && !customFilter && (colType=='number')"
                   [clrDgNumericFilter]="registered"
@@ -58,11 +58,11 @@ import { ClrPopoverToggleService } from '../../utils/popover/providers/popover-t
               <ng-content></ng-content>
           </ng-template>
 
-          <button 
-            class="datagrid-column-title" 
+          <button
+            class="datagrid-column-title"
             [attr.aria-label]="commonStrings.keys.sortColumn"
-            *ngIf="sortable" 
-            (click)="sort()" 
+            *ngIf="sortable"
+            (click)="sort()"
             type="button">
               <ng-container  *ngTemplateOutlet="columnTitle"></ng-container>
               <clr-icon
@@ -127,6 +127,15 @@ export class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<T, ClrDa
   }
 
   /*
+  * What type is this column?  This defaults to STRING, but can also be
+  * set to NUMBER.  Unsupported types default to STRING. Users can set it
+  * via the [clrDgColType] input by setting it to 'string' or 'number'.
+  */
+
+  // TODO: We might want to make this an enum in the future
+  @Input('clrDgColType') colType: 'string' | 'number' = 'string';
+
+  /*
      * Simple object property shortcut, activates both sorting and filtering
      * based on native comparison of the specified property on the items.
      */
@@ -178,15 +187,6 @@ export class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<T, ClrDa
       }
     }
   }
-
-  /*
-    * What type is this column?  This defaults to STRING, but can also be
-    * set to NUMBER.  Unsupported types default to STRING. Users can set it
-    * via the [clrDgColType] input by setting it to 'string' or 'number'.
-    */
-
-  // TODO: We might want to make this an enum in the future
-  @Input('clrDgColType') colType: 'string' | 'number' = 'string';
 
   /**
    * Indicates if the column is sortable


### PR DESCRIPTION
The order of the `@Input` needed to be changed, cause we are asking for a `colType` before it was assigned so it always defaulted to `string`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4567

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Close #4567
