### PR TITLE
fix(a11y): set aria-current instead of aria-selected in the Wizard's steps

### DIFF
--- a/packages/angular/golden/clr-angular.d.ts
+++ b/packages/angular/golden/clr-angular.d.ts
@@ -2082,6 +2082,7 @@ export declare class ClrWizardStepnavItem {
     navService: WizardNavigationService;
     page: ClrWizardPage;
     pageCollection: PageCollectionService;
+    get stepAriaCurrent(): string;
     constructor(navService: WizardNavigationService, pageCollection: PageCollectionService);
     click(): void;
 }

--- a/packages/angular/projects/clr-angular/src/wizard/wizard-stepnav-item.spec.ts
+++ b/packages/angular/projects/clr-angular/src/wizard/wizard-stepnav-item.spec.ts
@@ -290,36 +290,36 @@ export default function (): void {
           expect(myStepnavItem.classList.contains('clr-nav-link')).toBe(true, 'stepnav item has .clr-nav-link class');
         });
 
-        it('aria-selected should be false if page is not current', () => {
-          expect(myStepnavItem.hasAttribute('aria-selected')).toBeTruthy('stepnav item has aria-selected attr');
-          expect(myStepnavItem.getAttribute('aria-selected')).toBe(
+        it('aria-current should be false if page is not current', () => {
+          expect(myStepnavItem.hasAttribute('aria-current')).toBeTruthy('stepnav item has aria-current attr');
+          expect(myStepnavItem.getAttribute('aria-current')).toBe(
             'false',
-            'aria-selected should be false if page not current'
+            'aria-current should be false if page not current'
           );
         });
 
-        it('aria-selected should be true if page is current', () => {
+        it('aria-current should be true if page is current', () => {
           fakeOutPage.current = true;
           fixture.detectChanges();
-          expect(myStepnavItem.hasAttribute('aria-selected')).toBeTruthy('stepnav item has aria-selected attr');
-          expect(myStepnavItem.getAttribute('aria-selected')).toBe(
-            'true',
-            'aria-selected should be true if page is current'
+          expect(myStepnavItem.hasAttribute('aria-current')).toBeTruthy('stepnav item has aria-current attr');
+          expect(myStepnavItem.getAttribute('aria-current')).toBe(
+            'step',
+            'aria-current should be set if page is current'
           );
         });
 
-        it('aria-selected should update with page current state', () => {
-          expect(myStepnavItem.hasAttribute('aria-selected')).toBeTruthy('stepnav item has aria-selected attr');
-          expect(myStepnavItem.getAttribute('aria-selected')).toBe(
+        it('aria-current should update with page current state', () => {
+          expect(myStepnavItem.hasAttribute('aria-current')).toBeTruthy('stepnav item has aria-current attr');
+          expect(myStepnavItem.getAttribute('aria-current')).toBe(
             'false',
-            'aria-selected should be false if page not current'
+            'aria-current should be false if page not current'
           );
           fakeOutPage.current = true;
           fixture.detectChanges();
-          expect(myStepnavItem.hasAttribute('aria-selected')).toBeTruthy('stepnav item has aria-selected attr');
-          expect(myStepnavItem.getAttribute('aria-selected')).toBe(
-            'true',
-            'aria-selected should be true if page is current'
+          expect(myStepnavItem.hasAttribute('aria-current')).toBeTruthy('stepnav item has aria-current attr');
+          expect(myStepnavItem.getAttribute('aria-current')).toBe(
+            'step',
+            'aria-current should be true if page is current'
           );
         });
 
@@ -330,7 +330,7 @@ export default function (): void {
           );
         });
 
-        it('aria-selected have .active class if page is current', () => {
+        it('should have .active class if page is current', () => {
           fakeOutPage.current = true;
           fixture.detectChanges();
           expect(myStepnavItem.classList.contains('active')).toBe(
@@ -397,7 +397,7 @@ export default function (): void {
           );
         });
 
-        it('aria-selected have .complete class if page is completed', () => {
+        it('should have .complete class if page is completed', () => {
           fakeOutPage.completed = true;
           fixture.detectChanges();
           expect(myStepnavItem.classList.contains('complete')).toBe(
@@ -419,7 +419,7 @@ export default function (): void {
           );
         });
 
-        it('aria-selected have .error class if page has an error', () => {
+        it('should have .error class if page has an error', () => {
           fakeOutPage.completed = true;
           fakeOutPage.hasError = true;
           fixture.detectChanges();
@@ -443,7 +443,7 @@ export default function (): void {
           );
         });
 
-        it('aria-selected not have .error class if page has an error and page is not completed', () => {
+        it('should not have .error class if page has an error and page is not completed', () => {
           fakeOutPage.completed = false;
           fakeOutPage.hasError = true;
           fixture.detectChanges();

--- a/packages/angular/projects/clr-angular/src/wizard/wizard-stepnav-item.ts
+++ b/packages/angular/projects/clr-angular/src/wizard/wizard-stepnav-item.ts
@@ -34,7 +34,7 @@ import { ClrWizardPage } from './wizard-page';
   `,
   host: {
     '[id]': 'id',
-    '[attr.aria-selected]': 'isCurrent',
+    '[attr.aria-current]': 'stepAriaCurrent',
     '[attr.aria-controls]': 'id',
     '[class.clr-nav-link]': 'true',
     '[class.nav-item]': 'true',
@@ -59,6 +59,10 @@ export class ClrWizardStepnavItem {
   public get id(): string {
     this.pageGuard();
     return this.pageCollection.getStepItemIdForPage(this.page);
+  }
+
+  public get stepAriaCurrent(): string {
+    return this.isCurrent && 'step';
   }
 
   public get isDisabled(): boolean {


### PR DESCRIPTION
Signed-off-by: Stanimira Vlaeva <svlaeva@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The active pages in the Wizard were being assigned the `aria-selected` attribute.

Issue Number: 4080

## What is the new behavior?

The active pages are assigned the `aria-current: 'step'` attribute instead. This allows the assistive technologies to communicate that the element being read represents the current step in a series of steps.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

fixes #4080
