### PR TITLE
fix: core modal exception

### DIFF
--- a/packages/core/src/internal/base/focus-trap.base.spec.ts
+++ b/packages/core/src/internal/base/focus-trap.base.spec.ts
@@ -50,13 +50,34 @@ describe('modal element', () => {
       expect((component as any).focusTrap).toBeDefined();
     });
 
-    it('should remove the focus trap if hidden attr is used', async () => {
+    it('should remove the focus trap if hidden attr is set', async () => {
       await componentIsStable(component);
       expect(document.querySelector('.offscreen-focus-rebounder')).toBeTruthy();
 
       component.setAttribute('hidden', '');
       await componentIsStable(component);
       expect(document.querySelector('.offscreen-focus-rebounder')).toBeFalsy();
+    });
+  });
+
+  describe('initialized hidden modal', () => {
+    let testElement: HTMLElement;
+    let component: CdsBaseFocusTrap;
+
+    beforeEach(async () => {
+      testElement = createTestElement();
+      testElement.innerHTML = `<cds-base-focus-trap hidden></cds-base-focus-trap>`;
+      await waitForComponent('cds-base-focus-trap');
+      component = testElement.querySelector<CdsBaseFocusTrap>('cds-base-focus-trap');
+    });
+
+    afterEach(() => {
+      removeTestElement(testElement);
+    });
+
+    it('should remove the focus trap if initialized with hidden attr', async () => {
+      await componentIsStable(component);
+      expect(document.querySelector('.offscreen-focus-rebounder')).toBe(null);
     });
   });
 
@@ -85,7 +106,7 @@ describe('modal element', () => {
 
     it('should not create focus trap if demo mode', async () => {
       await componentIsStable(component);
-      expect((component as any).focusTrap).toBeUndefined();
+      expect(document.querySelector('.offscreen-focus-rebounder')).toBe(null);
     });
   });
 });

--- a/packages/core/src/internal/base/focus-trap.base.ts
+++ b/packages/core/src/internal/base/focus-trap.base.ts
@@ -9,7 +9,7 @@ import { FocusTrap } from '../utils/focus-trap.js';
 import { internalProperty, property } from '../decorators/property.js';
 
 export class CdsBaseFocusTrap extends LitElement {
-  protected focusTrap: FocusTrap;
+  protected focusTrap = new FocusTrap(this);
 
   /**
    * Its recommended to remove or add a focus trap element from the DOM
@@ -23,30 +23,31 @@ export class CdsBaseFocusTrap extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
-
-    if (!this.__demoMode) {
-      this.focusTrap = new FocusTrap(this);
-      this.focusTrap.enableFocusTrap();
-    }
+    this.toggleFocusTrap();
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
-
-    if (!this.__demoMode) {
-      this.focusTrap.removeFocusTrap();
-    }
+    this.focusTrap.removeFocusTrap();
   }
 
   attributeChangedCallback(name: string, old: string, value: string) {
     super.attributeChangedCallback(name, old, value);
 
-    if (name === 'hidden' && old !== value && !this.__demoMode) {
-      this.hasAttribute('hidden') ? this.focusTrap.removeFocusTrap() : this.focusTrap.enableFocusTrap();
+    if (name === 'hidden' && old !== value) {
+      this.toggleFocusTrap();
     }
   }
 
   protected render() {
     return html`<slot></slot>`;
+  }
+
+  private toggleFocusTrap() {
+    if (!this.__demoMode && !this.hasAttribute('hidden')) {
+      this.focusTrap.enableFocusTrap();
+    } else {
+      this.focusTrap.removeFocusTrap();
+    }
   }
 }

--- a/packages/core/src/internal/utils/focus-trap.ts
+++ b/packages/core/src/internal/utils/focus-trap.ts
@@ -72,11 +72,11 @@ export function removeReboundElementsFromFocusTrapElement(focusTrapElement: Focu
   }
 }
 export class FocusTrap {
-  focusTrapElement: FocusTrapElement;
+  private focusTrapElement: FocusTrapElement;
   private previousFocus: HTMLElement;
   private onFocusInEvent: any;
 
-  constructor(public hostElement: HTMLElement) {
+  constructor(hostElement: HTMLElement) {
     this.focusTrapElement = hostElement as FocusTrapElement;
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?
The modal could throw an exception in certain use cases. If the modal is added to the DOM with a hidden attr applied by default an exception would occur due to the focus service not being defined. The fix was to create the focus service every time and then trigger and check if it should be activated or deactivated in the connected callback or attr change callback.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
