### PR TITLE
fix(toggle): popover toggle prevents default behavior of arrow key events

### DIFF
--- a/packages/angular/projects/clr-angular/src/utils/popover/popover-close-button.spec.ts
+++ b/packages/angular/projects/clr-angular/src/utils/popover/popover-close-button.spec.ts
@@ -12,6 +12,7 @@ import { ClrPopoverEventsService } from './providers/popover-events.service';
 import { ClrPopoverPositionService } from './providers/popover-position.service';
 import { ClrPopoverCloseButton } from './popover-close-button';
 import { ClrPopoverModuleNext } from './popover.module';
+import { KeyCodes } from '../../utils/enums/key-codes.enum';
 
 @Component({
   selector: 'test-host',

--- a/packages/angular/projects/clr-angular/src/utils/popover/popover-close-button.ts
+++ b/packages/angular/projects/clr-angular/src/utils/popover/popover-close-button.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  *
@@ -35,6 +35,7 @@ export class ClrPopoverCloseButton implements OnDestroy, AfterViewInit {
   @Output('clrPopoverOnCloseChange') closeChange: EventEmitter<void> = new EventEmitter<void>();
 
   @HostListener('click', ['$event'])
+  @HostListener('keydown', ['$event'])
   handleClick(event: MouseEvent) {
     this.smartOpenService.toggleWithEvent(event);
     this.smartEventsService.setAnchorFocus();

--- a/packages/angular/projects/clr-angular/src/utils/popover/popover-content.spec.ts
+++ b/packages/angular/projects/clr-angular/src/utils/popover/popover-content.spec.ts
@@ -17,6 +17,7 @@ import { ClrPopoverPositionService } from './providers/popover-position.service'
 import { ClrPopoverToggleService } from './providers/popover-toggle.service';
 import { ClrPopoverPosition } from './interfaces/popover-position.interface';
 import { ClrPopoverModuleNext } from './popover.module';
+import { KeyCodes } from '../../utils/enums/key-codes.enum';
 
 @Component({
   selector: 'test-host',
@@ -176,6 +177,18 @@ export default function (): void {
 
         expect(tick).not.toThrowAnyError();
       }));
+
+      it('prevents event default behavior when open with arrow key', function (this: Context) {
+        const anchorButton = this.eventService.anchorButtonRef.nativeElement;
+        anchorButton.focus();
+        this.fixture.detectChanges();
+        const event = new KeyboardEvent('keydown', { key: KeyCodes.ArrowDown });
+        spyOn(event, 'preventDefault');
+        anchorButton.dispatchEvent(event);
+        this.fixture.detectChanges();
+        expect(this.toggleService.open).toBeTrue();
+        expect(event.preventDefault).toHaveBeenCalled();
+      });
     });
   });
 }

--- a/packages/angular/projects/clr-angular/src/utils/popover/popover-open-close-button.ts
+++ b/packages/angular/projects/clr-angular/src/utils/popover/popover-open-close-button.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  *
@@ -29,6 +29,7 @@ export class ClrPopoverOpenCloseButton implements OnDestroy {
   @Output('clrPopoverOpenCloseChange') openCloseChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 
   @HostListener('click', ['$event'])
+  @HostListener('keydown', ['$event'])
   handleClick(event: MouseEvent) {
     this.smartOpenService.toggleWithEvent(event);
   }

--- a/packages/angular/projects/clr-angular/src/utils/popover/providers/popover-toggle.service.spec.ts
+++ b/packages/angular/projects/clr-angular/src/utils/popover/providers/popover-toggle.service.spec.ts
@@ -11,6 +11,7 @@ import { Observable } from 'rxjs';
 import { ClrPopoverEventsService } from './popover-events.service';
 import { ClrPopoverPositionService } from './popover-position.service';
 import { ClrPopoverToggleService } from './popover-toggle.service';
+import { KeyCodes } from '../../enums/key-codes.enum';
 
 @Component({
   selector: 'test-host',
@@ -93,6 +94,29 @@ export default function (): void {
         this.toggleService.toggleWithEvent(closeClickEvent);
         expect(this.toggleService.open).toBeFalse();
         expect(this.toggleService.openEvent).toBe(closeClickEvent);
+      });
+
+      /**
+       * Call `event.preventDefault` for arrow key events
+       * and
+       * skip `event.preventDefault` for non arrow key events
+       */
+      Object.keys(KeyCodes).forEach(key => {
+        const arrowKeyEvent = new KeyboardEvent(key, { key });
+        if (key.search('Arrow') > -1) {
+          // Arrow keys are ignored to prevent content from closing the popover content
+          it(`prevents the default toggle action for the ${key} key`, function (this: TestContext) {
+            spyOn(arrowKeyEvent, 'preventDefault');
+            this.toggleService.toggleWithEvent(arrowKeyEvent);
+            expect(arrowKeyEvent.preventDefault).toHaveBeenCalled();
+          });
+        } else {
+          it(`does not prevent the default toggle action for the ${key} key`, function (this: TestContext) {
+            spyOn(arrowKeyEvent, 'preventDefault');
+            this.toggleService.toggleWithEvent(arrowKeyEvent);
+            expect(arrowKeyEvent.preventDefault).not.toHaveBeenCalled();
+          });
+        }
       });
     });
   });

--- a/packages/angular/projects/clr-angular/src/utils/popover/providers/popover-toggle.service.ts
+++ b/packages/angular/projects/clr-angular/src/utils/popover/providers/popover-toggle.service.ts
@@ -6,6 +6,7 @@
  */
 import { Injectable } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
+import { preventArrowKeyScroll } from '../../focus/key-focus/util';
 
 @Injectable()
 export class ClrPopoverToggleService {
@@ -57,6 +58,8 @@ export class ClrPopoverToggleService {
    * This is for instance the case of components that open on a click, but close on a click outside.
    */
   public toggleWithEvent(event: any) {
+    preventArrowKeyScroll(event);
+
     this.openEvent = event;
     this.open = !this.open;
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #3622

## What is the new behavior?

When the container is too large and an arrow key initiates page scrolling, but at the same time initiates a popover opening, the popover doesn't close and stays open.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

It is somehow tricky to create a unit test for this because it is part of the popovers and they are represented as directives and services, and at the same time, it requires a parent with a template that has a scroll and a popover child component in it. It is not a good idea to add the unit test in the popover but at the same time it is not a good idea to set a single unit test for example only in dropdown cause this can be the same issue in the tooltips.