### PR TITLE
fix: allow projected pre rendered code examples

### DIFF
--- a/apps/website/.vuepress/config.js
+++ b/apps/website/.vuepress/config.js
@@ -1,4 +1,5 @@
 const markdownItAttrs = require('markdown-it-attrs');
+const markdownItInclude = require('markdown-it-include');
 const sidebar = require('./sidebar');
 const blocks = require('./blocks');
 const path = require('path');
@@ -34,6 +35,7 @@ module.exports = {
   markdown: {
     extendMarkdown: md => {
       md.use(markdownItAttrs);
+      md.use(markdownItInclude);
     },
     anchor: {
       permalink: true,

--- a/apps/website/.vuepress/theme/global-components/DocDemo.vue
+++ b/apps/website/.vuepress/theme/global-components/DocDemo.vue
@@ -3,6 +3,9 @@
     <div class="demo-wrapper" v-if="demoHTML" :class="{ center }">
       <span v-html="demoHTML"></span>
     </div>
+    <div class="demo-wrapper" v-if="$slots.demo">
+      <slot name="demo"></slot>
+    </div>
     <div class="code-wrapper" :class="{ expanded: state }" v-if="hasCodeProjection() || codeHTML">
       <button class="btn btn-primary btn-sm toggle-button" @click="toggleState()" v-if="showToggle">
         {{ state ? 'hide' : 'show' }} code

--- a/apps/website/components/button/README.md
+++ b/apps/website/components/button/README.md
@@ -219,39 +219,84 @@ If your icon button is has no text, we recommend adding the `title="` attribute 
 
 ### Solid Buttons
 
-<doc-demo file="/demos/button/solid-css.html" toggle="false" />
+<doc-demo toggle="false">
+<<< .vuepress/public/demos/button/solid-css.html
+::: slot demo
+!!!include(.vuepress/public/demos/button/solid-css.html)!!!
+:::
+</doc-demo>
 
 ### Outline
 
-<doc-demo file="/demos/button/outline-css.html" toggle="false" />
+<doc-demo toggle="false">
+<<< .vuepress/public/demos/button/outline-css.html
+::: slot demo
+!!!include(.vuepress/public/demos/button/outline-css.html)!!!
+:::
+</doc-demo>
 
 ### Flat Buttons
 
-<doc-demo file="/demos/button/flat-css.html" toggle="false" />
+<doc-demo toggle="false">
+<<< .vuepress/public/demos/button/flat-css.html
+::: slot demo
+!!!include(.vuepress/public/demos/button/flat-css.html)!!!
+:::
+</doc-demo>
 
 ### Types: Primary,Secondary and Tertiary
 
-<doc-demo file="/demos/button/types-css.html" toggle="false" />
+<doc-demo toggle="false">
+<<< .vuepress/public/demos/button/types-css.html
+::: slot demo
+!!!include(.vuepress/public/demos/button/types-css.html)!!!
+:::
+</doc-demo>
 
 ### States: Info, Success and Danger Outline Buttons
 
-<doc-demo file="/demos/button/states-css.html" toggle="false" />
+<doc-demo toggle="false">
+<<< .vuepress/public/demos/button/states-css.html
+::: slot demo
+!!!include(.vuepress/public/demos/button/states-css.html)!!!
+:::
+</doc-demo>
 
 ### Sizes: Normal, Small, Normal Flat, Small Flat
 
-<doc-demo file="/demos/button/sizes-css.html" />
+<doc-demo>
+<<< .vuepress/public/demos/button/sizes-css.html
+::: slot demo
+!!!include(.vuepress/public/demos/button/sizes-css.html)!!!
+:::
+</doc-demo>
 
 ### Block
 
-<doc-demo file="/demos/button/block-css.html" toggle="false" />
+<doc-demo toggle="false">
+<<< .vuepress/public/demos/button/block-css.html
+::: slot demo
+!!!include(.vuepress/public/demos/button/block-css.html)!!!
+:::
+</doc-demo>
 
 ### Inverse
 
-<doc-demo file="/demos/button/inverse-css.html" toggle="false" />
+<doc-demo toggle="false">
+<<< .vuepress/public/demos/button/inverse-css.html
+::: slot demo
+!!!include(.vuepress/public/demos/button/inverse-css.html)!!!
+:::
+</doc-demo>
 
 ### Icon
 
-<doc-demo file="/demos/button/icon-css.html" />
+<doc-demo>
+<<< .vuepress/public/demos/button/icon-css.html
+::: slot demo
+!!!include(.vuepress/public/demos/button/icon-css.html)!!!
+:::
+</doc-demo>
 
 ### Loading
 
@@ -261,5 +306,10 @@ Use the `clrLoading` directive to change the state of the spinner button. The di
 - `ClrLoadingState.LOADING`: replaces the button text with a spinner.
 - `ClrLoadingState.SUCCESS`: briefly shows a check mark, and automatically transition back to the ClrLoadingState.DEFAULT state.
 
-<doc-demo src="/demos/button/loading-ng.html"></doc-demo>
-<doc-demo src="/demos/button/loading.ts"></doc-demo>
+<doc-demo>
+<<< .vuepress/public/demos/button/loading-ng.html
+</doc-demo>
+
+<doc-demo>
+<<< .vuepress/public/demos/button/loading.ts
+</doc-demo>

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -15,6 +15,7 @@
     "@sentry/browser": "5.15.5",
     "@sentry/integrations": "5.15.5",
     "markdown-it-attrs": "^3.0.2",
+    "markdown-it-include": "^1.1.1",
     "vue-resource": "^1.5.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -21648,6 +21648,11 @@ markdown-it-emoji@^1.4.0:
   resolved "https://registry.yarnpkg.com/markdown-it-emoji/-/markdown-it-emoji-1.4.0.tgz#9bee0e9a990a963ba96df6980c4fddb05dfb4dcc"
   integrity sha1-m+4OmpkKljupbfaYDE/dsF37Tcw=
 
+markdown-it-include@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/markdown-it-include/-/markdown-it-include-1.1.1.tgz#7015209f7b64365d32bb6ccc25366bc15d3eadc9"
+  integrity sha512-jDWIHhOtiQkFIc6BqXqXK1r4LfCxKFOWtsdvwZjLw5zZaWk64n71lE5HWHtzyVvfDudYWxR+tH0hO10B2I1e3w==
+
 markdown-it-table-of-contents@^0.4.0:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.4.4.tgz#3dc7ce8b8fc17e5981c77cc398d1782319f37fbc"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:


## What is the new behavior?
This allows code demos to be imported and rendered at build time for the website. This improves SEO as the code samples are all pre-rendered into the html without the need of JS or PrismJS runtime. This also improves performance as Prism does not have to run for each code block. 

I only updated one doc page for this PR. This can wait till after the website release. I can help out with other pages in follow up PRs as well.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
