### PR TITLE
fix(a11y): match the DOM order of the Modal's title and close button with their visual order (backport)

### DIFF
--- a/packages/angular/projects/clr-angular/src/modal/_modal.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/modal/_modal.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -65,6 +65,16 @@
   .modal-header {
     border-bottom: none;
     padding: 0 0 $clr_baselineRem_1 0;
+
+    // TODO: This class is used only in the clr-modal template.
+    // It should be merged this with `.modal-header` in a major version
+    // because this would be breaking for the static modals.
+    &--accessible {
+      @extend .modal-header;
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+    }
 
     .modal-title {
       @include css-var(color, clr-modal-title-color, $clr-modal-title-color, $clr-use-custom-properties);

--- a/packages/angular/projects/clr-angular/src/modal/modal.html
+++ b/packages/angular/projects/clr-angular/src/modal/modal.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -24,7 +24,10 @@
       <ng-content select=".modal-nav"></ng-content>
 
       <div class="modal-content">
-        <div class="modal-header">
+        <div class="modal-header--accessible">
+          <div class="modal-title-wrapper" id="{{modalId}}" clrFocusOnViewInit>
+            <ng-content select=".modal-title"></ng-content>
+          </div>
           <button
             type="button"
             [attr.aria-label]="commonStrings.keys.close"
@@ -34,9 +37,6 @@
           >
             <clr-icon shape="close"></clr-icon>
           </button>
-          <div class="modal-title-wrapper" id="{{modalId}}" clrFocusOnViewInit>
-            <ng-content select=".modal-title"></ng-content>
-          </div>
         </div>
         <ng-content select=".modal-body"></ng-content>
         <ng-content select=".modal-footer"></ng-content>

--- a/packages/angular/projects/clr-angular/src/modal/modal.spec.ts
+++ b/packages/angular/projects/clr-angular/src/modal/modal.spec.ts
@@ -277,4 +277,14 @@ describe('Modal', () => {
     expect(messages[0].innerText).toBe('Beginning of Modal Content');
     expect(messages[1].innerText).toBe('End of Modal Content');
   }));
+
+  it('renders the title before the close button', fakeAsync(() => {
+    const modalHeader = compiled.querySelector('.modal-header--accessible');
+    expect(modalHeader.children.length).toBeGreaterThanOrEqual(2);
+
+    const maybeTitleWrapper = modalHeader.children[0];
+    const maybleCloseButton = modalHeader.children[1];
+    expect(maybeTitleWrapper.classList.contains('modal-title-wrapper')).toBeTrue();
+    expect(maybleCloseButton.classList.contains('close')).toBeTrue();
+  }));
 });

--- a/packages/angular/projects/clr-angular/src/wizard/_wizard.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/wizard/_wizard.clarity.scss
@@ -56,10 +56,6 @@
       // right padding nudged a bit to better align icons
       padding: $clr-wizard-default-space ($clr-wizard-default-space - $clr_baselineRem_5px) $clr_baselineRem_0_25
         $clr-wizard-default-space;
-      display: flex;
-      flex-direction: row-reverse;
-      justify-content: space-between;
-      align-items: flex-start;
     }
 
     .modal-title {


### PR DESCRIPTION
Backport of https://github.com/vmware/clarity/pull/4894