### PR TITLE
Correct link to ATTRIBUTION.md file

### DIFF
--- a/src/website/src/app/documentation/get-started/get-started.component.html
+++ b/src/website/src/app/documentation/get-started/get-started.component.html
@@ -197,7 +197,7 @@ ng update @clr/angular@next'"></clr-code-snippet>
     </p>
 
     <h2 id="attributions">Attributions</h2>
-    <p>See the <a href="https://github.com/vmware/clarity/blob/master/ATTRIBUTION.md" target="_blank">legal
+    <p>See the <a href="https://github.com/vmware/clarity/blob/master/docs/ATTRIBUTION.md" target="_blank">legal
         attributions</a> for third party software included in Clarity.
     </p>
     <div style="visibility: hidden; height: 80vh;">This is a spacer to force sidenav highlighting on scroll</div>


### PR DESCRIPTION
The link to the ATTRIBUTION.md file is missing the docs directory.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The link to the ATTRIBUTION file does not work 

Issue Number: N/A

## What is the new behavior?

The link to the ATTRIBUTION file now works.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
