### PR TITLE
fix(a11y): remove redundant title attribute from Stack View expand/collapse icon

### DIFF
--- a/packages/angular/golden/clr-angular.d.ts
+++ b/packages/angular/golden/clr-angular.d.ts
@@ -1567,7 +1567,6 @@ export declare class ClrStackBlock implements OnInit {
     ariaPosinset: number;
     ariaSetsize: number;
     get caretDirection(): string;
-    get caretTitle(): string;
     commonStrings: ClrCommonStringsService;
     expandable: boolean;
     expanded: boolean;

--- a/packages/angular/projects/clr-angular/src/data/stack-view/stack-block.ts
+++ b/packages/angular/projects/clr-angular/src/data/stack-view/stack-block.ts
@@ -26,13 +26,7 @@ import { UNIQUE_ID, UNIQUE_ID_PROVIDER } from '../../utils/id-generator/id-gener
       [attr.aria-level]="ariaLevel"
       [attr.aria-setsize]="ariaSetsize"
     >
-      <clr-icon
-        shape="caret"
-        class="stack-block-caret"
-        *ngIf="expandable"
-        [attr.dir]="caretDirection"
-        [attr.title]="caretTitle"
-      ></clr-icon>
+      <clr-icon shape="caret" class="stack-block-caret" *ngIf="expandable" [attr.dir]="caretDirection"></clr-icon>
       <span class="clr-sr-only" *ngIf="getChangedValue">{{ commonStrings.keys.stackViewChanged }}</span>
       <div class="stack-view-key">
         <!-- This structure changed to fix #3567 and the a11y request was to move away from dl's -->
@@ -145,10 +139,6 @@ export class ClrStackBlock implements OnInit {
 
   get caretDirection(): string {
     return this.expanded ? 'down' : 'right';
-  }
-
-  get caretTitle(): string {
-    return this.expanded ? this.commonStrings.keys.collapse : this.commonStrings.keys.expand;
   }
 
   get role(): string {


### PR DESCRIPTION
Signed-off-by: Stanimira Vlaeva <svlaeva@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The Stack View expand/collapse icon has a title attribute. The parent element also has an attribute `aria-expanded` which conveys the state and serves the same purpose.

Issue Number: #4525

## What is the new behavior?

The title attribute on the Stack View icon is removed as it's redundant and creates a tooltip that's not keyboard accessible.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

fixes #4525
