### PR TITLE
Revert "fix(datagrid): disable whitespace wrap in column title" 

### DIFF
--- a/src/clr-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clr-angular/data/datagrid/_datagrid.clarity.scss
@@ -839,14 +839,6 @@
         align-self: center;
         display: flex;
 
-        /**
-         * Default white space wrap causes the grid header to shrink vertically.
-         * When shrinking the title goes over the data in the grid and makes the data unreadable.
-         *
-         * Fix: #4872
-         */
-        white-space: nowrap;
-
         .signpost .signpost-action.btn {
           height: inherit;
           line-height: inherit;


### PR DESCRIPTION
This reverts commit 6468cda9187cc23433fd01e3cc193ff0037b3223.

Seems like the fix causes issues we didn't expect. We need to figure out a better way to fix it.