### PR TITLE
fix: prevent of calling indexOf on non array inside the datagrid and selection service

### DIFF
--- a/src/clr-angular/data/datagrid/providers/selection.spec.ts
+++ b/src/clr-angular/data/datagrid/providers/selection.spec.ts
@@ -772,6 +772,17 @@ export default function(): void {
         expect(selectionInstance.isSelected(4)).toBe(false);
       });
 
+      it('should not execute canItBeLocked block when there are no items to scan inside lockItem and isLocked method', function() {
+        itemsInstance.all = undefined;
+        selectionInstance = new Selection(itemsInstance, filtersInstance);
+        selectionInstance.selectionType = SelectionType.Multi;
+
+        // lock a row
+        selectionInstance.lockItem(4, true);
+        // make sure it's locked
+        expect(selectionInstance.isLocked(4)).toBe(false);
+      });
+
       /*
        * single selection is done with radio button so there is no logic to prevent
        * it from the provider - this must be handle at the component level

--- a/src/clr-angular/data/datagrid/providers/selection.ts
+++ b/src/clr-angular/data/datagrid/providers/selection.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -288,7 +288,7 @@ export class Selection<T = any> {
    */
   private selectItem(item: T): void {
     this.current.push(item);
-    if (this._items.trackBy) {
+    if (this._items.trackBy && this._items.all) {
       // Push selected ref onto array
       const lookup = this._items.all.findIndex(maybe => maybe === item);
       this.prevSelectionRefs.push(this._items.trackBy(lookup, item));
@@ -353,9 +353,16 @@ export class Selection<T = any> {
     return temp.length === displayedItems.length;
   }
 
-  private canItBeLocked() {
+  /**
+   * Make sure that it could be locked
+   *
+   * @remark
+   * Check also is items.all an array, if not there is no nothing to lock or compare to
+   *
+   */
+  private canItBeLocked(): boolean {
     // We depend on the trackBy and all so there are part of the requirment of is item could be locked
-    return this._selectionType !== SelectionType.None;
+    return this._selectionType !== SelectionType.None && Array.isArray(this._items.all);
   }
 
   /**


### PR DESCRIPTION
When using `ngFor` instead of `clrDgItems` `all` may not be populated so there is a need to have a check to be sure that `all` is array before we try to call array specific methods on it.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4504 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Close #4504 