### PR TITLE
fix(combobox): focus indicator was not animating

### DIFF
--- a/packages/angular/golden/clr-angular.d.ts
+++ b/packages/angular/golden/clr-angular.d.ts
@@ -293,6 +293,7 @@ export declare class ClrCombobox<T> extends WrappedFormControl<ClrComboboxContai
     control: NgControl;
     get displayField(): string;
     protected el: ElementRef;
+    focused: boolean;
     focusedPill: any;
     get id(): string;
     protected index: number;
@@ -319,6 +320,7 @@ export declare class ClrCombobox<T> extends WrappedFormControl<ClrComboboxContai
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
     onBlur(): void;
+    onFocus(): void;
     onKeyUp(event: KeyboardEvent): void;
     registerOnChange(onChange: any): void;
     registerOnTouched(onTouched: any): void;

--- a/packages/angular/projects/clr-angular/src/forms/combobox/_combobox.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/_combobox.clarity.scss
@@ -10,6 +10,23 @@
     align-items: stretch;
   }
 
+  // Focus indicator, this is a custom implementation compared with other controls due to DOM structure and potential growth of height
+  .clr-focus-indicator {
+    @include css-var(background-color, clr-forms-focused-color, $clr-forms-focused-color, $clr-use-custom-properties);
+    height: $clr_baselineRem_2px;
+    width: 0;
+    transition: width 0.2s ease;
+    position: absolute;
+    bottom: -$clr_baselineRem_1px;
+    left: 0;
+  }
+  .clr-focus {
+    width: 100%;
+  }
+  .clr-error .clr-focus-indicator {
+    @include css-var(background-color, clr-forms-invalid-color, $clr-forms-invalid-color, $clr-use-custom-properties);
+  }
+
   .clr-combobox-wrapper {
     position: relative;
 
@@ -35,23 +52,7 @@
       $clr-use-custom-properties
     );
 
-    border-bottom: $clr-global-borderwidth solid $clr-forms-border-color;
-
-    // the border color is on the component; we don't want it on the input itself
-    .clr-input.clr-combobox-input:focus {
-      background: none;
-    }
-
-    // ideally I want to just use &:focus-within, but cross-browser support is limited
-    // for now, we programmatically add/remove .clr-focus class to achieve this
-    &:focus-within,
-    &.clr-focus {
-      border-bottom: $clr_baselineRem_2px solid $clr-forms-focused-color;
-    }
-
-    &.invalid,
-    &.invalid:focus,
-    &.clr-focus.invalid {
+    &.invalid {
       border-bottom-color: $clr-forms-invalid-color;
     }
 

--- a/packages/angular/projects/clr-angular/src/forms/combobox/combobox.html
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/combobox.html
@@ -61,6 +61,7 @@
       class="clr-input clr-combobox-input"
       [(ngModel)]="searchText"
       (blur)="onBlur()"
+      (focus)="onFocus()"
       [attr.aria-expanded]="openState"
       [attr.aria-owns]="ariaOwns"
       aria-haspopup="listbox"
@@ -83,6 +84,8 @@
   >
     <clr-icon shape="caret down" size="12"></clr-icon>
   </button>
+
+  <div class="clr-focus-indicator" [class.clr-focus]="focused"></div>
 </div>
 
 <!-- Both close handlers are handled manually due to issues in Edge browser.

--- a/packages/angular/projects/clr-angular/src/forms/combobox/combobox.ts
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/combobox.ts
@@ -88,6 +88,7 @@ export class ClrCombobox<T> extends WrappedFormControl<ClrComboboxContainer>
   protected index = 1;
 
   invalid = false;
+  focused = false;
 
   constructor(
     vcr: ViewContainerRef,
@@ -211,6 +212,11 @@ export class ClrCombobox<T> extends WrappedFormControl<ClrComboboxContainer>
     if (this.control.control.updateOn === 'blur') {
       this.control.control.updateValueAndValidity();
     }
+    this.focused = false;
+  }
+
+  onFocus() {
+    this.focused = true;
   }
 
   getSelectionAriaLabel() {


### PR DESCRIPTION
The combobox focus indicator pushed down 1px and was not animating as expected. This updates the focus indicator to match the rest of Clarity controls.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
