### PR TITLE
fix: symlink setting vscode monorepo

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "search.followSymlinks": false,
   "files.exclude": {
     "**/*.element.css.ts": true,
     "**/*.global.css.ts": true


### PR DESCRIPTION

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [x] Other... Please describe:

## What is the current behavior?
VS Code can use a lot of CPU cycles due to it trying to follow symlink paths. This is a problem with using Yarn since it uses symlinks extensively.

## What is the new behavior?
Disabling this flag improved VSCode performance significantly. Typically we don't store editor specific settings in the repo but this one seemed pretty important to set. If we dont want to include this one I can close this PR out.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
