### PR TITLE
fix: handle stepper throwing TypeError

### DIFF
--- a/src/clr-angular/accordion/stepper/models/stepper.model.spec.ts
+++ b/src/clr-angular/accordion/stepper/models/stepper.model.spec.ts
@@ -82,6 +82,15 @@ describe('StepperModel', () => {
     expect(stepper.panels[1].status).toBe(AccordionStatus.Inactive);
   });
 
+  it('should not throw error when we could not find first element', () => {
+    /* make sure no panel had index set */
+    stepper = new StepperModel();
+    stepper.addPanel(step1Id);
+    stepper.addPanel(step2Id);
+    stepper.addPanel(step3Id);
+    expect(() => stepper.resetPanels()).not.toThrowAnyError();
+  });
+
   it('should allow user to open and close a previously completed step', () => {
     stepper.navigateToNextPanel(step1Id);
     expect(stepper.panels[0].status).toBe(AccordionStatus.Complete);

--- a/src/clr-angular/accordion/stepper/models/stepper.model.ts
+++ b/src/clr-angular/accordion/stepper/models/stepper.model.ts
@@ -80,6 +80,14 @@ export class StepperModel extends AccordionModel {
 
   private openFirstPanel() {
     const firstPanel = this.getFirstPanel();
+    /**
+     * You need to call updatePanelOrder first to get the correct order,
+     * else the list of panels will not have `index` set and we won't know
+     * how to find the first panel.
+     */
+    if (!firstPanel) {
+      return;
+    }
     this._panels[firstPanel.id].open = true;
     this._panels[firstPanel.id].disabled = true;
     this.stepperModelInitialize = true;


### PR DESCRIPTION
Handle case when there is not yet the first element to open.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Close: #4822 