### PR TITLE
fix(form): if-error call on undefined ViewContainerRef throw error

### DIFF
--- a/packages/angular/projects/clr-angular/src/forms/common/if-control-state/if-error.ts
+++ b/packages/angular/projects/clr-angular/src/forms/common/if-control-state/if-error.ts
@@ -36,7 +36,7 @@ export class ClrIfError extends AbstractIfState {
         options = { error: this.control.getError(this.error) };
       }
       this.container.createEmbeddedView(this.template, options);
-    } else if (!isInvalid) {
+    } else if (!isInvalid && this.container) {
       this.container.clear();
     }
     this.displayedContent = isInvalid;


### PR DESCRIPTION
Unhandle that there is a case at the start that the container could be undefined and calling a method on it will throw `undefined` error.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Close #4813