### PR TITLE
fix(form): export Layouts enum for correct input type

### DIFF
--- a/packages/angular/golden/clr-angular.d.ts
+++ b/packages/angular/golden/clr-angular.d.ts
@@ -2050,6 +2050,12 @@ export declare const IS_TOGGLE_PROVIDER: {
 
 export declare function isToggleFactory(): BehaviorSubject<boolean>;
 
+export declare enum Layouts {
+    VERTICAL = "vertical",
+    HORIZONTAL = "horizontal",
+    COMPACT = "compact"
+}
+
 export declare abstract class LoadingListener {
     abstract loadingStateChange(state: ClrLoadingState): void;
 }

--- a/packages/angular/projects/clr-angular/src/forms/common/index.ts
+++ b/packages/angular/projects/clr-angular/src/forms/common/index.ts
@@ -10,6 +10,7 @@ export * from './form';
 export * from './helper';
 export * from './label';
 export * from './layout';
+export { Layouts } from './providers/layout.service';
 export * from './abstract-container';
 export * from './control';
 export * from './control-container';


### PR DESCRIPTION
Export the Layouts enum to enable consumers with strict template checking to pass the correct input type.

Signed-off-by: Tobias Wittwer <t.wittwer95@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently I'm not able to import the `Layouts` enum and when using plain strings like `clrLayout="vertical"` the strict template checker complains about it, because the string is not assignable to the enum.

## What is the new behavior?

In my current proposal the `Layouts` enum gets exported. So it possible to pass the real enum value as input `[clrLayout]="Layouts.VERTICAL"`.

## Alternative

An alternative would be to use the [input setter coercion](https://angular.io/guide/template-typecheck#input-setter-coercion). Therefore, I would add a static property to the `ClrLayout` directive:  
`public static ngAcceptInputType_layout: Layouts | 'vertical' | 'horizontal' | 'compact';`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
