### PR TITLE
fix: firstItem-related issues; port from v3

### DIFF
--- a/packages/angular/projects/clr-angular/src/data/datagrid/all.spec.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/all.spec.ts
@@ -43,6 +43,7 @@ import ItemsProviderSpecs from './providers/items.spec';
 import PageProviderSpecs from './providers/page.spec';
 import SelectionProviderSpecs from './providers/selection.spec';
 import SortProviderSpecs from './providers/sort.spec';
+import StateProviderSpecs from './providers/state.provider.spec';
 import TableSizeServiceSpec from './providers/table-size.service.spec';
 import DatagridCellRendererSpecs from './render/cell-renderer.spec';
 import DomAdapterSpecs from '../../utils/dom-adapter/dom-adapter.spec';
@@ -61,6 +62,7 @@ describe('Datagrid', function () {
 
   describe('Providers', function () {
     SortProviderSpecs();
+    StateProviderSpecs();
     FiltersProviderSpecs();
     PageProviderSpecs();
     ItemsProviderSpecs();

--- a/packages/angular/projects/clr-angular/src/data/datagrid/providers/state.provider.spec.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/providers/state.provider.spec.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import { Page } from './page';
+import { StateDebouncer } from './state-debouncer.provider';
+import { Subscription } from 'rxjs';
+import { StateProvider } from './state.provider';
+import { FiltersProvider } from './filters';
+import { Sort } from './sort';
+
+export default function (): void {
+  describe('State Provider', function () {
+    let subscriptions: Subscription[] = [];
+    const page = new Page(new StateDebouncer());
+    let stateProviderInstance: StateProvider<any>;
+
+    beforeEach(function () {
+      stateProviderInstance = new StateProvider(
+        new FiltersProvider(new Page(new StateDebouncer()), new StateDebouncer()),
+        new Sort(new StateDebouncer()),
+        page,
+        new StateDebouncer()
+      );
+    });
+
+    afterEach(function () {
+      subscriptions.forEach(sub => sub.unsubscribe());
+      subscriptions = [];
+    });
+
+    it('has empty state upon uninitiated constructor parameters', function () {
+      expect(stateProviderInstance.state).toEqual({});
+    });
+
+    it('has proper page info in state upon page update', function () {
+      page.size = 20;
+      page.current = 2;
+
+      expect(stateProviderInstance.state.page).toEqual({
+        size: 20,
+        current: 2,
+        from: 20,
+        to: 39,
+      });
+
+      page.totalItems = 50;
+
+      expect(stateProviderInstance.state.page).toEqual({
+        size: 20,
+        current: 2,
+        from: 20,
+        to: 39,
+      });
+
+      page.totalItems = 9;
+
+      expect(stateProviderInstance.state.page).toEqual({
+        size: 20,
+        current: 1,
+        from: 0,
+        to: 8,
+      });
+
+      page.totalItems = 0;
+      expect(stateProviderInstance.state.page).toEqual({
+        size: 20,
+        current: 1,
+        from: -1,
+        to: -1,
+      });
+    });
+  });
+}

--- a/packages/angular/projects/dev/src/app/datagrid/preserve-selection/preserve-selection.ts
+++ b/packages/angular/projects/dev/src/app/datagrid/preserve-selection/preserve-selection.ts
@@ -59,7 +59,7 @@ export class DatagridPreserveSelectionDemo {
     this.inventory
       .filter(filters)
       .sort(state.sort as { by: string; reverse: boolean })
-      .fetch(state.page.from, state.page.size)
+      .fetch(state.page.size * (state.page.current - 1), state.page.size)
       .then((result: FetchResult) => {
         this.serverTrackByIdUsers = result.users;
         this.loading = false;

--- a/packages/angular/projects/dev/src/app/datagrid/selection-single/selection-single.ts
+++ b/packages/angular/projects/dev/src/app/datagrid/selection-single/selection-single.ts
@@ -50,7 +50,7 @@ export class DatagridSelectionSingleDemo {
     this.inventory
       .filter(filters)
       .sort(state.sort as { by: string; reverse: boolean })
-      .fetch(state.page.from, state.page.size)
+      .fetch(state.page.size * (state.page.current - 1), state.page.size)
       .then((result: FetchResult) => {
         setTimeout(() => {
           this.trackByIdServerUsers = result.users;

--- a/packages/angular/projects/dev/src/app/datagrid/selection/selection.ts
+++ b/packages/angular/projects/dev/src/app/datagrid/selection/selection.ts
@@ -46,7 +46,7 @@ export class DatagridSelectionDemo {
     this.inventory
       .filter(filters)
       .sort(state.sort as { by: string; reverse: boolean })
-      .fetch(state.page.from, state.page.size)
+      .fetch(state.page.size * (state.page.current - 1), state.page.size)
       .then((result: FetchResult) => {
         this.serverTrackByIdUsers = result.users;
         this.loading = false;

--- a/packages/angular/projects/dev/src/app/datagrid/server-driven/server-driven.ts
+++ b/packages/angular/projects/dev/src/app/datagrid/server-driven/server-driven.ts
@@ -37,7 +37,7 @@ export class DatagridServerDrivenDemo {
     this.inventory
       .filter(filters)
       .sort(state.sort as { by: string; reverse: boolean })
-      .fetch(state.page.from, state.page.size)
+      .fetch(state.page.size * (state.page.current - 1), state.page.size)
       .then((result: FetchResult) => {
         this.users = result.users;
         this.total = result.length;


### PR DESCRIPTION
* update pagination firstItem and lastItem description in documentation
* use page.size * (page.current - 1) to fetch items in server-driven datagrid
* partially add unit test for state provider
Note: website changes not merged in master/v4

Signed-off-by: KingMario <gcyyq@hotmail.com>
Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [x] Other... Please describe: Port from v3; docs and tests

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
