### PR TITLE
style: switch explicit-function-return-type TS rule to error for product code of core

### DIFF
--- a/packages/core/.eslintrc.js
+++ b/packages/core/.eslintrc.js
@@ -2,14 +2,14 @@ const OFF = 0;
 const WARN = 1;
 const ERROR = 2;
 
-// some temporary relaxation for spec and story files
+// temporary relaxations for story files
 const overrideRules = {
-  '@typescript-eslint/explicit-function-return-type': 0, // TOO MUCH WORK AT THE MOMENT ;)
+  '@typescript-eslint/explicit-function-return-type': 0,
 };
 
 const overrides = [
   {
-    files: ['*.stories.ts', '*.spec.ts'],
+    files: ['*.stories.ts'],
     rules: overrideRules,
   },
 ];

--- a/packages/core/.eslintrc.js
+++ b/packages/core/.eslintrc.js
@@ -2,6 +2,18 @@ const OFF = 0;
 const WARN = 1;
 const ERROR = 2;
 
+// some temporary relaxation for spec and story files
+const overrideRules = {
+  '@typescript-eslint/explicit-function-return-type': 0, // TOO MUCH WORK AT THE MOMENT ;)
+};
+
+const overrides = [
+  {
+    files: ['*.stories.ts', '*.spec.ts'],
+    rules: overrideRules,
+  },
+];
+
 const bannedTSTypes = {
   Array: 'Use [] instead.',
   Object: 'Use {} instead.',
@@ -12,7 +24,7 @@ const bannedTSTypes = {
 
 // only adding rules that override the defaults or enforce new standards
 const rules = {
-  '@typescript-eslint/explicit-function-return-type': OFF, // too much work at the moment
+  '@typescript-eslint/explicit-function-return-type': [ERROR, { allowExpressions: true }],
   '@typescript-eslint/no-explicit-any': OFF, // would LOVE to turn this on
   // cause slow analysis on TS files with Storybook, see
   // https://github.com/typescript-eslint/typescript-eslint/issues/1856
@@ -38,6 +50,7 @@ const config = {
   extends: '../../.eslintrc.js',
   parserOptions,
   rules,
+  overrides,
 };
 
 module.exports = config;

--- a/packages/core/src/alert/alert-actions.element.ts
+++ b/packages/core/src/alert/alert-actions.element.ts
@@ -5,7 +5,7 @@
  */
 
 import { baseStyles, registerElementSafely } from '@clr/core/internal';
-import { html, LitElement } from 'lit-element';
+import { CSSResultArray, html, LitElement, TemplateResult } from 'lit-element';
 import { styles } from './alert-actions.element.css.js';
 
 /**
@@ -28,16 +28,16 @@ import { styles } from './alert-actions.element.css.js';
  * @element cds-alert-actions
  */
 export class CdsAlertActions extends LitElement {
-  connectedCallback() {
+  connectedCallback(): void {
     super.connectedCallback();
     this.setAttribute('slot', 'actions');
   }
 
-  render() {
+  render(): TemplateResult {
     return html`<slot></slot>`;
   }
 
-  static get styles() {
+  static get styles(): CSSResultArray {
     return [baseStyles, styles];
   }
 }

--- a/packages/core/src/alert/alert-content.element.ts
+++ b/packages/core/src/alert/alert-content.element.ts
@@ -5,7 +5,7 @@
  */
 
 import { baseStyles, registerElementSafely } from '@clr/core/internal';
-import { html, LitElement } from 'lit-element';
+import { CSSResultArray, html, LitElement, TemplateResult } from 'lit-element';
 import { styles } from './alert-content.element.css.js';
 
 /**
@@ -32,11 +32,11 @@ import { styles } from './alert-content.element.css.js';
  * @element cds-alert-content
  */
 export class CdsAlertContent extends LitElement {
-  render() {
+  render(): TemplateResult {
     return html` <slot></slot> `;
   }
 
-  static get styles() {
+  static get styles(): CSSResultArray {
     return [baseStyles, styles];
   }
 }

--- a/packages/core/src/alert/alert.base.ts
+++ b/packages/core/src/alert/alert.base.ts
@@ -22,7 +22,7 @@ import {
   querySlotAll,
   returnOrFallthrough,
 } from '@clr/core/internal';
-import { html, LitElement } from 'lit-element';
+import { html, LitElement, TemplateResult } from 'lit-element';
 
 ClarityIcons.addIcons(checkCircleIcon, infoCircleIcon, exclamationCircleIcon, exclamationTriangleIcon, timesIcon);
 
@@ -69,7 +69,7 @@ export class CdsBaseAlert extends LitElement {
 
   @querySlotAll('cds-button') private buttons: NodeListOf<CdsButton>;
 
-  get alertIconShape() {
+  get alertIconShape(): string {
     /*
      * if the component's icon-shape attribute is set, that value is used.
      * otherwise, we check for status attribute and set an icon shape that matches.
@@ -84,7 +84,7 @@ export class CdsBaseAlert extends LitElement {
     );
   }
 
-  get alertIconTitle() {
+  get alertIconTitle(): string {
     /*
      * if the component's icon-title attribute is set, that value is used.
      * otherwise, we check for status attribute and set an icon shape that matches.
@@ -99,7 +99,7 @@ export class CdsBaseAlert extends LitElement {
     );
   }
 
-  updateButtons() {
+  updateButtons(): void {
     // buttons inside alert (usually app-level) have the style of small inverse buttons
     this.buttons.forEach(button => {
       button.status = 'inverse';
@@ -107,7 +107,7 @@ export class CdsBaseAlert extends LitElement {
     });
   }
 
-  render() {
+  render(): TemplateResult {
     return html`
       <div class="alert-wrapper">
         <div class="alert-item">
@@ -132,7 +132,7 @@ export class CdsBaseAlert extends LitElement {
     `;
   }
 
-  closeAlert() {
+  closeAlert(): void {
     this.closeChange.emit(true);
   }
 }

--- a/packages/core/src/alert/alert.element.ts
+++ b/packages/core/src/alert/alert.element.ts
@@ -7,6 +7,7 @@
 import { baseStyles, property, registerElementSafely } from '@clr/core/internal';
 import { CdsBaseAlert } from './alert.base.js';
 import { styles } from './alert.element.css.js';
+import { CSSResultArray } from 'lit-element';
 
 /**
  * Alerts are banners that communicate a message with a severity attached to it.
@@ -38,7 +39,7 @@ export class CdsAlert extends CdsBaseAlert {
   @property({ type: String })
   size: 'default' | 'sm';
 
-  static get styles() {
+  static get styles(): CSSResultArray {
     return [baseStyles, styles];
   }
 }

--- a/packages/core/src/alert/app-alert.element.ts
+++ b/packages/core/src/alert/app-alert.element.ts
@@ -7,6 +7,7 @@
 import { baseStyles, property, registerElementSafely } from '@clr/core/internal';
 import { CdsBaseAlert } from './alert.base.js';
 import { styles } from './app-alert.element.css.js';
+import { CSSResultArray } from 'lit-element';
 /**
  * App-level alerts are placed at the very top of the global context. They should
  * not be placed in any other configuration. Their purpose is to provide global
@@ -36,7 +37,7 @@ export class CdsAppAlert extends CdsBaseAlert {
   @property({ type: String })
   status: 'info' | 'warning' | 'danger';
 
-  static get styles() {
+  static get styles(): CSSResultArray {
     return [baseStyles, styles];
   }
 }

--- a/packages/core/src/badge/badge.element.ts
+++ b/packages/core/src/badge/badge.element.ts
@@ -5,7 +5,7 @@
  */
 
 import { baseStyles, property, registerElementSafely, StatusTypes } from '@clr/core/internal';
-import { html, LitElement } from 'lit-element';
+import { CSSResultArray, html, LitElement, TemplateResult } from 'lit-element';
 import { styles } from './badge.element.css.js';
 
 /**
@@ -45,7 +45,7 @@ export class CdsBadge extends LitElement {
   @property({ type: String })
   status: StatusTypes;
 
-  render() {
+  render(): TemplateResult {
     return html`
       <div class="private-host">
         <span
@@ -55,7 +55,7 @@ export class CdsBadge extends LitElement {
     `;
   }
 
-  static get styles() {
+  static get styles(): CSSResultArray {
     return [baseStyles, styles];
   }
 }

--- a/packages/core/src/button/button.element.ts
+++ b/packages/core/src/button/button.element.ts
@@ -19,7 +19,7 @@ import {
 } from '@clr/core/internal';
 import '@clr/core/icon';
 import { ClarityIcons, errorStandardIcon } from '@clr/core/icon-shapes';
-import { html, query } from 'lit-element';
+import { CSSResultArray, html, query, TemplateResult } from 'lit-element';
 import { styles as baseButtonStyles } from './base-button.element.css.js';
 import { styles } from './button.element.css.js';
 
@@ -36,7 +36,7 @@ export enum ClrLoadingState {
   ERROR = 'error',
 }
 
-function buttonSlots(icon: boolean, badge: boolean) {
+function buttonSlots(icon: boolean, badge: boolean): TemplateResult {
   // nested span tags allow for line-height erasers on the innermost span and flex-based centering on the outermost span
   const textSlot = html`<span class="button-content"
     ><span><slot></slot></span
@@ -129,7 +129,7 @@ export class CdsButton extends CdsBaseButton {
   @property({ type: String })
   loadingState = ClrLoadingState.DEFAULT;
 
-  firstUpdated(props: Map<string, any>) {
+  firstUpdated(props: Map<string, any>): void {
     super.firstUpdated(props);
 
     if (this.loadingState !== ClrLoadingState.DEFAULT) {
@@ -137,20 +137,20 @@ export class CdsButton extends CdsBaseButton {
     }
   }
 
-  connectedCallback() {
+  connectedCallback(): void {
     super.connectedCallback();
     setAttributes(this.icon, ['slot', 'button-icon']);
     setAttributes(this.badge, ['slot', 'button-badge']);
   }
 
-  update(props: Map<string, any>) {
+  update(props: Map<string, any>): void {
     if (this.privateHost && props.has('loadingState')) {
       this.updateLoadingState();
     }
     super.update(props);
   }
 
-  render() {
+  render(): TemplateResult {
     const loadingState = this.loadingState;
     const hasIcon = !!this.icon;
     const hasBadge = !!this.badge;
@@ -166,11 +166,11 @@ export class CdsButton extends CdsBaseButton {
     </div>`;
   }
 
-  static get styles() {
+  static get styles(): CSSResultArray {
     return [baseStyles, baseButtonStyles, styles];
   }
 
-  private updateLoadingState() {
+  private updateLoadingState(): void {
     switch (this.loadingState) {
       case ClrLoadingState.LOADING:
         this.disableButton();
@@ -186,12 +186,12 @@ export class CdsButton extends CdsBaseButton {
     }
   }
 
-  private disableButton() {
+  private disableButton(): void {
     this.style.width = getElementWidth(this);
     this.disabled = true;
   }
 
-  private enableButton() {
+  private enableButton(): void {
     this.loadingState = ClrLoadingState.DEFAULT;
     this.style.removeProperty('width');
     this.disabled = false;

--- a/packages/core/src/button/icon-button.element.ts
+++ b/packages/core/src/button/icon-button.element.ts
@@ -12,7 +12,7 @@ import {
   property,
   registerElementSafely,
 } from '@clr/core/internal';
-import { html } from 'lit-element';
+import { CSSResultArray, html, TemplateResult } from 'lit-element';
 import { styles as baseButtonStyles } from './base-button.element.css.js';
 import { styles } from './icon-button.element.css.js';
 import { CdsButton, ClrLoadingState } from './button.element.js';
@@ -51,7 +51,7 @@ export class CdsIconButton extends CdsButton {
   @property({ type: String, required: 'warning' })
   ariaLabel: string;
 
-  render() {
+  render(): TemplateResult {
     return html`
       <div class="private-host">
         ${this.loadingState === ClrLoadingState.LOADING ? iconSpinner : ''}
@@ -61,7 +61,7 @@ export class CdsIconButton extends CdsButton {
     `;
   }
 
-  static get styles() {
+  static get styles(): CSSResultArray {
     return [baseStyles, baseButtonStyles, styles];
   }
 }

--- a/packages/core/src/icon-shapes/collections/chart.ts
+++ b/packages/core/src/icon-shapes/collections/chart.ts
@@ -50,7 +50,7 @@ export const chartCollectionAliases: IconAlias[] = [[lineChartIconName, ['analyt
  * ```
  *
  */
-export function loadChartIconSet() {
+export function loadChartIconSet(): void {
   ClarityIcons.addIcons(...chartCollectionIcons);
   ClarityIcons.addAliases(...chartCollectionAliases);
 }

--- a/packages/core/src/icon-shapes/collections/commerce.ts
+++ b/packages/core/src/icon-shapes/collections/commerce.ts
@@ -70,7 +70,7 @@ export const commerceCollectionAliases: IconAlias[] = [[piggyBankIconName, ['sav
  * ```
  *
  */
-export function loadCommerceIconSet() {
+export function loadCommerceIconSet(): void {
   ClarityIcons.addIcons(...commerceCollectionIcons);
   ClarityIcons.addAliases(...commerceCollectionAliases);
 }

--- a/packages/core/src/icon-shapes/collections/core.ts
+++ b/packages/core/src/icon-shapes/collections/core.ts
@@ -113,7 +113,7 @@ export const coreCollectionAliases: IconAlias[] = [
  * ```
  *
  */
-export function loadCoreIconSet() {
+export function loadCoreIconSet(): void {
   ClarityIcons.addIcons(...coreCollectionIcons);
   ClarityIcons.addAliases(...coreCollectionAliases);
 }

--- a/packages/core/src/icon-shapes/collections/essential.ts
+++ b/packages/core/src/icon-shapes/collections/essential.ts
@@ -289,7 +289,7 @@ export const essentialCollectionAliases: IconAlias[] = [
  * ```
  *
  */
-export function loadEssentialIconSet() {
+export function loadEssentialIconSet(): void {
   ClarityIcons.addIcons(...essentialCollectionIcons);
   ClarityIcons.addAliases(...essentialCollectionAliases);
 }

--- a/packages/core/src/icon-shapes/collections/media.ts
+++ b/packages/core/src/icon-shapes/collections/media.ts
@@ -68,7 +68,7 @@ export const mediaCollectionAliases: IconAlias[] = [];
  * ```
  *
  */
-export function loadMediaIconSet() {
+export function loadMediaIconSet(): void {
   ClarityIcons.addIcons(...mediaCollectionIcons);
   ClarityIcons.addAliases(...mediaCollectionAliases);
 }

--- a/packages/core/src/icon-shapes/collections/mini.ts
+++ b/packages/core/src/icon-shapes/collections/mini.ts
@@ -49,7 +49,7 @@ export const miniCollectionAliases: IconAlias[] = [
  * ```
  *
  */
-export function loadMiniIconSet() {
+export function loadMiniIconSet(): void {
   ClarityIcons.addIcons(...miniCollectionIcons);
   ClarityIcons.addAliases(...miniCollectionAliases);
 }

--- a/packages/core/src/icon-shapes/collections/social.ts
+++ b/packages/core/src/icon-shapes/collections/social.ts
@@ -72,7 +72,7 @@ export const socialCollectionAliases: IconAlias[] = [
  * ```
  *
  */
-export function loadSocialIconSet() {
+export function loadSocialIconSet(): void {
   ClarityIcons.addIcons(...socialCollectionIcons);
   ClarityIcons.addAliases(...socialCollectionAliases);
 }

--- a/packages/core/src/icon-shapes/collections/technology.ts
+++ b/packages/core/src/icon-shapes/collections/technology.ts
@@ -230,7 +230,7 @@ export const technologyCollectionAliases: IconAlias[] = [
  * ```
  *
  */
-export function loadTechnologyIconSet() {
+export function loadTechnologyIconSet(): void {
   ClarityIcons.addIcons(...technologyCollectionIcons);
   ClarityIcons.addAliases(...technologyCollectionAliases);
 }

--- a/packages/core/src/icon-shapes/collections/text-edit.ts
+++ b/packages/core/src/icon-shapes/collections/text-edit.ts
@@ -80,7 +80,7 @@ export const textEditCollectionAliases: IconAlias[] = [];
  * ```
  *
  */
-export function loadTextEditIconSet() {
+export function loadTextEditIconSet(): void {
   ClarityIcons.addIcons(...textEditCollectionIcons);
   ClarityIcons.addAliases(...textEditCollectionAliases);
 }

--- a/packages/core/src/icon-shapes/collections/travel.ts
+++ b/packages/core/src/icon-shapes/collections/travel.ts
@@ -53,7 +53,7 @@ export const travelCollectionAliases: IconAlias[] = [
  * ```
  *
  */
-export function loadTravelIconSet() {
+export function loadTravelIconSet(): void {
   ClarityIcons.addIcons(...travelCollectionIcons);
   ClarityIcons.addAliases(...travelCollectionAliases);
 }

--- a/packages/core/src/icon-shapes/icon.element.ts
+++ b/packages/core/src/icon-shapes/icon.element.ts
@@ -16,7 +16,7 @@ import {
   StatusTypes,
   UniqueId,
 } from '@clr/core/internal';
-import { html, LitElement, query } from 'lit-element';
+import { CSSResultArray, html, LitElement, query, TemplateResult } from 'lit-element';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html';
 import { styles } from './icon.element.css.js';
 import { ClarityIcons } from './icon.service.js';
@@ -48,7 +48,7 @@ applyMixins(IconMixinClass, [UniqueId, CssHelpers]);
  * @cssprop --badge-color
  */
 export class CdsIcon extends IconMixinClass {
-  static get styles() {
+  static get styles(): CSSResultArray {
     return [baseStyles, styles];
   }
 
@@ -56,7 +56,7 @@ export class CdsIcon extends IconMixinClass {
   private _size: string;
 
   @property({ type: String })
-  get shape() {
+  get shape(): string {
     return hasIcon(this._shape, ClarityIcons.registry) ? this._shape : 'unknown';
   }
 
@@ -72,7 +72,7 @@ export class CdsIcon extends IconMixinClass {
     }
   }
 
-  get size() {
+  get size(): string {
     return this._size;
   }
 
@@ -164,29 +164,29 @@ export class CdsIcon extends IconMixinClass {
 
   private idForAriaLabel = 'aria-' + this._idPrefix + this._uniqueId;
 
-  firstUpdated() {
+  firstUpdated(): void {
     this.updateSVGAriaLabel();
   }
 
-  updated(props: Map<string, any>) {
+  updated(props: Map<string, any>): void {
     if (props.has('title')) {
       this.updateSVGAriaLabel();
     }
   }
 
-  connectedCallback() {
+  connectedCallback(): void {
     super.connectedCallback();
     this.setAttribute('role', 'none');
   }
 
-  protected render() {
+  protected render(): TemplateResult {
     return html`
       ${unsafeHTML(ClarityIcons.registry[this.shape])}
       ${this.title ? html`<span id="${this.idForAriaLabel}" class="clr-sr-only">${this.title}</span>` : ''}
     `;
   }
 
-  private updateSVGAriaLabel() {
+  private updateSVGAriaLabel(): void {
     if (this.title) {
       this.svg.removeAttribute('aria-label'); // remove empty label that makes icon decorative by default
       this.svg.setAttribute('aria-labelledby', this.idForAriaLabel); // use labelledby for better SR support

--- a/packages/core/src/icon-shapes/icon.renderer.ts
+++ b/packages/core/src/icon-shapes/icon.renderer.ts
@@ -7,7 +7,7 @@ import { isString, transformToUnspacedString } from '@clr/core/internal';
 import { IconShapeCollection, IconShapeSources } from './interfaces/icon.interfaces.js';
 import { decorateSvgWithClassnames, getIconSvgClosingTag, getIconSvgOpeningTag } from './utils/icon.svg-helpers.js';
 
-export function getInnerSvgFromShapes(iconShapes: IconShapeSources) {
+export function getInnerSvgFromShapes(iconShapes: IconShapeSources): (() => string)[] {
   const renderFns = [];
   for (const shape in iconShapes) {
     // eslint-disable-next-line no-prototype-builtins

--- a/packages/core/src/icon-shapes/icon.service.ts
+++ b/packages/core/src/icon-shapes/icon.service.ts
@@ -7,6 +7,7 @@
 import {
   IconAlias,
   IconAliasLegacyObject,
+  IconNameString,
   IconRegistry,
   IconShapeSources,
   IconShapeTuple,
@@ -41,15 +42,15 @@ export class ClarityIcons {
     return { ...iconRegistry };
   }
 
-  static addIcons(...shapes: IconShapeTuple[]) {
+  static addIcons(...shapes: IconShapeTuple[]): void {
     addIcons(shapes, iconRegistry);
   }
 
-  static addAliases(...aliases: IconAlias[]) {
+  static addAliases(...aliases: IconAlias[]): void {
     aliases.forEach(alias => setIconAliases(alias, iconRegistry));
   }
 
-  static getIconNameFromShape(iconShape: IconShapeTuple) {
+  static getIconNameFromShape(iconShape: IconShapeTuple): IconNameString {
     return iconShape[0];
   }
 
@@ -59,7 +60,7 @@ export class ClarityIcons {
   }
 
   /** @deprecated legacy API */
-  static add(shapes: IconShapeSources) {
+  static add(shapes: IconShapeSources): void {
     for (const shapeName in shapes) {
       // eslint-disable-next-line no-prototype-builtins
       if (shapes.hasOwnProperty(shapeName)) {
@@ -69,7 +70,7 @@ export class ClarityIcons {
   }
 
   /** @deprecated legacy API */
-  static alias(alias: IconAliasLegacyObject) {
+  static alias(alias: IconAliasLegacyObject): void {
     legacyAlias(alias, iconRegistry);
   }
 }

--- a/packages/core/src/icon-shapes/interfaces/icon.interfaces.ts
+++ b/packages/core/src/icon-shapes/interfaces/icon.interfaces.ts
@@ -7,7 +7,7 @@
 import { IconRegistrySources } from '@clr/core/internal';
 
 type IconSvgString = string;
-type IconNameString = string;
+export type IconNameString = string;
 type IconAliases = string[];
 
 export interface IconShapeCollection {

--- a/packages/core/src/icon-shapes/utils/icon.classnames.ts
+++ b/packages/core/src/icon-shapes/utils/icon.classnames.ts
@@ -30,7 +30,7 @@ export enum IconShapeClassnames {
   SolidAlerted = 'solid--alerted',
 }
 
-export function getShapeClassname(shapeType: string) {
+export function getShapeClassname(shapeType: string): string {
   const classNamePrefix = 'clr-i-';
   let className: string;
 
@@ -82,18 +82,24 @@ export function getIconTshirtSizeClassname(
   return '';
 }
 
-export function getAllIconTshirtSizeClassnames(prefix = iconTshirtSizeClassnamePrefix, sizes = IconTshirtSizes) {
-  return getEnumValues(sizes).map(sz => prefix + sz);
+export function getAllIconTshirtSizeClassnames(
+  prefix = iconTshirtSizeClassnamePrefix,
+  sizes = IconTshirtSizes
+): string[] {
+  return getEnumValues(sizes).map((sz: IconTshirtSizes) => prefix + sz);
 }
 
-export function isIconTshirtSizeClassname(classname: string, sizes = IconTshirtSizes) {
+export function isIconTshirtSizeClassname(classname: string, sizes = IconTshirtSizes): boolean {
   return getEnumValues(sizes).indexOf(classname) > -1;
 }
 
 export function getIconSvgClasses(icon: IconShapeCollection): string {
-  const testSolid = (i: IconShapeCollection) => (iconHasSolidShapes(i) ? IconSvgClassnames.Solid : '');
-  const testBadged = (i: IconShapeCollection) => (iconHasBadgedShapes(i) ? IconSvgClassnames.Badged : '');
-  const testAlerted = (i: IconShapeCollection) => (iconHasAlertedShapes(i) ? IconSvgClassnames.Alerted : '');
+  const testSolid = (i: IconShapeCollection): IconSvgClassnames | string =>
+    iconHasSolidShapes(i) ? IconSvgClassnames.Solid : '';
+  const testBadged = (i: IconShapeCollection): IconSvgClassnames | string =>
+    iconHasBadgedShapes(i) ? IconSvgClassnames.Badged : '';
+  const testAlerted = (i: IconShapeCollection): IconSvgClassnames | string =>
+    iconHasAlertedShapes(i) ? IconSvgClassnames.Alerted : '';
   const tests = [testSolid, testBadged, testAlerted];
   return transformToSpacedString(tests, icon);
 }
@@ -105,7 +111,7 @@ export enum SizeUpdateStrategies {
   NilSizeValue = 'value-is-nil',
 }
 
-export function getUpdateSizeStrategy(size: string) {
+export function getUpdateSizeStrategy(size: string): SizeUpdateStrategies {
   if (isNil(size) || size === '') {
     return SizeUpdateStrategies.NilSizeValue;
   }
@@ -121,7 +127,7 @@ export function getUpdateSizeStrategy(size: string) {
   return SizeUpdateStrategies.BadSizeValue;
 }
 
-export function updateIconSizeStyleOrClassnames(el: CdsIcon, size: string) {
+export function updateIconSizeStyleOrClassnames(el: CdsIcon, size: string): void {
   const updateStrategy = getUpdateSizeStrategy(size);
   const newTshirtSize = getIconTshirtSizeClassname(size);
 

--- a/packages/core/src/icon-shapes/utils/icon.service-helpers.ts
+++ b/packages/core/src/icon-shapes/utils/icon.service-helpers.ts
@@ -9,7 +9,7 @@ import has from 'ramda/es/has';
 import { renderIcon } from '../icon.renderer.js';
 import { IconAlias, IconAliasLegacyObject, IconRegistry, IconShapeTuple } from '../interfaces/icon.interfaces.js';
 
-export function addIcons(shapes: IconShapeTuple[], registry: IconRegistry) {
+export function addIcons(shapes: IconShapeTuple[], registry: IconRegistry): void {
   shapes.forEach(s => {
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     addIcon(s, registry);
@@ -24,19 +24,19 @@ export function getIcon(shapeName: string, registry: IconRegistry): string {
   return registry[shapeName] ? (registry[shapeName] as string) : (registry.unknown as string);
 }
 
-function addIconToRegistry(shape: IconShapeTuple, registry: IconRegistry) {
+function addIconToRegistry(shape: IconShapeTuple, registry: IconRegistry): void {
   const [shapeName, template] = shape;
   registry[shapeName] = renderIcon(template);
 }
 
-export function addIcon(shape: IconShapeTuple, registry: IconRegistry) {
+export function addIcon(shape: IconShapeTuple, registry: IconRegistry): void {
   const [shapeName] = shape;
   if (!hasIcon(shapeName, registry)) {
     addIconToRegistry(shape, registry);
   }
 }
 
-export function setIconAlias(shapeName: string, aliasName: string, registry: IconRegistry) {
+export function setIconAlias(shapeName: string, aliasName: string, registry: IconRegistry): void {
   if (existsIn([shapeName], registry)) {
     Object.defineProperty(registry, aliasName, {
       get: () => {
@@ -48,7 +48,7 @@ export function setIconAlias(shapeName: string, aliasName: string, registry: Ico
   }
 }
 
-export function setIconAliases(iconAlias: IconAlias, registry: IconRegistry) {
+export function setIconAliases(iconAlias: IconAlias, registry: IconRegistry): void {
   if (registry[iconAlias[0]]) {
     iconAlias[1].forEach(a => {
       setIconAlias(iconAlias[0], a, registry);
@@ -56,7 +56,7 @@ export function setIconAliases(iconAlias: IconAlias, registry: IconRegistry) {
   }
 }
 
-export function legacyAlias(aliases: IconAliasLegacyObject, registry: IconRegistry) {
+export function legacyAlias(aliases: IconAliasLegacyObject, registry: IconRegistry): void {
   for (const shapeNameKey in aliases) {
     // eslint-disable-next-line no-prototype-builtins
     if (aliases.hasOwnProperty(shapeNameKey)) {

--- a/packages/core/src/icon-shapes/utils/icon.svg-helpers.ts
+++ b/packages/core/src/icon-shapes/utils/icon.svg-helpers.ts
@@ -7,7 +7,7 @@
 import { IconShapeCollection } from '../interfaces/icon.interfaces.js';
 import { getIconSvgClasses, getShapeClassname, IconDecorationClassnames } from './icon.classnames.js';
 
-export function getBadgeSvg(shapeClassname: string) {
+export function getBadgeSvg(shapeClassname: string): string {
   return [
     '<circle cx="30" cy="6" r="5"  class="',
     [shapeClassname, IconDecorationClassnames.Badge].join(' '),
@@ -15,7 +15,7 @@ export function getBadgeSvg(shapeClassname: string) {
   ].join('');
 }
 
-export function getAlertSvg(shapeClassname: string) {
+export function getAlertSvg(shapeClassname: string): string {
   return [
     '<path d="M26.85,1.14,21.13,11A1.28,1.28,0,0,0,22.23,13H33.68A1.28,1.28,0,0,0,34.78,11L29.06,1.14A1.28,1.28,0,0,0,26.85,1.14Z" class="',
     [shapeClassname, IconDecorationClassnames.Alert].join(' '),
@@ -23,7 +23,7 @@ export function getAlertSvg(shapeClassname: string) {
   ].join('');
 }
 
-export function decorateSvgWithClassnames(shapeName: string, shapeSvg: string) {
+export function decorateSvgWithClassnames(shapeName: string, shapeSvg: string): string {
   const shapeClassname = getShapeClassname(shapeName);
   let transformedSvg = shapeSvg.split('/>').join(` class="${shapeClassname}"/>`);
 
@@ -42,7 +42,7 @@ export function decorateSvgWithClassnames(shapeName: string, shapeSvg: string) {
   return transformedSvg;
 }
 
-export function getIconSvgOpeningTag(icon: IconShapeCollection) {
+export function getIconSvgOpeningTag(icon: IconShapeCollection): string {
   const iconSvgViewboxSize = 36;
   const iconSvgClasses = getIconSvgClasses(icon);
 

--- a/packages/core/src/internal/base/button.base.ts
+++ b/packages/core/src/internal/base/button.base.ts
@@ -5,7 +5,7 @@
  */
 
 import { removeAttributes } from '@clr/core/internal';
-import { html, LitElement, query } from 'lit-element';
+import { html, LitElement, query, TemplateResult } from 'lit-element';
 import { ifDefined } from 'lit-html/directives/if-defined';
 
 import { property } from '../decorators/property.js';
@@ -41,7 +41,7 @@ export class CdsBaseButton extends LitElement {
 
   @querySlot('a') private anchor: HTMLAnchorElement;
 
-  protected get hiddenButtonTemplate() {
+  protected get hiddenButtonTemplate(): TemplateResult {
     return this.readonly
       ? html``
       : html` <button
@@ -58,21 +58,21 @@ export class CdsBaseButton extends LitElement {
   @query('button') private templateButton: HTMLButtonElement;
   private hiddenButton: HTMLButtonElement;
 
-  protected render() {
+  protected render(): TemplateResult {
     return html`
       <slot></slot>
       ${this.hiddenButtonTemplate}
     `;
   }
 
-  protected firstUpdated(props: Map<string, any>) {
+  protected firstUpdated(props: Map<string, any>): void {
     super.firstUpdated(props);
     this.updateButtonAttributes();
     this.setupAnchorFocus();
     this.setupNativeButtonBehavior();
   }
 
-  protected updated(props: Map<string, any>) {
+  protected updated(props: Map<string, any>): void {
     super.updated(props);
     // if readonly or disabled attribute was updated, button attributes might need updating
     if (props.has('readonly') || props.has('disabled')) {
@@ -80,7 +80,7 @@ export class CdsBaseButton extends LitElement {
     }
   }
 
-  private setupAnchorFocus() {
+  private setupAnchorFocus(): void {
     if (this.anchor) {
       this.anchor.addEventListener('focus', () => this.setAttribute('focused', ''));
       this.anchor.addEventListener('blur', () => this.removeAttribute('focused'));
@@ -91,13 +91,13 @@ export class CdsBaseButton extends LitElement {
    * We have to append a hidden button outside the web component in the light DOM
    * This allows us to trigger native submit events within a form element.
    */
-  private setupNativeButtonBehavior() {
+  private setupNativeButtonBehavior(): void {
     this.appendHiddenButton();
     this.addEventListener('click', this.triggerNativeButtonBehavior);
     this.addEventListener('keydown', this.emulateKeyBoardEventBehavior);
   }
 
-  private triggerNativeButtonBehavior(event: Event) {
+  private triggerNativeButtonBehavior(event: Event): void {
     if (!this.readonly) {
       if (this.disabled) {
         stopEvent(event);
@@ -107,20 +107,20 @@ export class CdsBaseButton extends LitElement {
     }
   }
 
-  private appendHiddenButton() {
+  private appendHiddenButton(): void {
     if (!this.hiddenButton && this.templateButton) {
       this.hiddenButton = this.appendChild(this.templateButton);
     }
   }
 
-  private emulateKeyBoardEventBehavior(e: KeyboardEvent) {
+  private emulateKeyBoardEventBehavior(e: KeyboardEvent): void {
     if (!this.anchor && (e.key === KeyCodes.Enter || e.code === KeyCodes.Space)) {
       this.click();
       stopEvent(e);
     }
   }
 
-  private updateButtonAttributes() {
+  private updateButtonAttributes(): void {
     const oldRole = this.role;
     const oldTabIndex = this.tabIndex;
 

--- a/packages/core/src/internal/base/focus-trap.base.ts
+++ b/packages/core/src/internal/base/focus-trap.base.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { html, LitElement } from 'lit-element';
+import { html, LitElement, TemplateResult } from 'lit-element';
 import { FocusTrap } from '../utils/focus-trap.js';
 import { property } from '../decorators/property.js';
 export class CdsBaseFocusTrap extends LitElement {
@@ -13,7 +13,7 @@ export class CdsBaseFocusTrap extends LitElement {
   @property({ type: Boolean })
   private __demoMode = false;
 
-  connectedCallback() {
+  connectedCallback(): void {
     super.connectedCallback();
 
     if (!this.__demoMode) {
@@ -21,7 +21,8 @@ export class CdsBaseFocusTrap extends LitElement {
       this.focusTrap.enableFocusTrap();
     }
   }
-  disconnectedCallback() {
+
+  disconnectedCallback(): void {
     super.disconnectedCallback();
 
     if (!this.__demoMode) {
@@ -29,7 +30,7 @@ export class CdsBaseFocusTrap extends LitElement {
     }
   }
 
-  protected render() {
+  protected render(): TemplateResult {
     return html`<slot></slot>`;
   }
 }

--- a/packages/core/src/internal/decorators/element.ts
+++ b/packages/core/src/internal/decorators/element.ts
@@ -22,7 +22,7 @@ import { registerElementSafely } from './../utils/register.js';
  */
 
 // TC39 Decorators proposal
-const standardCustomElement = (tagName: string, descriptor: ClassDescriptor) => {
+const standardCustomElement = (tagName: string, descriptor: ClassDescriptor): any => {
   const { kind, elements } = descriptor;
   return {
     kind,
@@ -34,7 +34,7 @@ const standardCustomElement = (tagName: string, descriptor: ClassDescriptor) => 
 };
 
 // Legacy TS Decorator
-const legacyCustomElement = (tagName: string, classDef: Constructor<HTMLElement>) => {
+const legacyCustomElement = (tagName: string, classDef: Constructor<HTMLElement>): any => {
   registerElementSafely(tagName, classDef);
   return classDef as any;
 };

--- a/packages/core/src/internal/decorators/event.ts
+++ b/packages/core/src/internal/decorators/event.ts
@@ -16,7 +16,7 @@ export interface EventOptions {
 export class EventEmitter<T> {
   constructor(private target: HTMLElement, private eventName: string) {}
 
-  emit(value: T, options?: EventOptions) {
+  emit(value: T, options?: EventOptions): void {
     this.target.dispatchEvent(
       new CustomEvent<T>(this.eventName, { detail: value, ...options })
     );
@@ -24,12 +24,12 @@ export class EventEmitter<T> {
 }
 
 // Legacy TS Decorator
-function legacyEvent(descriptor: PropertyDescriptor, protoOrDescriptor: {}, name: PropertyKey) {
+function legacyEvent(descriptor: PropertyDescriptor, protoOrDescriptor: {}, name: PropertyKey): void {
   Object.defineProperty(protoOrDescriptor, name, descriptor);
 }
 
 // TC39 Decorators proposal
-function standardEvent(descriptor: PropertyDescriptor, element: { key: string }) {
+function standardEvent(descriptor: PropertyDescriptor, element: { key: string }): any {
   return {
     kind: 'method',
     placement: 'prototype',

--- a/packages/core/src/internal/decorators/property.spec.ts
+++ b/packages/core/src/internal/decorators/property.spec.ts
@@ -56,7 +56,7 @@ describe('@property decorator defaults', () => {
     class Proto {
       testProp: undefined;
       tagName = 'cds-test-error';
-      connectedCallback() {
+      connectedCallback(): void {
         // do nothing
       }
     }
@@ -83,7 +83,7 @@ describe('@property decorator defaults', () => {
     class Proto {
       test: undefined;
       tagName = 'cds-test-warning';
-      connectedCallback() {
+      connectedCallback(): void {
         // do nothing
       }
     }

--- a/packages/core/src/internal/decorators/property.ts
+++ b/packages/core/src/internal/decorators/property.ts
@@ -65,7 +65,7 @@ export function getDefaultOptions(propertyKey: string, options?: PropertyConfig)
   }
 }
 
-export function requirePropertyCheck(protoOrDescriptor: any, name: string, options?: PropertyConfig) {
+export function requirePropertyCheck(protoOrDescriptor: any, name: string, options?: PropertyConfig): void {
   const targetConnectedCallback: () => void = protoOrDescriptor.connectedCallback;
 
   function connectedCallback(this: any): void {
@@ -86,7 +86,7 @@ export function requirePropertyCheck(protoOrDescriptor: any, name: string, optio
   protoOrDescriptor.connectedCallback = connectedCallback;
 }
 
-function getRequiredMessage(level = 'warning', propertyName: string, tagName: string) {
+function getRequiredMessage(level = 'warning', propertyName: string, tagName: string): string {
   const tag = tagName.toLocaleLowerCase();
   return (
     `${capitalizeFirstLetter(

--- a/packages/core/src/internal/decorators/query-slot.spec.ts
+++ b/packages/core/src/internal/decorators/query-slot.spec.ts
@@ -5,7 +5,7 @@
  */
 
 import { registerElementSafely } from '@clr/core/internal';
-import { html, LitElement } from 'lit-element';
+import { html, LitElement, TemplateResult } from 'lit-element';
 
 import { componentIsStable, createTestElement, removeTestElement, waitForComponent } from './../../test/utils.js';
 import { querySlot, querySlotAll } from './query-slot.js';
@@ -18,7 +18,7 @@ class TestElement extends LitElement {
   @querySlot('#errorMessage', { required: 'error', requiredMessage: 'test message' })
   testErrorWithMessage: HTMLDivElement;
 
-  render() {
+  render(): TemplateResult {
     return html` <slot></slot> `;
   }
 }
@@ -62,12 +62,12 @@ describe('query slot decorator', () => {
   });
 
   it('should throw if element is required', () => {
-    const el = () => component.testError;
+    const el = (): any => component.testError;
     expect(el).toThrow();
   });
 
   it('should throw custom message if element is required ', () => {
-    const el = () => component.testErrorWithMessage;
+    const el = (): any => component.testErrorWithMessage;
     expect(el).toThrow(new Error('test message'));
   });
 

--- a/packages/core/src/internal/decorators/query-slot.ts
+++ b/packages/core/src/internal/decorators/query-slot.ts
@@ -10,11 +10,11 @@ import { LogService } from '../services/log.service.js';
 // Slot Query decorators are similar to the query decorator in lit-element.
 // Instead of querying the component template they query the content slot of the component.
 
-const legacyQuery = (descriptor: PropertyDescriptor, proto: {}, name: PropertyKey) => {
+const legacyQuery = (descriptor: PropertyDescriptor, proto: {}, name: PropertyKey): void => {
   Object.defineProperty(proto, name, descriptor);
 };
 
-const standardQuery = (descriptor: PropertyDescriptor, element: any) => ({
+const standardQuery = (descriptor: PropertyDescriptor, element: any): any => ({
   kind: 'method',
   placement: 'prototype',
   key: element.key,

--- a/packages/core/src/internal/mixins/apply-mixins.spec.ts
+++ b/packages/core/src/internal/mixins/apply-mixins.spec.ts
@@ -4,14 +4,14 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { html, LitElement } from 'lit-element';
+import { html, LitElement, TemplateResult } from 'lit-element';
 import { registerElementSafely } from '../utils/register.js';
 import { componentIsStable, createTestElement, removeTestElement, waitForComponent } from './../../test/utils.js';
 import { applyMixins } from './apply-mixins.js';
 import { UniqueId } from './unique-id.js';
 
 class PristineElement extends LitElement {
-  render() {
+  render(): TemplateResult {
     return html`ohai`;
   }
 }
@@ -27,7 +27,7 @@ interface MixinBaseElement extends LitElement, UniqueId {}
 
 // Create mixin element
 class MixinElement extends MixinBaseElement {
-  render() {
+  render(): TemplateResult {
     return html`aloha`;
   }
 }

--- a/packages/core/src/internal/mixins/apply-mixins.ts
+++ b/packages/core/src/internal/mixins/apply-mixins.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-export function applyMixins(derivedCtor: any, baseCtors: any[]) {
+export function applyMixins(derivedCtor: any, baseCtors: any[]): void {
   baseCtors.forEach(baseCtor => {
     Object.getOwnPropertyNames(baseCtor.prototype).forEach(name => {
       Object.defineProperty(

--- a/packages/core/src/internal/mixins/css-helpers.spec.ts
+++ b/packages/core/src/internal/mixins/css-helpers.spec.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { html, LitElement } from 'lit-element';
+import { html, LitElement, TemplateResult } from 'lit-element';
 import { registerElementSafely } from '../utils/register.js';
 import { componentIsStable, createTestElement, removeTestElement, waitForComponent } from './../../test/utils.js';
 import { applyMixins } from './apply-mixins.js';
@@ -15,7 +15,7 @@ class CssHelpersTestBaseElement extends LitElement {}
 applyMixins(CssHelpersTestBaseElement, [CssHelpers]);
 
 class CssHelpersTestElement extends CssHelpersTestBaseElement {
-  render() {
+  render(): TemplateResult {
     return html`ohai`;
   }
 }

--- a/packages/core/src/internal/mixins/css-helpers.ts
+++ b/packages/core/src/internal/mixins/css-helpers.ts
@@ -8,19 +8,19 @@
 export interface CssHelpers extends HTMLElement {}
 
 export class CssHelpers {
-  hasClassname(text: string) {
+  hasClassname(text: string): boolean {
     return this.classList.contains(text);
   }
 
-  addClassname(text: string) {
+  addClassname(text: string): void {
     this.classList.add(text);
   }
 
-  removeClassname(text: string) {
+  removeClassname(text: string): void {
     this.classList.remove(text);
   }
 
-  removeClassnamesUnless(classnamesToRemove: string[], classnamesToKeep: string[]) {
+  removeClassnamesUnless(classnamesToRemove: string[], classnamesToKeep: string[]): void {
     classnamesToRemove.forEach(removeMe => {
       if (classnamesToKeep.indexOf(removeMe) < 0) {
         this.classList.remove(removeMe);
@@ -28,20 +28,20 @@ export class CssHelpers {
     });
   }
 
-  removeClassnames(classnamesToRemove: string[]) {
+  removeClassnames(classnamesToRemove: string[]): void {
     this.removeClassnamesUnless(classnamesToRemove, []);
   }
 
-  updateEquilateralStyles(size?: string) {
+  updateEquilateralStyles(size?: string): void {
     this.style.width = size || '';
     this.style.height = size || '';
   }
 
-  removeEquilateralStyles() {
+  removeEquilateralStyles(): void {
     this.updateEquilateralStyles();
   }
 
-  addEquilateralStyles(size: string) {
+  addEquilateralStyles(size: string): void {
     this.updateEquilateralStyles(size);
   }
 }

--- a/packages/core/src/internal/mixins/unique-id.spec.ts
+++ b/packages/core/src/internal/mixins/unique-id.spec.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { html, LitElement } from 'lit-element';
+import { html, LitElement, PropertyDeclarations, TemplateResult } from 'lit-element';
 import { registerElementSafely } from '../utils/register.js';
 import { componentIsStable, createTestElement, removeTestElement, waitForComponent } from './../../test/utils.js';
 import { applyMixins } from './apply-mixins.js';
@@ -17,16 +17,16 @@ class UniqueIdTestBaseElement extends LitElement {}
 applyMixins(UniqueIdTestBaseElement, [UniqueId]);
 
 class UniqueIdTestElement extends UniqueIdTestBaseElement {
-  static get properties() {
+  static get properties(): PropertyDeclarations {
     return {
       id: { type: String, reflect: true },
     };
   }
-  firstUpdated() {
+  firstUpdated(): void {
     this.id = this._idPrefix + this._uniqueId;
     this.setAttribute('id', this.id);
   }
-  render() {
+  render(): TemplateResult {
     return html`ohai`;
   }
 }

--- a/packages/core/src/internal/mixins/unique-id.ts
+++ b/packages/core/src/internal/mixins/unique-id.ts
@@ -12,14 +12,14 @@ export interface UniqueId extends HTMLElement {}
 export class UniqueId {
   private _id: number;
 
-  get _uniqueId() {
+  get _uniqueId(): number {
     if (typeof this._id === 'undefined') {
       this._id = idGenerator++;
     }
     return this._id;
   }
 
-  get _idPrefix() {
+  get _idPrefix(): string {
     return this.tagName.toLowerCase() + '-';
   }
 }

--- a/packages/core/src/internal/services/common-strings.service.ts
+++ b/packages/core/src/internal/services/common-strings.service.ts
@@ -20,14 +20,14 @@ export class CommonStringsServiceInternal {
   /**
    * Allows you to pass in new overrides for localization
    */
-  localize(overrides: Partial<ClrCommonStrings>) {
+  localize(overrides: Partial<ClrCommonStrings>): void {
     this.strings = { ...this.strings, ...overrides };
   }
 
   /**
    * Parse a string with a set of tokens to replace
    */
-  parse(source: string, tokens: { [key: string]: string } = {}) {
+  parse(source: string, tokens: { [key: string]: string } = {}): string {
     const names = Object.keys(tokens);
     let output = source;
     if (names.length) {

--- a/packages/core/src/internal/services/focus-trap-tracker.service.ts
+++ b/packages/core/src/internal/services/focus-trap-tracker.service.ts
@@ -11,15 +11,15 @@
 export class FocusTrapTracker {
   private static focusTrapElements: Element[] = [];
 
-  static setCurrent(el: Element) {
+  static setCurrent(el: Element): void {
     this.focusTrapElements.unshift(el);
   }
 
-  static activatePreviousCurrent() {
+  static activatePreviousCurrent(): void {
     this.focusTrapElements.shift();
   }
 
-  static getCurrent() {
+  static getCurrent(): Element {
     return this.focusTrapElements[0];
   }
 }

--- a/packages/core/src/internal/services/log.service.ts
+++ b/packages/core/src/internal/services/log.service.ts
@@ -7,25 +7,25 @@
 import { existsInWindow } from '../utils/exists.js';
 
 export class LogService {
-  static log(...args: any) {
+  static log(...args: any): void {
     if (notTestingEnvironment()) {
       console.log(...args);
     }
   }
 
-  static warn(...args: any) {
+  static warn(...args: any): void {
     if (notTestingEnvironment()) {
       console.warn(...args);
     }
   }
 
-  static error(...args: any) {
+  static error(...args: any): void {
     if (notTestingEnvironment()) {
       console.error(...args);
     }
   }
 }
 
-function notTestingEnvironment() {
+function notTestingEnvironment(): boolean {
   return !existsInWindow(['jasmine']);
 }

--- a/packages/core/src/internal/utils/conditional.ts
+++ b/packages/core/src/internal/utils/conditional.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-export function returnOrFallthrough(conditions: any[], fallthrough: any) {
+export function returnOrFallthrough(conditions: any[], fallthrough: any): any {
   const truthyCondition = conditions.find(cond => !!cond[0]);
   if (truthyCondition) {
     return truthyCondition[1]();

--- a/packages/core/src/internal/utils/dom.ts
+++ b/packages/core/src/internal/utils/dom.ts
@@ -6,27 +6,27 @@
 import includes from 'ramda/es/includes';
 import without from 'ramda/es/without';
 
-export function getElementWidth(element: HTMLElement, unit = 'px') {
+export function getElementWidth(element: HTMLElement, unit = 'px'): string {
   if (element) {
     return element.getBoundingClientRect ? element.getBoundingClientRect().width + unit : '';
   }
   return '';
 }
 
-export function getElementWidthUnless(element: HTMLElement, unless: boolean) {
+export function getElementWidthUnless(element: HTMLElement, unless: boolean): string {
   if (!unless) {
     return getElementWidth(element);
   }
   return '';
 }
 
-export function isHTMLElement(el: any) {
+export function isHTMLElement(el: any): boolean {
   return !!el && el instanceof HTMLElement;
 }
 
 export type HTMLAttributeTuple = [string, string | boolean];
 
-export function setAttributes(element: HTMLElement, ...attributeTuples: HTMLAttributeTuple[]) {
+export function setAttributes(element: HTMLElement, ...attributeTuples: HTMLAttributeTuple[]): void {
   if (element) {
     attributeTuples.forEach(([attr, val]) => {
       if (val === false || val === null) {
@@ -38,7 +38,7 @@ export function setAttributes(element: HTMLElement, ...attributeTuples: HTMLAttr
   }
 }
 
-export function removeAttributes(element: HTMLElement, ...attrs: string[]) {
+export function removeAttributes(element: HTMLElement, ...attrs: string[]): void {
   if (element) {
     attrs.forEach(attr => {
       element.removeAttribute(attr);
@@ -46,7 +46,7 @@ export function removeAttributes(element: HTMLElement, ...attrs: string[]) {
   }
 }
 
-export function addAttributeValue(element: HTMLElement, attr: string, value: string) {
+export function addAttributeValue(element: HTMLElement, attr: string, value: string): void {
   if (element) {
     const currentAttrVal = element.getAttribute(attr);
     if (!currentAttrVal) {
@@ -58,7 +58,7 @@ export function addAttributeValue(element: HTMLElement, attr: string, value: str
   }
 }
 
-export function removeAttributeValue(element: HTMLElement, attr: string, value: string) {
+export function removeAttributeValue(element: HTMLElement, attr: string, value: string): void {
   if (element) {
     const currentAttrVal = element.getAttribute(attr);
     if (currentAttrVal) {

--- a/packages/core/src/internal/utils/events.ts
+++ b/packages/core/src/internal/utils/events.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-export function stopEvent(event: Event) {
+export function stopEvent(event: Event): void {
   event.preventDefault();
   event.stopPropagation();
 }

--- a/packages/core/src/internal/utils/exists.ts
+++ b/packages/core/src/internal/utils/exists.ts
@@ -26,6 +26,6 @@ export function elementExists(tagName: string, registry?: { get: (name: string) 
 
 export const existsInWindow = existsIn(__, window);
 
-export function isBrowser(win = window) {
+export function isBrowser(win = window): boolean {
   return !isNil(win);
 }

--- a/packages/core/src/internal/utils/focus-trap.spec.ts
+++ b/packages/core/src/internal/utils/focus-trap.spec.ts
@@ -208,7 +208,7 @@ describe('Focus Trap Utilities: ', () => {
       });
 
       it('should throw an error if enabledFocusTrap is called again', () => {
-        const secondCall = () => focusTrap.enableFocusTrap();
+        const secondCall = (): void => focusTrap.enableFocusTrap();
         expect(secondCall).toThrow();
       });
     });

--- a/packages/core/src/internal/utils/focus-trap.ts
+++ b/packages/core/src/internal/utils/focus-trap.ts
@@ -15,7 +15,7 @@ export interface FocusTrapElement extends HTMLElement {
 export function focusElementIfInCurrentFocusTrapElement(
   focusedElement: HTMLElement,
   focusTrapElement: FocusTrapElement
-) {
+): void {
   if (
     FocusTrapTracker.getCurrent() === focusTrapElement &&
     elementIsOutsideFocusTrapElement(focusedElement, focusTrapElement)
@@ -24,7 +24,10 @@ export function focusElementIfInCurrentFocusTrapElement(
   }
 }
 
-export function elementIsOutsideFocusTrapElement(focusedElement: HTMLElement, focusTrapElement: FocusTrapElement) {
+export function elementIsOutsideFocusTrapElement(
+  focusedElement: HTMLElement,
+  focusTrapElement: FocusTrapElement
+): boolean {
   return (
     !focusTrapElement.contains(focusedElement) ||
     focusedElement === focusTrapElement.topReboundElement ||
@@ -32,14 +35,14 @@ export function elementIsOutsideFocusTrapElement(focusedElement: HTMLElement, fo
   );
 }
 
-export function createFocusTrapReboundElement() {
+export function createFocusTrapReboundElement(): HTMLElement {
   const offScreenSpan = document.createElement('span');
   offScreenSpan.setAttribute('tabindex', '0');
   offScreenSpan.classList.add('offscreen-focus-rebounder');
   return offScreenSpan;
 }
 
-export function addReboundElementsToFocusTrapElement(focusTrapElement: FocusTrapElement) {
+export function addReboundElementsToFocusTrapElement(focusTrapElement: FocusTrapElement): void {
   if (focusTrapElement) {
     focusTrapElement.topReboundElement = createFocusTrapReboundElement();
     focusTrapElement.bottomReboundElement = createFocusTrapReboundElement();
@@ -58,7 +61,7 @@ export function addReboundElementsToFocusTrapElement(focusTrapElement: FocusTrap
   }
 }
 
-export function removeReboundElementsFromFocusTrapElement(focusTrapElement: FocusTrapElement) {
+export function removeReboundElementsFromFocusTrapElement(focusTrapElement: FocusTrapElement): void {
   if (focusTrapElement) {
     if (focusTrapElement.topReboundElement && focusTrapElement.parentElement) {
       focusTrapElement.parentElement.removeChild(focusTrapElement.topReboundElement);
@@ -80,7 +83,7 @@ export class FocusTrap {
     this.focusTrapElement = hostElement as FocusTrapElement;
   }
 
-  enableFocusTrap() {
+  enableFocusTrap(): void {
     if (FocusTrapTracker.getCurrent() === this.focusTrapElement) {
       throw new Error('Focus trap is already enabled for this instance.');
     }
@@ -97,7 +100,7 @@ export class FocusTrap {
     document.addEventListener('focusin', this.onFocusInEvent);
   }
 
-  removeFocusTrap() {
+  removeFocusTrap(): void {
     document.removeEventListener('focusin', this.onFocusInEvent);
     removeAttributeValue(document.body, 'cds-layout', 'no-scrolling');
     removeReboundElementsFromFocusTrapElement(this.focusTrapElement);
@@ -107,7 +110,7 @@ export class FocusTrap {
     }
   }
 
-  private onFocusIn(event: FocusEvent) {
+  private onFocusIn(event: FocusEvent): void {
     focusElementIfInCurrentFocusTrapElement(event.target as HTMLElement, this.focusTrapElement);
   }
 }

--- a/packages/core/src/internal/utils/framework.ts
+++ b/packages/core/src/internal/utils/framework.ts
@@ -13,7 +13,7 @@ let angularVersion: string | undefined;
 let reactVersion: string | undefined;
 let vueVersion: string | undefined;
 
-export function getAngularVersion(useCache = true) {
+export function getAngularVersion(useCache = true): typeof angularVersion {
   if (!useCache || !angularVersion) {
     const appRoot = document && document.querySelector('[ng-version]');
     angularVersion = appRoot ? `${appRoot.getAttribute('ng-version')}` : undefined;
@@ -21,7 +21,7 @@ export function getAngularVersion(useCache = true) {
   return angularVersion;
 }
 
-export function getReactVersion(useCache = true) {
+export function getReactVersion(useCache = true): typeof reactVersion {
   if (!useCache || !reactVersion) {
     reactVersion = document.querySelector('[data-reactroot], [data-reactid]') ? 'unknown version' : undefined;
   }
@@ -29,7 +29,7 @@ export function getReactVersion(useCache = true) {
   return reactVersion;
 }
 
-export function getVueVersion(useCache = true) {
+export function getVueVersion(useCache = true): typeof vueVersion {
   if (!useCache || !vueVersion) {
     const all = document.querySelectorAll('*');
     let el;
@@ -45,6 +45,6 @@ export function getVueVersion(useCache = true) {
   return vueVersion;
 }
 
-export function isStorybook() {
+export function isStorybook(): boolean {
   return window.location.href.includes('localhost:6006');
 }

--- a/packages/core/src/internal/utils/global.ts
+++ b/packages/core/src/internal/utils/global.ts
@@ -28,7 +28,7 @@ declare global {
   }
 }
 
-function getVersion() {
+function getVersion(): CDSLog {
   const log: CDSLog = {
     versions: window.CDS._version,
     loadedElements: window.CDS._loadedElements,
@@ -40,7 +40,7 @@ function getVersion() {
   return log;
 }
 
-function initializeCDSGlobal() {
+function initializeCDSGlobal(): void {
   window.CDS = window.CDS || {
     _version: [],
     _loadedElements: [],
@@ -48,7 +48,7 @@ function initializeCDSGlobal() {
   };
 }
 
-function setRunningVersion() {
+function setRunningVersion(): void {
   const loadedVersion = '@VERSION';
   if (window.CDS._version.indexOf(loadedVersion) < 0) {
     window.CDS._version.push(loadedVersion);
@@ -63,7 +63,7 @@ function setRunningVersion() {
   }
 }
 
-export function setupCDSGlobal() {
+export function setupCDSGlobal(): void {
   if (isBrowser()) {
     initializeCDSGlobal();
     setRunningVersion();

--- a/packages/core/src/internal/utils/identity.ts
+++ b/packages/core/src/internal/utils/identity.ts
@@ -20,11 +20,11 @@ export function isStringOrNil(val: any): boolean {
   return is(String, val) || isNil(val);
 }
 
-export function isObject(val: any) {
+export function isObject(val: any): boolean {
   return is(Object, val);
 }
 
-export function isObjectAndNotNilOrEmpty(val: any) {
+export function isObjectAndNotNilOrEmpty(val: any): boolean {
   return !isNilOrEmpty(val) && isObject(val);
 }
 
@@ -42,6 +42,6 @@ export function hasStringPropertyChangedAndNotNil(val: string | null | undefined
   return !isNilOrEmpty(val) && hasPropertyChanged(val, oldVal);
 }
 
-export function getEnumValues(enumeration: any) {
+export function getEnumValues(enumeration: any): any {
   return Object.values(enumeration);
 }

--- a/packages/core/src/internal/utils/register.ts
+++ b/packages/core/src/internal/utils/register.ts
@@ -25,7 +25,7 @@ const addElementToRegistry = curryN(
   }
 );
 
-export function registerElementSafely(tagName: string, elementClass: any) {
+export function registerElementSafely(tagName: string, elementClass: any): void {
   if (isBrowser() && existsInWindow(['customElements'])) {
     addElementToRegistry(tagName, elementClass, window.customElements);
   }

--- a/packages/core/src/internal/utils/string.ts
+++ b/packages/core/src/internal/utils/string.ts
@@ -22,18 +22,18 @@ export function transformToUnspacedString(fns: any[], ...args: any[]): string {
   return transformToString('', fns, ...args);
 }
 
-export function camelCaseToKebabCase(value: string) {
+export function camelCaseToKebabCase(value: string): string {
   return value.replace(/[A-Z]/g, l => `-${l.toLowerCase()}`);
 }
 
-export function kebabCaseToCamelCase(str: string) {
+export function kebabCaseToCamelCase(str: string): string {
   return str
     .split('-')
     .map((item, index) => (index ? item.charAt(0).toUpperCase() + item.slice(1).toLowerCase() : item))
     .join('');
 }
 
-export function kebabCaseToPascalCase(string: string) {
+export function kebabCaseToPascalCase(string: string): string {
   const camelCase = kebabCaseToCamelCase(string);
   return capitalizeFirstLetter(camelCase);
 }
@@ -42,14 +42,14 @@ export function kebabCaseToPascalCase(string: string) {
  * Take a object map of css properties and if value concatenate string of all computed values
  * Useful for dynamic style tags in lit-html templates
  */
-export function setStyles(styles: { [key: string]: string }) {
+export function setStyles(styles: { [key: string]: string }): string {
   return Object.keys(styles).reduce(
     (allStyles, prop) => `${allStyles}${styles[prop] ? `${prop}:${styles[prop]};` : ''}`,
     ''
   );
 }
 
-export function capitalizeFirstLetter(string: string) {
+export function capitalizeFirstLetter(string: string): string {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
 

--- a/packages/core/src/modal/modal-actions.element.ts
+++ b/packages/core/src/modal/modal-actions.element.ts
@@ -5,7 +5,7 @@
  */
 
 import { baseStyles, registerElementSafely } from '@clr/core/internal';
-import { html, LitElement } from 'lit-element';
+import { CSSResultArray, html, LitElement, TemplateResult } from 'lit-element';
 
 /**
  * Web component modal actions to be used inside modal.
@@ -32,16 +32,16 @@ import { html, LitElement } from 'lit-element';
  * @element cds-modal-actions
  */
 export class CdsModalActions extends LitElement {
-  connectedCallback() {
+  connectedCallback(): void {
     super.connectedCallback();
     this.setAttribute('slot', 'modal-actions');
   }
 
-  render() {
+  render(): TemplateResult {
     return html`<slot></slot>`;
   }
 
-  static get styles() {
+  static get styles(): CSSResultArray {
     return [baseStyles];
   }
 }

--- a/packages/core/src/modal/modal-content.element.ts
+++ b/packages/core/src/modal/modal-content.element.ts
@@ -5,7 +5,7 @@
  */
 
 import { baseStyles, registerElementSafely } from '@clr/core/internal';
-import { html, LitElement } from 'lit-element';
+import { CSSResultArray, html, LitElement, TemplateResult } from 'lit-element';
 
 /**
  * Web component modal content to be used inside modal.
@@ -31,11 +31,11 @@ import { html, LitElement } from 'lit-element';
  * @element cds-modal-content
  */
 export class CdsModalContent extends LitElement {
-  render() {
+  render(): TemplateResult {
     return html` <slot></slot> `;
   }
 
-  static get styles() {
+  static get styles(): CSSResultArray {
     return [baseStyles];
   }
 }

--- a/packages/core/src/modal/modal-header-actions.element.ts
+++ b/packages/core/src/modal/modal-header-actions.element.ts
@@ -5,7 +5,7 @@
  */
 
 import { baseStyles, registerElementSafely } from '@clr/core/internal';
-import { html, LitElement } from 'lit-element';
+import { CSSResultArray, html, LitElement, TemplateResult } from 'lit-element';
 
 /**
  * Web component modal header actions to be used inside modal.
@@ -31,16 +31,16 @@ import { html, LitElement } from 'lit-element';
  * @element cds-modal-header-actions
  */
 export class CdsModalHeaderActions extends LitElement {
-  connectedCallback() {
+  connectedCallback(): void {
     super.connectedCallback();
     this.setAttribute('slot', 'modal-header-actions');
   }
 
-  render() {
+  render(): TemplateResult {
     return html`<slot></slot>`;
   }
 
-  static get styles() {
+  static get styles(): CSSResultArray {
     return [baseStyles];
   }
 }

--- a/packages/core/src/modal/modal-header.element.ts
+++ b/packages/core/src/modal/modal-header.element.ts
@@ -5,7 +5,7 @@
  */
 
 import { baseStyles, registerElementSafely } from '@clr/core/internal';
-import { html, LitElement } from 'lit-element';
+import { CSSResult, html, LitElement, TemplateResult } from 'lit-element';
 
 /**
  * Web component modal header to be used inside modal.
@@ -31,16 +31,16 @@ import { html, LitElement } from 'lit-element';
  * @element cds-modal-header
  */
 export class CdsModalHeader extends LitElement {
-  connectedCallback() {
+  connectedCallback(): void {
     super.connectedCallback();
     this.setAttribute('slot', 'modal-header');
   }
 
-  render() {
+  render(): TemplateResult {
     return html`<slot></slot>`;
   }
 
-  static get styles() {
+  static get styles(): CSSResult[] {
     return [baseStyles];
   }
 }

--- a/packages/core/src/modal/modal.element.ts
+++ b/packages/core/src/modal/modal.element.ts
@@ -16,7 +16,7 @@ import {
   registerElementSafely,
   UniqueId,
 } from '@clr/core/internal';
-import { html } from 'lit-element';
+import { CSSResult, html, TemplateResult } from 'lit-element';
 import { CdsBaseFocusTrap } from '../internal/base/focus-trap.base.js';
 import { styles } from './modal.element.css.js';
 
@@ -48,7 +48,7 @@ applyMixins(ModalMixinClass, [UniqueId, CssHelpers]);
  * @element cds-modal
  */
 export class CdsModal extends ModalMixinClass {
-  static get styles() {
+  static get styles(): CSSResult[] {
     return [baseStyles, styles];
   }
   @event() private closeChange: EventEmitter<boolean>;
@@ -63,7 +63,7 @@ export class CdsModal extends ModalMixinClass {
 
   private idForAriaLabel = `${this._idPrefix}${this._uniqueId}`;
 
-  render() {
+  render(): TemplateResult {
     return html`
       <div class="private-host" cds-layout="horizontal p:md p@md:xl align:center">
         <div class="modal-dialog" role="dialog" aria-modal="true" aria-labelledby="${this.idForAriaLabel}">
@@ -104,21 +104,21 @@ export class CdsModal extends ModalMixinClass {
     `;
   }
 
-  connectedCallback() {
+  connectedCallback(): void {
     super.connectedCallback();
     window.addEventListener('keydown', this.fireEventOnEscape);
   }
 
-  disconnectedCallback() {
+  disconnectedCallback(): void {
     super.disconnectedCallback();
     window.removeEventListener('keydown', this.fireEventOnEscape);
   }
 
-  closeModal() {
+  closeModal(): void {
     this.closeChange.emit(true);
   }
 
-  private fireEventOnEscape = (e: KeyboardEvent) => {
+  private fireEventOnEscape = (e: KeyboardEvent): void => {
     if (e.keyCode === ESC || e.key === 'Esc') {
       this.closeModal();
     }

--- a/packages/core/src/tag/tag.element.spec.ts
+++ b/packages/core/src/tag/tag.element.spec.ts
@@ -16,7 +16,10 @@ describe('tag element', () => {
 
   const closeIconString = '<cds-icon shape="times"';
 
-  function getTagComponentFromElement(el: HTMLElement, type: 'readonly' | 'closable' | 'clickable' = 'clickable') {
+  function getTagComponentFromElement(
+    el: HTMLElement,
+    type: 'readonly' | 'closable' | 'clickable' = 'clickable'
+  ): CdsTag {
     return el.querySelector<CdsTag>(`cds-tag.${type}-tag`);
   }
 

--- a/packages/core/src/tag/tag.element.ts
+++ b/packages/core/src/tag/tag.element.ts
@@ -14,7 +14,7 @@ import {
   setAttributes,
   StatusTypes,
 } from '@clr/core/internal';
-import { html } from 'lit-element';
+import { CSSResult, html, TemplateResult } from 'lit-element';
 import { styles } from './tag.element.css.js';
 
 ClarityIcons.addIcons(timesIcon);
@@ -53,7 +53,7 @@ export class CdsTag extends CdsBaseButton {
   /** Sets the color of the tag (and badge if present) from a predefined list of choices */
   @property({ type: String })
   color: 'gray' | 'purple' | 'blue' | 'orange' | 'light-blue';
-  static get styles() {
+  static get styles(): CSSResult[] {
     return [baseStyles, styles];
   }
 
@@ -71,7 +71,7 @@ export class CdsTag extends CdsBaseButton {
 
   @querySlot('cds-badge') private badge: HTMLElement;
 
-  connectedCallback() {
+  connectedCallback(): void {
     super.connectedCallback();
     // TODO: this routine is repeated in button.element.ts. it may make sense to find a way to
     // abstract it for dry-ing and reuse
@@ -79,7 +79,7 @@ export class CdsTag extends CdsBaseButton {
     setAttributes(this.badge, ['slot', 'tag-badge']);
   }
 
-  updated(props: Map<string, string | boolean | null | undefined>) {
+  updated(props: Map<string, string | boolean | null | undefined>): void {
     super.updated(props);
 
     if (props.has('closable') && props.get('closable') === true) {
@@ -91,7 +91,7 @@ export class CdsTag extends CdsBaseButton {
     }
   }
 
-  render() {
+  render(): TemplateResult {
     return html`
       <div class="private-host" cds-layout="horizontal">
         ${this.icon ? html`<span class="tag-icon"><slot name="tag-icon"></slot></span>` : html``}

--- a/packages/core/src/test-dropdown/test-dropdown.element.ts
+++ b/packages/core/src/test-dropdown/test-dropdown.element.ts
@@ -12,7 +12,7 @@ import {
   property,
   registerElementSafely,
 } from '@clr/core/internal';
-import { html, LitElement } from 'lit-element';
+import { CSSResult, html, LitElement, TemplateResult } from 'lit-element';
 
 import { styles } from './test-dropdown.element.css.js';
 
@@ -31,7 +31,7 @@ import { styles } from './test-dropdown.element.css.js';
  *
  * @beta
  * @slot default - Content slot for dropdown content
- * @event {boolean} openChange - notify open state change of dropdown
+ * @event boolean openChange - notify open state change of dropdown
  * @cssprop --border-color
  * @cssprop --background-color
  * @cssprop --text-color
@@ -41,7 +41,7 @@ export class CdsTestDropdown extends LitElement {
 
   private _open = false;
 
-  get open() {
+  get open(): boolean {
     return this._open;
   }
 
@@ -60,11 +60,11 @@ export class CdsTestDropdown extends LitElement {
   @property({ type: String })
   title = 'dropdown';
 
-  static get styles() {
+  static get styles(): CSSResult[] {
     return [baseStyles, styles];
   }
 
-  render() {
+  render(): TemplateResult {
     return html`
       <div class="dropdown">
         <button @click="${() => this.toggle()}" class="btn">${this.title}</button>
@@ -79,7 +79,7 @@ export class CdsTestDropdown extends LitElement {
   }
 
   /** Toggle the current open state of the dropdown */
-  toggle() {
+  toggle(): void {
     this.open = !this.open;
   }
 }

--- a/packages/core/src/test/utils.ts
+++ b/packages/core/src/test/utils.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-export const spyOnFunction = <T>(obj: T, func: keyof T) => {
+export const spyOnFunction = <T>(obj: T, func: keyof T): jasmine.Spy => {
   // eslint-disable-next-line jasmine/no-unsafe-spy
   const spy = jasmine.createSpy(func as string);
   spyOnProperty(obj, func, 'get').and.returnValue(spy);
@@ -18,7 +18,7 @@ export function createTestElement(): HTMLElement {
   return element;
 }
 
-export function removeTestElement(element: HTMLElement) {
+export function removeTestElement(element: HTMLElement): void {
   element.remove();
 }
 
@@ -40,7 +40,12 @@ export function getComponentSlotContent(component: HTMLElement): { [name: string
   );
 }
 
-function retry(fn: any, maxTries = 10, promise?: Promise<any>, promiseObject?: { resolve: any; reject: any }) {
+function retry(
+  fn: any,
+  maxTries = 10,
+  promise?: Promise<any>,
+  promiseObject?: { resolve: any; reject: any }
+): Promise<any> {
   maxTries--;
   promiseObject = promiseObject || {
     resolve: null,
@@ -69,7 +74,7 @@ function retry(fn: any, maxTries = 10, promise?: Promise<any>, promiseObject?: {
   return promise;
 }
 
-export function componentIsStable(component: any) {
+export function componentIsStable(component: any): Promise<string> {
   return retry(
     () =>
       // eslint-disable-next-line no-async-promise-executor


### PR DESCRIPTION
Signed-off-by: Alex Malitsky <1457274+amalitsky@users.noreply.github.com>

## PR Type

What kind of change does this PR introduce?
- [X] Code style update (formatting, local variables)

## What is the current behavior?
Currently `@typescript-eslint/explicit-function-return-type` rule is set to _off_ for all files inside _packages/core_. That means that providing function/method return value type is **not required**.

Issue Number: No issue at this point, please let me know if I need to create one.

## What is the new behavior?
`@typescript-eslint/explicit-function-return-type` rule is set to _error_ for all files besides _.stories.ts_ and _spec.ts_. All linting errors caused by enabling the rule were fixed as well.

Once this PR is merged providing type for function/method return value will be **required**.

I will look into how many occurrences need to be fixed for _spec_ and _story_ files and might update this PR with more commits or raise another PR. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## References
- rule description: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-function-return-type.md