### PR TITLE
fix: prevent combobox form submit on selection with enter

### DIFF
--- a/packages/angular/projects/clr-angular/src/forms/combobox/combobox.html
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/combobox.html
@@ -66,6 +66,7 @@
       [attr.aria-owns]="ariaOwns"
       aria-haspopup="listbox"
       aria-autocomplete="list"
+      autocomplete="off"
       [attr.aria-invalid]="control?.invalid? true: null"
       [disabled]="control?.disabled? true: null"
       [attr.aria-activedescendant]="getActiveDescendant()"

--- a/packages/angular/projects/clr-angular/src/forms/combobox/providers/combobox-focus-handler.service.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/providers/combobox-focus-handler.service.spec.ts
@@ -13,13 +13,18 @@ import { SingleSelectComboboxModel } from '../model/single-select-combobox.model
 import { KeyCodes } from '../../../utils/enums/key-codes.enum';
 
 @Component({
-  template: `<input type="text" #textInput /><button #trigger></button>
-    <ul #listbox></ul>`,
+  template: `<form (submit)="onSubmit()">
+    <input type="text" #textInput /><button #trigger></button>
+    <ul #listbox></ul>
+  </form>`,
 })
 class SimpleHost {
   @ViewChild('textInput') textInput: ElementRef;
   @ViewChild('trigger') trigger: ElementRef;
   @ViewChild('listbox') listbox: ElementRef;
+  onSubmit() {
+    // do nothing; it makes eslint happy
+  }
 }
 
 interface TestContext {
@@ -142,6 +147,21 @@ export default function (): void {
 
       expect(item.equals(sameItem)).toBeTrue();
       expect(item.equals(otherItem)).toBeFalse();
+    });
+
+    it('does submit on Enter when dialog is closed', function (this: TestContext) {
+      spyOn(this.testComponent, 'onSubmit');
+      const event = new KeyboardEvent('keydown', { key: KeyCodes.Enter });
+      this.testComponent.textInput.nativeElement.dispatchEvent(event);
+      expect(this.testComponent.onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('does not submit on Enter when dialog is open', function (this: TestContext) {
+      spyOn(this.testComponent, 'onSubmit');
+      this.toggleService.open = true;
+      const event = new KeyboardEvent('keydown', { key: KeyCodes.Enter });
+      this.testComponent.textInput.nativeElement.dispatchEvent(event);
+      expect(this.testComponent.onSubmit).not.toHaveBeenCalled();
     });
   });
 }

--- a/packages/angular/projects/clr-angular/src/forms/combobox/providers/combobox-focus-handler.service.ts
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/providers/combobox-focus-handler.service.ts
@@ -112,11 +112,9 @@ export class ComboboxFocusHandler<T> {
     if (event) {
       switch (key) {
         case KeyCodes.Enter:
-          if (!this.toggleService.open) {
-            this.toggleService.open = true;
-            preventDefault = true;
-          } else if (this.pseudoFocus.model) {
+          if (this.toggleService.open && this.pseudoFocus.model) {
             this.selectionService.select(this.pseudoFocus.model.value);
+            preventDefault = true;
           }
           break;
         case KeyCodes.Space:


### PR DESCRIPTION
- also fix prevention of auto-suggestion ontop of the popover
Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Opens popover with options on enter.
Submits form when using enter to select an option.
Shows browser form suggestions.

Issue Number: #4983 

## What is the new behavior?

Submits form on enter when popover is closed.
Does not submit form when using enter to select an option.
Browser does not show form suggestions.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
