### PR TITLE
docs(navigation): adds height constraint to css demos

### DIFF
--- a/apps/website/.vuepress/public/demos/themes/angular.json
+++ b/apps/website/.vuepress/public/demos/themes/angular.json
@@ -1,0 +1,3 @@
+{
+  "styles": ["../node_modules/@clr/icons/clr-icons.min.css", "../node_modules/@clr/ui/clr-ui-dark.min.css"]
+}

--- a/apps/website/.vuepress/public/demos/themes/webpack.js
+++ b/apps/website/.vuepress/public/demos/themes/webpack.js
@@ -1,0 +1,10 @@
+module.exports = {
+  entry: {
+    main: ['./src/main.ts'],
+    styles: [
+      './node_modules/@clr/icons/clr-icons.min.css',
+      './node_modules/@clr/ui/clr-ui-dark.min.css',
+      './src/styles.css',
+    ],
+  },
+};

--- a/apps/website/.vuepress/theme/styles/containers.scss
+++ b/apps/website/.vuepress/theme/styles/containers.scss
@@ -69,6 +69,12 @@
 
 .doc-demo-main-container {
   min-height: unset;
+  height: fit-content;
+  .content-container {
+    .content-area {
+      height: fit-content;
+    }
+  }
 }
 
 .relative-contianer {

--- a/apps/website/foundation/navigation/README.md
+++ b/apps/website/foundation/navigation/README.md
@@ -33,8 +33,6 @@ When establishing your navigation model, consider:
 </div>
 <div class="clr-col" cds-layout="m-t:xl">
 
-{.custom-container}
-
 The <a href="/components/header">header</a> is for primary navigation. Benefits of this navigation pattern are:
 
 - Users often look for navigation in the header.

--- a/apps/website/foundation/themes/README.md
+++ b/apps/website/foundation/themes/README.md
@@ -147,33 +147,14 @@ Clarity UI ships with two css files, `clr-ui.min.css` for the light theme and `c
 
 #### Angular CLI Builds
 
-Consume the dark theme code in `clr-ui-dark.min.css` by adding it to your styles array in the `.angular-cli.json` file.
+Consume the dark theme code in `clr-ui-dark.min.css` by adding it to your styles array in the `angular.json` file.
 
-```
-"styles": [
-      ...
-      "../node_modules/@clr/icons/clr-icons.min.css",
-      "../node_modules/@clr/ui/clr-ui-dark.min.css",
-      ...
-  ]
-```
+<doc-demo src="/demos/themes/angular.json" />
 
 #### Webpack Builds
 
 Modify your `webpack.config.js` entry styles to consume the new `clr-ui-dark.min.css`
-
-```
-"entry": {
-    "main": [
-      "./src/main.ts"
-    ],
-    "styles": [
-      "./node_modules/@clr/icons/clr-icons.min.css",
-      "./node_modules/@clr/ui/clr-ui-dark.min.css",
-      "./src/styles.css"
-    ]
-  },
-```
+<doc-demo src="/demos/themes/webpack.js" />
 
 ## Custom Themes
 
@@ -193,7 +174,7 @@ SASS-based theming is deprecated in Clarity 3.0 and will no longer work when Cla
 
 SASS-based theming is most familiar to those who use SASS/SCSS in their own products to build CSS stylesheets. SASS acts like a superset of CSS that enables convenient nesting syntax and programming-like functionality in a CSS-based language that compiles to CSS. SASS also gives developers variables they can reuse throughout their SASS codebase.
 
-Clarity has a number of such variables. The [\_variables.clarity.scss](https://github.com/vmware/clarity/blob/master/src/clr-angular/utils/_variables.clarity.scss) file in the Clarity project can serve as a directory for where all of the variable files can be found.
+Clarity has a number of such variables. The [\_variables.clarity.scss](https://github.com/vmware/clarity/blob/master/packages/angular/projects/clr-angular/src/utils/_variables.clarity.scss) file in the Clarity project can serve as a directory for where all of the variable files can be found.
 
 It is these variables that we override in SASS to build out a new CSS file for our theme.
 


### PR DESCRIPTION
Updated navigation code snippits to use doc-demo
Adds a constraint class that can be combined with main-container to limit height to content size

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Change to the home page for new website. 
Simplified transition between hero and content. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
