### PR TITLE
chore: Fix license only on staged files

### DIFF
--- a/scripts/update-license.js
+++ b/scripts/update-license.js
@@ -16,6 +16,9 @@ const path = require('path');
 
 const supported = ['.js', '.ts', '.html', '.css', '.scss', '.sass'];
 
+// Stash unstaged files
+exec('git stash --keep-index --include-untracked');
+
 // Grab list of staged files
 const files = exec('git diff --name-only --cached --diff-filter=d', { encoding: 'utf8' }).split('\n');
 const year = new Date().getFullYear();
@@ -32,3 +35,6 @@ files.forEach(file => {
 console.log('Updated license headers');
 
 exec(`git add ${files.map(file => "'" + path.join(__dirname, '../', file) + "'").join(' ')}`);
+
+// Restore from stash
+exec('git stash pop');


### PR DESCRIPTION


Fixes #4679

Signed-off-by: Sajini De Silva <sdesilva28@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Files from Untracked and Changes not staged for commit zone are pulled into the staging (and subsequently into commit) by npm run license:fix script run by pre-commit githook.

Issue Number: #4679

## What is the new behavior?

Stash all the files that are not staged before fixing the license and
then un-stash them after.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
