### PR TITLE
fix(a11y): let datagrid placeholder to be focusable from SR

### DIFF
--- a/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-placeholder.spec.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-placeholder.spec.ts
@@ -56,6 +56,11 @@ export default function (): void {
       it('projects content when there are no items', function () {
         expect(context.clarityElement.textContent.trim()).toMatch('Hello world');
       });
+
+      it('should have role attribute for accessibility', function () {
+        expect(context.clarityElement.querySelector('.datagrid-placeholder[role=row]')).not.toBeNull();
+        expect(context.clarityElement.querySelector('span[role=gridcell]')).not.toBeNull();
+      });
     });
   });
 }

--- a/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-placeholder.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-placeholder.ts
@@ -9,9 +9,9 @@ import { Items } from './providers/items';
 @Component({
   selector: 'clr-dg-placeholder',
   template: `
-    <div class="datagrid-placeholder" [class.datagrid-empty]="emptyDatagrid">
+    <div class="datagrid-placeholder" [class.datagrid-empty]="emptyDatagrid" role="row">
       <div class="datagrid-placeholder-image" *ngIf="emptyDatagrid"></div>
-      <ng-content *ngIf="emptyDatagrid"></ng-content>
+      <span role="gridcell"><ng-content *ngIf="emptyDatagrid"></ng-content></span>
     </div>
   `,
   host: { '[class.datagrid-placeholder-container]': 'true' },


### PR DESCRIPTION
Provide `role='row'` and `role='gridcell'` to datagrid-placeholder so it could be selectable by SR when visible.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4090 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Close #4090 