### PR TITLE
backport: prevent of calling indexOf on non array inside the datagrid and selection service

### DIFF
--- a/packages/angular/projects/clr-angular/src/data/datagrid/providers/selection.spec.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/providers/selection.spec.ts
@@ -748,6 +748,17 @@ export default function (): void {
         expect(selectionInstance.isSelected(4)).toBe(false);
       });
 
+      it('should not execute canItBeLocked block when there are no items to scan inside lockItem and isLocked method', function () {
+        itemsInstance.all = undefined;
+        selectionInstance = new Selection(itemsInstance, filtersInstance);
+        selectionInstance.selectionType = SelectionType.Multi;
+
+        // lock a row
+        selectionInstance.lockItem(4, true);
+        // make sure it's locked
+        expect(selectionInstance.isLocked(4)).toBe(false);
+      });
+
       /*
        * single selection is done with radio button so there is no logic to prevent
        * it from the provider - this must be handle at the component level

--- a/packages/angular/projects/clr-angular/src/data/datagrid/providers/selection.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/providers/selection.ts
@@ -275,7 +275,7 @@ export class Selection<T = any> {
    */
   private selectItem(item: T): void {
     this.current.push(item);
-    if (this._items.trackBy) {
+    if (this._items.trackBy && this._items.all) {
       // Push selected ref onto array
       const lookup = this._items.all.findIndex(maybe => maybe === item);
       this.prevSelectionRefs.push(this._items.trackBy(lookup, item));
@@ -341,9 +341,16 @@ export class Selection<T = any> {
     return temp.length === displayedItems.length;
   }
 
-  private canItBeLocked() {
+  /**
+   * Make sure that it could be locked
+   *
+   * @remark
+   * Check also is items.all an array, if not there is no nothing to lock or compare to
+   *
+   */
+  private canItBeLocked(): boolean {
     // We depend on the trackBy and all so there are part of the requirment of is item could be locked
-    return this._selectionType !== SelectionType.None;
+    return this._selectionType !== SelectionType.None && Array.isArray(this._items.all);
   }
 
   /**


### PR DESCRIPTION
Backport fix from v3 to master/v4

#4626

