### PR TITLE
fix(date-picker): adds input setter coercion

### DIFF
--- a/packages/angular/golden/clr-angular.d.ts
+++ b/packages/angular/golden/clr-angular.d.ts
@@ -799,6 +799,7 @@ export declare class ClrDateInput extends WrappedFormControl<ClrDateContainer> i
     onValueChange(target: HTMLInputElement): void;
     setFocusStates(): void;
     triggerValidation(): void;
+    static ngAcceptInputType_date: Date | null;
 }
 
 export declare class ClrDatepickerModule {

--- a/packages/angular/projects/clr-angular/src/forms/datepicker/date-input.ts
+++ b/packages/angular/projects/clr-angular/src/forms/datepicker/date-input.ts
@@ -54,6 +54,8 @@ import { isBooleanAttributeSet } from '../../utils/component/is-boolean-attribut
   providers: [DatepickerFocusService],
 })
 export class ClrDateInput extends WrappedFormControl<ClrDateContainer> implements OnInit, AfterViewInit, OnDestroy {
+  public static ngAcceptInputType_date: Date | null;
+
   @Input() placeholder: string;
   @Output('clrDateChange') dateChange: EventEmitter<Date> = new EventEmitter<Date>(false);
   @Input('clrDate')


### PR DESCRIPTION
Adds input setter coercion for the date input to enable a nullable input according  to the nullable output in projects with strict template checks.
https://angular.io/guide/template-typecheck#input-setter-coercion

Signed-off-by: Tobias Wittwer <t.wittwer95@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

It is not possible to pass `null` as empty value to the date picker input in strict template mode.

## What is the new behavior?

Date picker accepts `Date | null` as input.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

A better option would be add `null` in the input setter as well in the output.
```diff
- @Output('clrDateChange') dateChange: EventEmitter<Date> = new EventEmitter<Date>(false);
+ @Output('clrDateChange') dateChange: EventEmitter<Date | null> = new EventEmitter<Date | null>(false);
```
```diff
- set date(date: Date) {
+ set date(date: Date | null) {
```
If this is acceptable I would update the PR accordingly. 