### PR TITLE
fix(datagrid): current selection immutability

### DIFF
--- a/packages/angular/projects/clr-angular/src/data/datagrid/providers/selection.spec.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/providers/selection.spec.ts
@@ -3,8 +3,8 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { TrackByFunction } from '@angular/core';
-import { fakeAsync, tick } from '@angular/core/testing';
+import { TrackByFunction, NgZone } from '@angular/core';
+import { fakeAsync, tick, TestBed } from '@angular/core/testing';
 import { Subject } from 'rxjs';
 
 import { ClrDatagridFilterInterface } from '../interfaces/filter.interface';
@@ -38,8 +38,8 @@ export default function (): void {
         itemsInstance = new Items(filtersInstance, sortInstance, pageInstance);
         itemsInstance.smartenUp();
         itemsInstance.all = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-
-        selectionInstance = new Selection(itemsInstance, filtersInstance);
+        const ngZone = TestBed.get(NgZone);
+        selectionInstance = new Selection(itemsInstance, filtersInstance, ngZone);
       });
 
       afterEach(function () {
@@ -193,7 +193,7 @@ export default function (): void {
         expect(currentSelection.sort(numberSort)).toEqual(itemsInstance.displayed);
         selectionInstance.toggleAll();
         expect(currentSelection).toEqual([]);
-        expect(nbChanges).toBe(3);
+        expect(nbChanges).toBe(4);
       });
 
       it('exposes an Observable to follow selection changes in single selection type', function () {
@@ -347,6 +347,27 @@ export default function (): void {
 
         expect(selectionInstance.current).toEqual([4, 2]);
       });
+
+      it('does not mutate the selection array when selecting or deselecting', function () {
+        selectionInstance.selectionType = SelectionType.Multi;
+        const selection = [4, 2];
+        selectionInstance.current = selection;
+
+        selectionInstance.setSelected(1, true);
+        expect(selectionInstance.current === selection).toBe(false);
+
+        selectionInstance.setSelected(1, false);
+        expect(selectionInstance.current === selection).toBe(false);
+      });
+
+      it('does not mutate the selection array when clearing the selection', function () {
+        selectionInstance.selectionType = SelectionType.Multi;
+        const selection = [4, 2];
+        selectionInstance.current = selection;
+
+        selectionInstance.clearSelection();
+        expect(selectionInstance.current === selection).toBe(false);
+      });
     });
 
     describe('clrDgPreserveSelection', () => {
@@ -364,8 +385,8 @@ export default function (): void {
         itemsInstance = new Items(filtersInstance, sortInstance, pageInstance);
         itemsInstance.smartenUp();
         itemsInstance.all = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-
-        selectionInstance = new Selection(itemsInstance, filtersInstance);
+        const ngZone = TestBed.get(NgZone);
+        selectionInstance = new Selection(itemsInstance, filtersInstance, ngZone);
         selectionInstance.preserveSelection = true;
       });
 
@@ -459,8 +480,8 @@ export default function (): void {
         itemsInstance.smartenUp();
         itemsInstance.all = items;
         pageInstance.size = 3;
-
-        selectionInstance = new Selection(itemsInstance, filtersInstance);
+        const ngZone = TestBed.get(NgZone);
+        selectionInstance = new Selection(itemsInstance, filtersInstance, ngZone);
       });
 
       afterEach(function () {
@@ -503,8 +524,10 @@ export default function (): void {
       });
 
       describe('single selection', function () {
+        let ngZone: NgZone;
         beforeEach(function () {
           selectionInstance.selectionType = SelectionType.Single;
+          ngZone = TestBed.get(NgZone);
         });
 
         it('should preserve selection on page change', function () {
@@ -528,7 +551,7 @@ export default function (): void {
 
         it('does not apply trackBy to single selection with no items', () => {
           const emptyItems = new Items(filtersInstance, sortInstance, pageInstance);
-          const selection = new Selection(emptyItems, filtersInstance);
+          const selection = new Selection(emptyItems, filtersInstance, ngZone);
 
           spyOn(emptyItems, 'trackBy');
 
@@ -595,8 +618,9 @@ export default function (): void {
         filtersInstance = new FiltersProvider(pageInstance, stateDebouncer);
         sortInstance = new Sort(stateDebouncer);
         itemsInstance = new Items(filtersInstance, sortInstance, pageInstance);
+        const ngZone = TestBed.get(NgZone);
 
-        selectionInstance = new Selection(itemsInstance, filtersInstance);
+        selectionInstance = new Selection(itemsInstance, filtersInstance, ngZone);
       });
 
       afterEach(function () {
@@ -721,8 +745,8 @@ export default function (): void {
         itemsInstance = new Items(filtersInstance, sortInstance, pageInstance);
         itemsInstance.smartenUp();
         itemsInstance.all = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-
-        selectionInstance = new Selection(itemsInstance, filtersInstance);
+        const ngZone = TestBed.get(NgZone);
+        selectionInstance = new Selection(itemsInstance, filtersInstance, ngZone);
       });
 
       afterEach(function () {
@@ -750,7 +774,8 @@ export default function (): void {
 
       it('should not execute canItBeLocked block when there are no items to scan inside lockItem and isLocked method', function () {
         itemsInstance.all = undefined;
-        selectionInstance = new Selection(itemsInstance, filtersInstance);
+        const ngZone = TestBed.get(NgZone);
+        selectionInstance = new Selection(itemsInstance, filtersInstance, ngZone);
         selectionInstance.selectionType = SelectionType.Multi;
 
         // lock a row


### PR DESCRIPTION
The current selection is now immutable, so that selection can directly be used with @ngrx/store strict checking.

Signed-off-by: Skip Geldens <skip@skipgeldens.nl>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently I cannot use [clrDgSelected] directly from a ngrx/store async variable because the datagrids mutates the content of the array of selected items instead of replacing the complete array. Shown in: https://stackblitz.com/edit/clarity-light-theme-v2-cpfinp

Issue Number: https://github.com/vmware/clarity/issues/4528

## What is the new behavior?

The `_current` array in the selection provider is not mutated but replaced on change.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
