### PR TITLE
fix: remove browser guard from core button element

### DIFF
--- a/packages/core/src/button/button.element.ts
+++ b/packages/core/src/button/button.element.ts
@@ -112,7 +112,7 @@ export class CdsButton extends CdsBaseButton {
     super.firstUpdated(props);
 
     // Find and wrap any text nodes into span elements
-    this.wrapTextNodes();
+    spanWrapper(this.childNodes);
 
     if (this.loadingState !== ClrLoadingState.DEFAULT) {
       this.updateLoadingState();
@@ -139,17 +139,10 @@ export class CdsButton extends CdsBaseButton {
           ? html`${iconSpinnerError}`
           : ''}${loadingState === ClrLoadingState.LOADING ? html`${iconSpinner}` : ''}${loadingState ===
         ClrLoadingState.DEFAULT
-          ? html`<slot @slotchange=${() => this.wrapTextNodes()}></slot>`
+          ? html`<slot @slotchange=${() => spanWrapper(this.childNodes)}></slot>`
           : ''}${this.hiddenButtonTemplate}
       </div>
     </div>`;
-  }
-
-  private wrapTextNodes() {
-    // only needs to run for Safari/IE
-    if (!this.hasFlexGapSupport) {
-      spanWrapper(this.childNodes);
-    }
   }
 
   static get styles() {

--- a/packages/core/src/file/file.element.spec.ts
+++ b/packages/core/src/file/file.element.spec.ts
@@ -4,7 +4,6 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { render, html } from 'lit-html';
 import { createTestElement, waitForComponent, removeTestElement, componentIsStable } from '@clr/core/test/utils';
 import { CdsButton } from '@clr/core/button';
 import { CdsFile } from '@clr/core/file';
@@ -17,17 +16,15 @@ describe('cds-file', () => {
 
   beforeEach(async () => {
     element = createTestElement();
-    render(
-      html` <cds-file>
+    element.innerHTML = `
+      <cds-file>
         <label>file</label>
         <input type="file" />
         <cds-control-message>message text</cds-control-message>
-      </cds-file>`,
-      element
-    );
+      </cds-file>
+    `;
 
     await waitForComponent('cds-file');
-
     component = element.querySelector<CdsFile>('cds-file');
     button = component.shadowRoot.querySelector('cds-button');
   });

--- a/packages/core/src/internal/utils/dom.ts
+++ b/packages/core/src/internal/utils/dom.ts
@@ -104,11 +104,13 @@ export function isVisible(element: HTMLElement) {
 }
 
 export function spanWrapper(nodeList: NodeListOf<ChildNode>): void {
-  nodeList.forEach(node => {
-    if (node.parentElement && node.textContent !== null && node.nodeType === 3) {
-      const spanWrapper = document.createElement('span');
-      node.after(spanWrapper);
-      spanWrapper.appendChild(node);
-    }
-  });
+  Array.from(nodeList)
+    .filter(node => node.textContent!.trim().length > 0)
+    .forEach(node => {
+      if (node.parentElement && node.textContent !== null && node.nodeType === 3) {
+        const spanWrapper = document.createElement('span');
+        node.after(spanWrapper);
+        spanWrapper.appendChild(node);
+      }
+    });
 }


### PR DESCRIPTION
This change removes a guard in the Core button element to make sure that the spanWrapper wrapps all textNodes in button elements for all browsers. 

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [x] Other... Please describe: no a bug fix but a change to core button behavior in all browsers. 

## What is the current behavior?
There is a guard that prevents a supported check that limits spanWrapping to only Safari and IE11. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
spanWrapper will run for buttons in all browsers. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
