### PR TITLE
chore: add auto-locking old threads to CI

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -1,0 +1,24 @@
+name: 'Lock threads'
+
+# This is a daily cron job that will lock closed issues and PRs over a certain age.
+# This is to limit the amount of noise on older issues and to encourage new issues.
+# This will only lock up to 50 per run.
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2
+        with:
+          github-token: ${{ github.token }}
+          issue-lock-inactive-days: '14'
+          issue-lock-comment: 'Hi there 👋, this is an automated message. To help Clarity keep track of discussions, we automatically lock closed issues after 14 days. Please look for another open issue or open a new issue with updated details and reference this one as necessary.'
+          issue-lock-reason: ''
+          pr-lock-inactive-days: '14'
+          pr-lock-comment: 'Hi there 👋, this is an automated message. To help Clarity keep track of discussions, we automatically lock closed PRs after 14 days. Please look for another open issue or open a new issue with updated details and reference this one as necessary.'
+          pr-lock-reason: ''
+          process-only: 'issues'


### PR DESCRIPTION
As part of our proposed issue management strategy, this PR introduces auto-locking after 14 days of closure. It only locks a closed issue, and batches them nightly. It will only run 50 at a time to avoid hitting API limits.

Caution: this will generate a lot of email noise for anyone on those old threads. You might want to setup an email filter for these.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [x] Other... Please describe: issue management

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
