### PR TITLE
docs: fixes for links with file extensions

### DIFF
--- a/apps/website/components/accordion/README.md
+++ b/apps/website/components/accordion/README.md
@@ -13,7 +13,7 @@ Accordions can make information processing and discovering more effective. Howev
 
 ## Anatomy
 
-Accordions are a collection of panels that encapsulate a title and content. You can read more about [ClrAccordionTitle](/components/accordion/api.html#clraccordiontitle) and [ClrAccordionContent](/components/accordion/api.html#clraccordioncontent) in the API section.
+Accordions are a collection of panels that encapsulate a title and content. You can read more about [ClrAccordionTitle](/components/accordion/api/#clraccordiontitle) and [ClrAccordionContent](/components/accordion/api/#clraccordioncontent) in the API section.
 
 Accordion titles use **13px Clarity City Medium** font. The default content font is **14px Clarity city Regular**.
 

--- a/apps/website/components/accordion/api.md
+++ b/apps/website/components/accordion/api.md
@@ -23,7 +23,7 @@ An accordion allows generic content to be collapsed and allows users to expand t
 
 ### ClrAccordionContent
 
-ClrAccordionContent is a child of [ClrAccordionPanel](./api.md#clraccordionpanel)
+ClrAccordionContent is a child of [ClrAccordionPanel](./api/#clraccordionpanel)
 
 #### Selector & Basic Usage
 
@@ -37,7 +37,7 @@ ClrAccordionContent is a child of [ClrAccordionPanel](./api.md#clraccordionpanel
 
 ### ClrAccordionDescription
 
-ClrAccordionDescription is a child of [ClrAccordionPanel](./api.md#clraccordionpanel)
+ClrAccordionDescription is a child of [ClrAccordionPanel](./api/#clraccordionpanel)
 
 #### Selector & Basic Usage
 
@@ -54,7 +54,7 @@ ClrAccordionDescription is a child of [ClrAccordionPanel](./api.md#clraccordionp
 ### ClrAccordionPanel
 
 Use content projection and give the panel a title and content that can be hidden or shown.
-ClrAccordionPanel is a child of [ClrAccordion](./api.md#clraccordion)
+ClrAccordionPanel is a child of [ClrAccordion](./api/#clraccordion)
 
 #### Selector & Basic Usage
 

--- a/apps/website/components/button-group/api.md
+++ b/apps/website/components/button-group/api.md
@@ -9,7 +9,7 @@ When you need to create a collection of similar action buttons, use a button gro
 
 ### ClrButtonGroup
 
-ClrButton group is a component made up of multiple [ClrButton](./api.md#clrbutton) elements. Button elements can
+ClrButton group is a component made up of multiple [ClrButton](./api/#clrbutton) elements. Button elements can
 optionally be designated for an overflow menu.
 
 #### Selector & Basic Usage
@@ -24,7 +24,7 @@ optionally be designated for an overflow menu.
 
 ### ClrButton
 
-Angular button component used only with [ClrButtonGroup](./api.md#clrbuttongroup).
+Angular button component used only with [ClrButtonGroup](./api/#clrbuttongroup).
 
 #### Selector & Basic Usage
 

--- a/apps/website/components/stepper/api.md
+++ b/apps/website/components/stepper/api.md
@@ -27,7 +27,7 @@ A Stepper structures a multi-step process into two or more expanding panels.
 
 ### ClrStepPanel
 
-ClrStepperPanel extends [ClrAccordionPanel](../accordion/api.md#clraccordionpanel)
+ClrStepperPanel extends [ClrAccordionPanel](../accordion/api/#clraccordionpanel)
 
 #### Selector & Basic Usage
 
@@ -66,7 +66,7 @@ ClrStepperPanel extends [ClrAccordionPanel](../accordion/api.md#clraccordionpane
 </form>
 ```
 
-**Note:** `clr-step-title` is an overloaded selector and is the same component as [ClrAccordionTitle](../accordion/api.md#clraccordiontitle)
+**Note:** `clr-step-title` is an overloaded selector and is the same component as [ClrAccordionTitle](../accordion/api/#clraccordiontitle)
 
 ### ClrStepDescription
 
@@ -83,7 +83,7 @@ ClrStepperPanel extends [ClrAccordionPanel](../accordion/api.md#clraccordionpane
 </form>
 ```
 
-**Note:** `clr-step-description` is an overloaded selector and is the same component as [ClrAccordionDescription](../accordion/api.md#clraccordiondescription)
+**Note:** `clr-step-description` is an overloaded selector and is the same component as [ClrAccordionDescription](../accordion/api/#clraccordiondescription)
 
 ### ClrStepContent
 
@@ -100,7 +100,7 @@ ClrStepperPanel extends [ClrAccordionPanel](../accordion/api.md#clraccordionpane
 </form>
 ```
 
-**Note:** `clr-step-content` is an overloaded selector and is the same component as [ClrAccordionContent](../accordion/api.md#clraccordioncontent)
+**Note:** `clr-step-content` is an overloaded selector and is the same component as [ClrAccordionContent](../accordion/api/#clraccordioncontent)
 
 ## Angular Directives
 

--- a/apps/website/components/tab/README.md
+++ b/apps/website/components/tab/README.md
@@ -8,7 +8,7 @@ Tabs divide content into separate views which users navigate between.
 ## Usage
 
 - Use tabs in the main content area or, alternatively use the [vertical nav](/components/vertical-nav) component to break up separate views.
-- Don't use tabs to break user interactions into a series of steps. Serial workflows are best presented in a multi-step workflow, like [wizard](/components/wizards), [stepper](/components/stepper), or a [timeline](/components/timeline).
+- Don't use tabs to break user interactions into a series of steps. Serial workflows are best presented in a multi-step workflow, like [wizard](/components/wizard), [stepper](/components/stepper), or a [timeline](/components/timeline).
 
 ### Content
 
@@ -18,13 +18,13 @@ Content projected within tabs is flexible. Follow these guidelines to organize a
 2. Don’t force users to navigate back and forth to compare data
 3. Avoid cross-linking between tabs
 4. When the content within a view is broad, divide it into subsections
-5. Avoid using tabs in [cards](/components/cards) and [modals](/components/modals)
+5. Avoid using tabs in a [card](/components/card) and [modal](/components/modal)
 
 ### Presentation
 
 Tabs appear in a single, non-scrollable row, above their content. The width of each tab is dependent on its label.
 
-When there are seven or fewer tabs, limit the labels to on or two words. This ensures that all tabs appear in the container. If the application is using Angular and there need to be more than seven tabs look into the overflow input for [ClrTabLink](/components/tabs/api.html#clrtablink).
+When there are seven or fewer tabs, limit the labels to on or two words. This ensures that all tabs appear in the container. If the application is using Angular and there need to be more than seven tabs look into the overflow input for [ClrTabLink](/components/tab/api/#clrtablink).
 
 ### Labels
 
@@ -38,9 +38,9 @@ Use labels to organize the tabs and their content.
 
 ## Types
 
-There are four types of tabs that might be used. Go to the [demo](/components/tabs/demo.html) to see them in action.
+There are four types of tabs that might be used. Go to the [demo](/components/tab/demo) to see them in action.
 For optimization, tabs component uses the \*clrIfActive structural directive to lazy load the content of an active tab.
-If you need two-way binding on the active state of a tab, use the de-sugared syntax for the [ClrIfActive](/components/tabs/api.html#clrifactive) structural directive shown below in the two way binding example.
+If you need two-way binding on the active state of a tab, use the de-sugared syntax for the [ClrIfActive](/components/tab/api/#clrifactive) structural directive shown below in the two way binding example.
 
 ### Horizontal
 
@@ -65,23 +65,23 @@ Compose tabs with the following components and directives. ClrIfActive is option
 
 ### ClrTabs
 
-[ClrTabs](/components/tabs/api.html#clrtabs) is the parent container for all Angular children components. Its default layout is horizontal but it can also be set to vertical.
+[ClrTabs](/components/tab/api/#clrtabs) is the parent container for all Angular children components. Its default layout is horizontal but it can also be set to vertical.
 
 ### ClrTab
 
-[ClrTab](/compnents/tabs/api.html#clrtab) is a child of [ClrTabs](/components/tabs/api.html#clrtabs) that contains the tab link and the tab content which must be associated together.
+[ClrTab](/compnents/tab/api/#clrtab) is a child of [ClrTabs](/components/tab/api/#clrtabs) that contains the tab link and the tab content which must be associated together.
 
 ### ClrTabContent
 
-[ClrTabContent](/compnents/tabs/api.html#clrtabcontent) is a component where application content can be projected into for display.
+[ClrTabContent](/compnents/tab/api/#clrtabcontent) is a component where application content can be projected into for display.
 
 ### ClrTabLink
 
-[ClrTabLink](/compnents/tabs/api.html#clrtablink) is an attribute directive that designates button elements to be used as the displayed tab.
+[ClrTabLink](/compnents/tab/api/#clrtablink) is an attribute directive that designates button elements to be used as the displayed tab.
 
 ### ClrIfActive
 
-[ClrIfActive](/compnents/tabs/api.html#clrifactive) is a structural directive used to lazy load the tab content.
+[ClrIfActive](/compnents/tab/api/#clrifactive) is a structural directive used to lazy load the tab content.
 
 ## Accessibility
 

--- a/apps/website/components/tab/api.md
+++ b/apps/website/components/tab/api.md
@@ -25,7 +25,7 @@ Tabs structure content into separate views and allow navigation between.
 
 ### ClrTab
 
-ClrTab associates the [ClrTabContent](./api.md#clrtabcontent) component with the [ClrTabLink](./api.md#clrtablink) directive.
+ClrTab associates the [ClrTabContent](./api/#clrtabcontent) component with the [ClrTabLink](./api/#clrtablink) directive.
 
 #### Selector & Basic Usage
 

--- a/apps/website/components/toggle/README.md
+++ b/apps/website/components/toggle/README.md
@@ -16,33 +16,33 @@ Toggle inputs should be composed with the necessary parts needed to communicate 
 
 ### Label
 
-Use a label to clearly describe the setting. You will need to wrap your toggle switches with the [ClrToggleWrapper](/components/toggle/api.html#clrtogglewrapper) component when you include a label. This manages the label and display of the toggle switch for you.
+Use a label to clearly describe the setting. You will need to wrap your toggle switches with the [ClrToggleWrapper](/components/toggle/api/#clrtogglewrapper) component when you include a label. This manages the label and display of the toggle switch for you.
 
 Clarity supports a toggle switch without a label but beware, only use this approach if the purpose of the control clearly made elsewhere. For example, if there is a group label or section header that allows the user to infer the description of the option.
 
 ### Helper Message
 
-To use helper messages, wrap all toggle switches inside of the [ClrToggleContainer](/components/toggle/api.html#clrtogglecontainer). Helper messages are always visible with one exception. The toggle switch container tracks any validations placed on the toggle switch(es) and will replace helper messages with an error message if there is one.
+To use helper messages, wrap all toggle switches inside of the [ClrToggleContainer](/components/toggle/api/#clrtogglecontainer). Helper messages are always visible with one exception. The toggle switch container tracks any validations placed on the toggle switch(es) and will replace helper messages with an error message if there is one.
 
 <doc-demo src="/demos/toggle/helper-demo-ng.html" demo="/demos/toggle/helper-demo-css.html"></doc-demo>
 
 ### Error Message
 
-To use error messages, wrap all toggle switches inside of the [ClrToggleContainer](/components/toggle/api.html#clrtogglecontainer). The toggle switch container tracks any validations placed on the toggle switch(es) and will display the error message when appropriate.
+To use error messages, wrap all toggle switches inside of the [ClrToggleContainer](/components/toggle/api/#clrtogglecontainer). The toggle switch container tracks any validations placed on the toggle switch(es) and will display the error message when appropriate.
 <doc-demo src="/demos/toggle/error-demo-ng.html" demo="/demos/toggle/error-demo-css.html"></doc-demo>
 
 ## States
 
-There are two states that can change the layout and look of a [ClrToggle](/components/toggle/api.html#clrtoggle) control.
+There are two states that can change the layout and look of a [ClrToggle](/components/toggle/api/#clrtoggle) control.
 
 ### Inline
 
-Toggle switches can be placed inline when the clrInline directive is added to the [ClrToggleContainer](/components/toggle/api.html#clrtogglecontainer). The toggle switches will wrap if there is not enough space.
+Toggle switches can be placed inline when the clrInline directive is added to the [ClrToggleContainer](/components/toggle/api/#clrtogglecontainer). The toggle switches will wrap if there is not enough space.
 <doc-demo src="/demos/toggle/inline-demo-ng.html" demo="/demos/toggle/inline-demo-css.html"></doc-demo>
 
 ### Disabled
 
-A toggle switch can be disabled by putting the disabled attribute on the checkbox input. This requires that the toggle switch be inside of a [ClrToggleContainer](/components/toggle/api.html#clrtogglecontainer). When disabling groups of toggle switches, the last checkbox requires the disabled attribute. Angular doesn't support disabling individual checkboxes in a group.
+A toggle switch can be disabled by putting the disabled attribute on the checkbox input. This requires that the toggle switch be inside of a [ClrToggleContainer](/components/toggle/api/#clrtogglecontainer). When disabling groups of toggle switches, the last checkbox requires the disabled attribute. Angular doesn't support disabling individual checkboxes in a group.
 
 <doc-demo src="/demos/toggle/disabled-demo-ng.html" demo="/demos/toggle/disabled-demo-css.html"></doc-demo>
 

--- a/apps/website/components/tooltip/api.md
+++ b/apps/website/components/tooltip/api.md
@@ -41,7 +41,7 @@ toc: true
 
 ### ClrTooltipTrigger
 
-Used to designate the open/close element for [ClrTooltipContent](./api.md#clrtooltipcontent).
+Used to designate the open/close element for [ClrTooltipContent](./api/#clrtooltipcontent).
 
 #### Selector & Basic Usage
 

--- a/apps/website/components/tree-view/README.md
+++ b/apps/website/components/tree-view/README.md
@@ -199,7 +199,7 @@ A basic tree can be created by simply nesting `clr-tree-node` components at will
 
 ### Tracking expanded nodes
 
-Use two-way binding `[(clrExpanded)]="expanded"` on the [clrExpanded](/components/tree-view/api.html#properties) property to track when a node is expanded or collapsed.
+Use two-way binding `[(clrExpanded)]="expanded"` on the [clrExpanded](/components/tree-view/api/#clrifexpanded) property to track when a node is expanded or collapsed.
 <doc-demo src="/demos/tree-view/expanded-ng.html"/></doc-demo>
 
 ### Routing with a tree
@@ -209,7 +209,7 @@ Use the `.clr-treenode-link` class to style content inside of a Tree Node as cli
 
 ### Generating a tree dynamically
 
-When the tree structure is large and complex you can use iteration to generate nodes and child nodes based on the structure given to the [ClrTree](/components/tree-view/api.html#clrtree).
+When the tree structure is large and complex you can use iteration to generate nodes and child nodes based on the structure given to the [ClrTree](/components/tree-view/api/#clrtree).
 
 ![Dynamically Generated Tree](/images/components/tree-view/dynamic-tree.png)
 
@@ -223,10 +223,10 @@ When the tree structure is large and complex you can use iteration to generate n
 
 ### Checkbox tree
 
-Use checkbox when nodes of the tree need to be selected or unselected by users. There are three parts that are needed to implement a [ClrTree](/components/tree-view/api.html#clrtree) with checkbox controls.
+Use checkbox when nodes of the tree need to be selected or unselected by users. There are three parts that are needed to implement a [ClrTree](/components/tree-view/api/#clrtree) with checkbox controls.
 
 1. Data structured in a tree hierarchy
-1. The correct declaration on the [ClrTreeNode](/components/tree-view/api.html#clrtreenode)'s that need to be selectable
+1. The correct declaration on the [ClrTreeNode](/components/tree-view/api/#clrtreenode)'s that need to be selectable
 1. A ClrSelectedState for each node that is selectable
 
 <div class="clr-row custom-block">
@@ -251,7 +251,7 @@ Use checkbox when nodes of the tree need to be selected or unselected by users. 
 
 ### Binding selection to a boolean
 
-If you know a specific node can never become indeterminate, you probably want to use a boolean property on your node. As mentioned previously, `[(clrSelected)]` always outputs [ClrSelectedState](/components/tree-view/api.html#properties) enum values, making two-way binding with a boolean problematic. The most straightforward solution is to use the de-sugarized syntax of the two-way binding , transforming the output to a boolean directly.
+If you know a specific node can never become indeterminate, you probably want to use a boolean property on your node. As mentioned previously, `[(clrSelected)]` always outputs [ClrSelectedState](/components/tree-view/api/#bindings) enum values, making two-way binding with a boolean problematic. The most straightforward solution is to use the de-sugarized syntax of the two-way binding , transforming the output to a boolean directly.
 
 <div class="clr-row custom-block">
 <div class="clr-col">

--- a/apps/website/components/vertical-nav/README.md
+++ b/apps/website/components/vertical-nav/README.md
@@ -273,7 +273,7 @@ When collapsed, text will disappear and only icons will show. Clicking on an ico
 
 ### Smaller Screens - Responsive
 
-When screens drop below 768px wide, the navigation will hide completely and can be shown by clicking on one of the header icons. All normal vertical navigation designs and behaviors are the same in the responsive state. Read about [Responsive Navigation](/foundation/navigation/#responsive-navigation) and the [directives](/foundation/navigation/api.html#clrheader-clrmaincontainer-clrnavlevel) to use for implementation.
+When screens drop below 768px wide, the navigation will hide completely and can be shown by clicking on one of the header icons. All normal vertical navigation designs and behaviors are the same in the responsive state. Read about [Responsive Navigation](/foundation/navigation/#responsive-navigation) and the [directives](/foundation/navigation/api/#clrheader-clrmaincontainer-clrnavlevel) to use for implementation.
 
 <div class="clr-row">
 


### PR DESCRIPTION
This change removes any `.html` or `.md` file extensions from intra site links. 

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
