### PR TITLE
feat: adding smaller values to core layout spacing

### DIFF
--- a/packages/core/docs/browser-support.stories.mdx
+++ b/packages/core/docs/browser-support.stories.mdx
@@ -9,7 +9,7 @@ Core currently works across all modern browsers.
 <img
   alt="Device and Browser Support"
   src="https://clarity.design/assets/images/get-started/device_support.png"
-  cds-layout="p-b:md container:sm container:center"
+  cds-layout="p-b:lg container:md container:center"
 />
 
 ## IE11 Support

--- a/packages/core/docs/getting-started.stories.mdx
+++ b/packages/core/docs/getting-started.stories.mdx
@@ -70,7 +70,7 @@ Core works in most JavaScript frameworks. For detailed install steps for your
 framework, see our guides below. More framework guides and
 demos will be added in the near future.
 
-<cds-mdx cds-layout="horizontal align-items:center gap:sm">
+<cds-mdx cds-layout="horizontal align-items:center gap:md">
   <cds-button action="outline">
     <a href="./?path=/docs/documentation-angular--page">Angular</a>
   </cds-button>

--- a/packages/core/src/button/base-button.element.scss
+++ b/packages/core/src/button/base-button.element.scss
@@ -22,7 +22,7 @@
   --color: #{$cds-token-color-neutral-0};
   --font-size: #{$cds-token-space-size-6};
 
-  --padding: #{$cds-token-layout-space-sm};
+  --padding: #{$cds-token-layout-space-md};
   --height: #{$cds-token-space-size-11};
   height: var(--height); // height is set so button is not distorted when in flex container
   display: inline-block;
@@ -184,11 +184,11 @@
 }
 
 :host([size='sm']) {
-  --padding: #{$cds-token-layout-space-xs} #{$cds-token-layout-space-sm};
+  --padding: #{$cds-token-layout-space-sm} #{$cds-token-layout-space-md};
   --height: calc(#{$cds-token-space-size-9} + #{$cds-token-space-size-1});
 
   ::slotted(a) {
-    margin: calc(#{$cds-token-layout-space-xs} * -1) calc(#{$cds-token-layout-space-sm} * -1);
+    margin: calc(#{$cds-token-layout-space-sm} * -1) calc(#{$cds-token-layout-space-md} * -1);
   }
 }
 

--- a/packages/core/src/button/button.stories.ts
+++ b/packages/core/src/button/button.stories.ts
@@ -107,13 +107,13 @@ export const API = () => {
 export const form = () => {
   return html`
     <form
-      cds-layout="vertical gap:sm"
+      cds-layout="vertical gap:md"
       @submit="${(e: Event) => {
         e.preventDefault();
         action('submit')(e);
       }}"
     >
-      <div cds-layout="vertical gap:xs">
+      <div cds-layout="vertical gap:sm">
         <label for="name" cds-text="caption">Name</label>
         <input id="name" />
       </div>
@@ -124,7 +124,7 @@ export const form = () => {
 
 export const actions = () => {
   return html`
-    <div cds-layout="horizontal gap:xs">
+    <div cds-layout="horizontal gap:sm">
       <cds-button>solid</cds-button>
       <cds-button action="outline">outline</cds-button>
       <cds-button action="flat">link</cds-button>
@@ -134,7 +134,7 @@ export const actions = () => {
 
 export const status = () => {
   return html`
-    <div cds-layout="horizontal gap:xs">
+    <div cds-layout="horizontal gap:sm">
       <cds-button>primary</cds-button>
       <cds-button status="success">success</cds-button>
       <cds-button status="danger">danger</cds-button>
@@ -145,7 +145,7 @@ export const status = () => {
 
 export const statusOutline = () => {
   return html`
-    <div cds-layout="horizontal gap:xs">
+    <div cds-layout="horizontal gap:sm">
       <cds-button action="outline">primary</cds-button>
       <cds-button action="outline" status="success">success</cds-button>
       <cds-button action="outline" status="danger">danger</cds-button>
@@ -156,13 +156,13 @@ export const statusOutline = () => {
 
 export const iconWithText = () => {
   return html`
-    <div cds-layout="vertical gap:sm">
-      <div cds-layout="horizontal gap:xs">
+    <div cds-layout="vertical gap:md">
+      <div cds-layout="horizontal gap:sm">
         <cds-button><cds-icon shape="user"></cds-icon> user account</cds-button>
         <cds-button action="outline"><cds-icon shape="user"></cds-icon> user account</cds-button>
         <cds-button action="flat"><cds-icon shape="user"></cds-icon> user account</cds-button>
       </div>
-      <div cds-layout="horizontal gap:xs">
+      <div cds-layout="horizontal gap:sm">
         <cds-button size="sm"><cds-icon shape="user"></cds-icon> user account</cds-button>
         <cds-button size="sm" action="outline"><cds-icon shape="user"></cds-icon> user account</cds-button>
         <cds-button size="sm" action="flat"><cds-icon shape="user"></cds-icon> user account</cds-button>
@@ -173,8 +173,8 @@ export const iconWithText = () => {
 
 export const iconWithTextAndBadge = () => {
   return html`
-    <div cds-layout="vertical gap:sm">
-      <div cds-layout="horizontal gap:xs">
+    <div cds-layout="vertical gap:md">
+      <div cds-layout="horizontal gap:sm">
         <cds-button><cds-icon shape="user"></cds-icon> click <cds-badge color="blue">10</cds-badge></cds-button>
         <cds-button action="outline"
           ><cds-icon shape="user"></cds-icon> click <cds-badge color="blue">10</cds-badge></cds-button
@@ -183,7 +183,7 @@ export const iconWithTextAndBadge = () => {
           ><cds-icon shape="user"></cds-icon> click <cds-badge color="blue">10</cds-badge></cds-button
         >
       </div>
-      <div cds-layout="horizontal gap:xs">
+      <div cds-layout="horizontal gap:sm">
         <cds-button size="sm"
           ><cds-icon shape="user"></cds-icon> click <cds-badge color="blue">10</cds-badge></cds-button
         >
@@ -200,24 +200,24 @@ export const iconWithTextAndBadge = () => {
 
 export const textAndBadge = () => {
   return html`
-    <div cds-layout="vertical gap:sm">
-      <div cds-layout="horizontal gap:xs">
+    <div cds-layout="vertical gap:md">
+      <div cds-layout="horizontal gap:sm">
         <cds-button>Click Me <cds-badge>10</cds-badge></cds-button>
         <cds-button action="outline">Click Me <cds-badge>10</cds-badge></cds-button>
         <cds-button action="flat">Click Me <cds-badge>10</cds-badge></cds-button>
       </div>
-      <div cds-layout="horizontal gap:xs">
+      <div cds-layout="horizontal gap:sm">
         <cds-button status="danger">Click Me <cds-badge>10</cds-badge></cds-button>
         <cds-button status="danger" action="outline">Click Me <cds-badge>10</cds-badge></cds-button>
       </div>
-      <div cds-layout="horizontal gap:xs">
+      <div cds-layout="horizontal gap:sm">
         <cds-button status="success">Click Me <cds-badge>10</cds-badge></cds-button>
         <cds-button status="success" action="outline">Click Me <cds-badge>10</cds-badge></cds-button>
       </div>
-      <div cds-layout="horizontal gap:xs p-b:xs" style="background: #313131">
+      <div cds-layout="horizontal gap:sm p-b:xs" style="background: #313131">
         <cds-button status="inverse">Click Me <cds-badge>10</cds-badge></cds-button>
       </div>
-      <div cds-layout="horizontal gap:xs">
+      <div cds-layout="horizontal gap:sm">
         <cds-button size="sm">Click Me <cds-badge>10</cds-badge></cds-button>
         <cds-button size="sm" action="outline">Click Me <cds-badge>10</cds-badge></cds-button>
         <cds-button size="sm" action="flat">Click Me <cds-badge>10</cds-badge></cds-button>
@@ -228,29 +228,29 @@ export const textAndBadge = () => {
 
 export const links = () => {
   return html`
-    <div cds-layout="horizontal gap:xs">
+    <div cds-layout="horizontal gap:sm">
       <cds-button>
-        <a href="#">link</a>
+        <a href="javascript:void(0)">link</a>
       </cds-button>
 
       <cds-button>
-        <a href="#">this is a long link</a>
+        <a href="javascript:void(0)">this is a long link</a>
       </cds-button>
 
       <cds-button size="sm">
-        <a href="#">small link</a>
+        <a href="javascript:void(0)">small link</a>
       </cds-button>
       <br />
       <cds-button action="outline">
-        <a href="#">link</a>
+        <a href="javascript:void(0)">link</a>
       </cds-button>
 
       <cds-button action="outline">
-        <a href="#">this is a long link</a>
+        <a href="javascript:void(0)">this is a long link</a>
       </cds-button>
 
       <cds-button action="outline" size="sm">
-        <a href="#">small link</a>
+        <a href="javascript:void(0)">small link</a>
       </cds-button>
     </div>
   `;
@@ -258,12 +258,12 @@ export const links = () => {
 
 export const sizes = () => {
   return html`
-    <div cds-layout="vertical gap:sm">
-      <div cds-layout="horizontal align-items:left gap:xs">
+    <div cds-layout="vertical gap:md">
+      <div cds-layout="horizontal align-items:left gap:sm">
         <cds-button>Default ('md')</cds-button>
         <cds-button action="outline">Default ('md')</cds-button>
       </div>
-      <div cds-layout="horizontal align-items:left gap:xs">
+      <div cds-layout="horizontal align-items:left gap:sm">
         <cds-button size="sm">Compact ('sm')</cds-button>
         <cds-button action="outline" size="sm">Compact ('sm')</cds-button>
       </div>
@@ -273,7 +273,7 @@ export const sizes = () => {
 
 export const block = () => {
   return html`
-    <div cds-layout="vertical gap:xs align:horizontal-stretch">
+    <div cds-layout="vertical gap:sm align:horizontal-stretch">
       <cds-button block>Default ('md')</cds-button>
       <cds-button block action="outline">Default ('md')</cds-button>
       <cds-button block size="sm">Compact ('sm')</cds-button>
@@ -284,14 +284,14 @@ export const block = () => {
 
 export const loading = () => {
   return html`
-    <div cds-layout="vertical gap:sm">
-      <div cds-layout="horizontal gap:xs align-items:bottom">
+    <div cds-layout="vertical gap:md">
+      <div cds-layout="horizontal gap:sm align-items:bottom">
         <cds-button loading-state="default">default</cds-button>
         <cds-button loading-state="loading">default</cds-button>
         <cds-button loading-state="success">default</cds-button>
         <cds-button loading-state="error">default</cds-button>
       </div>
-      <div cds-layout="horizontal gap:xs align-items:bottom">
+      <div cds-layout="horizontal gap:sm align-items:bottom">
         <cds-button size="sm" loading-state="default">default</cds-button>
         <cds-button size="sm" loading-state="loading">default</cds-button>
         <cds-button size="sm" loading-state="success">default</cds-button>

--- a/packages/core/src/button/icon-button.stories.ts
+++ b/packages/core/src/button/icon-button.stories.ts
@@ -97,7 +97,7 @@ export const API = () => {
 
 export const actions = () => {
   return html`
-    <div cds-layout="horizontal gap:xs">
+    <div cds-layout="horizontal gap:sm">
       <cds-icon-button><cds-icon shape="user"></cds-icon></cds-icon-button>
       <cds-icon-button action="outline"><cds-icon shape="user"></cds-icon></cds-icon-button>
     </div>
@@ -106,7 +106,7 @@ export const actions = () => {
 
 export const status = () => {
   return html`
-    <div cds-layout="horizontal gap:xs">
+    <div cds-layout="horizontal gap:sm">
       <cds-icon-button><cds-icon shape="user"></cds-icon></cds-icon-button>
       <cds-icon-button status="success"><cds-icon shape="user"></cds-icon></cds-icon-button>
       <cds-icon-button status="danger"><cds-icon shape="user"></cds-icon></cds-icon-button>
@@ -117,7 +117,7 @@ export const status = () => {
 
 export const statusOutline = () => {
   return html`
-    <div cds-layout="horizontal gap:xs">
+    <div cds-layout="horizontal gap:sm">
       <cds-icon-button action="outline"><cds-icon shape="user"></cds-icon></cds-icon-button>
       <cds-icon-button action="outline" status="success"><cds-icon shape="user"></cds-icon></cds-icon-button>
       <cds-icon-button action="outline" status="danger"><cds-icon shape="user"></cds-icon></cds-icon-button>
@@ -128,13 +128,13 @@ export const statusOutline = () => {
 
 export const sizes = () => {
   return html`
-    <div cds-layout="vertical gap:sm">
-      <div cds-layout="horizontal align-items:left gap:xs">
+    <div cds-layout="vertical gap:md">
+      <div cds-layout="horizontal align-items:left gap:sm">
         <div cds-layout="p-r:sm align:vertical-center"><span cds-text="subsection">Default ('md')</span></div>
         <cds-icon-button><cds-icon shape="user"></cds-icon></cds-icon-button>
         <cds-icon-button action="outline"><cds-icon shape="user"></cds-icon></cds-icon-button>
       </div>
-      <div cds-layout="horizontal align-items:left gap:xs">
+      <div cds-layout="horizontal align-items:left gap:sm">
         <div cds-layout="p-r:sm align:vertical-center"><span cds-text="subsection">Compact ('sm')</span></div>
         <cds-icon-button size="sm"><cds-icon shape="user"></cds-icon></cds-icon-button>
         <cds-icon-button action="outline" size="sm"><cds-icon shape="user"></cds-icon></cds-icon-button>
@@ -145,7 +145,7 @@ export const sizes = () => {
 
 export const block = () => {
   return html`
-    <div cds-layout="vertical gap:xs align:horizontal-stretch">
+    <div cds-layout="vertical gap:sm align:horizontal-stretch">
       <cds-icon-button block><cds-icon shape="user"></cds-icon></cds-icon-button>
       <cds-icon-button block action="outline"><cds-icon shape="user"></cds-icon></cds-icon-button>
       <cds-icon-button block size="sm"><cds-icon shape="user"></cds-icon></cds-icon-button>
@@ -156,7 +156,7 @@ export const block = () => {
 
 export const loading = () => {
   return html`
-    <div cds-layout="horizontal gap:xs align-items:bottom">
+    <div cds-layout="horizontal gap:sm align-items:bottom">
       <cds-icon-button loading-state="loading"><cds-icon shape="user"></cds-icon></cds-icon-button>
       <cds-icon-button action="outline" loading-state="loading"><cds-icon shape="user"></cds-icon></cds-icon-button>
       <cds-icon-button size="sm" loading-state="loading"><cds-icon shape="user"></cds-icon></cds-icon-button>

--- a/packages/core/src/list/list.scss
+++ b/packages/core/src/list/list.scss
@@ -4,7 +4,7 @@
 
 @import './../styles/tokens/generated/index';
 
-$list-indent: $cds-token-layout-space-md;
+$list-indent: $cds-token-layout-space-lg;
 $list-default-ordered-type: decimal;
 $list-default-unordered-type: disc;
 

--- a/packages/core/src/modal/modal.element.ts
+++ b/packages/core/src/modal/modal.element.ts
@@ -65,11 +65,11 @@ export class CdsModal extends ModalMixinClass {
 
   render() {
     return html`
-      <div class="private-host" cds-layout="horizontal p:sm p@md:lg align:center">
+      <div class="private-host" cds-layout="horizontal p:md p@md:xl align:center">
         <div class="modal-dialog" role="dialog" aria-modal="true" aria-labelledby="${this.idForAriaLabel}">
           <div cds-layout="display:screen-reader-only">${CommonStringsService.keys.modalContentStart}</div>
-          <div class="modal-content" cds-layout="p:md">
-            <div cds-layout="horizontal gap:sm p-b:sm p-b@md:md">
+          <div class="modal-content" cds-layout="p:lg">
+            <div cds-layout="horizontal gap:md p-b:md p-b@md:lg">
               <div cds-layout="align-stretch" id="${this.idForAriaLabel}">
                 <slot name="modal-header"></slot>
               </div>
@@ -93,7 +93,7 @@ export class CdsModal extends ModalMixinClass {
             <div class="modal-body">
               <slot></slot>
             </div>
-            <div cds-layout="p-t:sm p-t@md:md">
+            <div cds-layout="p-t:md p-t@md:lg">
               <slot name="modal-actions" cds-layout="align-stretch"></slot>
             </div>
           </div>

--- a/packages/core/src/modal/modal.stories.mdx
+++ b/packages/core/src/modal/modal.stories.mdx
@@ -21,12 +21,12 @@ import '@clr/core/modal';
     <h3 cds-text="title">I have a nice title</h3>
   </cds-modal-header>
   <cds-modal-content>
-    <div cds-layout="vertical gap:md p-y:xs">
+    <div cds-layout="vertical gap:xl p-y:md">
       <p cds-text="body">But not much to say...</p>
     </div>
   </cds-modal-content>
   <cds-modal-actions>
-    <div cds-layout="horizontal gap:sm align:right">
+    <div cds-layout="horizontal gap:lg align:right">
       <cds-button action="outline">Cancel</cds-button>
       <cds-button>Ok</cds-button>
     </div>

--- a/packages/core/src/modal/modal.stories.ts
+++ b/packages/core/src/modal/modal.stories.ts
@@ -33,7 +33,7 @@ export const API = () => {
   const modalHeaderSlot = text('cds-modal-header', '<h3 cds-text="title">My Modal</h3>', propertiesGroup);
   const modalContentSlot = text(
     'cds-modal-content',
-    '<div cds-layout="vertical gap:md p-y:xs"><p cds-text="body">This is a modal.</p></div>',
+    '<div cds-layout="vertical gap:lg p-y:sm"><p cds-text="body">This is a modal.</p></div>',
     propertiesGroup
   );
   const modalFooterSlot = text(
@@ -100,12 +100,12 @@ export const defaultSize = () => {
         <h3 cds-text="title">My Modal</h3>
       </cds-modal-header>
       <cds-modal-content>
-        <div cds-layout="vertical gap:md p-y:xs">
+        <div cds-layout="vertical gap:lg p-y:sm">
           <p cds-text="body">Lorem Ipsum</p>
         </div>
       </cds-modal-content>
       <cds-modal-actions>
-        <div cds-layout="horizontal gap:sm align:right">
+        <div cds-layout="horizontal gap:md align:right">
           <cds-button action="outline">Cancel</cds-button>
           <cds-button>Ok</cds-button>
         </div>
@@ -127,12 +127,12 @@ export const small = () => {
         <h3 cds-text="title">My Modal</h3>
       </cds-modal-header>
       <cds-modal-content>
-        <div cds-layout="vertical gap:md p-y:xs">
+        <div cds-layout="vertical gap:lg p-y:sm">
           <p cds-text="body">Lorem Ipsum</p>
         </div>
       </cds-modal-content>
       <cds-modal-actions>
-        <div cds-layout="horizontal gap:sm align:right">
+        <div cds-layout="horizontal gap:md align:right">
           <cds-button action="outline">Cancel</cds-button>
           <cds-button>Ok</cds-button>
         </div>
@@ -154,12 +154,12 @@ export const large = () => {
         <h3 cds-text="title">My Modal</h3>
       </cds-modal-header>
       <cds-modal-content>
-        <div cds-layout="vertical gap:md p-y:xs">
+        <div cds-layout="vertical gap:lg p-y:sm">
           <p cds-text="body">Lorem Ipsum</p>
         </div>
       </cds-modal-content>
       <cds-modal-actions>
-        <div cds-layout="horizontal gap:sm align:right">
+        <div cds-layout="horizontal gap:md align:right">
           <cds-button action="outline">Cancel</cds-button>
           <cds-button>Ok</cds-button>
         </div>
@@ -181,12 +181,12 @@ export const extraLarge = () => {
         <h3 cds-text="title">My Modal</h3>
       </cds-modal-header>
       <cds-modal-content>
-        <div cds-layout="vertical gap:md p-y:xs">
+        <div cds-layout="vertical gap:lg p-y:sm">
           <p cds-text="body">Lorem Ipsum</p>
         </div>
       </cds-modal-content>
       <cds-modal-actions>
-        <div cds-layout="horizontal gap:sm align:right">
+        <div cds-layout="horizontal gap:md align:right">
           <cds-button action="outline">Cancel</cds-button>
           <cds-button>Ok</cds-button>
         </div>
@@ -216,12 +216,12 @@ export const customStyles = () => {
         <h3 cds-text="title">My Modal</h3>
       </cds-modal-header>
       <cds-modal-content>
-        <div cds-layout="vertical gap:md p-y:xs">
+        <div cds-layout="vertical gap:lg p-y:sm">
           <p cds-text="body">Lorem Ipsum</p>
         </div>
       </cds-modal-content>
       <cds-modal-actions>
-        <div cds-layout="horizontal gap:sm align:right">
+        <div cds-layout="horizontal gap:md align:right">
           <cds-button action="outline">Cancel</cds-button>
           <cds-button>Ok</cds-button>
         </div>

--- a/packages/core/src/styles/color/color.stories.mdx
+++ b/packages/core/src/styles/color/color.stories.mdx
@@ -5,7 +5,7 @@ import { html, LitElement } from 'lit-element';
 
 # Color
 
-<cds-alert status="warning" closable="false" cds-layout="m-b:md">
+<cds-alert status="warning" closable="false" cds-layout="m-b:lg">
   <cds-alert-content>
     This is an experimental API and likely will have breaking changes in the near future.
   </cds-alert-content>

--- a/packages/core/src/styles/layout/_optimize.scss
+++ b/packages/core/src/styles/layout/_optimize.scss
@@ -6,15 +6,19 @@
 // a "minified" value to reduce overall bundle size.
 
 :root {
+  --clxxs: var(--cds-token-layout-space-xxs, #{$cds-token-layout-space-xxs-static});
   --clxs: var(--cds-token-layout-space-xs, #{$cds-token-layout-space-xs-static});
   --clsm: var(--cds-token-layout-space-sm, #{$cds-token-layout-space-sm-static});
   --clmd: var(--cds-token-layout-space-md, #{$cds-token-layout-space-md-static});
   --cllg: var(--cds-token-layout-space-lg, #{$cds-token-layout-space-lg-static});
   --clxl: var(--cds-token-layout-space-xl, #{$cds-token-layout-space-xl-static});
+  --clxxl: var(--cds-token-layout-space-xxl, #{$cds-token-layout-space-xxl-static});
 }
 
+$cds-token-layout-space-xxs: var(--clxxs);
 $cds-token-layout-space-xs: var(--clxs);
 $cds-token-layout-space-sm: var(--clsm);
 $cds-token-layout-space-md: var(--clmd);
 $cds-token-layout-space-lg: var(--cllg);
 $cds-token-layout-space-xl: var(--clxl);
+$cds-token-layout-space-xxl: var(--clxxl);

--- a/packages/core/src/styles/layout/docs/grid.stories.mdx
+++ b/packages/core/src/styles/layout/docs/grid.stories.mdx
@@ -5,7 +5,7 @@ import { html, LitElement } from 'lit-element';
 
 # Grid
 
-<cds-alert status="warning" closable="false" cds-layout="m-b:md">
+<cds-alert status="warning" closable="false" cds-layout="m-b:lg">
   <cds-alert-content>
     This is an experimental API and likely will have breaking changes in the near future.
   </cds-alert-content>
@@ -15,7 +15,7 @@ The grid layout type enables columns to be defined for layout. This is useful
 for controlling the spacing of items within a container as well as responsive
 layout. Spacing, alignments and gap between items can all be configured with
 the component. The grid layout by default is a **12** column grid. Gap values
-are t-shirt size `[xs, sm, md, lg, xl]` and align with the [Layout Spacing Tokens](./?path=/docs/experimental-spacing-getting-started--page).
+are t-shirt size `[xxs, xs, sm, md, lg, xl, xxl]` and align with the [Layout Spacing Tokens](./?path=/docs/experimental-spacing-getting-started--page).
 
 ## Layout Grid
 

--- a/packages/core/src/styles/layout/docs/horizontal.stories.mdx
+++ b/packages/core/src/styles/layout/docs/horizontal.stories.mdx
@@ -4,7 +4,7 @@ import { Meta, Story, Preview, API } from '@storybook/addon-docs/blocks';
 
 # Horizontal
 
-<cds-alert status="warning" closable="false" cds-layout="m-b:md">
+<cds-alert status="warning" closable="false" cds-layout="m-b:lg">
   <cds-alert-content>
     This is an experimental API and likely will have breaking changes in the near future.
   </cds-alert-content>
@@ -12,7 +12,7 @@ import { Meta, Story, Preview, API } from '@storybook/addon-docs/blocks';
 
 The horizontal layout type enables horizontal rows of items that can wrap automatically.
 Spacing, alignments and gap between items can all be configured with the component.
-Gap values are t-shirt size `[xs, sm, md, lg, xl]` and align with the [Layout Spacing Tokens](./?path=/docs/experimental-spacing-getting-started--page).
+Gap values are t-shirt size `[xxs, xs, sm, md, lg, xl, xxl]` and align with the [Layout Spacing Tokens](./?path=/docs/experimental-spacing-getting-started--page).
 
 ## Horizontal Layout
 

--- a/packages/core/src/styles/layout/docs/layout.stories.mdx
+++ b/packages/core/src/styles/layout/docs/layout.stories.mdx
@@ -6,7 +6,7 @@ import '@clr/core/alert';
 
 # Layout
 
-<cds-alert status="warning" closable="false" cds-layout="m-b:md">
+<cds-alert status="warning" closable="false" cds-layout="m-b:lg">
   <cds-alert-content>
     This is an experimental API and likely will have breaking changes in the near future.
   </cds-alert-content>
@@ -45,7 +45,7 @@ Spacing, alignments and gap between items can all be configured with the compone
 <Story id="experimental-layout-stories--horizontal-layout" />
 
 ```html
-<div cds-layout="horizontal gap:sm">
+<div cds-layout="horizontal gap:md">
   <cds-placeholder>1</cds-placeholder>
   <cds-placeholder>2</cds-placeholder>
   <cds-placeholder>3</cds-placeholder>
@@ -62,7 +62,7 @@ stacked items can all be configured with the component.
 <Story id="experimental-layout-stories--vertical-layout" />
 
 ```html
-<div cds-layout="vertical gap:sm">
+<div cds-layout="vertical gap:md">
   <cds-placeholder>1</cds-placeholder>
   <cds-placeholder>2</cds-placeholder>
   <cds-placeholder>3</cds-placeholder>
@@ -79,7 +79,7 @@ the component. [Read More: Grid Layout](?path=/docs/experimental-layout-grid--pa
 <Story id="experimental-layout-stories--grid-layout-columns-responsive" />
 
 ```html
-<div cds-layout="grid cols@sm:6 cols@md:3 gap:sm">
+<div cds-layout="grid cols@sm:6 cols@md:3 gap:md">
   <cds-placeholder>1</cds-placeholder>
   <cds-placeholder>2</cds-placeholder>
   <cds-placeholder>3</cds-placeholder>

--- a/packages/core/src/styles/layout/docs/patterns.stories.mdx
+++ b/packages/core/src/styles/layout/docs/patterns.stories.mdx
@@ -5,7 +5,7 @@ import { html, LitElement } from 'lit-element';
 
 # Patterns
 
-<cds-alert status="warning" closable="false" cds-layout="m-b:md">
+<cds-alert status="warning" closable="false" cds-layout="m-b:lg">
   <cds-alert-content>
     This is an experimental API and likely will have breaking changes in the near future.
   </cds-alert-content>

--- a/packages/core/src/styles/layout/docs/spacing.stories.mdx
+++ b/packages/core/src/styles/layout/docs/spacing.stories.mdx
@@ -5,14 +5,14 @@ import { html, LitElement } from 'lit-element';
 
 # Spacing
 
-<cds-alert status="warning" closable="false" cds-layout="m-b:md">
+<cds-alert status="warning" closable="false" cds-layout="m-b:lg">
   <cds-alert-content>
     This is an experimental API and likely will have breaking changes in the near future.
   </cds-alert-content>
 </cds-alert>
 
 Spacing can be controlled three ways: `Gap`, `Padding` and `Margin`.
-Spacing values are t-shirt sizes `[xs, sm, md, lg, xl]` and align with
+Spacing values are t-shirt sizes `[xxs, xs, sm, md, lg, xl, xxl]` and align with
 the [Layout Spacing Tokens](./?path=/docs/experimental-spacing-getting-started--page).
 
 <br />
@@ -23,7 +23,7 @@ The Padding and Margin utilities have the following convention:
 
 ```html
 [type]-[side]@[breakpoint]:[size]
-<div cds-layout="pl@md:sm"></div>
+<div cds-layout="pl@md:md"></div>
 
 Padding Left at the medium breakpoint with size small types: p, m sides: t, r, b, l breakpoints/sizes: xs, sm, md, lg,
 xl
@@ -51,7 +51,7 @@ The Padding and Margin utilities have the following convention:
 
 ```html
 [type]-[side]@[breakpoint]:[size]
-<div cds-layout="pl@md:sm"></div>
+<div cds-layout="pl@md:md"></div>
 
 Margin Left at the medium breakpoint with size small types: p, m sides: t, r, b, l breakpoints/sizes: xs, sm, md, lg, xl
 ```

--- a/packages/core/src/styles/layout/docs/utilities.stories.mdx
+++ b/packages/core/src/styles/layout/docs/utilities.stories.mdx
@@ -8,7 +8,7 @@ import { html, LitElement } from 'lit-element';
 Outside of the horizontal, vertical, and grid layout types the `cds-layout`
 system provides additional utilities for managing visibility and centering.
 
-<cds-alert status="warning" closable="false" cds-layout="m-b:md">
+<cds-alert status="warning" closable="false" cds-layout="m-b:lg">
   <cds-alert-content>
     This is an experimental API and likely will have breaking changes in the near future.
   </cds-alert-content>

--- a/packages/core/src/styles/layout/docs/vertical.stories.mdx
+++ b/packages/core/src/styles/layout/docs/vertical.stories.mdx
@@ -4,7 +4,7 @@ import { Meta, Story, Preview, API } from '@storybook/addon-docs/blocks';
 
 # Vertical
 
-<cds-alert status="warning" closable="false" cds-layout="m-b:md">
+<cds-alert status="warning" closable="false" cds-layout="m-b:lg">
   <cds-alert-content>
     This is an experimental API and likely will have breaking changes in the near future.
   </cds-alert-content>
@@ -13,7 +13,7 @@ import { Meta, Story, Preview, API } from '@storybook/addon-docs/blocks';
 The vertical layout type enables stacks of items. This is useful for spacing
 cards, content and other block level items. Spacing, alignments and gap between
 stacked items can all be configured with the component. Gap values are t-shirt
-size `[xs, sm, md, lg, xl]` and align with the [Layout Spacing Tokens](./?path=/docs/experimental-spacing-getting-started--page).
+size `[xxs, xs, sm, md, lg, xl, xxl]` and align with the [Layout Spacing Tokens](./?path=/docs/experimental-spacing-getting-started--page).
 
 ## Vertical Layout
 

--- a/packages/core/src/styles/layout/layout.stories.ts
+++ b/packages/core/src/styles/layout/layout.stories.ts
@@ -20,7 +20,7 @@ export default {
 export const horizontalLayout = () => {
   return html`
     <cds-demo layout>
-      <div cds-layout="horizontal gap:sm">
+      <div cds-layout="horizontal gap:md">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -33,7 +33,7 @@ export const horizontalLayoutWrap = () => {
   return html`
     <!-- demonstrates gap is only applied between inline elements even when wrapped without pushing parent container -->
     <cds-demo layout style="max-width: 236px">
-      <div cds-layout="horizontal gap:sm">
+      <div cds-layout="horizontal gap:md">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -50,7 +50,7 @@ export const horizontalLayoutWrap = () => {
 export const horizontalLayoutNoWrap = () => {
   return html`
     <cds-demo layout style="max-width: 273px">
-      <div cds-layout="horizontal gap:sm no-wrap">
+      <div cds-layout="horizontal gap:md no-wrap">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -67,7 +67,7 @@ export const horizontalLayoutNoWrap = () => {
 export const horizontalLayoutAlignTop = () => {
   return html`
     <cds-demo layout tall>
-      <div cds-layout="horizontal gap:sm align:top">
+      <div cds-layout="horizontal gap:md align:top">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -79,7 +79,7 @@ export const horizontalLayoutAlignTop = () => {
 export const horizontalLayoutAlignBottom = () => {
   return html`
     <cds-demo layout tall>
-      <div cds-layout="horizontal gap:sm align:bottom">
+      <div cds-layout="horizontal gap:md align:bottom">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -91,7 +91,7 @@ export const horizontalLayoutAlignBottom = () => {
 export const horizontalLayoutAlignLeft = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="horizontal gap:sm align:left">
+      <div cds-layout="horizontal gap:md align:left">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -103,7 +103,7 @@ export const horizontalLayoutAlignLeft = () => {
 export const horizontalLayoutAlignRight = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="horizontal gap:sm align:right">
+      <div cds-layout="horizontal gap:md align:right">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -115,7 +115,7 @@ export const horizontalLayoutAlignRight = () => {
 export const horizontalLayoutAlignVerticalCenter = () => {
   return html`
     <cds-demo layout tall>
-      <div cds-layout="horizontal gap:sm align:vertical-center">
+      <div cds-layout="horizontal gap:md align:vertical-center">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -127,7 +127,7 @@ export const horizontalLayoutAlignVerticalCenter = () => {
 export const horizontalLayoutAlignHorizontalCenter = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="horizontal gap:sm align:horizontal-center">
+      <div cds-layout="horizontal gap:md align:horizontal-center">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -139,7 +139,7 @@ export const horizontalLayoutAlignHorizontalCenter = () => {
 export const horizontalLayoutAlignCenter = () => {
   return html`
     <cds-demo layout wide tall>
-      <div cds-layout="horizontal gap:sm align:center">
+      <div cds-layout="horizontal gap:md align:center">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -151,7 +151,7 @@ export const horizontalLayoutAlignCenter = () => {
 export const horizontalLayoutAlignVerticalStretch = () => {
   return html`
     <cds-demo layout wide tall>
-      <div cds-layout="horizontal gap:sm align:vertical-stretch">
+      <div cds-layout="horizontal gap:md align:vertical-stretch">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -163,7 +163,7 @@ export const horizontalLayoutAlignVerticalStretch = () => {
 export const horizontalLayoutAlignHorizontalStretch = () => {
   return html`
     <cds-demo layout wide tall>
-      <div cds-layout="horizontal gap:sm align:horizontal-stretch">
+      <div cds-layout="horizontal gap:md align:horizontal-stretch">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -175,7 +175,7 @@ export const horizontalLayoutAlignHorizontalStretch = () => {
 export const horizontalLayoutAlignStretch = () => {
   return html`
     <cds-demo layout wide tall>
-      <div cds-layout="horizontal gap:sm align:stretch">
+      <div cds-layout="horizontal gap:md align:stretch">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -187,7 +187,7 @@ export const horizontalLayoutAlignStretch = () => {
 export const horizontalLayoutItemStretch = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="horizontal gap:sm">
+      <div cds-layout="horizontal gap:md">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder cds-layout="align:stretch">2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -199,7 +199,7 @@ export const horizontalLayoutItemStretch = () => {
 export const horizontalLayoutItemShrink = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="horizontal gap:sm align:horizontal-stretch">
+      <div cds-layout="horizontal gap:md align:horizontal-stretch">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder cds-layout="align:shrink">2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -211,7 +211,7 @@ export const horizontalLayoutItemShrink = () => {
 export const horizontalLayoutItemAlignCenter = () => {
   return html`
     <cds-demo layout wide tall>
-      <div cds-layout="horizontal gap:sm align:vertical-stretch">
+      <div cds-layout="horizontal gap:md align:vertical-stretch">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder cds-layout="align:center">2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -223,7 +223,7 @@ export const horizontalLayoutItemAlignCenter = () => {
 export const horizontalLayoutItemAlignVerticalCenter = () => {
   return html`
     <cds-demo layout tall>
-      <div cds-layout="horizontal gap:sm align:vertical-stretch">
+      <div cds-layout="horizontal gap:md align:vertical-stretch">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder cds-layout="align:vertical-center">2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -235,7 +235,7 @@ export const horizontalLayoutItemAlignVerticalCenter = () => {
 export const horizontalLayoutItemAlignHorizontalCenter = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="horizontal gap:sm">
+      <div cds-layout="horizontal gap:md">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder cds-layout="align:horizontal-center">2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -247,7 +247,7 @@ export const horizontalLayoutItemAlignHorizontalCenter = () => {
 export const horizontalLayoutItemAlignTop = () => {
   return html`
     <cds-demo layout tall>
-      <div cds-layout="horizontal gap:sm align:vertical-stretch">
+      <div cds-layout="horizontal gap:md align:vertical-stretch">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder cds-layout="align:top">2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -259,7 +259,7 @@ export const horizontalLayoutItemAlignTop = () => {
 export const horizontalLayoutItemAlignBottom = () => {
   return html`
     <cds-demo layout tall>
-      <div cds-layout="horizontal gap:sm align:vertical-stretch">
+      <div cds-layout="horizontal gap:md align:vertical-stretch">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder cds-layout="align:bottom">2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -271,7 +271,7 @@ export const horizontalLayoutItemAlignBottom = () => {
 export const horizontalLayoutItemAlignRight = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="horizontal gap:sm">
+      <div cds-layout="horizontal gap:md">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder cds-layout="align:right">2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -283,7 +283,7 @@ export const horizontalLayoutItemAlignRight = () => {
 export const horizontalLayoutItemAlignLeft = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="horizontal gap:sm align:right">
+      <div cds-layout="horizontal gap:md align:right">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder cds-layout="align:left">2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -294,7 +294,15 @@ export const horizontalLayoutItemAlignLeft = () => {
 
 export const horizontalGap = () => {
   return html`
-    <div cds-layout="vertical gap:md">
+    <div cds-layout="vertical gap:lg">
+      <cds-demo layout>
+        <div cds-layout="horizontal gap:xxs">
+          <cds-placeholder>1</cds-placeholder>
+          <cds-placeholder>2</cds-placeholder>
+          <cds-placeholder>3</cds-placeholder>
+        </div>
+      </cds-demo>
+
       <cds-demo layout>
         <div cds-layout="horizontal gap:xs">
           <cds-placeholder>1</cds-placeholder>
@@ -334,6 +342,14 @@ export const horizontalGap = () => {
           <cds-placeholder>3</cds-placeholder>
         </div>
       </cds-demo>
+
+      <cds-demo layout>
+        <div cds-layout="horizontal gap:xxl">
+          <cds-placeholder>1</cds-placeholder>
+          <cds-placeholder>2</cds-placeholder>
+          <cds-placeholder>3</cds-placeholder>
+        </div>
+      </cds-demo>
     </div>
   `;
 };
@@ -341,7 +357,7 @@ export const horizontalGap = () => {
 export const horizontalGapResponsive = () => {
   return html`
     <cds-demo layout>
-      <div cds-layout="horizontal gap@sm:md">
+      <div cds-layout="horizontal gap@sm:lg">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -357,7 +373,7 @@ export const horizontalGapResponsive = () => {
 export const verticalLayout = () => {
   return html`
     <cds-demo layout>
-      <div cds-layout="vertical gap:sm">
+      <div cds-layout="vertical gap:md">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -370,7 +386,7 @@ export const verticalLayoutWrap = () => {
   return html`
     <!-- demonstrates gap is only applied between stacked elements without pushing parent container -->
     <cds-demo layout style="width: 50px">
-      <div cds-layout="vertical gap:sm">
+      <div cds-layout="vertical gap:md">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -383,7 +399,7 @@ export const verticalLayoutWrap = () => {
 export const verticalLayoutAlignTop = () => {
   return html`
     <cds-demo layout tall>
-      <div cds-layout="vertical gap:sm align:top">
+      <div cds-layout="vertical gap:md align:top">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
       </div>
@@ -394,7 +410,7 @@ export const verticalLayoutAlignTop = () => {
 export const verticalLayoutAlignBottom = () => {
   return html`
     <cds-demo layout tall>
-      <div cds-layout="vertical gap:sm align:bottom">
+      <div cds-layout="vertical gap:md align:bottom">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
       </div>
@@ -405,7 +421,7 @@ export const verticalLayoutAlignBottom = () => {
 export const verticalLayoutAlignLeft = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="vertical gap:sm align:left">
+      <div cds-layout="vertical gap:md align:left">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
       </div>
@@ -416,7 +432,7 @@ export const verticalLayoutAlignLeft = () => {
 export const verticalLayoutAlignRight = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="vertical gap:sm align:right">
+      <div cds-layout="vertical gap:md align:right">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
       </div>
@@ -427,7 +443,7 @@ export const verticalLayoutAlignRight = () => {
 export const verticalLayoutAlignVerticalCenter = () => {
   return html`
     <cds-demo layout tall>
-      <div cds-layout="vertical gap:sm align:vertical-center">
+      <div cds-layout="vertical gap:md align:vertical-center">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
       </div>
@@ -438,7 +454,7 @@ export const verticalLayoutAlignVerticalCenter = () => {
 export const verticalLayoutAlignHorizontalCenter = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="vertical gap:sm align:horizontal-center">
+      <div cds-layout="vertical gap:md align:horizontal-center">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
       </div>
@@ -449,7 +465,7 @@ export const verticalLayoutAlignHorizontalCenter = () => {
 export const verticalLayoutAlignCenter = () => {
   return html`
     <cds-demo layout wide tall>
-      <div cds-layout="vertical gap:sm align:center">
+      <div cds-layout="vertical gap:md align:center">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -461,7 +477,7 @@ export const verticalLayoutAlignCenter = () => {
 export const verticalLayoutAlignVerticalStretch = () => {
   return html`
     <cds-demo layout tall>
-      <div cds-layout="vertical gap:sm align:vertical-stretch">
+      <div cds-layout="vertical gap:md align:vertical-stretch">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
       </div>
@@ -472,7 +488,7 @@ export const verticalLayoutAlignVerticalStretch = () => {
 export const verticalLayoutAlignHorizontalStretch = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="vertical gap:sm align:horizontal-stretch">
+      <div cds-layout="vertical gap:md align:horizontal-stretch">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
       </div>
@@ -483,7 +499,7 @@ export const verticalLayoutAlignHorizontalStretch = () => {
 export const verticalLayoutAlignStretch = () => {
   return html`
     <cds-demo layout wide tall>
-      <div cds-layout="vertical gap:sm align:stretch">
+      <div cds-layout="vertical gap:md align:stretch">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
       </div>
@@ -494,7 +510,7 @@ export const verticalLayoutAlignStretch = () => {
 export const verticalLayoutItemStretch = () => {
   return html`
     <cds-demo layout tall>
-      <div cds-layout="vertical gap:sm">
+      <div cds-layout="vertical gap:md">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder cds-layout="align:stretch">2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -506,7 +522,7 @@ export const verticalLayoutItemStretch = () => {
 export const verticalLayoutItemShrink = () => {
   return html`
     <cds-demo layout tall>
-      <div cds-layout="vertical gap:sm align:vertical-stretch">
+      <div cds-layout="vertical gap:md align:vertical-stretch">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder cds-layout="align:shrink">2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -518,7 +534,7 @@ export const verticalLayoutItemShrink = () => {
 export const verticalLayoutItemAlignCenter = () => {
   return html`
     <cds-demo layout tall wide>
-      <div cds-layout="vertical gap:sm">
+      <div cds-layout="vertical gap:md">
         <cds-placeholder cds-layout="align:top">1</cds-placeholder>
         <cds-placeholder cds-layout="align:center">2</cds-placeholder>
         <cds-placeholder cds-layout="align:bottom">3</cds-placeholder>
@@ -530,7 +546,7 @@ export const verticalLayoutItemAlignCenter = () => {
 export const verticalLayoutItemAlignVerticalCenter = () => {
   return html`
     <cds-demo layout tall>
-      <div cds-layout="vertical gap:sm">
+      <div cds-layout="vertical gap:md">
         <cds-placeholder cds-layout="align:top">1</cds-placeholder>
         <cds-placeholder cds-layout="align:vertical-center">2</cds-placeholder>
         <cds-placeholder cds-layout="align:bottom">3</cds-placeholder>
@@ -542,7 +558,7 @@ export const verticalLayoutItemAlignVerticalCenter = () => {
 export const verticalLayoutItemAlignHorizontalCenter = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="vertical gap:sm">
+      <div cds-layout="vertical gap:md">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder cds-layout="align:horizontal-center">2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -554,7 +570,7 @@ export const verticalLayoutItemAlignHorizontalCenter = () => {
 export const verticalLayoutItemAlignTop = () => {
   return html`
     <cds-demo layout tall>
-      <div cds-layout="vertical gap:sm align:bottom">
+      <div cds-layout="vertical gap:md align:bottom">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder cds-layout="align:top">2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -566,7 +582,7 @@ export const verticalLayoutItemAlignTop = () => {
 export const verticalLayoutItemAlignBottom = () => {
   return html`
     <cds-demo layout tall>
-      <div cds-layout="vertical gap:sm">
+      <div cds-layout="vertical gap:md">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder cds-layout="align:bottom">2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -578,7 +594,7 @@ export const verticalLayoutItemAlignBottom = () => {
 export const verticalLayoutItemAlignRight = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="vertical gap:sm">
+      <div cds-layout="vertical gap:md">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder cds-layout="align:right">2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -590,7 +606,7 @@ export const verticalLayoutItemAlignRight = () => {
 export const verticalLayoutItemAlignLeft = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="vertical gap:sm align:right">
+      <div cds-layout="vertical gap:md align:right">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder cds-layout="align:left">2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -601,7 +617,15 @@ export const verticalLayoutItemAlignLeft = () => {
 
 export const verticalGap = () => {
   return html`
-    <div cds-layout="horizontal gap:md">
+    <div cds-layout="horizontal gap:lg">
+      <cds-demo layout>
+        <div cds-layout="vertical gap:xxs">
+          <cds-placeholder>1</cds-placeholder>
+          <cds-placeholder>2</cds-placeholder>
+          <cds-placeholder>3</cds-placeholder>
+        </div>
+      </cds-demo>
+
       <cds-demo layout>
         <div cds-layout="vertical gap:xs">
           <cds-placeholder>1</cds-placeholder>
@@ -641,6 +665,14 @@ export const verticalGap = () => {
           <cds-placeholder>3</cds-placeholder>
         </div>
       </cds-demo>
+
+      <cds-demo layout>
+        <div cds-layout="vertical gap:xxl">
+          <cds-placeholder>1</cds-placeholder>
+          <cds-placeholder>2</cds-placeholder>
+          <cds-placeholder>3</cds-placeholder>
+        </div>
+      </cds-demo>
     </div>
   `;
 };
@@ -648,7 +680,7 @@ export const verticalGap = () => {
 export const verticalGapResponsive = () => {
   return html`
     <cds-demo layout>
-      <div cds-layout="vertical gap@sm:md">
+      <div cds-layout="vertical gap@sm:lg">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -663,7 +695,7 @@ export const verticalGapResponsive = () => {
 export const gridLayout = () => {
   return html`
     <cds-demo layout tall wide>
-      <div cds-layout="grid gap:sm">
+      <div cds-layout="grid gap:md">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -705,7 +737,7 @@ export const gridLayout = () => {
 export const gridLayoutColumns = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="grid cols:6 gap:sm">
+      <div cds-layout="grid cols:6 gap:md">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
       </div>
@@ -716,7 +748,7 @@ export const gridLayoutColumns = () => {
 export const gridLayoutColumnsExplicit = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="grid gap:sm">
+      <div cds-layout="grid gap:md">
         <cds-placeholder cds-layout="col:4">1</cds-placeholder>
         <cds-placeholder cds-layout="col:8">2</cds-placeholder>
       </div>
@@ -727,7 +759,7 @@ export const gridLayoutColumnsExplicit = () => {
 export const gridLayoutColumnsAuto = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="grid cols:auto gap:sm">
+      <div cds-layout="grid cols:auto gap:md">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -739,7 +771,7 @@ export const gridLayoutColumnsAuto = () => {
 export const gridLayoutColumnsResponsive = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="grid cols@sm:6 cols@md:3 gap:sm">
+      <div cds-layout="grid cols@sm:6 cols@md:3 gap:md">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -752,7 +784,7 @@ export const gridLayoutColumnsResponsive = () => {
 export const gridLayoutColumnsResponsiveExplicit = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="grid gap:sm">
+      <div cds-layout="grid gap:md">
         <cds-placeholder cds-layout="col@sm:4">1</cds-placeholder>
         <cds-placeholder cds-layout="col@sm:8">2</cds-placeholder>
       </div>
@@ -763,7 +795,7 @@ export const gridLayoutColumnsResponsiveExplicit = () => {
 export const gridLayoutColumnsWrap = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="grid cols:6 gap:sm">
+      <div cds-layout="grid cols:6 gap:md">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -776,7 +808,7 @@ export const gridLayoutColumnsWrap = () => {
 export const gridLayoutColumnsStartEnd = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="grid gap:sm">
+      <div cds-layout="grid gap:md">
         <cds-placeholder cds-layout="col:start-3 col:8">1</cds-placeholder>
         <cds-placeholder cds-layout="col:start-1 col:end-5">2</cds-placeholder>
         <cds-placeholder cds-layout="col:4 col:end-13">3</cds-placeholder>
@@ -789,7 +821,7 @@ export const gridLayoutColumnsStartEnd = () => {
 export const gridLayoutColumnsStartEndResponsive = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="grid cols@sm:6 cols@md:4 gap:sm">
+      <div cds-layout="grid cols@sm:6 cols@md:4 gap:md">
         <cds-placeholder cds-layout="col@md:start-2">1</cds-placeholder>
         <cds-placeholder cds-layout="col@md:end-12">2</cds-placeholder>
       </div>
@@ -800,7 +832,7 @@ export const gridLayoutColumnsStartEndResponsive = () => {
 export const gridLayoutRows = () => {
   return html`
     <cds-demo layout tall wide>
-      <div cds-layout="grid cols:6 rows:8 gap:sm align:stretch">
+      <div cds-layout="grid cols:6 rows:8 gap:md align:stretch">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder cds-layout="col:12 row:4">3</cds-placeholder>
@@ -812,7 +844,7 @@ export const gridLayoutRows = () => {
 export const gridLayoutRowsResponsive = () => {
   return html`
     <cds-demo layout tall wide>
-      <div cds-layout="grid cols:6 rows:4 rows@sm:8 gap:sm align:stretch">
+      <div cds-layout="grid cols:6 rows:4 rows@sm:8 gap:md align:stretch">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder cds-layout="col:12 row:8 row@sm:4">3</cds-placeholder>
@@ -824,7 +856,7 @@ export const gridLayoutRowsResponsive = () => {
 export const gridLayoutRowsStartEnd = () => {
   return html`
     <cds-demo layout tall wide>
-      <div cds-layout="grid cols:4 gap:sm align:stretch">
+      <div cds-layout="grid cols:4 gap:md align:stretch">
         <cds-placeholder cds-layout="row:4 row:start-6">1</cds-placeholder>
         <cds-placeholder cds-layout="row:3 row:start-4">2</cds-placeholder>
         <cds-placeholder cds-layout="row:12">3</cds-placeholder>
@@ -836,7 +868,7 @@ export const gridLayoutRowsStartEnd = () => {
 export const gridLayoutRowsStartEndResponsive = () => {
   return html`
     <cds-demo layout tall wide>
-      <div cds-layout="grid cols@md:12 rows@sm:4 gap:sm align:stretch">
+      <div cds-layout="grid cols@md:12 rows@sm:4 gap:md align:stretch">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder cds-layout="row@sm:start-10">2</cds-placeholder>
       </div>
@@ -847,7 +879,7 @@ export const gridLayoutRowsStartEndResponsive = () => {
 export const gridLayoutAlignTop = () => {
   return html`
     <cds-demo layout tall wide>
-      <div cds-layout="grid gap:sm">
+      <div cds-layout="grid gap:md">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -860,7 +892,7 @@ export const gridLayoutAlignTop = () => {
 export const gridLayoutAlignBottom = () => {
   return html`
     <cds-demo layout tall wide>
-      <div cds-layout="grid gap:sm align:bottom">
+      <div cds-layout="grid gap:md align:bottom">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -873,7 +905,7 @@ export const gridLayoutAlignBottom = () => {
 export const gridLayoutAlignLeft = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="grid cols:auto gap:sm align:left">
+      <div cds-layout="grid cols:auto gap:md align:left">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -886,7 +918,7 @@ export const gridLayoutAlignLeft = () => {
 export const gridLayoutAlignRight = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="grid cols:auto gap:sm align:right">
+      <div cds-layout="grid cols:auto gap:md align:right">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -899,7 +931,7 @@ export const gridLayoutAlignRight = () => {
 export const gridLayoutAlignVerticalCenter = () => {
   return html`
     <cds-demo layout tall wide>
-      <div cds-layout="grid gap:sm align:vertical-center">
+      <div cds-layout="grid gap:md align:vertical-center">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -912,7 +944,7 @@ export const gridLayoutAlignVerticalCenter = () => {
 export const gridLayoutAlignHorizontalCenter = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="grid cols:auto gap:sm align:horizontal-center">
+      <div cds-layout="grid cols:auto gap:md align:horizontal-center">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -925,7 +957,7 @@ export const gridLayoutAlignHorizontalCenter = () => {
 export const gridLayoutAlignCenter = () => {
   return html`
     <cds-demo layout tall wide>
-      <div cds-layout="grid cols:auto gap:sm align:center">
+      <div cds-layout="grid cols:auto gap:md align:center">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -938,7 +970,7 @@ export const gridLayoutAlignCenter = () => {
 export const gridLayoutAlignVerticalStretch = () => {
   return html`
     <cds-demo layout tall wide>
-      <div cds-layout="grid gap:sm align:vertical-stretch">
+      <div cds-layout="grid gap:md align:vertical-stretch">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -951,7 +983,7 @@ export const gridLayoutAlignVerticalStretch = () => {
 export const gridLayoutAlignHorizontalStretch = () => {
   return html`
     <cds-demo layout tall wide>
-      <div cds-layout="grid cols:3 gap:sm align:horizontal-stretch">
+      <div cds-layout="grid cols:3 gap:md align:horizontal-stretch">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -964,7 +996,7 @@ export const gridLayoutAlignHorizontalStretch = () => {
 export const gridLayoutAlignStretch = () => {
   return html`
     <cds-demo layout tall wide>
-      <div cds-layout="grid cols:auto gap:sm align:stretch">
+      <div cds-layout="grid cols:auto gap:md align:stretch">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -976,7 +1008,16 @@ export const gridLayoutAlignStretch = () => {
 
 export const gridGap = () => {
   return html`
-    <div cds-layout="vertical gap:md">
+    <div cds-layout="vertical gap:lg">
+      <cds-demo layout>
+        <div cds-layout="grid gap:xxs cols:6">
+          <cds-placeholder>1</cds-placeholder>
+          <cds-placeholder>2</cds-placeholder>
+          <cds-placeholder>3</cds-placeholder>
+          <cds-placeholder>4</cds-placeholder>
+        </div>
+      </cds-demo>
+
       <cds-demo layout>
         <div cds-layout="grid gap:xs cols:6">
           <cds-placeholder>1</cds-placeholder>
@@ -1021,6 +1062,15 @@ export const gridGap = () => {
           <cds-placeholder>4</cds-placeholder>
         </div>
       </cds-demo>
+
+      <cds-demo layout>
+        <div cds-layout="grid gap:xxl cols:6">
+          <cds-placeholder>1</cds-placeholder>
+          <cds-placeholder>2</cds-placeholder>
+          <cds-placeholder>3</cds-placeholder>
+          <cds-placeholder>4</cds-placeholder>
+        </div>
+      </cds-demo>
     </div>
   `;
 };
@@ -1028,7 +1078,7 @@ export const gridGap = () => {
 export const gridGapResponsive = () => {
   return html`
     <cds-demo layout>
-      <div cds-layout="grid gap@sm:md cols:6">
+      <div cds-layout="grid gap@sm:lg cols:6">
         <cds-placeholder>1</cds-placeholder>
         <cds-placeholder>2</cds-placeholder>
         <cds-placeholder>3</cds-placeholder>
@@ -1043,25 +1093,29 @@ export const gridGapResponsive = () => {
  */
 export const spacingPadding = () => {
   return html`
-    <cds-demo spacing-padding cds-layout="vertical gap:lg">
+    <cds-demo spacing-padding cds-layout="vertical gap:xl">
       <div cds-layout="p:none"><cds-placeholder>p:none</cds-placeholder></div>
+      <div cds-layout="p:xxs"><cds-placeholder>p:xxs</cds-placeholder></div>
       <div cds-layout="p:xs"><cds-placeholder>p:xs</cds-placeholder></div>
       <div cds-layout="p:sm"><cds-placeholder>p:sm</cds-placeholder></div>
       <div cds-layout="p:md"><cds-placeholder>p:md</cds-placeholder></div>
       <div cds-layout="p:lg"><cds-placeholder>p:lg</cds-placeholder></div>
       <div cds-layout="p:xl"><cds-placeholder>p:xl</cds-placeholder></div>
+      <div cds-layout="p:xxl"><cds-placeholder>p:xxl</cds-placeholder></div>
     </cds-demo>
   `;
 };
 
 export const spacingPaddingSides = () => {
   return html`
-    <cds-demo spacing-padding cds-layout="vertical gap:lg">
+    <cds-demo spacing-padding cds-layout="vertical gap:xl">
+      <div cds-layout="p-t:xxs"><cds-placeholder>p-t:xxs</cds-placeholder></div>
       <div cds-layout="p-t:xs"><cds-placeholder>p-t:xs</cds-placeholder></div>
       <div cds-layout="p-t:sm"><cds-placeholder>p-t:sm</cds-placeholder></div>
       <div cds-layout="p-r:md"><cds-placeholder>p-r:md</cds-placeholder></div>
       <div cds-layout="p-b:lg"><cds-placeholder>p-b:lg</cds-placeholder></div>
       <div cds-layout="p-l:xl"><cds-placeholder>p-l:xl</cds-placeholder></div>
+      <div cds-layout="p-b:xxl"><cds-placeholder>p-b:xxl</cds-placeholder></div>
 
       <div cds-layout="p-x:md"><cds-placeholder>p-x:md</cds-placeholder></div>
       <div cds-layout="p-y:md"><cds-placeholder>p-y:md</cds-placeholder></div>
@@ -1072,7 +1126,7 @@ export const spacingPaddingSides = () => {
 
 export const spacingPaddingResponsive = () => {
   return html`
-    <cds-demo spacing-padding cds-layout="vertical gap:lg">
+    <cds-demo spacing-padding cds-layout="vertical gap:xl">
       <div cds-layout="p@sm:md"><cds-placeholder>p@sm:md</cds-placeholder></div>
       <div cds-layout="p-l@sm:lg"><cds-placeholder>p-l@sm:lg</cds-placeholder></div>
     </cds-demo>
@@ -1081,25 +1135,29 @@ export const spacingPaddingResponsive = () => {
 
 export const spacingMargin = () => {
   return html`
-    <cds-demo spacing-margin cds-layout="vertical gap:lg">
+    <cds-demo spacing-margin cds-layout="vertical gap:xl">
       <div><cds-placeholder cds-layout="m:none">m:none</cds-placeholder></div>
+      <div><cds-placeholder cds-layout="m:xxs">m:xxs</cds-placeholder></div>
       <div><cds-placeholder cds-layout="m:xs">m:xs</cds-placeholder></div>
       <div><cds-placeholder cds-layout="m:sm">m:sm</cds-placeholder></div>
       <div><cds-placeholder cds-layout="m:md">m:md</cds-placeholder></div>
       <div><cds-placeholder cds-layout="m:lg">m:lg</cds-placeholder></div>
       <div><cds-placeholder cds-layout="m:xl">m:xl</cds-placeholder></div>
+      <div><cds-placeholder cds-layout="m:xxl">m:xxl</cds-placeholder></div>
     </cds-demo>
   `;
 };
 
 export const spacingMarginSides = () => {
   return html`
-    <cds-demo spacing-margin cds-layout="vertical gap:lg">
+    <cds-demo spacing-margin cds-layout="vertical gap:xl">
+      <div><cds-placeholder cds-layout="m-t:xxs">m-t:xxs</cds-placeholder></div>
       <div><cds-placeholder cds-layout="m-t:xs">m-t:xs</cds-placeholder></div>
       <div><cds-placeholder cds-layout="m-t:sm">m-t:sm</cds-placeholder></div>
       <div><cds-placeholder cds-layout="m-r:md">m-r:md</cds-placeholder></div>
       <div><cds-placeholder cds-layout="m-b:lg">m-b:lg</cds-placeholder></div>
       <div><cds-placeholder cds-layout="m-l:xl">m-l:xl</cds-placeholder></div>
+      <div><cds-placeholder cds-layout="m-l:xxl">m-l:xxl</cds-placeholder></div>
 
       <div><cds-placeholder cds-layout="m-x:md">m-x:md</cds-placeholder></div>
       <div><cds-placeholder cds-layout="m-y:md">m-y:md</cds-placeholder></div>
@@ -1110,7 +1168,7 @@ export const spacingMarginSides = () => {
 
 export const spacingMarginResponsive = () => {
   return html`
-    <cds-demo spacing-margin cds-layout="vertical gap:lg">
+    <cds-demo spacing-margin cds-layout="vertical gap:xl">
       <div><cds-placeholder cds-layout="m@sm:md">m@sm:md</cds-placeholder></div>
       <div><cds-placeholder cds-layout="m-l@sm:lg">m-l@sm:lg</cds-placeholder></div>
     </cds-demo>
@@ -1120,7 +1178,7 @@ export const spacingMarginResponsive = () => {
 export const utilitiesDisplay = () => {
   return html`
     <cds-demo layout wide>
-      <div cds-layout="vertical gap:md align:stretch" cds-text="body">
+      <div cds-layout="vertical gap:lg align:stretch" cds-text="body">
         <cds-placeholder cds-layout="display:none display@sm:flex">display:none display@sm:flex</cds-placeholder>
         <cds-placeholder
           >...<span cds-layout="display:none display@md:inline">display:none display@md:inline</span
@@ -1144,7 +1202,7 @@ export const utilitiesDisplayScreenReaderOnly = () => {
 
 export const utilitiesContainers = () => {
   return html`
-    <div cds-layout="vertical gap:md">
+    <div cds-layout="vertical gap:lg">
       <cds-demo layout cds-layout="container:xs">container:xs (576px)</cds-demo>
       <cds-demo layout cds-layout="container:sm">container:sm (768px)</cds-demo>
       <cds-demo layout cds-layout="container:md">container:md (992px)</cds-demo>
@@ -1182,18 +1240,18 @@ const scrollableContentHtml = html`${scrollableContent}`;
 export const patternsApplicationVerticalLayout = () => {
   return html`
     <div class="demo-layout demo-app-layout" cds-layout="vertical align:stretch">
-      <header class="demo-header" cds-layout="p:sm p@md:md">
+      <header class="demo-header" cds-layout="p:md p@md:lg">
         header
       </header>
       <div cds-layout="horizontal align:stretch no-wrap">
-        <nav class="demo-sidenav" cds-layout="p:sm p@md:md">sidebar</nav>
+        <nav class="demo-sidenav" cds-layout="p:md p@md:lg">sidebar</nav>
         <div cds-layout="vertical align:stretch">
           <div class="demo-content demo-scrollable-content">
-            <div cds-layout="vertical gap:sm p:md">
+            <div cds-layout="vertical gap:md p:lg">
               ${scrollableContentHtml}
             </div>
           </div>
-          <footer class="demo-footer" cds-layout="p-y:sm p-x:md">footer</footer>
+          <footer class="demo-footer" cds-layout="p-y:md p-x:lg">footer</footer>
         </div>
       </div>
     </div>
@@ -1203,19 +1261,19 @@ export const patternsApplicationVerticalLayout = () => {
 export const patternsApplicationVerticalLayoutSubnav = () => {
   return html`
     <div class="demo-layout demo-app-layout" cds-layout="vertical align:stretch">
-      <header class="demo-header" cds-layout="p:sm p@md:md align:shrink">
+      <header class="demo-header" cds-layout="p:md p@md:lg align:shrink">
         header
       </header>
-      <div class="demo-subnav" cds-layout="p-y:xs p-x:sm p-x@md:md align:shrink">subnav</div>
+      <div class="demo-subnav" cds-layout="p-y:sm p-x:md p-x@md:lg align:shrink">subnav</div>
       <div cds-layout="horizontal align:stretch">
-        <nav class="demo-sidenav" cds-layout="p:sm p@md:md align:shrink">sidebar</nav>
+        <nav class="demo-sidenav" cds-layout="p:md p@md:lg align:shrink">sidebar</nav>
         <div class="demo-content demo-scrollable-content" cds-layout="align:stretch">
-          <div cds-layout="vertical gap:sm p:md">
+          <div cds-layout="vertical gap:md p:lg">
             ${scrollableContentHtml}
           </div>
         </div>
       </div>
-      <footer class="demo-footer" cds-layout="p:sm p@md:md align:shrink">footer</footer>
+      <footer class="demo-footer" cds-layout="p:md p@md:lg align:shrink">footer</footer>
     </div>
   `;
 };
@@ -1223,7 +1281,7 @@ export const patternsApplicationVerticalLayoutSubnav = () => {
 export const patternsApplicationVerticalIconLayout = () => {
   return html`
     <div class="demo-layout demo-app-layout" cds-layout="horizontal no-wrap">
-      <header class="demo-header demo-alt-header" cds-layout="p:sm vertical gap:md">
+      <header class="demo-header demo-alt-header" cds-layout="p:md vertical gap:lg">
         <cds-icon shape="applications" size="lg" inverse></cds-icon>
         <cds-icon shape="blocks-group" size="lg" inverse></cds-icon>
         <cds-icon shape="bundle" size="lg" inverse></cds-icon>
@@ -1235,13 +1293,13 @@ export const patternsApplicationVerticalIconLayout = () => {
           <p cds-text="section">sidebar</p>
         </nav>
         <div cds-layout="vertical align:stretch">
-          <div class="demo-header demo-alt-content-header" cds-layout="p:sm align:shrink">header</div>
+          <div class="demo-header demo-alt-content-header" cds-layout="p:md align:shrink">header</div>
           <div class="demo-content demo-scrollable-content demo-alt-content" cds-layout="align:stretch">
-            <div cds-layout="vertical gap:sm p:md">
+            <div cds-layout="vertical gap:md p:lg">
               ${scrollableContentHtml}
             </div>
           </div>
-          <footer class="demo-footer" cds-layout="p:sm align:shrink">footer</footer>
+          <footer class="demo-footer" cds-layout="p:md align:shrink">footer</footer>
         </div>
       </div>
     </div>
@@ -1251,7 +1309,7 @@ export const patternsApplicationVerticalIconLayout = () => {
 export const patternsApplicationVerticalIconLayoutHybrid = () => {
   return html`
     <div class="demo-layout demo-app-layout" cds-layout="horizontal no-wrap">
-      <header class="demo-header demo-alt-header-2" cds-layout="p:sm vertical gap:md">
+      <header class="demo-header demo-alt-header-2" cds-layout="p:md vertical gap:lg">
         <cds-icon shape="applications" size="lg" inverse></cds-icon>
         <cds-icon shape="blocks-group" size="lg" inverse></cds-icon>
         <cds-icon shape="bundle" size="lg" inverse></cds-icon>
@@ -1259,18 +1317,18 @@ export const patternsApplicationVerticalIconLayoutHybrid = () => {
         <cds-icon shape="cog" size="lg" inverse cds-layout="align:bottom"></cds-icon>
       </header>
       <div cds-layout="vertical align:stretch">
-        <header class="demo-header" cds-layout="p:sm p@md:md">
+        <header class="demo-header" cds-layout="p:md p@md:lg">
           header
         </header>
         <div cds-layout="horizontal align:stretch">
-          <nav class="demo-sidenav" cds-layout="p:sm p@md:md align:shrink">sidebar</nav>
+          <nav class="demo-sidenav" cds-layout="p:md p@md:lg align:shrink">sidebar</nav>
           <div class="demo-content demo-scrollable-content" cds-layout="align:stretch">
-            <div cds-layout="vertical gap:sm p:md">
+            <div cds-layout="vertical gap:md p:lg">
               ${scrollableContentHtml}
             </div>
           </div>
         </div>
-        <footer class="demo-footer" cds-layout="p:sm p@md:md align:shrink">footer</footer>
+        <footer class="demo-footer" cds-layout="p:md p@md:lg align:shrink">footer</footer>
       </div>
     </div>
   `;
@@ -1279,15 +1337,15 @@ export const patternsApplicationVerticalIconLayoutHybrid = () => {
 export const patternsContentSiteThreeColumn = () => {
   return html`
     <div class="demo-layout" cds-layout="vertical align:stretch" style="height: 100vh">
-      <header class="demo-header" cds-layout="p:sm p@md:md align:shrink">
+      <header class="demo-header" cds-layout="p:md p@md:lg align:shrink">
         header
       </header>
       <div cds-layout="horizontal align:vertical-stretch" class="demo-content">
-        <nav class="demo-sidenav" cds-layout="p:sm p@md:md">sidebar</nav>
-        <div class="demo-content" cds-layout="p:sm p@md:md align:stretch">content</div>
-        <section class="demo-sidebar" cds-layout="p:sm p@md:md">sidebar</section>
+        <nav class="demo-sidenav" cds-layout="p:md p@md:lg">sidebar</nav>
+        <div class="demo-content" cds-layout="p:md p@md:lg align:stretch">content</div>
+        <section class="demo-sidebar" cds-layout="p:md p@md:lg">sidebar</section>
       </div>
-      <footer class="demo-footer" cds-layout="p:sm p@md:md align:shrink">footer</footer>
+      <footer class="demo-footer" cds-layout="p:md p@md:lg align:shrink">footer</footer>
     </div>
   `;
 };
@@ -1295,11 +1353,11 @@ export const patternsContentSiteThreeColumn = () => {
 export const patternsContentSiteSingleRail = () => {
   return html`
     <div class="demo-layout">
-      <header class="demo-header" cds-layout="p:sm p@sm:md">
+      <header class="demo-header" cds-layout="p:md p@sm:lg">
         header
       </header>
-      <div cds-layout="grid gap:md gap@md:lg p:md p@sm:lg p-y@lg:xl container:lg container:center">
-        <div cds-layout="vertical gap:md gap@md:lg col@sm:7">
+      <div cds-layout="grid gap:md gap@md:xl p:lg p@sm:xl p-y@lg:xxl container:xl container:center">
+        <div cds-layout="vertical gap:lg gap@md:xl col@sm:7">
           <h3 cds-text="display">Title</h3>
           <p cds-text="message">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
@@ -1317,13 +1375,13 @@ export const patternsContentSiteSingleRail = () => {
         />
       </div>
       <div class="demo-content">
-        <div cds-layout="grid cols@sm:4 gap:md p:md p@md:xl container:lg container:center" cds-text="center">
-          <cds-card cds-layout="p:lg p@md:xl">card</cds-card>
-          <cds-card cds-layout="p:lg p@md:xl">card</cds-card>
-          <cds-card cds-layout="p:lg p@md:xl">card</cds-card>
+        <div cds-layout="grid cols@sm:4 gap:lg p:lg p@md:xxl container:xl container:center" cds-text="center">
+          <cds-card cds-layout="p:xl p@md:xxl">card</cds-card>
+          <cds-card cds-layout="p:xl p@md:xxl">card</cds-card>
+          <cds-card cds-layout="p:xl p@md:xxl">card</cds-card>
         </div>
       </div>
-      <footer cds-layout="grid cols@sm:4 gap:sm gap@md:lg p:sm p@sm:lg container:md container:center" cds-text="center">
+      <footer cds-layout="grid cols@sm:4 gap:md gap@md:xl p:md p@sm:xl container:lg container:center" cds-text="center">
         <div>
           footer links<br />
           footer links<br />
@@ -1347,11 +1405,11 @@ export const patternsContentSiteSingleRail = () => {
 export const patternsResponsiveImageGallery = () => {
   return html`
     <div class="demo-layout" cds-layout="vertical align:horizontal-stretch">
-      <header class="demo-header" cds-layout="p:sm p@md:md">
+      <header class="demo-header" cds-layout="p:md p@md:lg">
         header
       </header>
       <div
-        cds-layout="grid cols@sm:6 cols@md:4 cols@lg:3 cols@xl:2 p:md gap:sm align:horizontal-stretch"
+        cds-layout="grid cols@sm:6 cols@md:4 cols@lg:3 cols@xl:2 p:lg gap:md align:horizontal-stretch"
         class="demo-content"
       >
         <img src="https://dummyimage.com/600x400/000/fff" alt="placeholder image" cds-layout="container:fill" />
@@ -1367,7 +1425,7 @@ export const patternsResponsiveImageGallery = () => {
         <img src="https://dummyimage.com/600x400/000/fff" alt="placeholder image" cds-layout="container:fill" />
         <img src="https://dummyimage.com/600x400/000/fff" alt="placeholder image" cds-layout="container:fill" />
       </div>
-      <footer class="demo-footer" cds-layout="p:sm p@md:md">footer</footer>
+      <footer class="demo-footer" cds-layout="p:md p@md:lg">footer</footer>
     </div>
   `;
 };

--- a/packages/core/src/styles/layout/mixins/_mixins.scss
+++ b/packages/core/src/styles/layout/mixins/_mixins.scss
@@ -4,11 +4,13 @@
 
 $cds-layout-sizes: (
   'none': 0,
+  'xxs': $cds-token-layout-space-xxs,
   'xs': $cds-token-layout-space-xs,
   'sm': $cds-token-layout-space-sm,
   'md': $cds-token-layout-space-md,
   'lg': $cds-token-layout-space-lg,
   'xl': $cds-token-layout-space-xl,
+  'xxl': $cds-token-layout-space-xxl,
 );
 
 $cds-layout-breakpoints: (

--- a/packages/core/src/styles/spacing/spacing.stories.mdx
+++ b/packages/core/src/styles/spacing/spacing.stories.mdx
@@ -5,7 +5,7 @@ import { html, LitElement } from 'lit-element';
 
 # Spacing
 
-<cds-alert status="warning" closable="false" cds-layout="m-b:md">
+<cds-alert status="warning" closable="false" cds-layout="m-b:lg">
   <cds-alert-content>
     This is an experimental API and likely will have breaking changes in the near future.
   </cds-alert-content>

--- a/packages/core/src/styles/tokens/tokens.stories.mdx
+++ b/packages/core/src/styles/tokens/tokens.stories.mdx
@@ -5,7 +5,7 @@ import { html, LitElement } from 'lit-element';
 
 # Design Tokens
 
-<cds-alert status="warning" closable="false" cds-layout="m-b:md">
+<cds-alert status="warning" closable="false" cds-layout="m-b:lg">
   <cds-alert-content>
     This is an experimental API and likely will have breaking changes in the near future.
   </cds-alert-content>

--- a/packages/core/src/styles/tokens/tokens.stories.ts
+++ b/packages/core/src/styles/tokens/tokens.stories.ts
@@ -55,7 +55,7 @@ function getTokenPxValueTemplate(token: Token) {
 
 export const global = () => {
   return html`
-    <div cds-layout="horizontal gap:md">
+    <div cds-layout="horizontal gap:xl">
       ${getTokensByCategory('global').map(
         token => html`<p cds-text="subsection">${token.cssProp}: ${getTokenPxValueTemplate(token)}</p>`
       )}
@@ -65,7 +65,7 @@ export const global = () => {
 
 export const space = () => {
   return html`
-    <div cds-layout="vertical gap:md">
+    <div cds-layout="vertical gap:xl">
       ${getTokensByCategory('space').map(
         token => html`
           <div cds-text="message">
@@ -80,7 +80,7 @@ export const space = () => {
 
 export const layoutSpace = () => {
   return html`
-    <div cds-layout="vertical gap:md">
+    <div cds-layout="vertical gap:xl">
       ${getTokensByCategory('layout-space').map(
         token => html`
           <div cds-text="message">
@@ -95,7 +95,7 @@ export const layoutSpace = () => {
 
 export const layout = () => {
   return html`
-    <div cds-layout="horizontal gap:md">
+    <div cds-layout="horizontal gap:xl">
       ${getTokensByCategory('layout').map(
         token => html`<p cds-text="subsection">${token.cssProp}: ${getTokenPxValueTemplate(token)}</p>`
       )}
@@ -105,7 +105,7 @@ export const layout = () => {
 
 export const typography = () => {
   return html`
-    <div cds-layout="horizontal gap:md">
+    <div cds-layout="horizontal gap:xl">
       ${getTokensByCategory('typography').map(
         token => html`<p cds-text="subsection">${token.cssProp}: ${getTokenPxValueTemplate(token)}</p>`
       )}
@@ -123,7 +123,7 @@ function getColorGroup(group: string) {
           token => html`
             <div
               style="background: ${token.value}; color: ${token['value-on']}"
-              cds-layout="p:sm display:flex"
+              cds-layout="p:md display:flex"
               cds-text="body"
             >
               ${token.cssProp}<br />${token.value};
@@ -136,28 +136,28 @@ function getColorGroup(group: string) {
 
 export const color = () => {
   return html`
-    <div cds-layout="grid cols@sm:6 cols@md:4 gap:md">
-      <div cds-layout="vertical gap:md">
+    <div cds-layout="grid cols@sm:6 cols@md:4 gap:xl">
+      <div cds-layout="vertical gap:xl">
         <h2 cds-text="section">Neutral</h2>
         ${getColorGroup('neutral')}
       </div>
-      <div cds-layout="vertical gap:md">
+      <div cds-layout="vertical gap:xl">
         <h2 cds-text="section">Action</h2>
         ${getColorGroup('color-action')}
       </div>
-      <div cds-layout="vertical gap:md">
+      <div cds-layout="vertical gap:xl">
         <h2 cds-text="section">Secondary Action</h2>
         ${getColorGroup('secondary')}
       </div>
-      <div cds-layout="vertical gap:md">
+      <div cds-layout="vertical gap:xl">
         <h2 cds-text="section">Danger</h2>
         ${getColorGroup('danger')}
       </div>
-      <div cds-layout="vertical gap:md">
+      <div cds-layout="vertical gap:xl">
         <h2 cds-text="section">Warning</h2>
         ${getColorGroup('warning')}
       </div>
-      <div cds-layout="vertical gap:md">
+      <div cds-layout="vertical gap:xl">
         <h2 cds-text="section">Success</h2>
         ${getColorGroup('success')}
       </div>

--- a/packages/core/src/styles/typography/typography.stories.mdx
+++ b/packages/core/src/styles/typography/typography.stories.mdx
@@ -5,7 +5,7 @@ import { html, LitElement } from 'lit-element';
 
 # Typography
 
-<cds-alert status="warning" closable="false" cds-layout="m-b:md">
+<cds-alert status="warning" closable="false" cds-layout="m-b:lg">
   <cds-alert-content>
     This is an experimental API and likely will have breaking changes in the near future.
   </cds-alert-content>

--- a/packages/core/src/styles/typography/typography.stories.ts
+++ b/packages/core/src/styles/typography/typography.stories.ts
@@ -22,7 +22,7 @@ export default {
 
 export const headings = () => {
   return html`
-    <cds-demo cds-layout="vertical gap:md">
+    <cds-demo cds-layout="vertical gap:lg">
       <p cds-text="display">The five boxing wizards jump quickly (display)</p>
       <p cds-text="heading">The five boxing wizards jump quickly (heading)</p>
       <p cds-text="title">The five boxing wizards jump quickly (title)</p>
@@ -34,7 +34,7 @@ export const headings = () => {
 
 export const content = () => {
   return html`
-    <cds-demo cds-layout="vertical gap:md">
+    <cds-demo cds-layout="vertical gap:lg">
       <p cds-text="body">The quick brown fox jumps over the lazy dog. (body)</p>
       <p cds-text="message">The quick brown fox jumps over the lazy dog. (message)</p>
       <p cds-text="secondary">The quick brown fox jumps over the lazy dog. (secondary)</p>
@@ -58,7 +58,7 @@ export const code = () => {
 
 export const weights = () => {
   return html`
-    <cds-demo cds-layout="vertical gap:md">
+    <cds-demo cds-layout="vertical gap:lg">
       <p cds-text="body light">The <em>200</em> quick brown foxes <em>lightly</em> jump over the lazy dog. (light)</p>
       <p cds-text="body regular">
         The <em>400</em> quick brown foxes <em>regularly</em> jump over the lazy dog. (regular)
@@ -91,7 +91,7 @@ export const inline = () => {
 
 export const position = () => {
   return html`
-    <cds-demo cds-layout="vertical gap:md">
+    <cds-demo cds-layout="vertical gap:lg">
       <p cds-text="body left">Text Left (left)</p>
       <p cds-text="body right">Text Right (right)</p>
       <p cds-text="body center">Text Center (center)</p>
@@ -105,7 +105,7 @@ export const position = () => {
 
 export const transforms = () => {
   return html`
-    <cds-demo cds-layout="vertical gap:md">
+    <cds-demo cds-layout="vertical gap:lg">
       <p cds-text="body capitalize">text title case (capitalize)</p>
       <p cds-text="body uppercase">Text uppercase (uppercase)</p>
       <p cds-text="body lowercase">Text lowercase (lowercase)</p>
@@ -116,7 +116,7 @@ export const transforms = () => {
 
 export const legacyHeaders = () => {
   return html`
-    <cds-demo cds-layout="vertical gap:md">
+    <cds-demo cds-layout="vertical gap:lg">
       <p cds-text="h0">The five boxing wizards jump quickly (h0)</p>
       <p cds-text="h1">The five boxing wizards jump quickly (h1)</p>
       <p cds-text="h2">The five boxing wizards jump quickly (h2)</p>
@@ -130,7 +130,7 @@ export const legacyHeaders = () => {
 
 export const legacyParagraphs = () => {
   return html`
-    <cds-demo cds-layout="vertical gap:md">
+    <cds-demo cds-layout="vertical gap:lg">
       <p cds-text="p0">The quick brown fox jumps over the lazy dog. (p0)</p>
       <p cds-text="p1">The quick brown fox jumps over the lazy dog. (p1)</p>
       <p cds-text="p2">The quick brown fox jumps over the lazy dog. (p2)</p>
@@ -151,7 +151,7 @@ export const disableLineHightRemover = () => {
         box-shadow: inset 0 0 0 1rem hsl(93, 52%, 88%);
       }
     </style>
-    <cds-demo cds-layout="vertical gap:md">
+    <cds-demo cds-layout="vertical gap:lg">
       <cds-card show-padding>
         <p cds-text="body disable-lhe">The quick brown fox jumps over the lazy dog. (body)</p>
         <p cds-text="message disable-lhe">The quick brown fox jumps over the lazy dog. (message)</p>

--- a/packages/core/src/tag/tag.stories.ts
+++ b/packages/core/src/tag/tag.stories.ts
@@ -62,7 +62,7 @@ export const API = () => {
 
 export const status = () => {
   return html`
-    <div cds-layout="vertical gap:xs">
+    <div cds-layout="vertical gap:sm">
       <cds-tag readonly status="info">Info</cds-tag>
       <cds-tag readonly status="success">Success</cds-tag>
       <cds-tag readonly status="warning">Warning</cds-tag>
@@ -73,7 +73,7 @@ export const status = () => {
 
 export const color = () => {
   return html`
-    <div cds-layout="vertical gap:xs">
+    <div cds-layout="vertical gap:sm">
       <cds-tag readonly color="gray">Default</cds-tag>
       <cds-tag readonly color="purple">Purple</cds-tag>
       <cds-tag readonly color="blue">Blue</cds-tag>
@@ -85,7 +85,7 @@ export const color = () => {
 
 export const badgesStatus = () => {
   return html`
-    <div cds-layout="vertical gap:xs">
+    <div cds-layout="vertical gap:sm">
       <cds-tag readonly status="info">Info <cds-badge status="info">1</cds-badge></cds-tag>
       <cds-tag readonly status="success">Success <cds-badge status="success">2</cds-badge></cds-tag>
       <cds-tag readonly status="warning">Warning <cds-badge status="warning">3</cds-badge> </cds-tag>
@@ -107,15 +107,15 @@ export const badgesColor = () => {
 
 export const clickable = () => {
   return html`
-    <div cds-layout="vertical gap:xs">
-      <div cds-layout="horizontal gap:xs">
+    <div cds-layout="vertical gap:sm">
+      <div cds-layout="horizontal gap:sm">
         <cds-tag aria-label="Clickable example of a default tag" color="gray">Default</cds-tag>
         <cds-tag aria-label="Clickable example of a purple tag" color="purple">Purple</cds-tag>
         <cds-tag aria-label="Clickable example of a blue tag" color="blue">Blue</cds-tag>
         <cds-tag aria-label="Clickable example of an orange tag" color="orange">Orange</cds-tag>
         <cds-tag aria-label="Clickable example of a light blue tag" color="light-blue">Light Blue</cds-tag>
       </div>
-      <div cds-layout="horizontal gap:xs">
+      <div cds-layout="horizontal gap:sm">
         <cds-tag aria-label="Clickable example of a tag with the info status" status="info"
           >Info <cds-badge status="info">1</cds-badge></cds-tag
         >
@@ -129,7 +129,7 @@ export const clickable = () => {
           >Danger <cds-badge status="danger">12</cds-badge></cds-tag
         >
       </div>
-      <div cds-layout="horizontal gap:xs">
+      <div cds-layout="horizontal gap:sm">
         <cds-tag aria-label="Clickable example of a default tag with a badge" color="gray"
           >Default <cds-badge>A</cds-badge></cds-tag
         >
@@ -146,7 +146,7 @@ export const clickable = () => {
           >Light Blue <cds-badge>E</cds-badge></cds-tag
         >
       </div>
-      <div cds-layout="horizontal gap:xs">
+      <div cds-layout="horizontal gap:sm">
         <cds-tag aria-label="Clickable example of a gray tag with an icon and a badge" color="gray"
           ><cds-icon shape="user"></cds-icon>Default <cds-badge>A</cds-badge></cds-tag
         >

--- a/packages/core/test-bundles/bundlesize.json
+++ b/packages/core/test-bundles/bundlesize.json
@@ -6,7 +6,7 @@
     },
     {
       "path": "./dist/core/styles/module.layout.min.css",
-      "maxSize": "8 kB"
+      "maxSize": "9 kB"
     },
     {
       "path": "./dist/core/styles/module.reset.min.css",

--- a/packages/core/tokens.yml
+++ b/packages/core/tokens.yml
@@ -75,23 +75,31 @@ props:
     value: '72px'
     type: 'px'
     category: 'space'
+  - name: xxs
+    value: '2px'
+    type: 'px'
+    category: 'layout-space'
   - name: xs
-    value: '6px'
+    value: '4px'
     type: 'px'
     category: 'layout-space'
   - name: sm
-    value: '12px'
+    value: '6px'
     type: 'px'
     category: 'layout-space'
   - name: md
-    value: '24px'
+    value: '12px'
     type: 'px'
     category: 'layout-space'
   - name: lg
-    value: '48px'
+    value: '24px'
     type: 'px'
     category: 'layout-space'
   - name: xl
+    value: '48px'
+    type: 'px'
+    category: 'layout-space'
+  - name: xxl
     value: '96px'
     type: 'px'
     category: 'layout-space'


### PR DESCRIPTION
• added "2px" spacer
• added "4px" spacer
• these are needed for sizing layouts in compact versions of our components
• shifted all existing values up a size
• sizes now go from xxs to xxl

Signed-off-by: Scott Mathis <smathis@vmware.com>
