### PR TITLE
fix: change the node reference for spanWrapper

### DIFF
--- a/packages/core/src/internal/utils/dom.ts
+++ b/packages/core/src/internal/utils/dom.ts
@@ -107,9 +107,8 @@ export function spanWrapper(nodeList: NodeListOf<ChildNode>): void {
   nodeList.forEach(node => {
     if (node.parentElement && node.textContent !== null && node.nodeType === 3) {
       const spanWrapper = document.createElement('span');
-      const parent = node.parentElement;
-      spanWrapper!.appendChild(node);
-      parent!.appendChild(spanWrapper);
+      node.after(spanWrapper);
+      spanWrapper.appendChild(node);
     }
   });
 }


### PR DESCRIPTION
Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?
This is a fix for an optimization I missed in the Core button icons PR yesterday. 

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
The spanWrapper fn does not properly reference the parent node.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
The spanWrapper fn properly wraps the parent node. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
