### PR TITLE
fix(form): missing ng-touched on controls that are touched

### DIFF
--- a/packages/angular/projects/clr-angular/src/forms/common/wrapped-control.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/common/wrapped-control.spec.ts
@@ -106,6 +106,13 @@ class WithControl {
   model = '';
 }
 
+@Component({
+  template: `<test-wrapper3><input type="number" testControl3 [(ngModel)]="model" required /></test-wrapper3>`,
+})
+class WithNumberControl {
+  model = '';
+}
+
 interface TestContext {
   fixture: ComponentFixture<any>;
   wrapper: TestWrapper;
@@ -235,6 +242,14 @@ export default function (): void {
         this.input.blur();
         this.fixture.detectChanges();
         expect(IfControlStateService.prototype.triggerStatusChange).toHaveBeenCalled();
+      });
+
+      it('blur marks the control as touched', function (this: TestContext) {
+        setupTest(this, WithNumberControl, TestControl3);
+        this.input.focus();
+        this.input.blur();
+        this.fixture.detectChanges();
+        expect(this.input.className).toContain('ng-touched');
       });
 
       it('implements ngOnDestroy', function (this: TestContext) {

--- a/packages/angular/projects/clr-angular/src/forms/common/wrapped-control.ts
+++ b/packages/angular/projects/clr-angular/src/forms/common/wrapped-control.ts
@@ -95,6 +95,13 @@ export class WrappedFormControl<W extends DynamicWrapper> implements OnInit, Aft
   @HostListener('blur')
   triggerValidation() {
     if (this.ifControlStateService) {
+      /**
+       * For some reason the <input type="number" /> on blur ngControl doesn't set the control to 'touched'
+       * This one is a workaround to provide the control to be 'touched' on blur and fix #4480.
+       */
+      if (this.ngControl && !this.ngControl.touched) {
+        this.markControlService.markAsTouched();
+      }
       this.ifControlStateService.triggerStatusChange();
     }
   }


### PR DESCRIPTION
Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #4480 

## What is the new behavior?

When you go to a form and click on a control for example of type "number" and then click outside of the control errors are shown if there are any.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
