### PR TITLE
docs: remove demo pages

### DIFF
--- a/apps/website/components/accordion/demo.md
+++ b/apps/website/components/accordion/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="accordion--basic" />

--- a/apps/website/components/alert/demo.md
+++ b/apps/website/components/alert/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="alert--basic" />

--- a/apps/website/components/badge/demo.md
+++ b/apps/website/components/badge/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="badge--basic" />

--- a/apps/website/components/button-group/demo.md
+++ b/apps/website/components/button-group/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="button-group--basic" />

--- a/apps/website/components/button/demo.md
+++ b/apps/website/components/button/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="button--basic" />

--- a/apps/website/components/card/demo.md
+++ b/apps/website/components/card/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="card--basic" />

--- a/apps/website/components/checkbox/demo.md
+++ b/apps/website/components/checkbox/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="forms--checkbox" />

--- a/apps/website/components/combobox/demo.md
+++ b/apps/website/components/combobox/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="combobox--basic" />

--- a/apps/website/components/datagrid/demo.md
+++ b/apps/website/components/datagrid/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="datagrid--basic" />

--- a/apps/website/components/datalist/demo.md
+++ b/apps/website/components/datalist/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="forms--datalist" />

--- a/apps/website/components/date-picker/demo.md
+++ b/apps/website/components/date-picker/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="date-picker--basic" />

--- a/apps/website/components/dropdown/demo.md
+++ b/apps/website/components/dropdown/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="dropdown--basic" />

--- a/apps/website/components/form/demo.md
+++ b/apps/website/components/form/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="forms--full" />

--- a/apps/website/components/grid/demo.md
+++ b/apps/website/components/grid/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="grid--basic" />

--- a/apps/website/components/header/demo.md
+++ b/apps/website/components/header/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="header--basic" />

--- a/apps/website/components/input/demo.md
+++ b/apps/website/components/input/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="forms--input" />

--- a/apps/website/components/label/demo.md
+++ b/apps/website/components/label/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="forms--label-demo" />

--- a/apps/website/components/list/demo.md
+++ b/apps/website/components/list/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="list--basic" />

--- a/apps/website/components/login/demo.md
+++ b/apps/website/components/login/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="login--basic" />

--- a/apps/website/components/modal/demo.md
+++ b/apps/website/components/modal/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="modal--basic" />

--- a/apps/website/components/password/demo.md
+++ b/apps/website/components/password/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="forms--password" />

--- a/apps/website/components/progress-bar/demo.md
+++ b/apps/website/components/progress-bar/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="progress--basic" />

--- a/apps/website/components/radio/demo.md
+++ b/apps/website/components/radio/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="forms--radio" />

--- a/apps/website/components/range/demo.md
+++ b/apps/website/components/range/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="forms--range" />

--- a/apps/website/components/select/demo.md
+++ b/apps/website/components/select/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="forms--select" />

--- a/apps/website/components/sidenav/demo.md
+++ b/apps/website/components/sidenav/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="navigation--basic" />

--- a/apps/website/components/signpost/demo.md
+++ b/apps/website/components/signpost/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="signpost--basic" />

--- a/apps/website/components/spinner/demo.md
+++ b/apps/website/components/spinner/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="spinner--basic" />

--- a/apps/website/components/stack-view/demo.md
+++ b/apps/website/components/stack-view/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="stack-view--basic" />

--- a/apps/website/components/stepper/demo.md
+++ b/apps/website/components/stepper/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="stepper--basic" />

--- a/apps/website/components/tab/demo.md
+++ b/apps/website/components/tab/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="tabs--basic" />

--- a/apps/website/components/table/demo.md
+++ b/apps/website/components/table/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="table--basic" />

--- a/apps/website/components/textarea/demo.md
+++ b/apps/website/components/textarea/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="forms--textarea" />

--- a/apps/website/components/timeline/demo.md
+++ b/apps/website/components/timeline/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="timeline--basic" />

--- a/apps/website/components/toggle/demo.md
+++ b/apps/website/components/toggle/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="forms--toggle" />

--- a/apps/website/components/tooltip/demo.md
+++ b/apps/website/components/tooltip/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="tooltip--basic" />

--- a/apps/website/components/tree-view/demo.md
+++ b/apps/website/components/tree-view/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="tree-view--basic" />

--- a/apps/website/components/vertical-nav/demo.md
+++ b/apps/website/components/vertical-nav/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="vertical-nav--basic" />

--- a/apps/website/components/wizard/demo.md
+++ b/apps/website/components/wizard/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-<doc-storybook story="wizard--basic" />


### PR DESCRIPTION
We are removing the iframe storybook pages from the new website, because they are slow to startup and you incur the cost to load the storybook app with each visit to a demo tab. Instead we'll add links later that kick off to the storybook app for users as needed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
