### PR TITLE
fix(form): export form layout enum for strict typing

### DIFF
--- a/packages/angular/golden/clr-angular.d.ts
+++ b/packages/angular/golden/clr-angular.d.ts
@@ -1051,6 +1051,12 @@ export declare class ClrForm {
     onFormSubmit(): void;
 }
 
+export declare enum ClrFormLayout {
+    VERTICAL = "vertical",
+    HORIZONTAL = "horizontal",
+    COMPACT = "compact"
+}
+
 export declare class ClrFormsModule {
 }
 
@@ -1147,7 +1153,7 @@ export declare class ClrLabel implements OnInit, OnDestroy {
 }
 
 export declare class ClrLayout implements OnInit {
-    layout: Layouts;
+    layout: ClrFormLayout;
     layoutService: LayoutService;
     constructor(layoutService: LayoutService);
     ngOnInit(): void;

--- a/packages/angular/projects/clr-angular/src/forms/common/index.ts
+++ b/packages/angular/projects/clr-angular/src/forms/common/index.ts
@@ -6,6 +6,7 @@
 
 export * from './if-control-state/if-error';
 export * from './if-control-state/if-success';
+export { ClrFormLayout } from './providers/layout.service';
 export * from './error';
 export * from './success';
 export * from './form';

--- a/packages/angular/projects/clr-angular/src/forms/common/label.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/common/label.spec.ts
@@ -12,7 +12,7 @@ import { ClrInputContainer } from '../input/input-container';
 
 import { ClrLabel } from './label';
 import { ControlIdService } from './providers/control-id.service';
-import { Layouts, LayoutService } from './providers/layout.service';
+import { ClrFormLayout, LayoutService } from './providers/layout.service';
 import { NgControlService } from './providers/ng-control.service';
 
 @Component({ template: `<label></label>` })
@@ -106,7 +106,7 @@ export default function (): void {
       });
       const fixture = TestBed.createComponent(ContainerizedTest);
       const layoutService = fixture.debugElement.injector.get(LayoutService);
-      layoutService.layout = Layouts.HORIZONTAL;
+      layoutService.layout = ClrFormLayout.HORIZONTAL;
       fixture.detectChanges();
       const label = fixture.nativeElement.querySelector('label');
       expect(label.classList.contains('clr-col-md-2')).toBeTrue();
@@ -121,7 +121,7 @@ export default function (): void {
       });
       const fixture = TestBed.createComponent(ContainerizedTest);
       const layoutService = fixture.debugElement.injector.get(LayoutService);
-      layoutService.layout = Layouts.HORIZONTAL;
+      layoutService.layout = ClrFormLayout.HORIZONTAL;
       layoutService.labelSize = 3;
       fixture.detectChanges();
       const label = fixture.nativeElement.querySelector('label');
@@ -137,7 +137,7 @@ export default function (): void {
       });
       const fixture = TestBed.createComponent(ContainerizedTest);
       const layoutService = fixture.debugElement.injector.get(LayoutService);
-      layoutService.layout = Layouts.HORIZONTAL;
+      layoutService.layout = ClrFormLayout.HORIZONTAL;
       fixture.componentInstance.label.disableGrid();
       fixture.detectChanges();
       const label = fixture.nativeElement.querySelector('label');

--- a/packages/angular/projects/clr-angular/src/forms/common/layout.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/common/layout.spec.ts
@@ -8,9 +8,13 @@ import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { ClrLayout } from './layout';
-import { LayoutService, Layouts } from './providers/layout.service';
+import { LayoutService, ClrFormLayout } from './providers/layout.service';
 
-function customTestComponentFactory(layout: Layouts = Layouts.VERTICAL, hasLabelSize = false, labelSize: any = 2) {
+function customTestComponentFactory(
+  layout: ClrFormLayout = ClrFormLayout.VERTICAL,
+  hasLabelSize = false,
+  labelSize: any = 2
+) {
   @Component({
     template: `<div clrForm clrLayout="${layout}" ${hasLabelSize ? `clrLabelSize="${labelSize}"` : ''}></div>`,
     providers: [LayoutService],
@@ -28,7 +32,7 @@ export default function (): void {
       const service = fixture.debugElement.injector.get(LayoutService);
       fixture.detectChanges();
 
-      expect(service.layout).toEqual(Layouts.VERTICAL);
+      expect(service.layout).toEqual(ClrFormLayout.VERTICAL);
     });
 
     it('accepts layout option through layout input binding', function () {
@@ -40,22 +44,22 @@ export default function (): void {
       const service = fixture.debugElement.injector.get(LayoutService);
       fixture.detectChanges();
 
-      expect(directive.layout).toEqual(Layouts.VERTICAL);
-      expect(service.layout).toEqual(Layouts.VERTICAL);
+      expect(directive.layout).toEqual(ClrFormLayout.VERTICAL);
+      expect(service.layout).toEqual(ClrFormLayout.VERTICAL);
     });
 
     it('ignores invalid layout types', function () {
-      const testClass = customTestComponentFactory('invalid' as Layouts);
+      const testClass = customTestComponentFactory('invalid' as ClrFormLayout);
       TestBed.configureTestingModule({ declarations: [ClrLayout, testClass] });
       const fixture = TestBed.createComponent(testClass);
       const service = fixture.debugElement.injector.get(LayoutService);
       fixture.detectChanges();
 
-      expect(service.layout).toEqual(Layouts.HORIZONTAL);
+      expect(service.layout).toEqual(ClrFormLayout.HORIZONTAL);
     });
 
     it('label should have a default size of 2', () => {
-      const testClass = customTestComponentFactory(Layouts.HORIZONTAL);
+      const testClass = customTestComponentFactory(ClrFormLayout.HORIZONTAL);
       TestBed.configureTestingModule({ declarations: [ClrLayout, testClass] });
       const fixture = TestBed.createComponent(testClass);
       const service = fixture.debugElement.injector.get(LayoutService);
@@ -65,7 +69,7 @@ export default function (): void {
     });
 
     it('layout service should properly validate label sizes', () => {
-      const testClass = customTestComponentFactory(Layouts.HORIZONTAL);
+      const testClass = customTestComponentFactory(ClrFormLayout.HORIZONTAL);
       TestBed.configureTestingModule({ declarations: [ClrLayout, testClass] });
       const fixture = TestBed.createComponent(testClass);
       const service = fixture.debugElement.injector.get(LayoutService);
@@ -87,7 +91,7 @@ export default function (): void {
     });
 
     it('horizontal layout label that are out of (1, 12) range should default to size of 2', () => {
-      const testClass = customTestComponentFactory(Layouts.HORIZONTAL, true, -1);
+      const testClass = customTestComponentFactory(ClrFormLayout.HORIZONTAL, true, -1);
       TestBed.configureTestingModule({ declarations: [ClrLayout, testClass] });
       const fixture = TestBed.createComponent(testClass);
       const service = fixture.debugElement.injector.get(LayoutService);
@@ -97,7 +101,7 @@ export default function (): void {
     });
 
     it('compact layout label that are out of (1, 12) range should default to size of 2', () => {
-      const testClass = customTestComponentFactory(Layouts.COMPACT, true, -1);
+      const testClass = customTestComponentFactory(ClrFormLayout.COMPACT, true, -1);
       TestBed.configureTestingModule({ declarations: [ClrLayout, testClass] });
       const fixture = TestBed.createComponent(testClass);
       const service = fixture.debugElement.injector.get(LayoutService);
@@ -107,7 +111,7 @@ export default function (): void {
     });
 
     it("vertical layout label shouldn't be able to set label size", () => {
-      const testClass = customTestComponentFactory(Layouts.VERTICAL, true, 3);
+      const testClass = customTestComponentFactory(ClrFormLayout.VERTICAL, true, 3);
       TestBed.configureTestingModule({ declarations: [ClrLayout, testClass] });
       const fixture = TestBed.createComponent(testClass);
       const service = fixture.debugElement.injector.get(LayoutService);
@@ -117,113 +121,113 @@ export default function (): void {
     });
 
     it('ignores string label sizes for horizontal layout and defaults to 2', () => {
-      const testClass = customTestComponentFactory(Layouts.HORIZONTAL, true, '2');
+      const testClass = customTestComponentFactory(ClrFormLayout.HORIZONTAL, true, '2');
       TestBed.configureTestingModule({ declarations: [ClrLayout, testClass] });
       const fixture = TestBed.createComponent(testClass);
       const service = fixture.debugElement.injector.get(LayoutService);
       fixture.detectChanges();
 
-      expect(service.layout).toEqual(Layouts.HORIZONTAL);
+      expect(service.layout).toEqual(ClrFormLayout.HORIZONTAL);
       expect(service.labelSize).toEqual(2);
     });
 
     it('ignores boolean label sizes for horizontal layout and defaults to 2', () => {
-      const testClass = customTestComponentFactory(Layouts.HORIZONTAL, true, true);
+      const testClass = customTestComponentFactory(ClrFormLayout.HORIZONTAL, true, true);
       TestBed.configureTestingModule({ declarations: [ClrLayout, testClass] });
       const fixture = TestBed.createComponent(testClass);
       const service = fixture.debugElement.injector.get(LayoutService);
       fixture.detectChanges();
 
-      expect(service.layout).toEqual(Layouts.HORIZONTAL);
+      expect(service.layout).toEqual(ClrFormLayout.HORIZONTAL);
       expect(service.labelSize).toEqual(2);
     });
 
     it('ignores object label sizes for horizontal layout and defaults to 2', () => {
-      const testClass = customTestComponentFactory(Layouts.HORIZONTAL, true, new Object());
+      const testClass = customTestComponentFactory(ClrFormLayout.HORIZONTAL, true, new Object());
       TestBed.configureTestingModule({ declarations: [ClrLayout, testClass] });
       const fixture = TestBed.createComponent(testClass);
       const service = fixture.debugElement.injector.get(LayoutService);
       fixture.detectChanges();
 
-      expect(service.layout).toEqual(Layouts.HORIZONTAL);
+      expect(service.layout).toEqual(ClrFormLayout.HORIZONTAL);
       expect(service.labelSize).toEqual(2);
     });
 
     it('ignores null label sizes for horizontal layout and defaults to 2', () => {
-      const testClass = customTestComponentFactory(Layouts.HORIZONTAL, true, null);
+      const testClass = customTestComponentFactory(ClrFormLayout.HORIZONTAL, true, null);
       TestBed.configureTestingModule({ declarations: [ClrLayout, testClass] });
       const fixture = TestBed.createComponent(testClass);
       const service = fixture.debugElement.injector.get(LayoutService);
       fixture.detectChanges();
 
-      expect(service.layout).toEqual(Layouts.HORIZONTAL);
+      expect(service.layout).toEqual(ClrFormLayout.HORIZONTAL);
       expect(service.labelSize).toEqual(2);
     });
 
     it('ignores undefined label sizes for horizontal layout and defaults to 2', () => {
-      const testClass = customTestComponentFactory(Layouts.HORIZONTAL, true);
+      const testClass = customTestComponentFactory(ClrFormLayout.HORIZONTAL, true);
       TestBed.configureTestingModule({ declarations: [ClrLayout, testClass] });
       const fixture = TestBed.createComponent(testClass);
       const service = fixture.debugElement.injector.get(LayoutService);
       fixture.detectChanges();
 
-      expect(service.layout).toEqual(Layouts.HORIZONTAL);
+      expect(service.layout).toEqual(ClrFormLayout.HORIZONTAL);
       expect(service.labelSize).toEqual(2);
     });
     //
 
     it('ignores string label sizes for compact layout and defaults to 2', () => {
-      const testClass = customTestComponentFactory(Layouts.COMPACT, true, '2');
+      const testClass = customTestComponentFactory(ClrFormLayout.COMPACT, true, '2');
       TestBed.configureTestingModule({ declarations: [ClrLayout, testClass] });
       const fixture = TestBed.createComponent(testClass);
       const service = fixture.debugElement.injector.get(LayoutService);
       fixture.detectChanges();
 
-      expect(service.layout).toEqual(Layouts.COMPACT);
+      expect(service.layout).toEqual(ClrFormLayout.COMPACT);
       expect(service.labelSize).toEqual(2);
     });
 
     it('ignores boolean label sizes for compact layout and defaults to 2', () => {
-      const testClass = customTestComponentFactory(Layouts.COMPACT, true, true);
+      const testClass = customTestComponentFactory(ClrFormLayout.COMPACT, true, true);
       TestBed.configureTestingModule({ declarations: [ClrLayout, testClass] });
       const fixture = TestBed.createComponent(testClass);
       const service = fixture.debugElement.injector.get(LayoutService);
       fixture.detectChanges();
 
-      expect(service.layout).toEqual(Layouts.COMPACT);
+      expect(service.layout).toEqual(ClrFormLayout.COMPACT);
       expect(service.labelSize).toEqual(2);
     });
 
     it('ignores object label sizes for compact layout and defaults to 2', () => {
-      const testClass = customTestComponentFactory(Layouts.COMPACT, true, new Object());
+      const testClass = customTestComponentFactory(ClrFormLayout.COMPACT, true, new Object());
       TestBed.configureTestingModule({ declarations: [ClrLayout, testClass] });
       const fixture = TestBed.createComponent(testClass);
       const service = fixture.debugElement.injector.get(LayoutService);
       fixture.detectChanges();
 
-      expect(service.layout).toEqual(Layouts.COMPACT);
+      expect(service.layout).toEqual(ClrFormLayout.COMPACT);
       expect(service.labelSize).toEqual(2);
     });
 
     it('ignores null label sizes for compact layout and defaults to 2', () => {
-      const testClass = customTestComponentFactory(Layouts.COMPACT, true, null);
+      const testClass = customTestComponentFactory(ClrFormLayout.COMPACT, true, null);
       TestBed.configureTestingModule({ declarations: [ClrLayout, testClass] });
       const fixture = TestBed.createComponent(testClass);
       const service = fixture.debugElement.injector.get(LayoutService);
       fixture.detectChanges();
 
-      expect(service.layout).toEqual(Layouts.COMPACT);
+      expect(service.layout).toEqual(ClrFormLayout.COMPACT);
       expect(service.labelSize).toEqual(2);
     });
 
     it('ignores undefined label sizes for compact layout and defaults to 2', () => {
-      const testClass = customTestComponentFactory(Layouts.COMPACT, true, undefined);
+      const testClass = customTestComponentFactory(ClrFormLayout.COMPACT, true, undefined);
       TestBed.configureTestingModule({ declarations: [ClrLayout, testClass] });
       const fixture = TestBed.createComponent(testClass);
       const service = fixture.debugElement.injector.get(LayoutService);
       fixture.detectChanges();
 
-      expect(service.layout).toEqual(Layouts.COMPACT);
+      expect(service.layout).toEqual(ClrFormLayout.COMPACT);
       expect(service.labelSize).toEqual(2);
     });
   });

--- a/packages/angular/projects/clr-angular/src/forms/common/layout.ts
+++ b/packages/angular/projects/clr-angular/src/forms/common/layout.ts
@@ -1,17 +1,17 @@
 /**
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { Directive, Input, OnInit } from '@angular/core';
-import { Layouts, LayoutService } from './providers/layout.service';
+import { ClrFormLayout, LayoutService } from './providers/layout.service';
 
 @Directive({
   selector: '[clrForm][clrLayout]',
 })
 export class ClrLayout implements OnInit {
-  @Input('clrLayout') layout: Layouts;
+  @Input('clrLayout') layout: ClrFormLayout;
 
   constructor(public layoutService: LayoutService) {}
 

--- a/packages/angular/projects/clr-angular/src/forms/common/providers/layout.service.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/common/providers/layout.service.spec.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { Layouts, LayoutService } from './layout.service';
+import { ClrFormLayout, LayoutService } from './layout.service';
 
 export default function (): void {
   describe('LayoutService', function () {
@@ -13,36 +13,36 @@ export default function (): void {
     });
 
     it('sets layout to horizontal by default', function () {
-      expect(service.layout).toEqual(Layouts.HORIZONTAL);
+      expect(service.layout).toEqual(ClrFormLayout.HORIZONTAL);
     });
 
     it('handles checking isVertical based on current layout', function () {
       expect(service.isVertical()).toBeFalse();
-      service.layout = Layouts.VERTICAL;
+      service.layout = ClrFormLayout.VERTICAL;
       expect(service.isVertical()).toBeTrue();
-      service.layout = Layouts.COMPACT;
+      service.layout = ClrFormLayout.COMPACT;
       expect(service.isVertical()).toBeFalse();
     });
 
     it('handles checking isCompact based on current layout', function () {
       expect(service.isCompact()).toBeFalse();
-      service.layout = Layouts.VERTICAL;
+      service.layout = ClrFormLayout.VERTICAL;
       expect(service.isCompact()).toBeFalse();
-      service.layout = Layouts.COMPACT;
+      service.layout = ClrFormLayout.COMPACT;
       expect(service.isCompact()).toBeTrue();
     });
 
     it('handles checking isHorizontal based on current layout', function () {
       expect(service.isHorizontal()).toBeTrue();
-      service.layout = Layouts.VERTICAL;
+      service.layout = ClrFormLayout.VERTICAL;
       expect(service.isHorizontal()).toBeFalse();
-      service.layout = Layouts.COMPACT;
+      service.layout = ClrFormLayout.COMPACT;
       expect(service.isHorizontal()).toBeFalse();
     });
 
     it('provides the class name', function () {
       expect(service.layoutClass).toEqual('clr-form-horizontal');
-      service.layout = Layouts.VERTICAL;
+      service.layout = ClrFormLayout.VERTICAL;
       expect(service.layoutClass).toEqual('clr-form-vertical');
     });
 

--- a/packages/angular/projects/clr-angular/src/forms/common/providers/layout.service.ts
+++ b/packages/angular/projects/clr-angular/src/forms/common/providers/layout.service.ts
@@ -6,7 +6,7 @@
 
 import { Injectable } from '@angular/core';
 
-export enum Layouts {
+export enum ClrFormLayout {
   VERTICAL = 'vertical',
   HORIZONTAL = 'horizontal',
   COMPACT = 'compact',
@@ -16,12 +16,12 @@ export enum Layouts {
 export class LayoutService {
   readonly minLabelSize = 1;
   readonly maxLabelSize = 12;
-  layout: Layouts = Layouts.HORIZONTAL;
+  layout: ClrFormLayout = ClrFormLayout.HORIZONTAL;
 
   // This is basically a replacement for Object.values(), which IE11 and Node <9 don't support :(
-  // String enums cannot be reverse-mapped, meaning Layouts['COMPACT'] does not return 'compact' so
+  // String enums cannot be reverse-mapped, meaning ClrFormLayout['COMPACT'] does not return 'compact' so
   // this exists to deal with this little caveat to get the list of the values as an array.
-  private layoutValues: string[] = Object.keys(Layouts).map(key => (Layouts as Record<string, any>)[key]);
+  private layoutValues: string[] = Object.keys(ClrFormLayout).map(key => (ClrFormLayout as Record<string, any>)[key]);
   private _labelSize = 2;
 
   set labelSize(size: number) {
@@ -35,15 +35,15 @@ export class LayoutService {
   }
 
   isVertical(): boolean {
-    return this.layout === Layouts.VERTICAL;
+    return this.layout === ClrFormLayout.VERTICAL;
   }
 
   isHorizontal(): boolean {
-    return this.layout === Layouts.HORIZONTAL;
+    return this.layout === ClrFormLayout.HORIZONTAL;
   }
 
   isCompact(): boolean {
-    return this.layout === Layouts.COMPACT;
+    return this.layout === ClrFormLayout.COMPACT;
   }
 
   get layoutClass(): string {

--- a/packages/angular/projects/clr-angular/src/forms/datepicker/date-container.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/datepicker/date-container.spec.ts
@@ -13,7 +13,7 @@ import { ClrPopoverToggleService } from '../../utils/popover/providers/popover-t
 import { ControlClassService } from '../common/providers/control-class.service';
 import { ControlIdService } from '../common/providers/control-id.service';
 import { FocusService } from '../common/providers/focus.service';
-import { Layouts, LayoutService } from '../common/providers/layout.service';
+import { ClrFormLayout, LayoutService } from '../common/providers/layout.service';
 import { NgControlService } from '../common/providers/ng-control.service';
 import { PopoverPosition } from '../../popover/common/popover-positions';
 
@@ -209,7 +209,7 @@ export default function () {
         expect(context.clarityDirective.controlClass()).toContain('clr-error');
         const controlClassService = context.getClarityProvider(ControlClassService);
         const layoutService = context.getClarityProvider(LayoutService);
-        layoutService.layout = Layouts.VERTICAL;
+        layoutService.layout = ClrFormLayout.VERTICAL;
         context.clarityDirective.state = CONTROL_STATE.VALID;
         expect(context.clarityDirective.controlClass()).not.toContain('clr-error');
         expect(context.clarityDirective.controlClass()).not.toContain('clr-col-md-10');

--- a/packages/angular/projects/clr-angular/src/forms/tests/container.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/tests/container.spec.ts
@@ -11,7 +11,7 @@ import { ClrIconModule } from '../../icon/icon.module';
 import { ClrCommonFormsModule } from '../common/common.module';
 
 import { NgControlService } from '../common/providers/ng-control.service';
-import { Layouts, LayoutService } from '../common/providers/layout.service';
+import { ClrFormLayout, LayoutService } from '../common/providers/layout.service';
 import { MarkControlService } from '../common/providers/mark-control.service';
 import { ControlIdService } from '../common/providers/control-id.service';
 import { DatalistIdService } from '../datalist/providers/datalist-id.service';
@@ -41,7 +41,7 @@ export function ContainerNoLabelSpec(testContainer, testControl, testComponent):
     });
 
     it('does not add an empty label when instantiated with vertical layout', () => {
-      layoutService.layout = Layouts.VERTICAL;
+      layoutService.layout = ClrFormLayout.VERTICAL;
       fixture.detectChanges();
       const labels = containerEl.querySelectorAll('label');
       expect(Array.prototype.filter.call(labels, label => label.textContent === '').length).toBe(0);
@@ -107,7 +107,7 @@ function fullSpec(description, testContainer, directives: any | any[], testCompo
 
     it('injects the layoutService', () => {
       expect(layoutService).toBeTruthy();
-      expect(layoutService.layout).toEqual(Layouts.HORIZONTAL);
+      expect(layoutService.layout).toEqual(ClrFormLayout.HORIZONTAL);
     });
 
     it('injects the IfControlStateService and subscribes', () => {
@@ -173,10 +173,10 @@ function fullSpec(description, testContainer, directives: any | any[], testCompo
 
     it('adds the .clr-row class to the host on non-vertical layouts', () => {
       expect(containerEl.classList).toContain('clr-row');
-      layoutService.layout = Layouts.VERTICAL;
+      layoutService.layout = ClrFormLayout.VERTICAL;
       fixture.detectChanges();
       expect(containerEl.classList).not.toContain('clr-row');
-      layoutService.layout = Layouts.COMPACT;
+      layoutService.layout = ClrFormLayout.COMPACT;
       fixture.detectChanges();
       expect(containerEl.classList).toContain('clr-row');
     });
@@ -189,7 +189,7 @@ function fullSpec(description, testContainer, directives: any | any[], testCompo
 
     it('adds the grid class for the control container when not vertical', () => {
       expect(container.controlClass()).toContain('clr-col-12');
-      layoutService.layout = Layouts.VERTICAL;
+      layoutService.layout = ClrFormLayout.VERTICAL;
       expect(container.controlClass()).not.toContain('clr-col-12');
     });
 


### PR DESCRIPTION
This opens up the Layout enum for Angular to be able to reference, and renames it for our public API. This is not considered a breaking change because this was internal before.

closes #4847 #4601

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4847 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
