### PR TITLE
fix: handle TypeError when calling triggerStatusChange

### DIFF
--- a/packages/angular/projects/clr-angular/src/forms/common/if-control-state/if-control-state.service.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/common/if-control-state/if-control-state.service.spec.ts
@@ -23,6 +23,10 @@ export default function (): void {
       expect(testControl.statusChanges.subscribe).toHaveBeenCalled();
     });
 
+    it('should not throw error when triggerStatusChange is called and control is not set yet', () => {
+      expect(() => service.triggerStatusChange()).not.toThrowError();
+    });
+
     it('provides observable for statusChanges, return valid when touched and no rules added', () => {
       const cb = jasmine.createSpy('cb');
       const sub = service.statusChanges.subscribe((control: CONTROL_STATE) => cb(control));

--- a/packages/angular/projects/clr-angular/src/forms/common/if-control-state/if-control-state.service.ts
+++ b/packages/angular/projects/clr-angular/src/forms/common/if-control-state/if-control-state.service.ts
@@ -45,12 +45,15 @@ export class IfControlStateService implements OnDestroy {
   }
 
   triggerStatusChange() {
-    // These status values are mutually exclusive, so a control
-    // cannot be both valid AND invalid or invalid AND disabled.
-    const status = CONTROL_STATE[this.control.status];
-    this._statusChanges.next(
-      this.control.touched && ['VALID', 'INVALID'].includes(status) ? status : CONTROL_STATE.NONE
-    );
+    /* Check if control is defined and run the code only then */
+    if (this.control) {
+      // These status values are mutually exclusive, so a control
+      // cannot be both valid AND invalid or invalid AND disabled.
+      const status = CONTROL_STATE[this.control.status];
+      this._statusChanges.next(
+        this.control.touched && ['VALID', 'INVALID'].includes(status) ? status : CONTROL_STATE.NONE
+      );
+    }
   }
 
   // Clean up subscriptions


### PR DESCRIPTION
Handle case when calling triggerStatusChange without `this.control` to be defined

```
main.28fcef2b19421f832d4b.js:1 ERROR TypeError: Cannot read property 'status' of undefined
    at triggerStatusChange (main.28fcef2b19421f832d4b.js:1)
    at triggerValidation (main.28fcef2b19421f832d4b.js:1)
    at triggerValidation (main.28fcef2b19421f832d4b.js:1)
    at main.28fcef2b19421f832d4b.js:1
    at ps (main.28fcef2b19421f832d4b.js:1)
    at r (main.28fcef2b19421f832d4b.js:1)
    at HTMLInputElement.<anonymous> (main.28fcef2b19421f832d4b.js:1)
    at HTMLInputElement.n (main.28fcef2b19421f832d4b.js:1)
    at l.invokeTask (polyfills.52bd7f36c0afeeaa4ae2.js:1)
    at Object.onInvokeTask (main.28fcef2b19421f832d4b.js:1)
    at l.invokeTask (polyfills.52bd7f36c0afeeaa4ae2.js:1)
    at i.runTask (polyfills.52bd7f36c0afeeaa4ae2.js:1)
    at u.invokeTask [as invoke] (polyfills.52bd7f36c0afeeaa4ae2.js:1)
    at p (polyfills.52bd7f36c0afeeaa4ae2.js:1)
    at HTMLInputElement.f (polyfills.52bd7f36c0afeeaa4ae2.js:1)
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Need to be backported to `master` 