### PR TITLE
build: improve ci logging

### DIFF
--- a/packages/angular/karma.conf.js
+++ b/packages/angular/karma.conf.js
@@ -20,7 +20,7 @@ module.exports = function (config) {
       reports: ['html', 'lcovonly', 'text-summary'],
       fixWebpackSourcePaths: true,
     },
-    reporters: ['progress', 'kjhtml'],
+    reporters: ['dots', 'kjhtml'],
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,

--- a/packages/core/karma.conf.js
+++ b/packages/core/karma.conf.js
@@ -37,7 +37,7 @@ module.exports = config => {
     restartOnFileChange: true,
     autoWatch: false,
     concurrency: Infinity,
-    reporters: ['progress', 'coverage-istanbul'],
+    reporters: ['dots', 'coverage-istanbul'],
     coverageIstanbulReporter: {
       dir: '../../reports/coverage/core',
       reports: ['html', 'lcovonly'],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "npm-run-all build -p build:watch storybook",
     "storybook": "start-storybook -s .storybook/public -p 6006 --config-dir=.storybook",
-    "dev:build": "build-storybook -s .storybook/public -c .storybook -o dist/storybook/core",
+    "dev:build": "build-storybook -s .storybook/public -c .storybook -o dist/storybook/core --quiet",
     "lint": "eslint \"**/*.ts\" --ignore-pattern \"dist\" && stylelint \"./**/*.scss\"",
     "lint:fix": "eslint --fix \"./**/*.ts\" && stylelint --fix \"./**/*.scss\"",
     "golden": "yarn build:api",

--- a/packages/icons/karma.conf.js
+++ b/packages/icons/karma.conf.js
@@ -31,7 +31,7 @@ module.exports = function (config) {
         html: '../../reports/clr-icons/html',
       },
     },
-    reporters: ['progress', 'karma-typescript'],
+    reporters: ['dots', 'karma-typescript'],
     colors: true,
     singleRun: true,
     browsers: ['ChromeHeadless'],


### PR DESCRIPTION

  * Change CI karma reporters to use dots to indicate that Karma is working but fix the issue with how `progress` reporter is been logged inside CI logs noise.

```
...
Chrome Headless 83.0.4103.97 (Linux x86_64): Executed 17 of 64 SUCCESS (0 secs / 0.162 secs)
Chrome Headless 83.0.4103.97 (Linux x86_64): Executed 18 of 64 SUCCESS (0 secs / 0.178 secs)
Chrome Headless 83.0.4103.97 (Linux x86_64): Executed 19 of 64 SUCCESS (0 secs / 0.179 secs)
Chrome Headless 83.0.4103.97 (Linux x86_64): Executed 20 of 64 SUCCESS (0 secs / 0.185 secs)
Chrome Headless 83.0.4103.97 (Linux x86_64): Executed 21 of 64 SUCCESS (0 secs / 0.186 secs)
Chrome Headless 83.0.4103.97 (Linux x86_64): Executed 22 of 64 SUCCESS (0 secs / 0.187 secs)
Chrome Headless 83.0.4103.97 (Linux x86_64): Executed 23 of 64 SUCCESS (0 secs / 0.188 secs)
Chrome Headless 83.0.4103.97 (Linux x86_64): Executed 24 of 64 SUCCESS (0 secs / 0.188 secs)
Chrome Headless 83.0.4103.97 (Linux x86_64): Executed 25 of 64 SUCCESS (0 secs / 0.188 secs)
Chrome Headless 83.0.4103.97 (Linux x86_64): Executed 26 of 64 SUCCESS (0 secs / 0.189 secs)
...
```
  * Use quite reporting when building development storybook - This is the only way to pass argument to Storybook internal webpack and hide `progress` output. Same as Karma reporter is generating a lot of noise and it's hard to find what is not working for failing builds

```
...
<s> [webpack.Progress] 18% building 69/127 modules 58 active /home/runner/work/clarity/clarity/packages/core/dist/core/custom-elements.json
<s> [webpack.Progress] 18% building 70/127 modules 57 active /home/runner/work/clarity/clarity/packages/core/dist/core/custom-elements.json
<s> [webpack.Progress] 18% building 71/127 modules 56 active /home/runner/work/clarity/clarity/packages/core/dist/core/custom-elements.json
<s> [webpack.Progress] 18% building 72/127 modules 55 active /home/runner/work/clarity/clarity/packages/core/dist/core/custom-elements.json
<s> [webpack.Progress] 18% building 73/127 modules 54 active /home/runner/work/clarity/clarity/packages/core/dist/core/custom-elements.json
<s> [webpack.Progress] 18% building 74/127 modules 53 active /home/runner/work/clarity/clarity/packages/core/dist/core/custom-elements.json
<s> [webpack.Progress] 19% building 75/127 modules 52 active /home/runner/work/clarity/clarity/packages/core/dist/core/custom-elements.json
<s> [webpack.Progress] 19% building 76/127 modules 51 active /home/runner/work/clarity/clarity/packages/core/dist/core/custom-elements.json
<s> [webpack.Progress] 19% building 77/127 modules 50 active /home/runner/work/clarity/clarity/packages/core/dist/core/custom-elements.json
<s> [webpack.Progress] 19% building 78/127 modules 49 active /home/runner/work/clarity/clarity/packages/core/dist/core/custom-elements.json
<s> [webpack.Progress] 19% building 79/127 modules 48 active /home/runner/work/clarity/clarity/packages/core/dist/core/custom-elements.json
<s> [webpack.Progress] 19% building 80/127 modules 47 active /home/runner/work/clarity/clarity/packages/core/dist/core/custom-elements.json
<s> [webpack.Progress] 19% building 81/127 modules 46 active /home/runner/work/clarity/clarity/packages/core/dist/core/custom-elements.json
<s> [webpack.Progress] 19% building 82/127 modules 45 active /home/runner/work/clarity/clarity/packages/core/dist/core/custom-elements.json
<s> [webpack.Progress] 19% building 83/127 modules 44 active /home/runner/work/clarity/clarity/packages/core/dist/core/custom-elements.json
<s> [webpack.Progress] 20% building 84/127 modules 43 active /home/runner/work/clarity/clarity/packages/core/dist/core/custom-elements.json
<s> [webpack.Progress] 20% building 85/127 modules 42 active /home/runner/work/clarity/clarity/packages/core/dist/core/custom-elements.json
<s> [webpack.Progress] 20% building 86/127 modules 41 active /home/runner/work/clarity/clarity/packages/core/dist/core/custom-elements.json
<s> [webpack.Progress] 20% building 87/127 modules 40 active /home/runner/work/clarity/clarity/packages/core/dist/core/custom-elements.json
...
``` 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
