### PR TITLE
fix(modal): import close icon in core modal

### DIFF
--- a/packages/core/src/modal/modal.element.ts
+++ b/packages/core/src/modal/modal.element.ts
@@ -16,9 +16,13 @@ import {
   registerElementSafely,
   UniqueId,
 } from '@clr/core/internal';
+import '@clr/core/icon';
+import { ClarityIcons, timesIcon } from '@clr/core/icon-shapes';
 import { html } from 'lit-element';
 import { CdsBaseFocusTrap } from '../internal/base/focus-trap.base.js';
 import { styles } from './modal.element.css.js';
+
+ClarityIcons.addIcons(timesIcon);
 
 class ModalMixinClass extends CdsBaseFocusTrap {}
 
@@ -85,7 +89,7 @@ export class CdsModal extends ModalMixinClass {
                       action="outline"
                       icon
                     >
-                      <cds-icon shape="close"></cds-icon>
+                      <cds-icon shape="times"></cds-icon>
                     </button>
                   `
                 : html``}


### PR DESCRIPTION
A tiny PR to add the missing import of close icon in the core modal.

Signed-off-by: Jeeyun Lim <jeeyun.lim@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
