### PR TITLE
fix: core icon color, website core icon load

### DIFF
--- a/apps/website/.vuepress/public/demos/sidenav/icons-css.html
+++ b/apps/website/.vuepress/public/demos/sidenav/icons-css.html
@@ -8,8 +8,8 @@
         <a class="nav-link nav-icon"><clr-icon shape="home"></clr-icon> Home</a>
         <a class="nav-link"><clr-icon shape="cog"></clr-icon> Settings</a>
         <a class="nav-link active"><clr-icon shape="user"></clr-icon> Users</a>
-        <a class="nav-link"><clr-icon shape="Folder-open"></clr-icon> Files</a>
-        <a class="nav-link"><clr-icon shape="Cloud"></clr-icon> Data</a>
+        <a class="nav-link"><clr-icon shape="folder-open"></clr-icon> Files</a>
+        <a class="nav-link"><clr-icon shape="cloud"></clr-icon> Data</a>
         <a class="nav-link"><clr-icon shape="image-gallery"> Photos</clr-icon> 6</a>
         <a class="nav-link"><clr-icon shape="video-gallery"></clr-icon> Videos</a>
       </section>

--- a/apps/website/.vuepress/theme/core.js
+++ b/apps/website/.vuepress/theme/core.js
@@ -20,27 +20,20 @@ import '@clr/core/time/register.js';
 import '@clr/core/toggle/register.js';
 
 import {
+  CdsIcon,
+  ClarityIcons,
+  linkIcon,
+  fileIcon,
+  pencilIcon,
+  folderOpenIcon,
+  cloudIcon,
+  imageGalleryIcon,
+  videoGalleryIcon,
   loadCoreIconSet,
-  loadChartIconSet,
-  loadCommerceIconSet,
-  loadEssentialIconSet,
-  loadMediaIconSet,
-  loadSocialIconSet,
-  loadTechnologyIconSet,
-  loadTextEditIconSet,
-  loadTravelIconSet,
 } from '@clr/core/icon';
 
+ClarityIcons.addIcons(linkIcon, fileIcon, pencilIcon, folderOpenIcon, cloudIcon, imageGalleryIcon, videoGalleryIcon);
 loadCoreIconSet();
-loadChartIconSet();
-loadEssentialIconSet();
-loadCommerceIconSet();
-loadMediaIconSet();
-loadSocialIconSet();
-loadTechnologyIconSet();
-loadTextEditIconSet();
-loadTravelIconSet();
 
-// TODO: replace clr-icon code with cds-icon and remove this
-import '@clr/icons';
-import '@clr/icons/shapes/all-shapes';
+class LegacyIcon extends CdsIcon {}
+customElements.define('clr-icon', LegacyIcon);

--- a/apps/website/data/icon-inventory.js
+++ b/apps/website/data/icon-inventory.js
@@ -18,7 +18,27 @@ import {
   travelCollectionAliases as travelAliases,
   textEditCollectionAliases as textEditAliases,
   technologyCollectionAliases as technologyAliases,
+  // load
+  loadChartIconSet,
+  loadEssentialIconSet,
+  loadCommerceIconSet,
+  loadMediaIconSet,
+  loadSocialIconSet,
+  loadTechnologyIconSet,
+  loadTextEditIconSet,
+  loadTravelIconSet,
 } from '@clr/core/icon';
+
+if (window) {
+  loadChartIconSet();
+  loadEssentialIconSet();
+  loadCommerceIconSet();
+  loadMediaIconSet();
+  loadSocialIconSet();
+  loadTechnologyIconSet();
+  loadTextEditIconSet();
+  loadTravelIconSet();
+}
 
 const ICONS_TO_HIDE = ['vm-bug', 'vm-bug-inverse'];
 

--- a/packages/core/src/icon/icon.element.scss
+++ b/packages/core/src/icon/icon.element.scss
@@ -28,6 +28,7 @@
   margin: 0;
   vertical-align: middle;
   fill: var(--color);
+  color: inherit; // inherit so older clr-icon based themes get currentColor from parent
   contain: strict;
 }
 


### PR DESCRIPTION

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?
Fixes an issue where cds-icon does not apply fill color based on legacy clr-ui behavior. Swaps the website icons to use cds-icon legacy mode instead of clr-icon. This reduces the home page landing JS from 417kb gzip to about 218kb gzip.

![Screen Shot 2020-08-03 at 3 55 57 PM](https://user-images.githubusercontent.com/2021067/89228916-17df0280-d5a6-11ea-92b1-d885eacf6d08.png)

![Screen Shot 2020-08-03 at 3 55 47 PM](https://user-images.githubusercontent.com/2021067/89228922-19a8c600-d5a6-11ea-8a77-6d795729cfea.png)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
