### PR TITLE
fix: header visually goes over the data

### DIFF
--- a/packages/angular/projects/clr-angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/_datagrid.clarity.scss
@@ -600,7 +600,6 @@
     // bug(popover): prevents action-overflow from being on top (first row).
     // Needed to keep select/radio and expand svgs underneath header on scrolling
     z-index: map-get($clr-layers, datagrid-header);
-    min-height: $clr_baselineRem_1_5;
     width: auto;
 
     .datagrid-column {


### PR DESCRIPTION
When there are two or more words in column title and the column size gets smaller the text starts to wrap. When the text starts to wrap, it forces the header to shrinks vertically and goes over the data in the grid.

The min-height with position:sticky make the .datagrid-header to keep its height and even when the content wraps the height of the .datagrid-header stays the same. That's why the header content goes over the data.

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4919 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
