### PR TITLE
docs: remove SoO from alert overview and add combobox basic story

### DIFF
--- a/apps/website/components/alert/README.md
+++ b/apps/website/components/alert/README.md
@@ -229,12 +229,6 @@ This class must be applied with `.alert` to render an app-level alert.
 
 <doc-demo src="/demos/alert/multiple-app-level-alerts-ng.html" />
 
-### Summary of Options
-
-<DocAlertSummaryOfOptions table="text-styles" />
-
-Deprecation: Since v4, we will no longer handle setting `aria-live` and announcing the message for you by default. Based on the application use case, you can use the new `ClrAriaLiveService` to make announcements when they make sense for a user to hear about updates or loading status changes. This will result in of removing few inputs provided by the component such as `clrPolite`, `clrAssertive`, `clrOff`
-
 ## Accessibility
 
 <cds-alert-group status="warning" type="default">

--- a/apps/website/components/alert/api.md
+++ b/apps/website/components/alert/api.md
@@ -3,6 +3,13 @@ title: API
 toc: true
 ---
 
+<cds-alert-group type="default" status="warning">
+ <cds-alert closable><strong>Deprecation</strong>: Since v4, we will no longer handle setting `aria-live` and announcing the message for you by default. Based on the application use case, you can use the new `ClrAriaLiveService` to make announcements when they make sense for a user to hear about updates or loading status changes. This will result in of removing few inputs provided by the component such as `clrPolite`, `clrAssertive`, `clrOff`.
+ <cds-alert-actions>
+ </cds-alert-actions>
+ </cds-alert>
+ </cds-alert-group>
+
 ## Angular Components
 
 {.section-header}

--- a/packages/angular/src/stories/combobox/basic.html
+++ b/packages/angular/src/stories/combobox/basic.html
@@ -1,0 +1,10 @@
+<clr-combobox-container>
+  <label>Two</label>
+  <clr-combobox [(ngModel)]="selected" name="two" required [disabled]="disabled">
+    <clr-options>
+      <clr-option clrValue="1">1</clr-option>
+      <clr-option clrValue="2">2</clr-option>
+      <clr-option clrValue="3">3</clr-option>
+    </clr-options>
+  </clr-combobox>
+</clr-combobox-container>

--- a/packages/angular/src/stories/combobox/combobox.stories.ts
+++ b/packages/angular/src/stories/combobox/combobox.stories.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2016-2020 VMware, Inc.
+ * All Rights ReserveThis software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { moduleMetadata } from '@storybook/angular';
+import { boolean } from '@storybook/addon-knobs';
+import { ClarityModule } from '@clr/angular';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+const basicTemplate = require('!!raw-loader!./basic.html'); // eslint-disable-line
+
+export default {
+  title: 'Combobox',
+  decorators: [
+    moduleMetadata({
+      imports: [BrowserAnimationsModule, ClarityModule],
+    }),
+  ],
+  props: {
+    clrMulti: false,
+  },
+};
+
+export const Basic = () => {
+  return {
+    title: 'Basic',
+    template: basicTemplate.default,
+    props: {
+      selected: null,
+      disabled: false,
+    },
+  };
+};


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Summary of Options exists in Alert overview page. There is no basic Combobox basic story 

## What is the new behavior?

Summary of Options removed from Alert overview page and Combobox basic story is available at storybook

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
