### PR TITLE
fix(datagrid): header visually goes over the data

### DIFF
--- a/packages/angular/projects/clr-angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/_datagrid.clarity.scss
@@ -600,7 +600,6 @@
     // bug(popover): prevents action-overflow from being on top (first row).
     // Needed to keep select/radio and expand svgs underneath header on scrolling
     z-index: map-get($clr-layers, datagrid-header);
-    min-height: $clr_baselineRem_1_5;
     width: auto;
 
     .datagrid-column {


### PR DESCRIPTION
A port from v3 #4919

Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>