### PR TITLE
fix(datagrid): disable whitespace wrap in column title

### DIFF
--- a/src/clr-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clr-angular/data/datagrid/_datagrid.clarity.scss
@@ -839,6 +839,14 @@
         align-self: center;
         display: flex;
 
+        /**
+         * Default white space wrap causes the grid header to shrink vertically.
+         * When shrinking the title goes over the data in the grid and makes the data unreadable.
+         *
+         * Fix: #4872
+         */
+        white-space: nowrap;
+
         .signpost .signpost-action.btn {
           height: inherit;
           line-height: inherit;


### PR DESCRIPTION
Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #4872

## What is the new behavior?

The title doesn't wrap on column resize.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Before
![image](https://user-images.githubusercontent.com/15037947/89758398-587fd400-daf0-11ea-9223-b6f0f25baa71.png)

After (horizontal scroll available)
![image](https://user-images.githubusercontent.com/15037947/89758426-6d5c6780-daf0-11ea-8853-f5d77d951bb9.png)

After (min-width => title content)
![image](https://user-images.githubusercontent.com/15037947/89758739-2a4ec400-daf1-11ea-8596-4780302ed5c4.png)


