### PR TITLE
feat: enable SHIFT+TAB in focus trap

### DIFF
--- a/packages/angular/projects/clr-angular/src/utils/focus-trap/focus-trap-config.interface.ts
+++ b/packages/angular/projects/clr-angular/src/utils/focus-trap/focus-trap-config.interface.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+export interface FocusTrapConfig {
+  strict: boolean;
+}


### PR DESCRIPTION
- if the focus goes out to the top rebound element, it means a user has pressed SHIFT+TAB from the first focusable element in the trap.
So the focus trap will rebound the focus to its last focusable element.
- if the focus goes out to the bottom rebound element, it means a user has pressed TAB from the last focusable element in the trap.
So the focus trap will rebound the focus to its first focusable element.
- if the focus goes out to an element outside that is not rebounder element, it means a user has used a mouse to click and focus.
So the focus trap will rebound the focus to its host element. This is the case if the focus trap config is on strict mode.
If the trap config is on not strict mode, the focus trap will not rebound the focus.

Fixes #2400

Signed-off-by: stsogoo <stsogoo@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2400

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
