### PR TITLE
fix: accept clrLabelSize values provided without binding

### DIFF
--- a/packages/angular/golden/clr-angular.d.ts
+++ b/packages/angular/golden/clr-angular.d.ts
@@ -1044,7 +1044,7 @@ export declare class ClrFocusOnViewInitModule {
 }
 
 export declare class ClrForm {
-    set labelSize(size: number);
+    set labelSize(size: number | string);
     labels: QueryList<ClrLabel>;
     layoutService: LayoutService;
     constructor(layoutService: LayoutService, markControlService: MarkControlService);

--- a/packages/angular/projects/clr-angular/src/forms/common/form.ts
+++ b/packages/angular/projects/clr-angular/src/forms/common/form.ts
@@ -20,8 +20,9 @@ import { ClrLabel } from './label';
 })
 export class ClrForm {
   @Input('clrLabelSize')
-  set labelSize(size: number) {
-    this.layoutService.labelSize = size;
+  set labelSize(size: number | string) {
+    const sizeNumber = parseInt(size as string, 10) || 2;
+    this.layoutService.labelSize = sizeNumber;
   }
 
   constructor(public layoutService: LayoutService, private markControlService: MarkControlService) {}


### PR DESCRIPTION
Signed-off-by: Stanimira Vlaeva <svlaeva@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Values provided without binding are ignored:

```
<form clrForm clrLayout="horizontal" clrLabelSize="6">
```

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4432

## What is the new behavior?

Values provided without binding are converted to numbers and set as the size.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

closes #4432