### PR TITLE
fix: core doc fixes

### DIFF
--- a/apps/core-parcel-js/package.json
+++ b/apps/core-parcel-js/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "clarity-performance",
+  "name": "core-parcel-js",
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "start": "parcel src/index.html --cache-dir=./.parcel-cache",
+    "start": "yarn run clean && parcel src/index.html --cache-dir=./.parcel-cache",
     "build": "yarn run clean && parcel build src/index.html --cache-dir=./.parcel-cache",
     "bundle": "source-map-explorer dist/*.js",
     "clean": "del ./dist .parcel-cache"

--- a/packages/core/docs/angular.stories.mdx
+++ b/packages/core/docs/angular.stories.mdx
@@ -43,3 +43,9 @@ To listen to events use the Angular <code>(event)</code> binding syntax.
   Hello World
 </cds-alert>
 ```
+
+<cds-button>
+  <a href="https://github.com/vmware/clarity/tree/master/apps" target="_blank" rel="noopener">
+    Example Apps
+  </a>
+</cds-button>

--- a/packages/core/docs/angularjs.stories.mdx
+++ b/packages/core/docs/angularjs.stories.mdx
@@ -48,3 +48,9 @@ To listen to custom events use the [`ng-on` directive](https://docs.angularjs.or
   Hello World
 </cds-alert>
 ```
+
+<cds-button>
+  <a href="https://github.com/vmware/clarity/tree/master/apps" target="_blank" rel="noopener">
+    Example Apps
+  </a>
+</cds-button>

--- a/packages/core/docs/preact.stories.mdx
+++ b/packages/core/docs/preact.stories.mdx
@@ -26,3 +26,9 @@ Example of an alert web component in Preact
   Hello World
 </cds-alert>
 ```
+
+<cds-button>
+  <a href="https://github.com/vmware/clarity/tree/master/apps" target="_blank" rel="noopener">
+    Example Apps
+  </a>
+</cds-button>

--- a/packages/core/docs/react.stories.mdx
+++ b/packages/core/docs/react.stories.mdx
@@ -3,50 +3,43 @@ import { html, LitElement } from 'lit-element';
 
 <Meta title="Documentation/React" />
 
-# Preact
+# React
 
-To use Clarity Core with Preact follow the package <a href="./?path=/docs/documentation-getting-started--page">installation instructions</a>.
-Once installed import the component into your JavaScript file.
+Clarity Core is a suite of Web Components from the [Clarity Design System](https://clarity.design).
+Because React [doesn't fully interoperate with custom elements](https://custom-elements-everywhere.com/)
+we have developed this library of React components that wrap Clarity Web Components
+
+## Installation
+
+1.  Install the Clarity Core package from npm.
+
+```bash
+npm install @clr/core --save
+```
+
+2.  Install the Clarity React package from npm.
+
+```bash
+npm install @clr/react --save
+```
+
+3.  Import desired component into your JavaScript or TypeScript
 
 ```typescript
-import '@clr/core/alert/register.js';
+import { CdsModal, CdsModalActions, CdsModalContent, CdsModalHeader } from '@clr/react/modal';
 ```
+
+4.  Use React wrapped Web Component in React
+
+Web Components are kebab cased tag name which in `@clr/react` will be converted to
+Pascal case. For example, `<cds-alert>` element will be `<CdsAlert>` in React.
+In addition our event props will follow the React naming convention of camel case for props
+and start with `on`. So the custom event `closeChange` will be `onCloseChange`.
 
 ```jsx
 /*
-Example of an alert web component in Preact
-- status - attribute style hook
-- closable - setting the 'closable' property on the element
-- onCloseChange - listen for the 'closeChange' custom event
-*/
-
-<cds-alert status="info" closable={this.state.closable} onCloseChange={this.log}>
-  Hello World
-</cds-alert>
-```
-
-## React
-
-A shim layer <em>(a.k.a wrapper)</em> must be used for web components to work in
-React applications. This is due to React not being compatible with Web Standards
-such as <a href="https://custom-elements-everywhere.com">custom elements</a>.
-
-We have a react wrapper package that you must install and use in your react application.
-
-Generally our kebab cased tag names will be in Pascal case. For example, `<cds-alert>`
-element will be `<CdsAlert>` in react.
-
-In addition our event props will follow the react naming convention of camel case for props
-and start with `on`. So 'closeChange' will be `onCloseChange` and so forth.
-
-```typescript
-import { CdsAlert } from '@clr/react/alert';
-```
-
-```jsx
-/*
-Example of an alert web component in react
-- status - attribute style hook
+Example of an alert component in React
+- status - attribute/property style hook
 - closable - setting the 'closable' property on the element
 - onCloseChange - listen for the 'closeChange' custom event
 */
@@ -56,5 +49,42 @@ Example of an alert web component in react
 </CdsAlert>
 ```
 
-You can try out an <a href="https://stackblitz.com/edit/react-ts-drskpx">early
-work in progress prototype here</a>.
+## Using refs
+
+In React [refs](https://reactjs.org/docs/refs-and-the-dom.html) provide a way to access DOM nodes or
+React elements created in the render method. Because web components' lifecycle lives outside of react's
+lifecycle our components provide a way to use refs when the underlying web component has finished rendering:
+
+```typescript
+import React from 'react';
+import { CdsButton } from '@clr/react/button';
+
+export default class App extends React.Component<{}, {}> {
+  buttonRef: React.RefObject<CdsButton>;
+
+  constructor(props: any) {
+    super(props);
+    this.buttonRef = React.createRef<CdsButton>();
+  }
+
+  componentDidMount() {
+    this.buttonRef.current.nativeElement.then(element => {
+      element.focus();
+    });
+  }
+
+  render() {
+    return (
+      <div>
+        <CdsButton ref={this.buttonRef}>My button</CdsButton>
+      </div>
+    );
+  }
+}
+```
+
+<cds-button>
+  <a href="https://github.com/vmware/clarity/tree/master/apps" target="_blank" rel="noopener">
+    Example Apps
+  </a>
+</cds-button>

--- a/packages/core/docs/vue.stories.mdx
+++ b/packages/core/docs/vue.stories.mdx
@@ -25,3 +25,9 @@ Example of a alert web component in Vue
 
 <cds-alert status="info" :closable="true" @closeChange="log"> Hello World </cds-alert>`
 ```
+
+<cds-button>
+  <a href="https://github.com/vmware/clarity/tree/master/apps" target="_blank" rel="noopener">
+    Example Apps
+  </a>
+</cds-button>

--- a/packages/core/src/button/base-button.element.scss
+++ b/packages/core/src/button/base-button.element.scss
@@ -86,20 +86,22 @@
 }
 
 ::slotted {
-  line-height: 1em;
-  color: inherit;
+  line-height: 1em !important;
+  color: inherit !important;
 }
 
 ::slotted(a) {
   text-decoration: none !important;
-  display: block;
-  color: inherit;
-  margin: calc(var(--padding) * -1);
-  padding: var(--padding);
-  min-width: var(--min-width);
-  line-height: 1em;
+  display: block !important;
+  color: inherit !important;
+  font-size: inherit !important;
+  font-family: inherit !important;
+  margin: calc(var(--padding) * -1) !important;
+  padding: var(--padding) !important;
+  min-width: var(--min-width) !important;
+  line-height: 1em !important;
   box-sizing: border-box !important;
-  outline: 0;
+  outline: 0 !important;
 }
 
 ::slotted(cds-icon) {

--- a/packages/core/src/styles/typography/_typography.scss
+++ b/packages/core/src/styles/typography/_typography.scss
@@ -17,7 +17,6 @@
   font-family: $cds-token-typography-font-family;
   margin-top: 0;
   margin-bottom: 0;
-  width: 100%;
 }
 
 [cds-text*='display'],

--- a/packages/core/src/styles/typography/typography.stories.mdx
+++ b/packages/core/src/styles/typography/typography.stories.mdx
@@ -87,6 +87,21 @@ create consistent and coherent experiences.
   <Story id="foundation-typography-stories--inline" />
 </Preview>
 
+## Headings h1-h6
+
+Core provides the same html tag name based styles that exist in Clarity UI for
+both headings and paragraphs.
+
+<Preview>
+  <Story id="foundation-typography-stories--legacy-headers" />
+</Preview>
+
+## Paragraphs p1-p6
+
+<Preview>
+  <Story id="foundation-typography-stories--legacy-paragraphs" />
+</Preview>
+
 ## Tokens
 
 <Preview>

--- a/packages/core/src/styles/typography/typography.stories.ts
+++ b/packages/core/src/styles/typography/typography.stories.ts
@@ -117,7 +117,6 @@ export const transforms = () => {
 export const legacyHeaders = () => {
   return html`
     <cds-demo cds-layout="vertical gap:lg">
-      <p cds-text="h0">The five boxing wizards jump quickly (h0)</p>
       <p cds-text="h1">The five boxing wizards jump quickly (h1)</p>
       <p cds-text="h2">The five boxing wizards jump quickly (h2)</p>
       <p cds-text="h3">The five boxing wizards jump quickly (h3)</p>
@@ -131,7 +130,6 @@ export const legacyHeaders = () => {
 export const legacyParagraphs = () => {
   return html`
     <cds-demo cds-layout="vertical gap:lg">
-      <p cds-text="p0">The quick brown fox jumps over the lazy dog. (p0)</p>
       <p cds-text="p1">The quick brown fox jumps over the lazy dog. (p1)</p>
       <p cds-text="p2">The quick brown fox jumps over the lazy dog. (p2)</p>
       <p cds-text="p3">The quick brown fox jumps over the lazy dog. (p3)</p>

--- a/packages/core/tokens.yml
+++ b/packages/core/tokens.yml
@@ -284,7 +284,7 @@ props:
     type: 'em'
     category: 'typography'
   - name: display-font-weight
-    value: 500
+    value: 400
     type: 'number'
     category: 'typography'
 
@@ -306,7 +306,7 @@ props:
     type: 'em'
     category: 'typography'
   - name: heading-font-weight
-    value: 500
+    value: 400
     type: 'number'
     category: 'typography'
 
@@ -328,7 +328,7 @@ props:
     type: 'em'
     category: 'typography'
   - name: title-font-weight
-    value: 500
+    value: 400
     type: 'number'
     category: 'typography'
 
@@ -350,7 +350,7 @@ props:
     type: 'em'
     category: 'typography'
   - name: section-font-weight
-    value: 500
+    value: 400
     type: 'number'
     category: 'typography'
 
@@ -372,7 +372,7 @@ props:
     type: 'em'
     category: 'typography'
   - name: subsection-font-weight
-    value: 500
+    value: 400
     type: 'number'
     category: 'typography'
 
@@ -489,7 +489,7 @@ props:
     category: 'typography'
     private: true
   - name: h0-font-weight
-    value: 500
+    value: 200
     type: 'number'
     category: 'typography'
     private: true
@@ -517,7 +517,7 @@ props:
     category: 'typography'
     private: true
   - name: h1-font-weight
-    value: 500
+    value: 200
     type: 'number'
     category: 'typography'
     private: true
@@ -545,7 +545,7 @@ props:
     category: 'typography'
     private: true
   - name: h2-font-weight
-    value: 500
+    value: 200
     type: 'number'
     category: 'typography'
     private: true
@@ -573,7 +573,7 @@ props:
     category: 'typography'
     private: true
   - name: h3-font-weight
-    value: 500
+    value: 200
     type: 'number'
     category: 'typography'
     private: true
@@ -601,7 +601,7 @@ props:
     category: 'typography'
     private: true
   - name: h4-font-weight
-    value: 500
+    value: 200
     type: 'number'
     category: 'typography'
     private: true
@@ -629,7 +629,7 @@ props:
     category: 'typography'
     private: true
   - name: h5-font-weight
-    value: 500
+    value: 400
     type: 'number'
     category: 'typography'
     private: true


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?
- minor improve getting started guides
  Added react docs from react package readme and added a link to the demo apps.
- link styles in cds-button in global context
  When global styles exist they could override a link style in the cds-button component
- font heading weights
  The weights were scalling up to high in browsers since CIty is loading the regular weight vs medium font file. This caused excess font weight in the browser when compared to the medium font file in the original design. 
- typography docs
  Added example of the heading/paragraph API

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
