### PR TITLE
fix: adds input setter coercion for ClrLoading

### DIFF
--- a/packages/angular/golden/clr-angular.d.ts
+++ b/packages/angular/golden/clr-angular.d.ts
@@ -1083,6 +1083,7 @@ export declare class ClrLoading implements OnDestroy {
     set loadingState(value: boolean | ClrLoadingState);
     constructor(listener: LoadingListener);
     ngOnDestroy(): void;
+    static ngAcceptInputType_loadingState: boolean | ClrLoadingState | null;
 }
 
 export declare class ClrLoadingButton implements LoadingListener {

--- a/packages/angular/projects/clr-angular/src/utils/loading/loading.ts
+++ b/packages/angular/projects/clr-angular/src/utils/loading/loading.ts
@@ -16,6 +16,8 @@ export enum ClrLoadingState {
 
 @Directive({ selector: '[clrLoading]' })
 export class ClrLoading implements OnDestroy {
+  public static ngAcceptInputType_loadingState: boolean | ClrLoadingState | null;
+
   // We find the first parent that handles something loading
   constructor(@Optional() private listener: LoadingListener) {}
 


### PR DESCRIPTION
Adds input setter coercion to enable a nullable input (as it is already handled by the code) for projects with strict template checks.
https://angular.io/guide/template-typecheck#input-setter-coercion

Signed-off-by: Tobias Wittwer <t.wittwer95@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

It is not possible to use an observable with async pipe as data source for `clrLoading` in strict template mode, because async pipe intially emits `null` and `clrLoading` only accepts `boolean | ClrLoadingState` but handles null as well.

## What is the new behavior?

 `clrLoading` accepts `boolean | ClrLoadingState | null` via input setter coercion.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
