### PR TITLE
chore: update core possible enums to const enums

### DIFF
--- a/packages/core/src/button/button.element.ts
+++ b/packages/core/src/button/button.element.ts
@@ -27,7 +27,7 @@ const iconSpinnerError = html`<span class="button-status-icon" cds-layout="horiz
   ><cds-icon shape="error-standard" cds-layout="align:center"></cds-icon
 ></span>`;
 
-export enum ClrLoadingState {
+export const enum ClrLoadingState {
   DEFAULT = 'default',
   LOADING = 'loading',
   SUCCESS = 'success',

--- a/packages/core/src/icon/utils/icon.classnames.ts
+++ b/packages/core/src/icon/utils/icon.classnames.ts
@@ -18,18 +18,18 @@ import { CdsIcon } from '../icon.element.js';
 import { IconShapeCollection } from '../interfaces/icon.interfaces.js';
 import { iconHasAlertedShapes, iconHasBadgedShapes, iconHasSolidShapes } from './icon.has-shape.js';
 
-export enum IconSvgClassnames {
+export const enum IconSvgClassnames {
   Badged = 'can-badge',
   Alerted = 'can-alert',
   Solid = 'has-solid',
 }
 
-export enum IconDecorationClassnames {
+export const enum IconDecorationClassnames {
   Badge = 'clr-i-badge',
   Alert = 'clr-i-alert',
 }
 
-export enum IconShapeClassnames {
+export const enum IconShapeClassnames {
   Outline = 'outline',
   Solid = 'solid',
   OutlineBadged = 'outline--badged',
@@ -106,7 +106,7 @@ export function getIconSvgClasses(icon: IconShapeCollection): string {
   return transformToSpacedString(tests, icon);
 }
 
-export enum SizeUpdateStrategies {
+export const enum SizeUpdateStrategies {
   BadSizeValue = 'bad-value',
   ValidSizeString = 'value-is-string',
   ValidNumericString = 'value-is-numeric',

--- a/packages/core/src/internal/enums/aria-roles.ts
+++ b/packages/core/src/internal/enums/aria-roles.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-export enum AriaRole {
+export const enum AriaRole {
   Presentation = 'presentation',
   Button = 'button',
 }


### PR DESCRIPTION
Reduces the `@clr/core` memory size with 0.2MB.

Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

Reduces the `@clr/core` with 0.2MB by moving the possible enums to `const` enums

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior? 

Unchanged

## What is the new behavior?

Unchanged

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
