### PR TITLE
fix: datagrid-row correct way of assigning clrDgSelectable

### DIFF
--- a/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-row.spec.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-row.spec.ts
@@ -111,7 +111,41 @@ export default function (): void {
         expect(context.clarityDirective.selected).toBe(true);
       });
 
-      it('should be able you toggle the state of selection when clrDgSelectable is false', () => {
+      it('should be able to toggle selection through API when clrDgSelectable is false', () => {
+        selectionProvider.selectionType = SelectionType.Multi;
+        context.clarityDirective.toggle(true);
+        context.testComponent.clrDgSelectable = false;
+        context.detectChanges();
+        context.clarityDirective.toggle();
+        expect(context.clarityDirective.selected).toBe(false);
+      });
+    });
+
+    describe('Conditional selection switch order or arguments', function () {
+      let context: TestContext<ClrDatagridRow, SelectableRowOrder>;
+      let selectionProvider: Selection;
+      let checkbox: HTMLElement;
+
+      beforeEach(function () {
+        context = this.create(ClrDatagridRow, SelectableRowOrder, DATAGRID_SPEC_PROVIDERS);
+        selectionProvider = TestBed.get(Selection);
+        TestBed.get(Items).all = [{ id: 1 }, { id: 2 }];
+      });
+
+      it('should toggle when clrDgSelectable is false for type  SelectionType.Multi', () => {
+        selectionProvider.selectionType = SelectionType.Multi;
+        context.testComponent.clrDgSelectable = false;
+        context.detectChanges();
+        checkbox = context.clarityElement.querySelector("input[type='checkbox']");
+
+        expect(checkbox.getAttribute('disabled')).toBe('true');
+        expect(checkbox.getAttribute('aria-disabled')).toBe('true');
+
+        context.clarityDirective.toggle();
+        expect(context.clarityDirective.selected).toBe(true);
+      });
+
+      it('should be able to toggle selection through API when clrDgSelectable is false', () => {
         selectionProvider.selectionType = SelectionType.Multi;
         context.clarityDirective.toggle(true);
         context.testComponent.clrDgSelectable = false;
@@ -452,10 +486,18 @@ export default function (): void {
 class ProjectionTest {}
 
 @Component({
-  template: `<clr-dg-row [clrDgSelectable]="clrDgSelectable" [clrDgItem]="item">None</clr-dg-row>`,
+  template: `<clr-dg-row [clrDgItem]="item" [clrDgSelectable]="clrDgSelectable">None</clr-dg-row>`,
 })
 class SelectableRow {
   clrDgSelectable = true;
+  item: Item = { id: 42 };
+}
+
+@Component({
+  template: `<clr-dg-row [clrDgSelectable]="clrDgSelectable" [clrDgItem]="item">None</clr-dg-row>`,
+})
+class SelectableRowOrder {
+  clrDgSelectable = undefined;
   item: Item = { id: 42 };
 }
 

--- a/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-row.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-row.ts
@@ -132,7 +132,7 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
     }
   }
 
-  // By default every item is selectable
+  // By default every item is selectable; it becomes not selectable only if it's explicitly set to false
   @Input('clrDgSelectable')
   public set clrDgSelectable(value: boolean) {
     this.selection.lockItem(this.item, value === false);
@@ -261,6 +261,7 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
 
   ngOnInit() {
     this.wrappedInjector = new HostWrapper(WrappedRow, this.vcr);
+    this.selection.lockItem(this.item, this.clrDgSelectable === false);
   }
 
   public get _view() {

--- a/packages/angular/projects/dev/src/app/datagrid/conditional-selection/conditional-selection.html
+++ b/packages/angular/projects/dev/src/app/datagrid/conditional-selection/conditional-selection.html
@@ -6,6 +6,48 @@
 
 <h2>Datagrid: Conditional selection</h2>
 
+<h3>Lock the how table</h3>
+
+<button class="btn btn-primary" (click)="canItBeSelected = !canItBeSelected">
+  {{ canItBeSelected ? 'Lock' : 'UnLock' }} Table
+</button>
+
+<clr-datagrid [(clrDgSingleSelected)]="selected">
+  <clr-dg-column>User ID</clr-dg-column>
+  <clr-dg-column>Name</clr-dg-column>
+  <clr-dg-column>Creation date</clr-dg-column>
+  <clr-dg-column>Favorite color</clr-dg-column>
+
+  <clr-dg-row [clrDgSelectable]="canItBeSelected" *clrDgItems="let user of users" [clrDgItem]="user">
+    <clr-dg-cell>{{user.id}}</clr-dg-cell>
+    <clr-dg-cell>{{user.name}}</clr-dg-cell>
+    <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+    <clr-dg-cell>
+      <span class="color-square" [style.backgroundColor]="user.color"></span>
+    </clr-dg-cell>
+  </clr-dg-row>
+
+  <clr-dg-footer>{{users.length}} users</clr-dg-footer>
+</clr-datagrid>
+
+<clr-datagrid [(clrDgSelected)]="selectedRows">
+  <clr-dg-column>User ID</clr-dg-column>
+  <clr-dg-column>Name</clr-dg-column>
+  <clr-dg-column>Creation date</clr-dg-column>
+  <clr-dg-column>Favorite color</clr-dg-column>
+
+  <clr-dg-row [clrDgSelectable]="canItBeSelected" *clrDgItems="let user of usersMulti" [clrDgItem]="user">
+    <clr-dg-cell>{{user.id}}</clr-dg-cell>
+    <clr-dg-cell>{{user.name}}</clr-dg-cell>
+    <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
+    <clr-dg-cell>
+      <span class="color-square" [style.backgroundColor]="user.color"></span>
+    </clr-dg-cell>
+  </clr-dg-row>
+
+  <clr-dg-footer>{{usersMulti.length}} users</clr-dg-footer>
+</clr-datagrid>
+
 <h3>Single selection rows</h3>
 
 <button class="btn btn-primary" (click)="singleSelectionLockRows()">Lock Rows</button>

--- a/packages/angular/projects/dev/src/app/datagrid/conditional-selection/conditional-selection.ts
+++ b/packages/angular/projects/dev/src/app/datagrid/conditional-selection/conditional-selection.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -16,6 +16,7 @@ import { User } from '../inventory/user';
   styleUrls: ['../datagrid.demo.scss'],
 })
 export class DatagridConditionalSelectionsDemo {
+  canItBeSelected = true;
   users: User[];
   usersMulti: User[] = [];
   selected: User;


### PR DESCRIPTION
Same as `colDgType`, `clrDgSelectable` is called in some cases before `clrDgItem` is defined so there is no way to lock it or unlock it. 

Moving this inside `ngOnChanges` and checking it there solve this. 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4993

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Close #4993 
