### PR TITLE
fix: react package.json path for core build

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -8,7 +8,7 @@
     "build:copy": "cpy './react' '../../../dist' --cwd=./dist --parents",
     "build:package": "cpy '**/package.json' '../dist/react/' --cwd=./src --parents && cpy ./package.json ./dist/react/ && cpy ./README.md ./dist/react/ && node ./package.js",
     "build:ts": "tsc --b ./tsconfig.project.json --force",
-    "core:build": "yarn --cwd packages/core run build",
+    "core:build": "yarn --cwd ../core run build",
     "lint": "eslint \"*/**/*.{ts,tsx}\" --ignore-pattern \"dist\"",
     "lint:fix": "eslint --fix \"*/**/*.{ts,tsx}\" --ignore-pattern \"dist\"",
     "test": "jest --coverage",


### PR DESCRIPTION
Fixing relative path for building core as a pre-step to react package's `start` script.

Signed-off-by: Jeeyun Lim <jeeyun.lim@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
