### PR TITLE
fix(datagrid): header visually goes over the data

### DIFF
--- a/src/clr-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clr-angular/data/datagrid/_datagrid.clarity.scss
@@ -180,7 +180,6 @@
     // bug(popover): prevents action-overflow from being on top (first row).
     // Needed to keep select/radio and expand svgs underneath header on scrolling
     z-index: map-get($clr-layers, datagrid-header);
-    min-height: 1.5rem;
     width: auto;
 
     .datagrid-column {


### PR DESCRIPTION
A backport from v3 #4919

Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>