### PR TITLE
Fix typo and add functional wrapper for Clarity Core components

### DIFF
--- a/packages/react/src/button/index.tsx
+++ b/packages/react/src/button/index.tsx
@@ -9,5 +9,5 @@ export type CdsIconButtonType = IconButton;
 export type CdsInlineButtonType = InlineButton;
 
 export class CdsButton extends createReactComponent<CdsButtonType>('cds-button') {}
-export class CdsIconButton extends createReactComponent<CdsIconButtonType>('cds-button') {}
-export class CdsInlineButton extends createReactComponent<CdsInlineButtonType>('cds-button') {}
+export class CdsIconButton extends createReactComponent<CdsIconButtonType>('cds-icon-button') {}
+export class CdsInlineButton extends createReactComponent<CdsInlineButtonType>('cds-inline-button') {}

--- a/packages/react/src/wrapper/TestComponent.mock.ts
+++ b/packages/react/src/wrapper/TestComponent.mock.ts
@@ -1,0 +1,6 @@
+export default class TestComponent extends HTMLElement {
+  prop1: string;
+  prop2: number;
+  event1: (e: any) => string;
+  event2: (e: any) => number;
+}

--- a/packages/react/src/wrapper/__snapshots__/wrapCustomElement.test.tsx.snap
+++ b/packages/react/src/wrapper/__snapshots__/wrapCustomElement.test.tsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CdsTestComponent snapshot 1`] = `
+<CustomElement(cds-test-component)
+  prop1="val1"
+  prop2={3}
+>
+  <cds-test-component>
+    Hello World
+  </cds-test-component>
+</CustomElement(cds-test-component)>
+`;

--- a/packages/react/src/wrapper/entrypoint.tsconfig.json
+++ b/packages/react/src/wrapper/entrypoint.tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.lib.json",
+  "compilerOptions": {
+    "composite": true
+  }
+}

--- a/packages/react/src/wrapper/index.ts
+++ b/packages/react/src/wrapper/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+export { default, wrapCustomElement } from './wrapCustomElement';

--- a/packages/react/src/wrapper/package.json
+++ b/packages/react/src/wrapper/package.json
@@ -1,0 +1,4 @@
+{
+  "sideEffects": false,
+  "name": "@clr/react/wrapper"
+}

--- a/packages/react/src/wrapper/useAddEventListener.ts
+++ b/packages/react/src/wrapper/useAddEventListener.ts
@@ -1,0 +1,26 @@
+import { RefObject, useEffect, useRef } from 'react';
+
+/**
+ * Add event listener hook.
+ *
+ * @param ref Ref to the DOM element.
+ */
+export const useAddEventListener = <Target extends HTMLElement>(ref: RefObject<Target>) => {
+  /** Event listener tuple array [eventName, listener]. */
+  const eventListeners = useRef<[string, EventListener][]>([]);
+
+  useEffect(() => () => {
+    eventListeners.current.forEach(([event, handler]) => ref.current?.removeEventListener(event, handler));
+    eventListeners.current = [];
+  });
+
+  return (propertyName: string, propertyValue: EventListener) => {
+    /** Transform onEventName into eventName */
+    const eventName = propertyName.replace(/on./u, prefix => prefix.substr(2).toLowerCase());
+    const handler: EventListener = (event: Event) => propertyValue(event);
+    eventListeners.current = [...eventListeners.current, [eventName, handler]];
+    ref.current?.addEventListener(eventName, handler);
+  };
+};
+
+export default useAddEventListener;

--- a/packages/react/src/wrapper/usePropertyToAttribute.ts
+++ b/packages/react/src/wrapper/usePropertyToAttribute.ts
@@ -1,0 +1,35 @@
+import { RefObject } from 'react';
+import { useAddEventListener } from './useAddEventListener';
+import { useSetAttribute } from './useSetAttribute';
+
+/**
+ * React property to element attribute setter hook.
+ *
+ * @param ref Ref to the DOM element.
+ */
+export const usePropertyToAttribute = <Target extends HTMLElement>(ref: RefObject<Target>) => {
+  const addEventListener = useAddEventListener(ref);
+  const [setAttribute, removeAttribute] = useSetAttribute(ref);
+  const reactProperties: (keyof Target | 'ref')[] = ['children', 'className', 'localName', 'ref', 'style'];
+
+  return (property: keyof Target, value: Target[typeof property]) => {
+    if (!reactProperties.includes(property) && typeof property === 'string') {
+      if (typeof value === 'function') {
+        return addEventListener(property, (value as unknown) as EventListener);
+      } else {
+        if (ref.current) {
+          ref.current[property as keyof Target] = value;
+        }
+        if (typeof value === 'string') {
+          return setAttribute(property, value);
+        } else {
+          return value !== null && value !== undefined
+            ? setAttribute(property, JSON.stringify(value))
+            : removeAttribute(property);
+        }
+      }
+    }
+  };
+};
+
+export default usePropertyToAttribute;

--- a/packages/react/src/wrapper/useSetAttribute.ts
+++ b/packages/react/src/wrapper/useSetAttribute.ts
@@ -1,0 +1,15 @@
+import { RefObject } from 'react';
+
+/**
+ * Set/Remove attribute tuple hook.
+ *
+ * @param ref Ref to the DOM element.
+ */
+export const useSetAttribute = <Target extends HTMLElement>(ref: RefObject<Target>) =>
+  [
+    (name: string, value: string) =>
+      ref.current?.getAttribute(name) !== value ? ref.current?.setAttribute(name, value) : undefined,
+    (name: string) => (ref.current?.getAttribute(name) ? ref.current?.removeAttribute(name) : undefined),
+  ] as const;
+
+export default useSetAttribute;

--- a/packages/react/src/wrapper/withRef.ts
+++ b/packages/react/src/wrapper/withRef.ts
@@ -1,0 +1,19 @@
+import { forwardRef, ForwardRefRenderFunction } from 'react';
+
+/**
+ * Wraps forwardRef and adds a required displayName field.
+ *
+ * @param displayName Component displayName.
+ * @param Component Component to be forwarded.
+ */
+export const withRef = <HTMLElementType, Props = HTMLElementType>(
+  displayName: string,
+  Component: ForwardRefRenderFunction<HTMLElementType, Props>
+) => {
+  const ForwardedComponent = forwardRef(Component);
+  ForwardedComponent.displayName = displayName;
+
+  return ForwardedComponent;
+};
+
+export default withRef;

--- a/packages/react/src/wrapper/wrapCustomElement.test.tsx
+++ b/packages/react/src/wrapper/wrapCustomElement.test.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import { mount, shallow } from 'enzyme';
+import TestComponent from './TestComponent.mock';
+import { wrapCustomElement } from './wrapCustomElement';
+
+describe('CdsTestComponent', () => {
+  const setup = () =>
+    wrapCustomElement<
+      TestComponent & {
+        onEvent1: TestComponent['event1'];
+        onEvent2: TestComponent['event2'];
+      }
+    >('cds-test-component');
+
+  it('renders', () => {
+    const CdsTestComponent = setup();
+    const wrapper = shallow(
+      <div>
+        <CdsTestComponent>Hello World</CdsTestComponent>
+      </div>
+    );
+    const renderedComponent = wrapper.find('CustomElement(cds-test-component)');
+    expect(renderedComponent.html()).toMatch(/Hello World/);
+  });
+
+  it('creates custom properties', () => {
+    const CdsTestComponent = setup();
+    const wrapper = shallow(
+      <div>
+        <CdsTestComponent prop1="val1" prop2={3}>
+          Hello World
+        </CdsTestComponent>
+      </div>
+    );
+    const renderedComponent = wrapper.find('CustomElement(cds-test-component)');
+
+    expect(renderedComponent.prop('prop1')).toEqual('val1');
+    expect(renderedComponent.prop('prop2')).toEqual(3);
+  });
+
+  it('creates custom events', () => {
+    const CdsTestComponent = setup();
+    const event1Handler = () => 'event1';
+    const event2Handler = () => 5;
+
+    const wrapper = shallow(
+      <div>
+        <CdsTestComponent onEvent1={event1Handler} onEvent2={event2Handler}>
+          Hello World
+        </CdsTestComponent>
+      </div>
+    );
+    const renderedComponent = wrapper.find('CustomElement(cds-test-component)');
+
+    const eventHandler1 = renderedComponent.prop('onEvent1');
+    const eventHandler2 = renderedComponent.prop('onEvent2');
+
+    expect(typeof eventHandler1).toBe('function');
+    expect(typeof eventHandler2).toBe('function');
+  });
+
+  it('returns a ref through nativeElement getter', () => {
+    const CdsTestComponent = setup();
+    const wrapper = shallow(
+      <div>
+        <CdsTestComponent>Hello World</CdsTestComponent>
+      </div>
+    );
+    const renderedComponent = wrapper.find('CustomElement(cds-test-component)');
+    renderedComponent;
+  });
+
+  it('snapshot', () => {
+    const CdsTestComponent = setup();
+    const wrapper = mount(
+      <CdsTestComponent prop1="val1" prop2={3}>
+        Hello World
+      </CdsTestComponent>
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/packages/react/src/wrapper/wrapCustomElement.ts
+++ b/packages/react/src/wrapper/wrapCustomElement.ts
@@ -1,0 +1,39 @@
+import { createElement, DOMAttributes, useEffect, useRef } from 'react';
+import { usePropertyToAttribute } from './usePropertyToAttribute';
+import { withRef } from './withRef';
+
+/**
+ * Wrap custom element to be "react compatible".
+ *
+ * @param tagName Name of the component being wrapped.
+ */
+export const wrapCustomElement = <WrappedElement extends HTMLElement = HTMLElement>(tagName: string) =>
+  withRef<WrappedElement, Partial<Omit<WrappedElement, 'children'> & DOMAttributes<WrappedElement>>>(
+    `CustomElement(${tagName})`,
+    ({ children, ...properties }, passedRef) => {
+      const ref = useRef<WrappedElement>(null);
+      const propertyToAttribute = usePropertyToAttribute<WrappedElement>(ref);
+
+      if (passedRef) {
+        // If is a RefCallback
+        if (typeof passedRef === 'function') {
+          passedRef(ref.current);
+        } else {
+          // If is a RefObject
+          if (typeof passedRef === 'object') {
+            passedRef.current = ref.current;
+          }
+        }
+      }
+
+      useEffect(() => {
+        Object.entries(properties).forEach(([property, value]) =>
+          propertyToAttribute(property as keyof WrappedElement, value as WrappedElement[keyof WrappedElement])
+        );
+      }, [properties, propertyToAttribute]);
+
+      return createElement(tagName, { ref }, children);
+    }
+  );
+
+export default wrapCustomElement;


### PR DESCRIPTION
## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

- There was a typo in the exported button components which exported all as `cds-button`
- Currently the Core components are only wrapped with classes.

## What is the new behavior?

- The exported button components where fixed to include `cds-icon-button` and `cds-inline-button`.
- The new wrapper (`wrapCustomElement`):
  - Returns a functional component instead of a class.
  - Has a custom name for every component for react dev tools `CustomElement(tag-name)`, instead of having `ReactWrapperComponent`.
  - Doesn't require the `nativeElement` "hack", it uses `ref` directly (using `forwardRef` internally).
  - Syntax can be cleaner:
```tsx
// Instead of this:
export class CdsAlert extends createReactComponent<CdsAlertType>('cds-alert') {}

// We can just do this:
export const CdsAlert = wrapCustomElement<CdsAlertType>('cds-alert');
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
