### PR TITLE
fix(datagrid): header visually goes over the data

### DIFF
--- a/src/clr-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clr-angular/data/datagrid/_datagrid.clarity.scss
@@ -600,7 +600,6 @@
     // bug(popover): prevents action-overflow from being on top (first row).
     // Needed to keep select/radio and expand svgs underneath header on scrolling
     z-index: map-get($clr-layers, datagrid-header);
-    min-height: $clr_baselineRem_1_5;
     width: auto;
 
     .datagrid-column {


### PR DESCRIPTION
When there are two or more words in column title and the column size gets smaller the text starts to wrap. When the text starts to wrap, it forces the header to shrinks vertically and goes over the data in the grid.

The `min-height` with `position:sticky` make the .datagrid-header to keep its height and even when the content wraps the `height` of the .datagrid-header stays the same. That's why the header content goes over the data.

Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #4872

## What is the new behavior?

The header of datagrid doesn't hide some of the data based on column headers content size.

More 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Additional

Before
![image](https://user-images.githubusercontent.com/15037947/90542549-f62c7080-e18c-11ea-9a3a-32007f1234f6.png)

After
![image](https://user-images.githubusercontent.com/15037947/90542649-1c521080-e18d-11ea-8f3f-1ea9929ec192.png)