### PR TITLE
fix: core check that prop exists before warning

### DIFF
--- a/packages/core/src/icon/icon.element.ts
+++ b/packages/core/src/icon/icon.element.ts
@@ -167,7 +167,8 @@ export class CdsIcon extends LitElement {
   @id()
   private idForAriaLabel: string;
 
-  firstUpdated() {
+  firstUpdated(props: Map<string, any>) {
+    super.firstUpdated(props);
     this.updateSVGAriaLabel();
   }
 

--- a/packages/core/src/internal/decorators/property.spec.ts
+++ b/packages/core/src/internal/decorators/property.spec.ts
@@ -81,18 +81,20 @@ describe('@property decorator defaults', () => {
     spyOn(console, 'warn');
 
     class Proto {
-      test: undefined;
+      test: 'value';
       tagName = 'cds-test-warning';
       firstUpdated() {
         // do nothing
       }
     }
 
-    requirePropertyCheck(Proto.prototype, 'test', { type: String, required: 'warning' });
+    const obj = new Proto();
+    requirePropertyCheck.apply(obj, [Proto.prototype, 'test', { type: String, required: 'warning' }]);
 
-    new Proto().firstUpdated();
-
+    obj.test = undefined;
+    obj.firstUpdated();
     expect(console.warn).toHaveBeenCalled();
+
     window.jasmine = jasmine;
   });
 });

--- a/packages/core/src/internal/decorators/property.ts
+++ b/packages/core/src/internal/decorators/property.ts
@@ -8,6 +8,7 @@ import { property as prop } from 'lit-element';
 import { camelCaseToKebabCase, kebabCaseToPascalCase, capitalizeFirstLetter } from '../utils/string.js';
 import { LogService } from '../services/log.service.js';
 import { getAngularVersion, getReactVersion, getVueVersion } from '../utils/framework.js';
+import { isNilOrEmpty } from '../utils/identity.js';
 
 export interface CustomPropertyConfig {
   type: unknown;
@@ -70,7 +71,7 @@ export function requirePropertyCheck(protoOrDescriptor: any, name: string, optio
   const targetFirstUpdated: () => void = protoOrDescriptor.firstUpdated;
 
   function firstUpdated(this: any, props: Map<string, any>): void {
-    if (options && options.required) {
+    if (options && options.required && isNilOrEmpty(this[name])) {
       const message = options.requiredMessage || getRequiredMessage(options.required, name, this.tagName);
       if (options.required === 'error') {
         throw new Error(message);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?
The prop warning will now check if the prop was set with a value before logging. Currently it logs regardless of the value.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
