### PR TITLE
fix(datagrid): colType and field are set before trying to configure filters

### DIFF
--- a/packages/angular/golden/clr-angular.d.ts
+++ b/packages/angular/golden/clr-angular.d.ts
@@ -515,7 +515,7 @@ export declare class ClrDatagridCell implements OnInit {
     ngOnInit(): void;
 }
 
-export declare class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<T, ClrDatagridFilterInterface<T>> implements OnDestroy, OnInit {
+export declare class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<T, ClrDatagridFilterInterface<T>> implements OnDestroy, OnInit, OnChanges {
     get _view(): any;
     get ariaSort(): "none" | "ascending" | "descending";
     get colType(): 'string' | 'number';
@@ -541,6 +541,7 @@ export declare class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<
     sortedChange: EventEmitter<boolean>;
     set updateFilterValue(newValue: string | [number, number]);
     constructor(_sort: Sort<T>, filters: FiltersProvider<T>, vcr: ViewContainerRef, detailService: DetailService, changeDetectorRef: ChangeDetectorRef, commonStrings: ClrCommonStringsService);
+    ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
     sort(reverse?: boolean): void;

--- a/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-column.spec.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-column.spec.ts
@@ -439,6 +439,14 @@ export default function (): void {
         expect(context.clarityDirective.registered.filter instanceof DatagridStringFilterImpl).toBe(true);
         expect(context.clarityElement.querySelector('clr-dg-string-filter')).toBeDefined();
       });
+
+      it('order of the argument should not have effect when settings filters', function () {
+        context.testComponent.field = 'id';
+        context.testComponent.type = 'number';
+        context.detectChanges();
+        expect(context.clarityDirective.registered.filter instanceof DatagridNumericFilterImpl).toBe(true);
+        expect(context.clarityElement.querySelector('clr-dg-numeric-filter')).toBeDefined();
+      });
     });
 
     describe('Column View Changes On ChangeDetectionStrategy.OnPush', function () {


### PR DESCRIPTION
  Angular could assign colType and field in an random order, so we need
  to wait before we could start using them to assign the filter type

  for that reason we use ngOnChanges to be sure everything is set and
  then call setupDefaultFilter

  Backport from v3 to v4 (master)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
