### PR TITLE
fix: display helper subtext into form-containers when success-content is missing 

### DIFF
--- a/packages/angular/golden/clr-angular.d.ts
+++ b/packages/angular/golden/clr-angular.d.ts
@@ -49,6 +49,7 @@ export declare abstract class ClrAbstractContainer implements DynamicWrapper, On
     _dynamic: boolean;
     control: NgControl;
     protected controlClassService: ControlClassService;
+    controlSuccessComponent: ClrControlSuccess;
     protected ifControlStateService: IfControlStateService;
     label: ClrLabel;
     protected layoutService: LayoutService;
@@ -263,7 +264,6 @@ export declare class ClrCheckboxContainer extends ClrAbstractContainer {
     set clrInline(value: boolean | string);
     get clrInline(): boolean | string;
     protected controlClassService: ControlClassService;
-    controlSuccessComponent: ClrControlSuccess;
     protected ifControlStateService: IfControlStateService;
     protected layoutService: LayoutService;
     protected ngControlService: NgControlService;
@@ -331,7 +331,6 @@ export declare class ClrCombobox<T> extends WrappedFormControl<ClrComboboxContai
 
 export declare class ClrComboboxContainer extends ClrAbstractContainer implements AfterContentInit, AfterViewInit {
     controlContainer: ElementRef;
-    controlSuccessComponent: ClrControlSuccess;
     label: ClrLabel;
     constructor(ifControlStateService: IfControlStateService, layoutService: LayoutService, controlClassService: ControlClassService, ngControlService: NgControlService, containerService: ComboboxContainerService, el: ElementRef);
     ngAfterContentInit(): void;
@@ -437,7 +436,6 @@ export declare class ClrControl extends WrappedFormControl<ClrControlContainer> 
 }
 
 export declare class ClrControlContainer extends ClrAbstractContainer {
-    controlSuccessComponent: ClrControlSuccess;
 }
 
 export declare class ClrControlError {
@@ -810,7 +808,6 @@ export declare class ClrDatalist implements AfterContentInit {
 }
 
 export declare class ClrDatalistContainer extends ClrAbstractContainer {
-    controlSuccessComponent: ClrControlSuccess;
     focus: boolean;
     protected ifControlStateService: IfControlStateService;
     constructor(controlClassService: ControlClassService, layoutService: LayoutService, ngControlService: NgControlService, focusService: FocusService, ifControlStateService: IfControlStateService);
@@ -838,15 +835,15 @@ export declare class ClrDateContainer implements DynamicWrapper, OnDestroy, Afte
     control: NgControl;
     controlSuccessComponent: ClrControlSuccess;
     focus: boolean;
-    invalid: boolean;
     get isEnabled(): boolean;
     get isInputDateDisabled(): boolean;
     label: ClrLabel;
     get open(): boolean;
     get popoverPosition(): ClrPopoverPosition;
     showHelper: boolean;
+    showInvalid: boolean;
+    showValid: boolean;
     state: CONTROL_STATE;
-    valid: boolean;
     constructor(toggleService: ClrPopoverToggleService, dateNavigationService: DateNavigationService, datepickerEnabledService: DatepickerEnabledService, dateFormControlService: DateFormControlService, commonStrings: ClrCommonStringsService, focusService: FocusService, viewManagerService: ViewManagerService, controlClassService: ControlClassService, layoutService: LayoutService, ngControlService: NgControlService, ifControlStateService: IfControlStateService);
     addGrid(): boolean;
     controlClass(): string;
@@ -1133,7 +1130,6 @@ export declare class ClrInput extends WrappedFormControl<ClrInputContainer> {
 }
 
 export declare class ClrInputContainer extends ClrAbstractContainer {
-    controlSuccessComponent: ClrControlSuccess;
 }
 
 export declare class ClrInputModule {
@@ -1322,7 +1318,6 @@ export declare class ClrPasswordContainer extends ClrAbstractContainer {
     set clrToggle(state: boolean);
     get clrToggle(): boolean;
     commonStrings: ClrCommonStringsService;
-    controlSuccessComponent: ClrControlSuccess;
     focus: boolean;
     focusService: FocusService;
     show: boolean;
@@ -1441,7 +1436,6 @@ export declare class ClrRadioContainer extends ClrAbstractContainer {
     set clrInline(value: boolean | string);
     get clrInline(): boolean | string;
     protected controlClassService: ControlClassService;
-    controlSuccessComponent: ClrControlSuccess;
     protected ifControlStateService: IfControlStateService;
     protected layoutService: LayoutService;
     protected ngControlService: NgControlService;
@@ -1462,7 +1456,6 @@ export declare class ClrRange extends WrappedFormControl<ClrRangeContainer> {
 }
 
 export declare class ClrRangeContainer extends ClrAbstractContainer {
-    controlSuccessComponent: ClrControlSuccess;
     set hasProgress(val: boolean);
     get hasProgress(): boolean;
     protected ifControlStateService: IfControlStateService;
@@ -1493,7 +1486,6 @@ export declare class ClrSelect extends WrappedFormControl<ClrSelectContainer> {
 
 export declare class ClrSelectContainer extends ClrAbstractContainer {
     protected controlClassService: ControlClassService;
-    controlSuccessComponent: ClrControlSuccess;
     protected ifControlStateService: IfControlStateService;
     protected layoutService: LayoutService;
     multiple: SelectMultipleControlValueAccessor;
@@ -1743,7 +1735,6 @@ export declare class ClrTextarea extends WrappedFormControl<ClrTextareaContainer
 }
 
 export declare class ClrTextareaContainer extends ClrAbstractContainer {
-    controlSuccessComponent: ClrControlSuccess;
 }
 
 export declare class ClrTextareaModule {

--- a/packages/angular/projects/clr-angular/src/forms/checkbox/checkbox-container.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/checkbox/checkbox-container.spec.ts
@@ -21,7 +21,11 @@ import { ContainerNoLabelSpec, TemplateDrivenSpec, ReactiveSpec } from '../tests
 import { IfControlStateService } from '../common/if-control-state/if-control-state.service';
 
 @Component({
-  template: ` <clr-checkbox-container></clr-checkbox-container> `,
+  template: `
+    <clr-checkbox-container>
+      <clr-control-helper>Helper text</clr-control-helper>
+    </clr-checkbox-container>
+  `,
 })
 class NoLabelTest {}
 

--- a/packages/angular/projects/clr-angular/src/forms/checkbox/checkbox-container.ts
+++ b/packages/angular/projects/clr-angular/src/forms/checkbox/checkbox-container.ts
@@ -4,13 +4,12 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, Input, Optional, ContentChild } from '@angular/core';
+import { Component, Input, Optional } from '@angular/core';
 
 import { ControlClassService } from '../common/providers/control-class.service';
 import { NgControlService } from '../common/providers/ng-control.service';
 import { ClrAbstractContainer } from '../common/abstract-container';
 import { LayoutService } from '../common/providers/layout.service';
-import { ClrControlSuccess } from '../common/success';
 import { IfControlStateService } from '../common/if-control-state/if-control-state.service';
 
 @Component({
@@ -28,12 +27,7 @@ import { IfControlStateService } from '../common/if-control-state/if-control-sta
           shape="exclamation-circle"
           aria-hidden="true"
         ></clr-icon>
-        <clr-icon
-          *ngIf="showValid && controlSuccessComponent"
-          class="clr-validate-icon"
-          shape="check-circle"
-          aria-hidden="true"
-        ></clr-icon>
+        <clr-icon *ngIf="showValid" class="clr-validate-icon" shape="check-circle" aria-hidden="true"></clr-icon>
         <ng-content select="clr-control-error" *ngIf="showInvalid"></ng-content>
         <ng-content select="clr-control-success" *ngIf="showValid"></ng-content>
       </div>
@@ -48,7 +42,6 @@ import { IfControlStateService } from '../common/if-control-state/if-control-sta
 })
 export class ClrCheckboxContainer extends ClrAbstractContainer {
   private inline = false;
-  @ContentChild(ClrControlSuccess) controlSuccessComponent: ClrControlSuccess;
 
   constructor(
     @Optional() protected layoutService: LayoutService,

--- a/packages/angular/projects/clr-angular/src/forms/checkbox/toggle-container.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/checkbox/toggle-container.spec.ts
@@ -21,7 +21,11 @@ import { ClrCheckboxWrapper } from './checkbox-wrapper';
 import { ContainerNoLabelSpec, TemplateDrivenSpec, ReactiveSpec } from '../tests/container.spec';
 
 @Component({
-  template: ` <clr-toggle-container></clr-toggle-container> `,
+  template: `
+    <clr-toggle-container>
+      <clr-control-helper>Helper text</clr-control-helper>
+    </clr-toggle-container>
+  `,
 })
 class NoLabelTest {}
 

--- a/packages/angular/projects/clr-angular/src/forms/combobox/combobox-container.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/combobox-container.spec.ts
@@ -18,7 +18,11 @@ import { By } from '@angular/platform-browser';
 import { ComboboxContainerService } from './providers/combobox-container.service';
 
 @Component({
-  template: ` <clr-combobox-container></clr-combobox-container> `,
+  template: `
+    <clr-combobox-container>
+      <clr-control-helper>Helper text</clr-control-helper>
+    </clr-combobox-container>
+  `,
 })
 class NoLabelTest {}
 

--- a/packages/angular/projects/clr-angular/src/forms/combobox/combobox-container.ts
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/combobox-container.ts
@@ -21,7 +21,6 @@ import { LayoutService } from '../common/providers/layout.service';
 import { ComboboxContainerService } from './providers/combobox-container.service';
 import { ClrAbstractContainer } from '../common/abstract-container';
 import { ClrLabel } from '../common/label';
-import { ClrControlSuccess } from '../common/success';
 import { IfControlStateService } from '../common/if-control-state/if-control-state.service';
 
 @Component({
@@ -32,12 +31,7 @@ import { IfControlStateService } from '../common/if-control-state/if-control-sta
     <div class="clr-control-container" [ngClass]="controlClass()" #controlContainer>
       <ng-content select="clr-combobox"></ng-content>
       <clr-icon *ngIf="showInvalid" class="clr-validate-icon" shape="exclamation-circle" aria-hidden="true"></clr-icon>
-      <clr-icon
-        *ngIf="showValid && controlSuccessComponent"
-        class="clr-validate-icon"
-        shape="check-circle"
-        aria-hidden="true"
-      ></clr-icon>
+      <clr-icon *ngIf="showValid" class="clr-validate-icon" shape="check-circle" aria-hidden="true"></clr-icon>
       <ng-content select="clr-control-helper" *ngIf="showHelper"></ng-content>
       <ng-content select="clr-control-error" *ngIf="showInvalid"></ng-content>
       <ng-content select="clr-control-success" *ngIf="showValid"></ng-content>
@@ -54,7 +48,6 @@ import { IfControlStateService } from '../common/if-control-state/if-control-sta
 export class ClrComboboxContainer extends ClrAbstractContainer implements AfterContentInit, AfterViewInit {
   @ViewChild('controlContainer') controlContainer: ElementRef;
   @ContentChild(ClrLabel) label: ClrLabel;
-  @ContentChild(ClrControlSuccess) controlSuccessComponent: ClrControlSuccess;
 
   constructor(
     ifControlStateService: IfControlStateService,

--- a/packages/angular/projects/clr-angular/src/forms/common/abstract-container.ts
+++ b/packages/angular/projects/clr-angular/src/forms/common/abstract-container.ts
@@ -14,6 +14,7 @@ import { ClrLabel } from './label';
 import { ControlClassService } from './providers/control-class.service';
 import { Subscription } from 'rxjs';
 import { IfControlStateService, CONTROL_STATE } from './if-control-state/if-control-state.service';
+import { ClrControlSuccess } from './success';
 
 @Directive()
 export abstract class ClrAbstractContainer implements DynamicWrapper, OnDestroy {
@@ -24,12 +25,17 @@ export abstract class ClrAbstractContainer implements DynamicWrapper, OnDestroy 
   control: NgControl;
   private state: CONTROL_STATE;
 
+  /**
+   * Search for `ClrSuccessComponent` to know do we want to display clr-success or not
+   */
+  @ContentChild(ClrControlSuccess) controlSuccessComponent: ClrControlSuccess;
+
   get showHelper(): boolean {
-    return this.state === CONTROL_STATE.NONE;
+    return this.state === CONTROL_STATE.NONE || (!this.showInvalid && !this.controlSuccessComponent);
   }
 
   get showValid(): boolean {
-    return this.state === CONTROL_STATE.VALID;
+    return this.state === CONTROL_STATE.VALID && !!this.controlSuccessComponent;
   }
 
   get showInvalid(): boolean {
@@ -56,6 +62,17 @@ export abstract class ClrAbstractContainer implements DynamicWrapper, OnDestroy 
   }
 
   controlClass() {
+    /**
+     * Decide what subtext to display:
+     *   - element is valid but no success component is implemented - show helper
+     *   - element is valid and success component is implemented - show success
+     */
+    if (!this.controlSuccessComponent && this.state === CONTROL_STATE.VALID) {
+      return this.controlClassService.controlClass(CONTROL_STATE.NONE, this.addGrid());
+    }
+    /**
+     * Pass form control state and return string of classes to be applyed to the container.
+     */
     return this.controlClassService.controlClass(this.state, this.addGrid());
   }
 

--- a/packages/angular/projects/clr-angular/src/forms/common/control-container.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/common/control-container.spec.ts
@@ -30,6 +30,7 @@ class SimpleTest {
 @Component({
   template: ` <clr-control-container>
     <input clrControl name="model" [(ngModel)]="model" />
+    <clr-control-helper>Helper text</clr-control-helper>
   </clr-control-container>`,
 })
 class NoLabelTest {

--- a/packages/angular/projects/clr-angular/src/forms/common/control-container.ts
+++ b/packages/angular/projects/clr-angular/src/forms/common/control-container.ts
@@ -4,14 +4,13 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, ContentChild } from '@angular/core';
+import { Component } from '@angular/core';
 
 import { ClrAbstractContainer } from '../common/abstract-container';
 import { NgControlService } from './providers/ng-control.service';
 import { ControlIdService } from './providers/control-id.service';
 import { ControlClassService } from './providers/control-class.service';
 import { IfControlStateService } from './if-control-state/if-control-state.service';
-import { ClrControlSuccess } from '../common/success';
 
 @Component({
   selector: 'clr-control-container',
@@ -27,12 +26,7 @@ import { ClrControlSuccess } from '../common/success';
           shape="exclamation-circle"
           aria-hidden="true"
         ></clr-icon>
-        <clr-icon
-          *ngIf="showValid && controlSuccessComponent"
-          class="clr-validate-icon"
-          shape="check-circle"
-          aria-hidden="true"
-        ></clr-icon>
+        <clr-icon *ngIf="showValid" class="clr-validate-icon" shape="check-circle" aria-hidden="true"></clr-icon>
       </div>
       <ng-content select="clr-control-helper" *ngIf="showHelper"></ng-content>
       <ng-content select="clr-control-error" *ngIf="showInvalid"></ng-content>
@@ -46,6 +40,4 @@ import { ClrControlSuccess } from '../common/success';
   },
   providers: [IfControlStateService, NgControlService, ControlIdService, ControlClassService],
 })
-export class ClrControlContainer extends ClrAbstractContainer {
-  @ContentChild(ClrControlSuccess) controlSuccessComponent: ClrControlSuccess;
-}
+export class ClrControlContainer extends ClrAbstractContainer {}

--- a/packages/angular/projects/clr-angular/src/forms/common/if-control-state/if-success.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/common/if-control-state/if-success.spec.ts
@@ -15,7 +15,6 @@ import { ClrIfSuccess } from './if-success';
 import { IfControlStateService } from './if-control-state.service';
 
 const successMessage = 'SUCCESS_MESSAGE';
-const minLengthMessage = 'MIN_LENGTH_MESSAGE';
 
 @Component({ template: `<div *clrIfSuccess></div>` })
 class InvalidUseTest {}
@@ -25,15 +24,6 @@ class InvalidUseTest {}
   providers: [IfControlStateService, NgControlService],
 })
 class GeneralSuccessTest {}
-
-@Component({
-  template: `
-    <clr-control-success *clrIfSuccess="'required'">${successMessage}</clr-control-success>
-    <clr-control-success *clrIfSuccess="'minlength'">${minLengthMessage}</clr-control-success>
-  `,
-  providers: [IfControlStateService, NgControlService],
-})
-class SpecificSuccessTest {}
 
 export default function (): void {
   describe('ClrIfSuccess', () => {
@@ -68,35 +58,6 @@ export default function (): void {
       it('displays the success message after touched', () => {
         expect(fixture.nativeElement.innerHTML).not.toContain(successMessage);
         const control = new FormControl('abc', Validators.required);
-        control.markAsTouched();
-        ngControlService.setControl(control);
-        ifControlStateService.triggerStatusChange();
-        fixture.detectChanges();
-        expect(fixture.nativeElement.innerHTML).toContain(successMessage);
-      });
-    });
-
-    describe('specific success', () => {
-      let fixture, ifControlStateService, ngControlService;
-
-      beforeEach(() => {
-        TestBed.configureTestingModule({
-          imports: [ClrIconModule, FormsModule],
-          declarations: [ClrInput, ClrControlSuccess, ClrInputContainer, ClrIfSuccess, SpecificSuccessTest],
-        });
-        fixture = TestBed.createComponent(SpecificSuccessTest);
-        fixture.detectChanges();
-        ngControlService = fixture.debugElement.injector.get(NgControlService);
-        ifControlStateService = fixture.debugElement.injector.get(IfControlStateService);
-      });
-
-      it('hides the success initially', () => {
-        expect(fixture.nativeElement.innerHTML).not.toContain(successMessage);
-      });
-
-      it('displays the success when the specific success is defined', () => {
-        expect(fixture.nativeElement.innerHTML).not.toContain(successMessage);
-        const control = new FormControl('abcde', [Validators.required, Validators.minLength(5)]);
         control.markAsTouched();
         ngControlService.setControl(control);
         ifControlStateService.triggerStatusChange();

--- a/packages/angular/projects/clr-angular/src/forms/common/if-control-state/if-success.ts
+++ b/packages/angular/projects/clr-angular/src/forms/common/if-control-state/if-success.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { Directive, Optional, TemplateRef, ViewContainerRef } from '@angular/core';
+import { Directive, Optional, TemplateRef, ViewContainerRef, Input } from '@angular/core';
 import { NgControlService } from '../providers/ng-control.service';
 import { IfControlStateService, CONTROL_STATE } from './if-control-state.service';
 import { AbstractIfState } from './abstract-if-state';
@@ -31,7 +31,7 @@ export class ClrIfSuccess extends AbstractIfState {
 
     if (isValid && !this.displayedContent) {
       this.container.createEmbeddedView(this.template);
-    } else if (!isValid) {
+    } else if (!isValid && this.container) {
       this.container.clear();
     }
     this.displayedContent = isValid;

--- a/packages/angular/projects/clr-angular/src/forms/datalist/datalist-container.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/datalist/datalist-container.spec.ts
@@ -41,6 +41,7 @@ class TemplateDrivenTest {
       <option [value]="'item2'"></option>
       <option [value]="'item3'"></option>
     </datalist>
+    <clr-control-helper>Helper text</clr-control-helper>
   </clr-datalist-container>`,
 })
 class NoLabelTest {}

--- a/packages/angular/projects/clr-angular/src/forms/datalist/datalist-container.ts
+++ b/packages/angular/projects/clr-angular/src/forms/datalist/datalist-container.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, Optional, ContentChild } from '@angular/core';
+import { Component, Optional } from '@angular/core';
 import { ControlClassService } from '../common/providers/control-class.service';
 import { LayoutService } from '../common/providers/layout.service';
 import { ControlIdService } from '../common/providers/control-id.service';
@@ -12,7 +12,6 @@ import { FocusService } from '../common/providers/focus.service';
 import { NgControlService } from '../common/providers/ng-control.service';
 import { DatalistIdService } from './providers/datalist-id.service';
 import { ClrAbstractContainer } from '../common/abstract-container';
-import { ClrControlSuccess } from '../common/success';
 import { IfControlStateService } from '../common/if-control-state/if-control-state.service';
 
 @Component({
@@ -32,12 +31,7 @@ import { IfControlStateService } from '../common/if-control-state/if-control-sta
           shape="exclamation-circle"
           aria-hidden="true"
         ></clr-icon>
-        <clr-icon
-          *ngIf="showValid && controlSuccessComponent"
-          class="clr-validate-icon"
-          shape="check-circle"
-          aria-hidden="true"
-        ></clr-icon>
+        <clr-icon *ngIf="showValid" class="clr-validate-icon" shape="check-circle" aria-hidden="true"></clr-icon>
       </div>
       <ng-content select="clr-control-helper" *ngIf="showHelper"></ng-content>
       <ng-content select="clr-control-error" *ngIf="showInvalid"></ng-content>
@@ -61,8 +55,6 @@ import { IfControlStateService } from '../common/if-control-state/if-control-sta
 })
 export class ClrDatalistContainer extends ClrAbstractContainer {
   focus = false;
-
-  @ContentChild(ClrControlSuccess) controlSuccessComponent: ClrControlSuccess;
 
   constructor(
     controlClassService: ControlClassService,

--- a/packages/angular/projects/clr-angular/src/forms/datepicker/date-container.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/datepicker/date-container.spec.ts
@@ -176,6 +176,22 @@ export default function () {
         context.detectChanges();
         expect(context.clarityDirective.popoverPosition).toEqual(ClrPopoverPositions['top-left']);
       });
+
+      it('should add/remove success icon and text', () => {
+        /* valid */
+        context.clarityDirective.showValid = true;
+        context.clarityDirective.showInvalid = false;
+        context.detectChanges();
+        expect(context.clarityElement.querySelector('clr-control-success')).toBeTruthy();
+        expect(context.clarityElement.querySelector('clr-icon[shape=check-circle]')).toBeTruthy();
+
+        /* invalid */
+        context.clarityDirective.showValid = false;
+        context.clarityDirective.showInvalid = true;
+        context.detectChanges();
+        expect(context.clarityElement.querySelector('clr-control-success')).toBeNull();
+        expect(context.clarityElement.querySelector('clr-icon[shape=check-circle]')).toBeNull();
+      });
     });
 
     describe('Typescript API', () => {
@@ -199,6 +215,7 @@ export default function () {
         expect(context.clarityDirective.controlClass()).not.toContain('clr-col-md-10');
         controlClassService.className = 'clr-col-2';
         expect(context.clarityDirective.controlClass()).not.toContain('clr-col-md-10');
+        expect(context.clarityDirective.controlClass()).toContain('clr-success');
       });
     });
   });
@@ -208,6 +225,7 @@ export default function () {
   template: `
     <clr-date-container [clrPosition]="position">
       <input type="date" clrDate [(ngModel)]="model" [disabled]="disabled" />
+      <clr-control-success>Valid</clr-control-success>
     </clr-date-container>
   `,
 })

--- a/packages/angular/projects/clr-angular/src/forms/datepicker/date-container.ts
+++ b/packages/angular/projects/clr-angular/src/forms/datepicker/date-container.ts
@@ -35,9 +35,9 @@ import { ClrPopoverPosition } from '../../utils/popover/interfaces/popover-posit
 import { ClrPopoverEventsService } from '../../utils/popover/providers/popover-events.service';
 import { ClrPopoverPositionService } from '../../utils/popover/providers/popover-position.service';
 import { ViewManagerService } from './providers/view-manager.service';
-import { ClrControlSuccess } from '../common/success';
 import { Subscription } from 'rxjs';
 import { IfControlStateService, CONTROL_STATE } from '../common/if-control-state/if-control-state.service';
+import { ClrControlSuccess } from '../common/success';
 
 @Component({
   selector: 'clr-date-container',
@@ -65,17 +65,17 @@ import { IfControlStateService, CONTROL_STATE } from '../common/if-control-state
             clrFocusTrap
           ></clr-datepicker-view-manager>
         </div>
-        <clr-icon class="clr-validate-icon" shape="exclamation-circle"></clr-icon>
         <clr-icon
-          *ngIf="valid && controlSuccessComponent"
+          *ngIf="showInvalid"
           class="clr-validate-icon"
-          shape="check-circle"
+          shape="exclamation-circle"
           aria-hidden="true"
         ></clr-icon>
+        <clr-icon *ngIf="showValid" class="clr-validate-icon" shape="check-circle" aria-hidden="true"></clr-icon>
       </div>
       <ng-content select="clr-control-helper" *ngIf="showHelper"></ng-content>
-      <ng-content select="clr-control-error" *ngIf="invalid"></ng-content>
-      <ng-content select="clr-control-success" *ngIf="valid"></ng-content>
+      <ng-content select="clr-control-error" *ngIf="showInvalid"></ng-content>
+      <ng-content select="clr-control-success" *ngIf="showValid"></ng-content>
     </div>
   `,
   providers: [
@@ -102,10 +102,10 @@ import { IfControlStateService, CONTROL_STATE } from '../common/if-control-state
 })
 export class ClrDateContainer implements DynamicWrapper, OnDestroy, AfterViewInit {
   _dynamic = false;
-  invalid = false;
+  showInvalid = false;
   showHelper = false;
   focus = false;
-  valid = false;
+  showValid = false;
   state: CONTROL_STATE;
   control: NgControl;
   @ContentChild(ClrLabel) label: ClrLabel;
@@ -169,9 +169,9 @@ export class ClrDateContainer implements DynamicWrapper, OnDestroy, AfterViewIni
     this.subscriptions.push(
       this.ifControlStateService.statusChanges.subscribe((state: CONTROL_STATE) => {
         this.state = state;
-        this.valid = CONTROL_STATE.VALID === state;
-        this.invalid = CONTROL_STATE.INVALID === state;
-        this.showHelper = CONTROL_STATE.NONE === state;
+        this.showValid = CONTROL_STATE.VALID === state && !!this.controlSuccessComponent;
+        this.showInvalid = CONTROL_STATE.INVALID === state;
+        this.showHelper = CONTROL_STATE.NONE === state || (!this.showInvalid && !this.controlSuccessComponent);
       })
     );
   }

--- a/packages/angular/projects/clr-angular/src/forms/input/input-container.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/input/input-container.spec.ts
@@ -30,6 +30,7 @@ class SimpleTest {
 @Component({
   template: ` <clr-input-container>
     <input clrInput name="model" [(ngModel)]="model" />
+    <clr-control-helper>Helper text</clr-control-helper>
   </clr-input-container>`,
 })
 class NoLabelTest {

--- a/packages/angular/projects/clr-angular/src/forms/input/input-container.ts
+++ b/packages/angular/projects/clr-angular/src/forms/input/input-container.ts
@@ -4,13 +4,12 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, ContentChild } from '@angular/core';
+import { Component } from '@angular/core';
 
 import { NgControlService } from '../common/providers/ng-control.service';
 import { ControlIdService } from '../common/providers/control-id.service';
 import { ControlClassService } from '../common/providers/control-class.service';
 import { ClrAbstractContainer } from '../common/abstract-container';
-import { ClrControlSuccess } from '../common/success';
 import { IfControlStateService } from '../common/if-control-state/if-control-state.service';
 
 @Component({
@@ -27,12 +26,7 @@ import { IfControlStateService } from '../common/if-control-state/if-control-sta
           shape="exclamation-circle"
           aria-hidden="true"
         ></clr-icon>
-        <clr-icon
-          *ngIf="showValid && controlSuccessComponent"
-          class="clr-validate-icon"
-          shape="check-circle"
-          aria-hidden="true"
-        ></clr-icon>
+        <clr-icon *ngIf="showValid" class="clr-validate-icon" shape="check-circle" aria-hidden="true"></clr-icon>
       </div>
       <ng-content select="clr-control-helper" *ngIf="showHelper"></ng-content>
       <ng-content select="clr-control-error" *ngIf="showInvalid"></ng-content>
@@ -46,6 +40,4 @@ import { IfControlStateService } from '../common/if-control-state/if-control-sta
   },
   providers: [IfControlStateService, NgControlService, ControlIdService, ControlClassService],
 })
-export class ClrInputContainer extends ClrAbstractContainer {
-  @ContentChild(ClrControlSuccess) controlSuccessComponent: ClrControlSuccess;
-}
+export class ClrInputContainer extends ClrAbstractContainer {}

--- a/packages/angular/projects/clr-angular/src/forms/password/password-container.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/password/password-container.spec.ts
@@ -37,6 +37,7 @@ class TemplateDrivenTest {
 @Component({
   template: ` <clr-password-container>
     <input clrPassword [(ngModel)]="model" />
+    <clr-control-helper>Helper text</clr-control-helper>
   </clr-password-container>`,
 })
 class NoLabelTest {}

--- a/packages/angular/projects/clr-angular/src/forms/password/password-container.ts
+++ b/packages/angular/projects/clr-angular/src/forms/password/password-container.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, Inject, InjectionToken, Input, Optional, ContentChild } from '@angular/core';
+import { Component, Inject, InjectionToken, Input, Optional } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 
 import { ControlClassService } from '../common/providers/control-class.service';
@@ -14,7 +14,6 @@ import { LayoutService } from '../common/providers/layout.service';
 import { NgControlService } from '../common/providers/ng-control.service';
 import { ClrCommonStringsService } from '../../utils/i18n/common-strings.service';
 import { ClrAbstractContainer } from '../common/abstract-container';
-import { ClrControlSuccess } from '../common/success';
 import { IfControlStateService } from '../common/if-control-state/if-control-state.service';
 
 export const TOGGLE_SERVICE = new InjectionToken<BehaviorSubject<boolean>>(undefined);
@@ -51,12 +50,7 @@ export const TOGGLE_SERVICE_PROVIDER = { provide: TOGGLE_SERVICE, useFactory: To
           shape="exclamation-circle"
           aria-hidden="true"
         ></clr-icon>
-        <clr-icon
-          *ngIf="showValid && controlSuccessComponent"
-          class="clr-validate-icon"
-          shape="check-circle"
-          aria-hidden="true"
-        ></clr-icon>
+        <clr-icon *ngIf="showValid" class="clr-validate-icon" shape="check-circle" aria-hidden="true"></clr-icon>
       </div>
       <ng-content select="clr-control-helper" *ngIf="showHelper"></ng-content>
       <ng-content select="clr-control-error" *ngIf="showInvalid"></ng-content>
@@ -81,8 +75,6 @@ export class ClrPasswordContainer extends ClrAbstractContainer {
   show = false;
   focus = false;
   private _toggle = true;
-
-  @ContentChild(ClrControlSuccess) controlSuccessComponent: ClrControlSuccess;
 
   @Input('clrToggle')
   set clrToggle(state: boolean) {

--- a/packages/angular/projects/clr-angular/src/forms/radio/radio-container.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/radio/radio-container.spec.ts
@@ -21,7 +21,11 @@ import { ContainerNoLabelSpec, TemplateDrivenSpec, ReactiveSpec } from '../tests
 import { IfControlStateService } from '../common/if-control-state/if-control-state.service';
 
 @Component({
-  template: ` <clr-radio-container></clr-radio-container> `,
+  template: `
+    <clr-radio-container>
+      <clr-control-helper>Helper text</clr-control-helper>
+    </clr-radio-container>
+  `,
 })
 class NoLabelTest {}
 

--- a/packages/angular/projects/clr-angular/src/forms/radio/radio-container.ts
+++ b/packages/angular/projects/clr-angular/src/forms/radio/radio-container.ts
@@ -4,13 +4,12 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, Input, Optional, ContentChild } from '@angular/core';
+import { Component, Input, Optional } from '@angular/core';
 
 import { ControlClassService } from '../common/providers/control-class.service';
 import { NgControlService } from '../common/providers/ng-control.service';
 import { ClrAbstractContainer } from '../common/abstract-container';
 import { LayoutService } from '../common/providers/layout.service';
-import { ClrControlSuccess } from '../common/success';
 import { IfControlStateService } from '../common/if-control-state/if-control-state.service';
 
 @Component({
@@ -28,12 +27,7 @@ import { IfControlStateService } from '../common/if-control-state/if-control-sta
           shape="exclamation-circle"
           aria-hidden="true"
         ></clr-icon>
-        <clr-icon
-          *ngIf="showValid && controlSuccessComponent"
-          class="clr-validate-icon"
-          shape="check-circle"
-          aria-hidden="true"
-        ></clr-icon>
+        <clr-icon *ngIf="showValid" class="clr-validate-icon" shape="check-circle" aria-hidden="true"></clr-icon>
         <ng-content select="clr-control-error" *ngIf="showInvalid"></ng-content>
         <ng-content select="clr-control-success" *ngIf="showValid"></ng-content>
       </div>
@@ -48,7 +42,6 @@ import { IfControlStateService } from '../common/if-control-state/if-control-sta
 })
 export class ClrRadioContainer extends ClrAbstractContainer {
   private inline = false;
-  @ContentChild(ClrControlSuccess) controlSuccessComponent: ClrControlSuccess;
 
   constructor(
     @Optional() protected layoutService: LayoutService,

--- a/packages/angular/projects/clr-angular/src/forms/range/range-container.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/range/range-container.spec.ts
@@ -30,6 +30,7 @@ class SimpleTest {
 @Component({
   template: ` <clr-range-container>
     <input clrRange name="model" [(ngModel)]="model" />
+    <clr-control-helper>Helper text</clr-control-helper>
   </clr-range-container>`,
 })
 class NoLabelTest {}

--- a/packages/angular/projects/clr-angular/src/forms/range/range-container.ts
+++ b/packages/angular/projects/clr-angular/src/forms/range/range-container.ts
@@ -4,14 +4,13 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, Input, Optional, Renderer2, ContentChild } from '@angular/core';
+import { Component, Input, Optional, Renderer2 } from '@angular/core';
 
 import { NgControlService } from '../common/providers/ng-control.service';
 import { LayoutService } from '../common/providers/layout.service';
 import { ControlIdService } from '../common/providers/control-id.service';
 import { ControlClassService } from '../common/providers/control-class.service';
 import { ClrAbstractContainer } from '../common/abstract-container';
-import { ClrControlSuccess } from '../common/success';
 import { IfControlStateService } from '../common/if-control-state/if-control-state.service';
 
 @Component({
@@ -29,12 +28,7 @@ import { IfControlStateService } from '../common/if-control-state/if-control-sta
           shape="exclamation-circle"
           aria-hidden="true"
         ></clr-icon>
-        <clr-icon
-          *ngIf="showValid && controlSuccessComponent"
-          class="clr-validate-icon"
-          shape="check-circle"
-          aria-hidden="true"
-        ></clr-icon>
+        <clr-icon *ngIf="showValid" class="clr-validate-icon" shape="check-circle" aria-hidden="true"></clr-icon>
       </div>
       <ng-content select="clr-control-helper" *ngIf="showHelper"></ng-content>
       <ng-content select="clr-control-error" *ngIf="showInvalid"></ng-content>
@@ -50,8 +44,6 @@ import { IfControlStateService } from '../common/if-control-state/if-control-sta
 })
 export class ClrRangeContainer extends ClrAbstractContainer {
   private _hasProgress = false;
-
-  @ContentChild(ClrControlSuccess) controlSuccessComponent: ClrControlSuccess;
 
   @Input('clrRangeHasProgress')
   set hasProgress(val: boolean) {

--- a/packages/angular/projects/clr-angular/src/forms/select/select-container.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/select/select-container.spec.ts
@@ -17,6 +17,7 @@ import { ContainerNoLabelSpec, TemplateDrivenSpec, ReactiveSpec } from '../tests
       <option value="1">one</option>
       <option value="2">two</option>
     </select>
+    <clr-control-helper>Helper text</clr-control-helper>
   </clr-select-container>`,
 })
 class NoLabelTest {}

--- a/packages/angular/projects/clr-angular/src/forms/select/select-container.ts
+++ b/packages/angular/projects/clr-angular/src/forms/select/select-container.ts
@@ -12,7 +12,6 @@ import { ControlIdService } from '../common/providers/control-id.service';
 import { ControlClassService } from '../common/providers/control-class.service';
 import { ClrAbstractContainer } from '../common/abstract-container';
 import { LayoutService } from '../common/providers/layout.service';
-import { ClrControlSuccess } from '../common/success';
 import { IfControlStateService } from '../common/if-control-state/if-control-state.service';
 
 @Component({
@@ -29,12 +28,7 @@ import { IfControlStateService } from '../common/if-control-state/if-control-sta
           shape="exclamation-circle"
           aria-hidden="true"
         ></clr-icon>
-        <clr-icon
-          *ngIf="showValid && controlSuccessComponent"
-          class="clr-validate-icon"
-          shape="check-circle"
-          aria-hidden="true"
-        ></clr-icon>
+        <clr-icon *ngIf="showValid" class="clr-validate-icon" shape="check-circle" aria-hidden="true"></clr-icon>
       </div>
       <ng-content select="clr-control-helper" *ngIf="showHelper"></ng-content>
       <ng-content select="clr-control-error" *ngIf="showInvalid"></ng-content>
@@ -49,9 +43,6 @@ import { IfControlStateService } from '../common/if-control-state/if-control-sta
   providers: [IfControlStateService, NgControlService, ControlIdService, ControlClassService],
 })
 export class ClrSelectContainer extends ClrAbstractContainer {
-  @ContentChild(ClrControlSuccess)
-  controlSuccessComponent: ClrControlSuccess;
-
   @ContentChild(SelectMultipleControlValueAccessor, { static: false })
   multiple: SelectMultipleControlValueAccessor;
   private multi = false;

--- a/packages/angular/projects/clr-angular/src/forms/tests/container.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/tests/container.spec.ts
@@ -19,7 +19,7 @@ import { IfControlStateService, CONTROL_STATE } from '../common/if-control-state
 
 export function ContainerNoLabelSpec(testContainer, testControl, testComponent): void {
   describe('no label', () => {
-    let fixture, containerDE, containerEl, layoutService;
+    let fixture, containerDE, containerEl, layoutService, container;
     beforeEach(() => {
       TestBed.configureTestingModule({
         imports: [ClrIconModule, ClrCommonFormsModule, FormsModule],
@@ -31,6 +31,7 @@ export function ContainerNoLabelSpec(testContainer, testControl, testComponent):
       containerDE = fixture.debugElement.query(By.directive(testContainer));
       containerEl = containerDE.nativeElement;
       layoutService = containerDE.injector.get(LayoutService);
+      container = containerDE.componentInstance;
     });
 
     it('adds an empty label when instantiated without vertical layout', () => {
@@ -44,6 +45,17 @@ export function ContainerNoLabelSpec(testContainer, testControl, testComponent):
       fixture.detectChanges();
       const labels = containerEl.querySelectorAll('label');
       expect(Array.prototype.filter.call(labels, label => label.textContent === '').length).toBe(0);
+    });
+
+    it('should display helper text when no success-component is present', () => {
+      fixture.detectChanges();
+      expect(containerEl.querySelector('clr-control-helper')).toBeTruthy();
+      container.state = CONTROL_STATE.INVALID;
+      fixture.detectChanges();
+      expect(containerEl.querySelector('clr-control-helper')).toBeFalsy();
+      container.state = CONTROL_STATE.VALID;
+      fixture.detectChanges();
+      expect(containerEl.querySelector('clr-control-helper')).toBeTruthy();
     });
   });
 }

--- a/packages/angular/projects/clr-angular/src/forms/textarea/textarea-container.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/textarea/textarea-container.spec.ts
@@ -30,6 +30,7 @@ class SimpleTest {
 @Component({
   template: ` <clr-textarea-container>
     <textarea clrTextarea [(ngModel)]="model"></textarea>
+    <clr-control-helper>Helper text</clr-control-helper>
   </clr-textarea-container>`,
 })
 class NoLabelTest {}

--- a/packages/angular/projects/clr-angular/src/forms/textarea/textarea-container.ts
+++ b/packages/angular/projects/clr-angular/src/forms/textarea/textarea-container.ts
@@ -4,13 +4,12 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, ContentChild } from '@angular/core';
+import { Component } from '@angular/core';
 
 import { NgControlService } from '../common/providers/ng-control.service';
 import { ControlIdService } from '../common/providers/control-id.service';
 import { ControlClassService } from '../common/providers/control-class.service';
 import { ClrAbstractContainer } from '../common/abstract-container';
-import { ClrControlSuccess } from '../common/success';
 import { IfControlStateService } from '../common/if-control-state/if-control-state.service';
 
 @Component({
@@ -27,12 +26,7 @@ import { IfControlStateService } from '../common/if-control-state/if-control-sta
           shape="exclamation-circle"
           aria-hidden="true"
         ></clr-icon>
-        <clr-icon
-          *ngIf="showValid && controlSuccessComponent"
-          class="clr-validate-icon"
-          shape="check-circle"
-          aria-hidden="true"
-        ></clr-icon>
+        <clr-icon *ngIf="showValid" class="clr-validate-icon" shape="check-circle" aria-hidden="true"></clr-icon>
       </div>
       <ng-content select="clr-control-helper" *ngIf="showHelper"></ng-content>
       <ng-content select="clr-control-error" *ngIf="showInvalid"></ng-content>
@@ -46,6 +40,4 @@ import { IfControlStateService } from '../common/if-control-state/if-control-sta
   },
   providers: [IfControlStateService, NgControlService, ControlIdService, ControlClassService],
 })
-export class ClrTextareaContainer extends ClrAbstractContainer {
-  @ContentChild(ClrControlSuccess) controlSuccessComponent: ClrControlSuccess;
-}
+export class ClrTextareaContainer extends ClrAbstractContainer {}

--- a/packages/angular/projects/dev/src/app/forms/reset/reset.html
+++ b/packages/angular/projects/dev/src/app/forms/reset/reset.html
@@ -14,7 +14,7 @@
     <clr-control-error *clrIfError="'required'">This is a required field</clr-control-error>
     <clr-control-error *clrIfError="'minlength'">Must be at least 5 characters</clr-control-error>
     <clr-control-error *clrIfError="'pattern'">It must match 'asdfasdf'</clr-control-error>
-    <clr-control-success *clrIfSuccess="'pattern'">That's correct the input must be 'asdfasdf' </clr-control-success>
+    <clr-control-success *clrIfSuccess>That's correct the input must be 'asdfasdf' </clr-control-success>
   </clr-input-container>
 
   <button class="btn btn-primary" type="button" (click)="validate()">Validate</button>

--- a/packages/angular/projects/dev/src/app/forms/validation/validation.html
+++ b/packages/angular/projects/dev/src/app/forms/validation/validation.html
@@ -15,8 +15,28 @@
       <clr-control-error *clrIfError="'required'">This is a required field</clr-control-error>
       <clr-control-error *clrIfError="'minlength'">Must be at least 5 characters</clr-control-error>
       <clr-control-error *clrIfError="'pattern'">It must match 'asdfasdf'</clr-control-error>
-      <clr-control-success *clrIfSuccess="'pattern'">That's correct the input must be 'asdfasdf' </clr-control-success>
+      <clr-control-success *clrIfSuccess>That's correct the input must be 'asdfasdf' </clr-control-success>
     </clr-input-container>
+
+    <clr-input-container>
+      <label>Input with only helper text</label>
+      <input clrInput placeholder="Input control" name="input-help" formControlName="input-help" />
+      <clr-control-helper>Helper text</clr-control-helper>
+    </clr-input-container>
+
+    <clr-date-container>
+      <label>Date Picker</label>
+      <input type="date" clrDate name="date" formControlName="date" />
+      <clr-control-helper>Helper text</clr-control-helper>
+      <clr-control-error *clrIfError="'required'">We require date</clr-control-error>
+      <clr-control-success *clrIfSuccess>The date was set</clr-control-success>
+    </clr-date-container>
+
+    <clr-date-container>
+      <label>Date Picker (Only Helper)</label>
+      <input type="date" clrDate name="date-helper" formControlName="date-helper" />
+      <clr-control-helper>Helper text</clr-control-helper>
+    </clr-date-container>
 
     <clr-textarea-container>
       <label>Textarea</label>
@@ -25,7 +45,7 @@
       <clr-control-error *clrIfError="'required'">This is a required field</clr-control-error>
       <clr-control-error *clrIfError="'minlength'">Must be at least 5 characters</clr-control-error>
       <clr-control-error *clrIfError="'pattern'">It must match 'asdfasdf'</clr-control-error>
-      <clr-control-success *clrIfSuccess="'pattern'">That's correct the input must be 'asdfasdf' </clr-control-success>
+      <clr-control-success *clrIfSuccess>That's correct the input must be 'asdfasdf' </clr-control-success>
     </clr-textarea-container>
 
     <clr-password-container>
@@ -35,7 +55,7 @@
       <clr-control-error *clrIfError="'required'">This is a required field</clr-control-error>
       <clr-control-error *clrIfError="'minlength'">Must be at least 5 characters</clr-control-error>
       <clr-control-error *clrIfError="'pattern'">It must match 'asdfasdf'</clr-control-error>
-      <clr-control-success *clrIfSuccess="'pattern'">That's correct the input must be 'asdfasdf' </clr-control-success>
+      <clr-control-success *clrIfSuccess>That's correct the input must be 'asdfasdf' </clr-control-success>
     </clr-password-container>
 
     <clr-radio-container>
@@ -50,7 +70,7 @@
       </clr-radio-wrapper>
       <clr-control-helper>Helper text</clr-control-helper>
       <clr-control-error *clrIfError="'required'">This field is required!</clr-control-error>
-      <clr-control-success *clrIfSuccess="'required'">Good job, mate! </clr-control-success>
+      <clr-control-success *clrIfSuccess>Good job, mate! </clr-control-success>
     </clr-radio-container>
 
     <clr-checkbox-container>
@@ -65,7 +85,7 @@
       </clr-checkbox-wrapper>
       <clr-control-helper>Helper text</clr-control-helper>
       <clr-control-error *clrIfError="'required'">This field is required!</clr-control-error>
-      <clr-control-success *clrIfSuccess="'required'">Good job, mate! </clr-control-success>
+      <clr-control-success *clrIfSuccess>Good job, mate! </clr-control-success>
     </clr-checkbox-container>
 
     <clr-select-container>
@@ -77,7 +97,7 @@
       </select>
       <clr-control-helper>Helper text</clr-control-helper>
       <clr-control-error *clrIfError="'required'">This field is required!</clr-control-error>
-      <clr-control-success *clrIfSuccess="'required'">Good job, mate! </clr-control-success>
+      <clr-control-success *clrIfSuccess>Good job, mate! </clr-control-success>
     </clr-select-container>
 
     <clr-range-container [clrRangeHasProgress]="true">
@@ -85,7 +105,7 @@
       <input type="range" clrRange formControlName="range" name="range" />
       <clr-control-helper>Helper text</clr-control-helper>
       <clr-control-error *clrIfError="'required'">This field is required!</clr-control-error>
-      <clr-control-success *clrIfSuccess="'required'">Good job, mate! </clr-control-success>
+      <clr-control-success *clrIfSuccess>Good job, mate! </clr-control-success>
     </clr-range-container>
 
     <clr-datalist-container>
@@ -96,7 +116,7 @@
       </datalist>
       <clr-control-helper>Helper text</clr-control-helper>
       <clr-control-error *clrIfError="'required'">This field is required!</clr-control-error>
-      <clr-control-success *clrIfSuccess="'required'">Good job, mate! </clr-control-success>
+      <clr-control-success *clrIfSuccess>Good job, mate! </clr-control-success>
     </clr-datalist-container>
   </form>
 </ng-template>

--- a/packages/angular/projects/dev/src/app/forms/validation/validation.ts
+++ b/packages/angular/projects/dev/src/app/forms/validation/validation.ts
@@ -17,6 +17,9 @@ export class FormsValidationDemo {
 
   model = new FormGroup({
     input: new FormControl('', [Validators.required, Validators.minLength(6), Validators.pattern(/asdfasdf/)]),
+    'input-help': new FormControl('', []),
+    date: new FormControl('', [Validators.required]),
+    'date-helper': new FormControl('', []),
     textarea: new FormControl('', [Validators.required, Validators.minLength(6), Validators.pattern(/asdfasdf/)]),
     password: new FormControl('', [Validators.required, Validators.minLength(6), Validators.pattern(/asdfasdf/)]),
     options: new FormControl('', [Validators.required]),


### PR DESCRIPTION
This PR solve this issues:
  
  * missing input for `clr-if-success` directive that was throwing error
  * update `clr-angular.d.ts` so non-ivy build will not throw errors.
  * when you blur a form-element that doesn't implement error or success component subtext the helper text if present will be displayed. 
  * don't add `clr-success` class to the wrapped container if `clr-success-container` is not implemented

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
