### PR TITLE
docs: fix page anchor links and words spelling in website

### DIFF
--- a/apps/website/components/button-group/README.md
+++ b/apps/website/components/button-group/README.md
@@ -223,7 +223,7 @@ Mix differently styled classes together, like solid and outlined.
 
 ## Antomy
 
-There are sevel layout options for button groups, including icon button groups, and button groups with overflow.
+There are several layout options for button groups, including icon button groups, and button groups with overflow.
 
 ### Icon Button Groups
 

--- a/apps/website/components/card/demo.md.orig
+++ b/apps/website/components/card/demo.md.orig
@@ -870,7 +870,7 @@ Cards can contain [progress bars](/documentation/progress).
 
 #### Card Layout
 
-Clarity recommends using cards in a [grid](/documentation/grid) or a CSS column layout.
+Clarity recommends using cards in a [grid](/components/grid) or a CSS column layout.
 
 ##### Cards in a Grid
 

--- a/apps/website/components/checkbox/README.md
+++ b/apps/website/components/checkbox/README.md
@@ -7,12 +7,12 @@ With checkboxes, users can select one or more options from a list of options.
 
 ## Usage
 
-Use a checkbox for yes or no choices, for example "Remember me" on the [login page](./login).
+Use a checkbox for yes or no choices, for example "Remember me" on the [login page](/components/login).
 
 - Checkboxes are best for seven or fewer options
 - For readability, keep the checkbox label to a single line
 
-For on and off options, use a [toggle switch](./toggles).
+For on and off options, use a [toggle switch](/components/toggle).
 
 <!-- [//]: # Types -->
 

--- a/apps/website/components/header/README.md
+++ b/apps/website/components/header/README.md
@@ -78,7 +78,7 @@ Use Text for navigational items.
   </div>
   <div class="header-nav">
     <a href="javascript://" class="nav-link">
-      <clr-icon shape="pencil" style="position: static; transform: translate3d(0, 0, 0);"></clr-icon> Composer  
+      <clr-icon shape="pencil" style="position: static; transform: translate3d(0, 0, 0);"></clr-icon> Composer
     </a>
     <a href="javascript://" class="active nav-link">
       <clr-icon shape="folder"></clr-icon>
@@ -257,7 +257,7 @@ The header and subnav support app-level information and navigation links.
 
 Info
 
-<!-- For information about headers with responsive navigation, see [Responsive Navigation](/documentation/navigation#responsive_navigation). -->
+<!-- For information about headers with responsive navigation, see [Responsive Navigation](/foundation/navigation#responsive_navigation). -->
 
 #### Types
 
@@ -269,6 +269,6 @@ Info
 
 ### Subnav
 
-`.subnav` immediately follows the `.header`. It wraps a [tab](/documentation/tabs) and an `aside` section.
+`.subnav` immediately follows the `.header`. It wraps a [tab](/components/tab) and an `aside` section.
 
 <doc-demo file="/demos/header/subnav.html" id="subnav-types" />

--- a/apps/website/components/password/README.md
+++ b/apps/website/components/password/README.md
@@ -7,7 +7,7 @@ Password fields are a specialized input field with the ability to toggle between
 
 ## Usage
 
-Use a password field when the user needs to set or input the password. When setting a password, display the password requirement in the helper text to guide the user. Don’t hide it a in signpost, or reveal it only after the user fails the frist attempt.
+Use a password field when the user needs to set or input the password. When setting a password, display the password requirement in the helper text to guide the user. Don’t hide it a in signpost, or reveal it only after the user fails the first attempt.
 
 <!-- [//]: # Types -->
 

--- a/apps/website/components/radio/README.md
+++ b/apps/website/components/radio/README.md
@@ -56,10 +56,10 @@ A radio can be disabled by simply putting the `disabled` attribute on the radio 
 
 ### Usage
 
-Use radio buttons when you want users to see all available options and the list of options is small. For mutually exclusive options, consider a [checkbox](/documentation/checkboxes) or [toggle switch](/documentation/toggle-switches).
+Use radio buttons when you want users to see all available options and the list of options is small. For mutually exclusive options, consider a [checkbox](/components/checkbox) or [toggle switch](/components/toggle).
 
 - Radio buttons are best for six or fewer options.
-- For more than six options, consider a [select box](/documentation/select-boxes), which prompts users to disclose the options.
+- For more than six options, consider a [select box](/components/select), which prompts users to disclose the options.
 
 ## Accessibility
 

--- a/apps/website/components/signpost/README.md
+++ b/apps/website/components/signpost/README.md
@@ -9,7 +9,7 @@ The signpost is a convenient, lightweight way to show contextual help of informa
 
 Use a signpost when you want to show a small amount of contextual help of information without taking the user out of the current context. Use sparingly as a supplemental element and not as a primary method of adding details.
 
-<ClrImage title="basic and pie chart" src="/images/components/signpost/basic-and-pie-chart.svg" align="cener" />
+<ClrImage title="basic and pie chart" src="/images/components/signpost/basic-and-pie-chart.svg" align="center" />
 
 Use a signpost:
 
@@ -29,7 +29,7 @@ Max-width 360px; Max-height 504px
 
 Clicking the icon triggers the signpost. It remains visible until the user clicks the close icon or clicks anywhere outside of the dialog to dismiss it. To keep the interface uncluttered, only one signpost is displayed at a time. When a dialog is visible, clicking an icon to open another one automatically dismisses the previous dialog.
 
-<ClrImage title="states" src="/images/components/signpost/states.svg" align="cener" />
+<ClrImage title="states" src="/images/components/signpost/states.svg" align="center" />
 
 ## Placement
 
@@ -37,7 +37,7 @@ Clicking the icon triggers the signpost. It remains visible until the user click
 
 Default position for the dialog is 6px to the right of the trigger icon.
 
-<ClrImage title="Trigger icon and dialog positioning" src="/images/components/signpost/positioning.svg" align="cener" />
+<ClrImage title="Trigger icon and dialog positioning" src="/images/components/signpost/positioning.svg" align="center" />
 
 [//]: # 'IMAGES x2 - icon position'
 
@@ -45,13 +45,13 @@ Default position for the dialog is 6px to the right of the trigger icon.
 
 <div class="clr-col-12 clr-col-md-6">
 
-<ClrImage title="Default position for the dialog is 6px from the end of the text" src="/images/components/signpost/inline-alignment.svg" align="cener" />
+<ClrImage title="Default position for the dialog is 6px from the end of the text" src="/images/components/signpost/inline-alignment.svg" align="center" />
 Default position for the dialog is 6px from the end of the text
 
 </div>
 <div class="clr-col-12 clr-col-md-6">
 
-<ClrImage title="In tables, the icons may be aligned in a column" src="/images/components/signpost/column-alignment.svg" align="cener" />
+<ClrImage title="In tables, the icons may be aligned in a column" src="/images/components/signpost/column-alignment.svg" align="center" />
 In tables, the icons may be aligned in a column
 
 </div>
@@ -82,7 +82,7 @@ The default signpost is shown to the right of the trigger icon with the content 
 
 There are twelve signpost positions to help place popover content in an appropriate position when it is shown. Control the position and direction by declaring a position that orients the Signpost content in one of these positions.
 
-To set a position, use the `clrInput` property on the [ClrSignpostContent](/components/signposts/api.html#clrsignpostcontent) element:
+To set a position, use the `clrInput` property on the [ClrSignpostContent](/components/signposts/api/#clrsignpostcontent) element:
 
 - top-left
 - top-middle
@@ -101,6 +101,6 @@ You can see the behavior for each position in the [demo](/demo.html).
 
 ## Custom Trigger
 
-Clarity provides a default trigger. If needed, a custom trigger can be provided for any icon or element. Adding the [ClrSignpostTrigger](/components/signposts/api.html#clrsignposttrigger) directive to any element will turn it into a toggle control for the content.
+Clarity provides a default trigger. If needed, a custom trigger can be provided for any icon or element. Adding the [ClrSignpostTrigger](/components/signpost/api/#clrsignposttrigger) directive to any element will turn it into a toggle control for the content.
 
 <doc-demo src="/demos/signpost/custom-ng.html" demo="/demos/signpost/custom-css.html"/></doc-demo>

--- a/apps/website/components/table/README.md
+++ b/apps/website/components/table/README.md
@@ -7,7 +7,7 @@ A table displays information in a grid of rows and columns providing a method of
 
 ## Usage
 
-Use the table styles wherever you need to present static data in a tabular format. For advanced features like sorting, filtering, pagination etc. see [Datagrid.](/documentation/datagrid)
+Use the table styles wherever you need to present static data in a tabular format. For advanced features like sorting, filtering, pagination etc. see [Datagrid.](/components/datagrid)
 
 ## Code Examples
 

--- a/apps/website/foundation/app-layout/README.md
+++ b/apps/website/foundation/app-layout/README.md
@@ -11,7 +11,7 @@ toc: true
 
 The `.main-container` is a vertical flexbox which wraps the following components:
 
-- [App-Level Alert](/componenst/alerts)
+- [App-Level Alert](/components/alerts)
 - [Header](/components/header)
 - [Subnav](/components/header)
 - Content Container
@@ -52,17 +52,17 @@ The content area is where users focus their attention most of the time, gatherin
 
 ### Layout
 
-Your layout should reflect the information or workflow of the selected [navigation](/documentation/navigation). When laying out the content, keep the following in mind:
+Your layout should reflect the information or workflow of the selected [navigation](/foundation/navigation). When laying out the content, keep the following in mind:
 
 - The flow of content–how to create a hierarchy and layout that draws attention to the areas of importance
-- The importance of designing to the [grid](/documentation/grid)
+- The importance of designing to the [grid](/components/grid)
 - How to aid users in completing their tasks
 - How to handle large amounts of data
 - Responsive design (if that is part of your product’s goals)
 
 #### Common Layout Patterns
 
-Content can consist of any of the [Clarity components](/documentation), or no components and just information. Following are common layout patterns and recommended usage. For information on navigation components, header, subnav, and sidenav, see [Navigation](/documentation/navigation).
+Content can consist of any of the [Clarity components](/components), or no components and just information. Following are common layout patterns and recommended usage. For information on navigation components, header, subnav, and sidenav, see [Navigation](/foundation/navigation).
 
 ##### Cards
 

--- a/apps/website/get-started/angular.md
+++ b/apps/website/get-started/angular.md
@@ -1,6 +1,6 @@
 # Angular Quickstart
 
-Clarity works best with Angular, and we are constantly updating Clarity to work best with the latest version of Angular. If you are not using Angular, then you'll want to review the [HTML/CSS Quickstart](./html).
+Clarity works best with Angular, and we are constantly updating Clarity to work best with the latest version of Angular. If you are not using Angular, then you'll want to review the [HTML/CSS Quickstart](/get-started/html).
 
 Before you begin, make sure that you have all of the prerequisites setup for your computer. You can review the [local environment setup on Angular's documentation](https://angular.io/guide/setup-local).
 


### PR DESCRIPTION
Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Some of the anchor tags are pointing to pages that not exist and some words are misspelled.

## What is the new behavior?

The anchor tags are pointing to the correct pages and words are spelled correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Other information
