### PR TITLE
fix: core link styles a11y

### DIFF
--- a/packages/core/src/button/inline-button.element.scss
+++ b/packages/core/src/button/inline-button.element.scss
@@ -6,7 +6,7 @@
 @import './../styles/mixins/mixins';
 
 :host {
-  --text-decoration: none;
+  --text-decoration: underline;
   --color: #{$cds-token-color-action-600};
   --font-size: inherit;
   --line-height: inherit;

--- a/packages/core/src/button/inline-button.element.ts
+++ b/packages/core/src/button/inline-button.element.ts
@@ -22,11 +22,11 @@ import { styles } from './inline-button.element.css.js';
  * @beta
  * @element cds-inline-button
  * @slot - Content slot for inside the button
+ * @cssprop --text-decoration
  * @cssprop --color
  * @cssprop --font-size
- * @cssprop --font-weight
+ * @cssprop --line-height
  * @cssprop --letter-spacing
- * @cssprop --text-decoration
  */
 export class CdsInlineButton extends CdsBaseButton {
   connectedCallback(): void {
@@ -40,12 +40,7 @@ export class CdsInlineButton extends CdsBaseButton {
   }
 
   render() {
-    return html`
-      <span class="private-host">
-        <slot></slot>
-        ${this.hiddenButtonTemplate}
-      </span>
-    `;
+    return html`<span class="private-host"><slot></slot>${this.hiddenButtonTemplate}</span>`;
   }
 
   static get styles() {

--- a/packages/core/src/styles/typography/_typography.scss
+++ b/packages/core/src/styles/typography/_typography.scss
@@ -373,13 +373,9 @@
 
 [cds-text~='link'] {
   color: $cds-token-color-action-600 !important;
-  text-decoration: none !important;
+  text-decoration: underline !important;
   line-height: inherit !important;
   font-size: inherit !important;
-
-  &:hover {
-    text-decoration: underline !important;
-  }
 }
 
 [cds-text~='code'] {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Links and inline buttons should have the underline style

## What is the new behavior?
Links and buttons have the proper underline style. Also removed a trailing white space that caused a bit of excess underline in the inline button.

## Does this PR introduce a breaking change?
minor visual but a fix for a11y
- [ ] Yes
- [x] No (ish)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
