### PR TITLE
fix: core test cleanup and docs

### DIFF
--- a/packages/core/docs/development/unit-testing.stories.mdx
+++ b/packages/core/docs/development/unit-testing.stories.mdx
@@ -26,3 +26,40 @@ import { Meta } from '@storybook/addon-docs/blocks';
 "@clr/core/button": "/base/dist/core/button/index.js",
 "@clr/core/button/register.js": "/base/dist/core/button/register.js",
 ```
+
+## Test Utilities
+
+There are a couple of test utilities provided to make testing a bit easier. These can be found in `/projects/core/test`.
+Here is a basic starter test for a Clarity Web Component.
+
+```typescript
+import { html } from 'lit-html';
+import '@clr/core/badge/register.js';
+import { CdsBadge } from '@clr/core/badge';
+import { componentIsStable, createTestElement, removeTestElement } from '@clr/core/test/utils';
+
+describe('badge element', () => {
+  let testElement: HTMLElement;
+  let component: CdsBadge;
+
+  beforeEach(async () => {
+    // create a test DOM element with the component to be tested
+    // this function is async to wait and check all custom elements to have been registered
+    testElement = await createTestElement(html`<cds-badge>10</cds-badge>`);
+
+    // query the test element to get a reference to our component instance
+    component = testElement.querySelector<CdsBadge>('cds-badge');
+  });
+
+  afterEach(() => {
+    // after each test cleanup and remove the test element so we do not pollute the DOM
+    removeTestElement(testElement);
+  });
+
+  it('should create the component', async () => {
+    // lit-element renders asynchronously, this utility will wait until all rendering has completed before continuing
+    await componentIsStable(component);
+    expect(component.innerText).toBe('10');
+  });
+});
+```

--- a/packages/core/src/alert/alert-actions.element.spec.ts
+++ b/packages/core/src/alert/alert-actions.element.spec.ts
@@ -4,10 +4,11 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
+import { html } from 'lit-html';
 import '@clr/core/alert/register.js';
 import '@clr/core/button/register.js';
 import { CdsAlertActions } from '@clr/core/alert';
-import { componentIsStable, createTestElement, removeTestElement, waitForComponent } from '@clr/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@clr/core/test/utils';
 
 describe('alert-actions element', () => {
   describe(' - the basics: ', () => {
@@ -16,10 +17,7 @@ describe('alert-actions element', () => {
     const placeholderText = 'Alert Text Placeholder';
 
     beforeEach(async () => {
-      testElement = createTestElement();
-      testElement.innerHTML = `<cds-alert-actions>${placeholderText}</cds-alert-actions>`;
-
-      await waitForComponent('cds-alert-actions');
+      testElement = await createTestElement(html`<cds-alert-actions>${placeholderText}</cds-alert-actions>`);
       component = testElement.querySelector<CdsAlertActions>('cds-alert-actions');
     });
 
@@ -38,13 +36,13 @@ describe('alert-actions element', () => {
     let component: CdsAlertActions;
 
     beforeEach(async () => {
-      testElement = createTestElement();
-      testElement.innerHTML = `<cds-alert-actions>
-        <cds-button>ohai</cds-button>
-        <cds-button>kthxbye</cds-button>
-      </cds-alert-actions>`;
+      testElement = await createTestElement(html`
+        <cds-alert-actions>
+          <cds-button>ohai</cds-button>
+          <cds-button>kthxbye</cds-button>
+        </cds-alert-actions>
+      `);
 
-      await waitForComponent('cds-alert-actions');
       component = testElement.querySelector<CdsAlertActions>('cds-alert-actions');
     });
 

--- a/packages/core/src/alert/alert-group.element.spec.ts
+++ b/packages/core/src/alert/alert-group.element.spec.ts
@@ -3,16 +3,12 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
+
+import { html } from 'lit-html';
 import '@clr/core/alert/register.js';
 import '@clr/core/icon/register.js';
 import { CdsAlert, CdsAlertGroup } from '@clr/core/alert';
-import {
-  componentIsStable,
-  createTestElement,
-  getComponentSlotContent,
-  removeTestElement,
-  waitForComponent,
-} from '@clr/core/test/utils';
+import { componentIsStable, createTestElement, getComponentSlotContent, removeTestElement } from '@clr/core/test/utils';
 
 describe('Alert groups – ', () => {
   let testElement: HTMLElement;
@@ -25,17 +21,15 @@ describe('Alert groups – ', () => {
     let compactAlertGroup: CdsAlertGroup;
 
     beforeEach(async () => {
-      testElement = createTestElement();
-      testElement.innerHTML = `
+      testElement = await createTestElement(html`
         <cds-alert-group id="default">
           <cds-alert>${placeholderText}</cds-alert>
         </cds-alert-group>
         <cds-alert-group id="small" size="sm">
           <cds-alert>${placeholderText}</cds-alert>
         </cds-alert-group>
-      `;
+      `);
 
-      await waitForComponent('cds-alert');
       alertGroup = testElement.querySelector<CdsAlertGroup>('#default');
       compactAlertGroup = testElement.querySelector<CdsAlertGroup>('#small');
     });
@@ -107,8 +101,7 @@ describe('Alert groups – ', () => {
     let lightAlertGroup: CdsAlertGroup;
 
     beforeEach(async () => {
-      testElement = createTestElement();
-      testElement.innerHTML = `
+      testElement = await createTestElement(html`
         <cds-alert-group id="default">
           <cds-alert>${placeholderText}</cds-alert>
           <cds-alert>${placeholderText}</cds-alert>
@@ -117,9 +110,8 @@ describe('Alert groups – ', () => {
           <cds-alert>${placeholderText}</cds-alert>
           <cds-alert>${placeholderText}</cds-alert>
         </cds-alert-group>
-      `;
+      `);
 
-      await waitForComponent('cds-alert');
       alertGroup = testElement.querySelector<CdsAlertGroup>('#default');
       lightAlertGroup = testElement.querySelector<CdsAlertGroup>('#light');
     });
@@ -176,16 +168,15 @@ describe('Alert groups – ', () => {
     let bannerAlertGroupWithNoStatus: CdsAlertGroup;
 
     beforeEach(async () => {
-      testElement = createTestElement();
-      testElement.innerHTML = `
+      testElement = await createTestElement(html`
         <cds-alert-group type="banner" id="bannerAlertGroup" status="warning">
           <cds-alert>${placeholderText}</cds-alert>
         </cds-alert-group>
         <cds-alert-group type="banner" id="bannerAlertGroupNoStatus">
           <cds-alert id="statusless">${placeholderText}</cds-alert>
         </cds-alert-group>
-      `;
-      await waitForComponent('cds-alert');
+      `);
+
       bannerAlertGroup = testElement.querySelector('#bannerAlertGroup');
       bannerAlertGroupWithNoStatus = testElement.querySelector('#bannerAlertGroupNoStatus');
     });
@@ -214,16 +205,14 @@ describe('Alert groups – ', () => {
     let loadingAlert: CdsAlert;
 
     beforeEach(async () => {
-      testElement = createTestElement();
-      testElement.innerHTML = `
+      testElement = await createTestElement(html`
         <cds-alert-group>
           <cds-alert id="defaultAlert">${placeholderText}</cds-alert>
           <cds-alert id="customAlert" status="warning"><cds-icon shape="ohai"></cds-icon>${placeholderText}</cds-alert>
           <cds-alert id="loadingAlert" status="loading">${placeholderText}</cds-alert>
         </cds-alert-group>
-      `;
+      `);
 
-      await waitForComponent('cds-alert');
       alertGroup = testElement.querySelector<CdsAlertGroup>('cds-alert-group');
       defaultAlert = alertGroup.querySelector('#defaultAlert');
       customAlert = alertGroup.querySelector('#customAlert');
@@ -294,8 +283,7 @@ describe('Alert groups – ', () => {
     let pager: HTMLElement;
 
     beforeEach(async () => {
-      testElement = createTestElement();
-      testElement.innerHTML = `
+      testElement = await createTestElement(html`
         <cds-alert-group id="noPager" type="banner">
           <cds-alert>${placeholderText}</cds-alert>
         </cds-alert-group>
@@ -303,9 +291,8 @@ describe('Alert groups – ', () => {
           <div id="pager" class="pager">Pager Here</div>
           <cds-alert>${placeholderText}</cds-alert>
         </cds-alert-group>
-      `;
+      `);
 
-      await waitForComponent('cds-alert');
       alertGroup = testElement.querySelector<CdsAlertGroup>('#noPager');
       alertGroupWithPager = testElement.querySelector<CdsAlertGroup>('#hasPager');
       pager = testElement.querySelector<HTMLElement>('#pager');

--- a/packages/core/src/alert/alert.element.spec.ts
+++ b/packages/core/src/alert/alert.element.spec.ts
@@ -3,18 +3,14 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
+
+import { html } from 'lit-html';
 import '@clr/core/alert/register.js';
 import '@clr/core/icon/register.js';
 import { CdsAlert, getIconStatusTuple, iconShapeIsAlertStatusType, iconTitleIsAlertStatusLabel } from '@clr/core/alert';
 import { CdsIcon, infoStandardIcon } from '@clr/core/icon';
 import { CommonStringsService } from '@clr/core/internal';
-import {
-  componentIsStable,
-  createTestElement,
-  getComponentSlotContent,
-  removeTestElement,
-  waitForComponent,
-} from '@clr/core/test/utils';
+import { componentIsStable, createTestElement, getComponentSlotContent, removeTestElement } from '@clr/core/test/utils';
 import { CdsInternalCloseButton } from '@clr/core/internal-components/close-button';
 
 describe('Alert element – ', () => {
@@ -25,12 +21,7 @@ describe('Alert element – ', () => {
 
   describe('Lightweight alerts: ', () => {
     beforeEach(async () => {
-      testElement = createTestElement();
-      testElement.innerHTML = `
-        <cds-alert>${placeholderText}</cds-alert>
-      `;
-
-      await waitForComponent('cds-alert');
+      testElement = await createTestElement(html`<cds-alert>${placeholderText}</cds-alert>`);
       component = testElement.querySelector<CdsAlert>('cds-alert');
     });
 
@@ -62,13 +53,11 @@ describe('Alert element – ', () => {
     let customComponent: CdsAlert;
 
     beforeEach(async () => {
-      testElement = createTestElement();
-      testElement.innerHTML = `
+      testElement = await createTestElement(html`
         <cds-alert id="defaultAlert">${placeholderText}</cds-alert>
         <cds-alert id="customAlert"><cds-icon shape="ohai"></cds-icon>${placeholderText}</cds-alert>
-      `;
+      `);
 
-      await waitForComponent('cds-alert');
       component = testElement.querySelector<CdsAlert>('#defaultAlert');
       customComponent = testElement.querySelector<CdsAlert>('#customAlert');
     });
@@ -133,13 +122,10 @@ describe('Alert element – ', () => {
     let customComponent: CdsAlert;
 
     beforeEach(async () => {
-      testElement = createTestElement();
-      testElement.innerHTML = `
+      testElement = await createTestElement(html`
         <cds-alert id="defaultAlert">${placeholderText}</cds-alert>
         <cds-alert id="customAlert"><cds-icon shape="ohai"></cds-icon>${placeholderText}</cds-alert>
-      `;
-
-      await waitForComponent('cds-alert');
+      `);
       component = testElement.querySelector<CdsAlert>('#defaultAlert');
       customComponent = testElement.querySelector<CdsAlert>('#customAlert');
     });
@@ -202,15 +188,13 @@ describe('Alert element – ', () => {
     const placeholderActionsText = 'This is where action elements go.';
 
     beforeEach(async () => {
-      testElement = createTestElement();
-      testElement.innerHTML = `
+      testElement = await createTestElement(html`
         <cds-alert alert-group-type="default">
           ${placeholderText}
           <cds-alert-actions>${placeholderActionsText}</cds-alert-actions>
         </cds-alert>
-      `;
+      `);
 
-      await waitForComponent('cds-alert');
       component = testElement.querySelector<CdsAlert>('cds-alert');
     });
 
@@ -229,7 +213,7 @@ describe('Alert element – ', () => {
       await componentIsStable(component);
       const slots = getComponentSlotContent(component);
       expect(slots.actions.trim()).toBe(
-        `<cds-alert-actions slot="actions" type="default">${placeholderActionsText}</cds-alert-actions>`
+        `<cds-alert-actions slot="actions" type="default"><!---->${placeholderActionsText}<!----></cds-alert-actions>`
       );
     });
   });
@@ -240,12 +224,9 @@ describe('Alert element – ', () => {
     const placeholderText = 'I am a default alert with no attributes.';
 
     beforeEach(async () => {
-      testElement = createTestElement();
-      testElement.innerHTML = `
-        <cds-alert-group type="banner"><cds-alert closable>${placeholderText}</cds-alert></cds-alert-group>
-      `;
-
-      await waitForComponent('cds-alert');
+      testElement = await createTestElement(
+        html`<cds-alert-group type="banner"><cds-alert closable>${placeholderText}</cds-alert></cds-alert-group>`
+      );
       component = testElement.querySelector<CdsAlert>('cds-alert');
     });
 
@@ -293,15 +274,13 @@ describe('Alert element – ', () => {
       component.shadowRoot.querySelector<CdsInternalCloseButton>('cds-internal-close-button');
 
     beforeEach(async () => {
-      testElement = createTestElement();
-      testElement.innerHTML = `
+      testElement = await createTestElement(html`
         <cds-alert alert-group-type="default">
           ${placeholderText}
           <cds-alert-actions>${placeholderActionsText}</cds-alert-actions>
         </cds-alert>
-      `;
+      `);
 
-      await waitForComponent('cds-alert');
       component = testElement.querySelector<CdsAlert>('cds-alert');
     });
 
@@ -364,13 +343,10 @@ describe('Alert element – ', () => {
   });
 
   describe('Aria: ', () => {
-    beforeEach(async () => {
-      testElement = createTestElement();
-      testElement.innerHTML = `
-        <cds-alert>${placeholderText}</cds-alert>
-      `;
+    let testElement: HTMLElement;
 
-      await waitForComponent('cds-alert');
+    beforeEach(async () => {
+      testElement = await createTestElement(html`<cds-alert>${placeholderText}</cds-alert>`);
       component = testElement.querySelector<CdsAlert>('cds-alert');
     });
 

--- a/packages/core/src/badge/badge.element.spec.ts
+++ b/packages/core/src/badge/badge.element.spec.ts
@@ -3,9 +3,10 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
+import { html } from 'lit-html';
 import '@clr/core/badge/register.js';
 import { CdsBadge } from '@clr/core/badge';
-import { componentIsStable, createTestElement, removeTestElement, waitForComponent } from '@clr/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@clr/core/test/utils';
 
 describe('badge element', () => {
   let testElement: HTMLElement;
@@ -13,10 +14,7 @@ describe('badge element', () => {
   const placeholderText = 'Badge Placeholder';
 
   beforeEach(async () => {
-    testElement = createTestElement();
-    testElement.innerHTML = `<cds-badge>${placeholderText}</cds-badge>`;
-
-    await waitForComponent('cds-badge');
+    testElement = await createTestElement(html`<cds-badge>${placeholderText}</cds-badge>`);
     component = testElement.querySelector<CdsBadge>('cds-badge');
   });
 

--- a/packages/core/src/button/button.element.spec.ts
+++ b/packages/core/src/button/button.element.spec.ts
@@ -3,16 +3,12 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
+
+import { html } from 'lit-html';
 import { CdsButton, ClrLoadingState } from '@clr/core/button';
 import '@clr/core/badge/register.js';
 import '@clr/core/button/register.js';
-import {
-  componentIsStable,
-  createTestElement,
-  getComponentSlotContent,
-  removeTestElement,
-  waitForComponent,
-} from '@clr/core/test/utils';
+import { componentIsStable, createTestElement, getComponentSlotContent, removeTestElement } from '@clr/core/test/utils';
 
 describe('button element', () => {
   let testElement: HTMLElement;
@@ -20,16 +16,14 @@ describe('button element', () => {
   const placeholderText = 'Button Placeholder';
 
   beforeEach(async () => {
-    testElement = createTestElement();
-    testElement.innerHTML = `
+    testElement = await createTestElement(html`
       <form>
         <cds-button>
           <span>${placeholderText}</span>
         </cds-button>
       </form>
-    `;
+    `);
 
-    await waitForComponent('cds-button');
     component = testElement.querySelector<CdsButton>('cds-button');
   });
 
@@ -205,13 +199,13 @@ describe('button element', () => {
     let anchorButton: HTMLAnchorElement;
 
     beforeEach(async () => {
-      testLinkElement = createTestElement();
-      testLinkElement.innerHTML = `
-        <cds-button><a href="about">About</a></cds-button> <!-- deprecated 4.0 in favor of wrapping -->
+      testLinkElement = await createTestElement(html`
+        <cds-button><a href="about">About</a></cds-button>
+        <!-- deprecated 4.0 in favor of wrapping -->
         <cds-button>About</cds-button>
         <a href="about"><cds-button>About</cds-button></a>
-      `;
-      await waitForComponent('cds-button');
+      `);
+
       componentLink = testLinkElement.querySelectorAll<CdsButton>('cds-button')[0];
       componentButton = testLinkElement.querySelectorAll<CdsButton>('cds-button')[1];
       anchor = componentLink.querySelector<HTMLAnchorElement>('a');
@@ -239,11 +233,11 @@ describe('button element', () => {
 
     it('should apply host focus styles when link is in focus', async () => {
       anchor.dispatchEvent(new Event('focusin'));
-      await waitForComponent('cds-button');
+      await componentIsStable(componentLink);
       expect(componentLink.getAttribute('focused')).toBe('');
 
       anchor.dispatchEvent(new Event('focusout'));
-      await waitForComponent('cds-button');
+      await componentIsStable(componentLink);
       expect(componentLink.getAttribute('focused')).toBe(null);
     });
 
@@ -277,8 +271,8 @@ describe('button element', () => {
 describe('buttonSlots: ', () => {
   let elem: HTMLElement;
 
-  beforeEach(() => {
-    elem = createTestElement();
+  beforeEach(async () => {
+    elem = await createTestElement(html`<cds-button>Text slot</cds-button>`);
   });
 
   afterEach(() => {
@@ -286,8 +280,6 @@ describe('buttonSlots: ', () => {
   });
 
   it('should project content into the slot', async () => {
-    elem.innerHTML = `<cds-button>Text slot</cds-button>`;
-    await waitForComponent('cds-button');
     const component = elem.querySelector<CdsButton>('cds-button');
     const slots = getComponentSlotContent(component);
     expect(slots.default).toContain('Text slot');

--- a/packages/core/src/button/icon-button.element.spec.ts
+++ b/packages/core/src/button/icon-button.element.spec.ts
@@ -3,25 +3,25 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
+
+import { html } from 'lit-html';
 import '@clr/core/button/register.js';
 import '@clr/core/icon/register.js';
 import { CdsIcon } from '@clr/core/icon';
 import { CdsIconButton, ClrLoadingState } from '@clr/core/button';
-import { componentIsStable, createTestElement, removeTestElement, waitForComponent } from '@clr/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@clr/core/test/utils';
 
 describe('Icon button element – ', () => {
   let testElement: HTMLElement;
   let component: CdsIconButton;
 
   beforeEach(async () => {
-    testElement = createTestElement();
-    testElement.innerHTML = `
+    testElement = await createTestElement(html`
       <form>
         <cds-icon-button><cds-icon></cds-icon></cds-icon-button>
       </form>
-    `;
+    `);
 
-    await waitForComponent('cds-icon-button');
     component = testElement.querySelector<CdsIconButton>('cds-icon-button');
   });
 
@@ -99,14 +99,14 @@ describe('Anchor Tags in Buttons: ', () => {
   let icon: CdsIcon;
 
   beforeEach(async () => {
-    testElement = createTestElement();
-    testElement.innerHTML = `
+    testElement = await createTestElement(html`
       <form>
-        <cds-icon-button><a href="javascript:void(0)"><cds-icon></cds-icon></a></cds-icon-button>
+        <cds-icon-button
+          ><a href="javascript:void(0)"><cds-icon></cds-icon></a
+        ></cds-icon-button>
       </form>
-    `;
+    `);
 
-    await waitForComponent('cds-icon-button');
     component = testElement.querySelector<CdsIconButton>('cds-icon-button');
     anchor = component.querySelector('a');
     icon = component.querySelector('cds-icon');

--- a/packages/core/src/button/inline-button.element.spec.ts
+++ b/packages/core/src/button/inline-button.element.spec.ts
@@ -3,11 +3,13 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
+
+import { html } from 'lit-html';
 import '@clr/core/button/register.js';
 import '@clr/core/icon/register.js';
 import { CdsInlineButton } from '@clr/core/button';
 import { CdsIcon } from '@clr/core/icon';
-import { componentIsStable, createTestElement, removeTestElement, waitForComponent } from '@clr/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@clr/core/test/utils';
 
 describe('Inline button element', () => {
   let testElement: HTMLElement;
@@ -15,14 +17,11 @@ describe('Inline button element', () => {
   const placeholderText = 'ohai';
 
   beforeEach(async () => {
-    testElement = createTestElement();
-    testElement.innerHTML = `
+    testElement = await createTestElement(html`
       <form>
         <cds-inline-button>${placeholderText}</cds-inline-button>
       </form>
-    `;
-
-    await waitForComponent('cds-inline-button');
+    `);
     component = testElement.querySelector<CdsInlineButton>('cds-inline-button');
   });
 
@@ -38,14 +37,12 @@ describe('Inline button element', () => {
 
 describe('Inline button element with icon', () => {
   it('add the anchored-icon classname to icons', async () => {
-    const testElement = createTestElement();
-    testElement.innerHTML = `
+    const testElement = await createTestElement(html`
       <form>
         <cds-inline-button><cds-icon shape="go-niners"></cds-icon>kthxbye</cds-inline-button>
       </form>
-    `;
+    `);
 
-    await waitForComponent('cds-inline-button');
     const component = testElement.querySelector<CdsInlineButton>('cds-inline-button');
     const icon = component.querySelector<CdsIcon>('cds-icon');
 

--- a/packages/core/src/checkbox/checkbox-group.element.spec.ts
+++ b/packages/core/src/checkbox/checkbox-group.element.spec.ts
@@ -4,8 +4,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { render, html } from 'lit-html';
-import { createTestElement, waitForComponent, removeTestElement, componentIsStable } from '@clr/core/test/utils';
+import { html } from 'lit-html';
+import { createTestElement, removeTestElement, componentIsStable } from '@clr/core/test/utils';
 import { CdsCheckboxGroup } from '@clr/core/checkbox';
 import '@clr/core/checkbox/register.js';
 
@@ -14,9 +14,8 @@ describe('cds-checkbox-group', () => {
   let element: HTMLElement;
 
   beforeEach(async () => {
-    element = createTestElement();
-    render(
-      html` <cds-checkbox-group>
+    element = await createTestElement(html`
+      <cds-checkbox-group>
         <label>checkbox group</label>
         <cds-checkbox>
           <label>checkbox 1</label>
@@ -27,11 +26,8 @@ describe('cds-checkbox-group', () => {
           <input type="checkbox" />
         </cds-checkbox>
         <cds-control-message>message text</cds-control-message>
-      </cds-checkbox-group>`,
-      element
-    );
-
-    await waitForComponent('cds-checkbox-group');
+      </cds-checkbox-group>
+    `);
 
     component = element.querySelector<CdsCheckboxGroup>('cds-checkbox-group');
   });

--- a/packages/core/src/checkbox/checkbox.element.spec.ts
+++ b/packages/core/src/checkbox/checkbox.element.spec.ts
@@ -4,8 +4,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { render, html } from 'lit-html';
-import { createTestElement, waitForComponent, removeTestElement, componentIsStable } from '@clr/core/test/utils';
+import { html } from 'lit-html';
+import { createTestElement, removeTestElement, componentIsStable } from '@clr/core/test/utils';
 import { CdsCheckbox } from '@clr/core/checkbox';
 import '@clr/core/checkbox/register.js';
 
@@ -14,17 +14,13 @@ describe('cds-checkbox', () => {
   let element: HTMLElement;
 
   beforeEach(async () => {
-    element = createTestElement();
-    render(
-      html` <cds-checkbox>
+    element = await createTestElement(html`
+      <cds-checkbox>
         <label>checkbox</label>
         <input type="checkbox" />
         <cds-control-message>message text</cds-control-message>
-      </cds-checkbox>`,
-      element
-    );
-
-    await waitForComponent('cds-checkbox');
+      </cds-checkbox>
+    `);
 
     component = element.querySelector<CdsCheckbox>('cds-checkbox');
   });

--- a/packages/core/src/datalist/datalist.element.spec.ts
+++ b/packages/core/src/datalist/datalist.element.spec.ts
@@ -4,8 +4,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { render, html } from 'lit-html';
-import { createTestElement, waitForComponent, removeTestElement, componentIsStable } from '@clr/core/test/utils';
+import { html } from 'lit-html';
+import { createTestElement, removeTestElement, componentIsStable } from '@clr/core/test/utils';
 import { CdsDatalist } from '@clr/core/datalist';
 import '@clr/core/datalist/register.js';
 
@@ -14,9 +14,8 @@ describe('cds-datalist', () => {
   let element: HTMLElement;
 
   beforeEach(async () => {
-    element = createTestElement();
-    render(
-      html` <cds-datalist>
+    element = await createTestElement(html`
+      <cds-datalist>
         <cds-datalist>
           <label>datalist</label>
           <input type="text" />
@@ -27,11 +26,8 @@ describe('cds-datalist', () => {
           </datalist>
           <cds-control-message>message text</cds-control-message>
         </cds-datalist>
-      </cds-datalist>`,
-      element
-    );
-
-    await waitForComponent('cds-datalist');
+      </cds-datalist>
+    `);
 
     component = element.querySelector<CdsDatalist>('cds-datalist');
   });

--- a/packages/core/src/date/date.element.spec.ts
+++ b/packages/core/src/date/date.element.spec.ts
@@ -4,8 +4,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { render, html } from 'lit-html';
-import { createTestElement, waitForComponent, removeTestElement, componentIsStable } from '@clr/core/test/utils';
+import { html } from 'lit-html';
+import { createTestElement, removeTestElement, componentIsStable } from '@clr/core/test/utils';
 import { CdsDate } from '@clr/core/date';
 import '@clr/core/date/register.js';
 
@@ -14,17 +14,13 @@ describe('cds-date', () => {
   let element: HTMLElement;
 
   beforeEach(async () => {
-    element = createTestElement();
-    render(
-      html` <cds-date>
+    element = await createTestElement(html`
+      <cds-date>
         <label>date</label>
         <input type="date" />
         <cds-control-message>message text</cds-control-message>
-      </cds-date>`,
-      element
-    );
-
-    await waitForComponent('cds-date');
+      </cds-date>
+    `);
 
     component = element.querySelector<CdsDate>('cds-date');
   });

--- a/packages/core/src/file/file.element.spec.ts
+++ b/packages/core/src/file/file.element.spec.ts
@@ -4,7 +4,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { createTestElement, waitForComponent, removeTestElement, componentIsStable } from '@clr/core/test/utils';
+import { html } from 'lit-html';
+import { createTestElement, removeTestElement, componentIsStable } from '@clr/core/test/utils';
 import { CdsButton } from '@clr/core/button';
 import { CdsFile } from '@clr/core/file';
 import '@clr/core/file/register.js';
@@ -15,16 +16,14 @@ describe('cds-file', () => {
   let element: HTMLElement;
 
   beforeEach(async () => {
-    element = createTestElement();
-    element.innerHTML = `
+    element = await createTestElement(html`
       <cds-file>
         <label>file</label>
         <input type="file" />
         <cds-control-message>message text</cds-control-message>
       </cds-file>
-    `;
+    `);
 
-    await waitForComponent('cds-file');
     component = element.querySelector<CdsFile>('cds-file');
     button = component.shadowRoot.querySelector('cds-button');
   });

--- a/packages/core/src/forms/control-action/control-action.element.spec.ts
+++ b/packages/core/src/forms/control-action/control-action.element.spec.ts
@@ -4,9 +4,9 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { render, html } from 'lit-html';
+import { html } from 'lit-html';
 import { CdsControlAction } from '@clr/core/forms';
-import { createTestElement, waitForComponent, removeTestElement, componentIsStable } from '@clr/core/test/utils';
+import { createTestElement, removeTestElement, componentIsStable } from '@clr/core/test/utils';
 import { LogService } from '@clr/core/internal';
 
 describe('cds-control-action', () => {
@@ -14,11 +14,7 @@ describe('cds-control-action', () => {
   let element: HTMLElement;
 
   beforeEach(async () => {
-    element = createTestElement();
-    render(html` <cds-control-action>test</cds-control-action> `, element);
-
-    await waitForComponent('cds-control-action');
-
+    element = await createTestElement(html` <cds-control-action>test</cds-control-action>`);
     controlAction = element.querySelector<CdsControlAction>('cds-control-action');
   });
 

--- a/packages/core/src/forms/control-group/control-group.element.spec.ts
+++ b/packages/core/src/forms/control-group/control-group.element.spec.ts
@@ -4,8 +4,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { render, html } from 'lit-html';
-import { removeTestElement, waitForComponent, createTestElement, componentIsStable } from '@clr/core/test/utils';
+import { html } from 'lit-html';
+import { removeTestElement, createTestElement, componentIsStable } from '@clr/core/test/utils';
 import { CdsControl, CdsInternalControlGroup } from '@clr/core/forms';
 import '@clr/core/forms/register.js';
 import { CdsControlMessage } from '../control-message/control-message.element';
@@ -18,29 +18,21 @@ let message: CdsControlMessage;
 
 describe('cds-internal-control-group', () => {
   beforeEach(async () => {
-    element = createTestElement();
-    render(
-      html`
-        <cds-internal-control-group>
-          <label>control group</label>
-          <cds-control>
-            <label>control</label>
-            <input type="text" />
-          </cds-control>
+    element = await createTestElement(html`
+      <cds-internal-control-group>
+        <label>control group</label>
+        <cds-control>
+          <label>control</label>
+          <input type="text" />
+        </cds-control>
 
-          <cds-control>
-            <label>control</label>
-            <input type="text" />
-          </cds-control>
-          <cds-control-message>message text</cds-control-message>
-        </cds-internal-control-group>
-      `,
-      element
-    );
-
-    await waitForComponent('cds-internal-control-group');
-    await waitForComponent('cds-control');
-    await waitForComponent('cds-control-message');
+        <cds-control>
+          <label>control</label>
+          <input type="text" />
+        </cds-control>
+        <cds-control-message>message text</cds-control-message>
+      </cds-internal-control-group>
+    `);
 
     controlGroup = element.querySelector<CdsInternalControlGroup>('cds-internal-control-group');
     controls = Array.from(element.querySelectorAll<CdsControl>('cds-control'));
@@ -87,6 +79,7 @@ describe('cds-internal-control-group', () => {
   });
 
   it('should apply status to all child controls', async () => {
+    await componentIsStable(controlGroup);
     expect(controlGroup.status).toBe('neutral');
     expect(controls[0].status).toBe('neutral');
     expect(controls[1].status).toBe('neutral');

--- a/packages/core/src/forms/control-inline/control-inline.element.spec.ts
+++ b/packages/core/src/forms/control-inline/control-inline.element.spec.ts
@@ -4,8 +4,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { render, html } from 'lit-html';
-import { removeTestElement, waitForComponent, createTestElement, componentIsStable } from '@clr/core/test/utils';
+import { html } from 'lit-html';
+import { removeTestElement, createTestElement, componentIsStable } from '@clr/core/test/utils';
 import { CdsInternalControlInline } from '@clr/core/forms';
 import '@clr/core/forms/register.js';
 
@@ -15,18 +15,13 @@ let input: HTMLInputElement;
 
 describe('cds-internal-control-inline', () => {
   beforeEach(async () => {
-    element = createTestElement();
-    render(
-      html`
-        <cds-internal-control-inline>
-          <label>control</label>
-          <input type="checkbox" />
-        </cds-internal-control-inline>
-      `,
-      element
-    );
+    element = await createTestElement(html`
+      <cds-internal-control-inline>
+        <label>control</label>
+        <input type="checkbox" />
+      </cds-internal-control-inline>
+    `);
 
-    await waitForComponent('cds-internal-control-inline');
     control = element.querySelector<CdsInternalControlInline>('cds-internal-control-inline');
     input = element.querySelector<HTMLInputElement>('input');
   });

--- a/packages/core/src/forms/control-label/control-label.element.spec.ts
+++ b/packages/core/src/forms/control-label/control-label.element.spec.ts
@@ -3,9 +3,11 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
+
+import { html } from 'lit-html';
 import { CdsInternalControlLabel } from '@clr/core/forms';
 import '@clr/core/forms/register.js';
-import { componentIsStable, createTestElement, removeTestElement, waitForComponent } from '@clr/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@clr/core/test/utils';
 
 describe('cds-internal-control-label element', () => {
   let testElement: HTMLElement;
@@ -13,10 +15,9 @@ describe('cds-internal-control-label element', () => {
   const placeholderText = 'Label';
 
   beforeEach(async () => {
-    testElement = createTestElement();
-    testElement.innerHTML = `<cds-internal-control-label>${placeholderText}</cds-internal-control-label>`;
-
-    await waitForComponent('cds-internal-control-label');
+    testElement = await createTestElement(
+      html`<cds-internal-control-label>${placeholderText}</cds-internal-control-label>`
+    );
     component = testElement.querySelector<CdsInternalControlLabel>('cds-internal-control-label');
   });
 

--- a/packages/core/src/forms/control-message/control-message.element.spec.ts
+++ b/packages/core/src/forms/control-message/control-message.element.spec.ts
@@ -4,9 +4,10 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
+import { html } from 'lit-html';
 import '@clr/core/forms/register.js';
 import { CdsControlMessage } from '@clr/core/forms';
-import { componentIsStable, createTestElement, removeTestElement, waitForComponent } from '@clr/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@clr/core/test/utils';
 
 describe('cds-control-message element', () => {
   let testElement: HTMLElement;
@@ -14,10 +15,7 @@ describe('cds-control-message element', () => {
   const placeholderText = 'message';
 
   beforeEach(async () => {
-    testElement = createTestElement();
-    testElement.innerHTML = `<cds-control-message>${placeholderText}</cds-control-message>`;
-
-    await waitForComponent('cds-control-message');
+    testElement = await createTestElement(html`<cds-control-message>${placeholderText}</cds-control-message>`);
     component = testElement.querySelector<CdsControlMessage>('cds-control-message');
   });
 

--- a/packages/core/src/forms/control/control.element.spec.ts
+++ b/packages/core/src/forms/control/control.element.spec.ts
@@ -4,8 +4,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { render, html } from 'lit-html';
-import { removeTestElement, waitForComponent, createTestElement, componentIsStable } from '@clr/core/test/utils';
+import { html } from 'lit-html';
+import { removeTestElement, createTestElement, componentIsStable } from '@clr/core/test/utils';
 import { CdsIcon } from '@clr/core/icon';
 import { CdsControl } from '@clr/core/forms';
 import '@clr/core/forms/register.js';
@@ -22,24 +22,18 @@ describe('cds-control', () => {
   const getStatusIcon = () => control.shadowRoot.querySelector<CdsIcon>('cds-icon');
 
   beforeEach(async () => {
-    element = createTestElement();
-    render(
-      html`
-        <cds-control validate>
-          <label>control</label>
-          <input type="text" require />
-          <datalist>
-            <option value="item 1"></option>
-            <option value="item 2"></option>
-            <option value="item 3"></option>
-          </datalist>
-          <cds-control-message error="valueMissing">message text</cds-control-message>
-        </cds-control>
-      `,
-      element
-    );
-
-    await waitForComponent('cds-control');
+    element = await createTestElement(html`
+      <cds-control validate>
+        <label>control</label>
+        <input type="text" require />
+        <datalist>
+          <option value="item 1"></option>
+          <option value="item 2"></option>
+          <option value="item 3"></option>
+        </datalist>
+        <cds-control-message error="valueMissing">message text</cds-control-message>
+      </cds-control>
+    `);
 
     control = element.querySelector<CdsControl>('cds-control');
     label = element.querySelector<HTMLLabelElement>('label');
@@ -163,21 +157,16 @@ describe('cds-control validation', () => {
   let message: CdsControlMessage;
 
   beforeEach(async () => {
-    element = createTestElement();
-    render(
-      html`
-        <form novalidate>
-          <cds-control validate>
-            <label>control</label>
-            <input type="text" require />
-            <cds-control-message error="valueMissing">message text</cds-control-message>
-          </cds-control>
-        </form>
-      `,
-      element
-    );
+    element = await createTestElement(html`
+      <form novalidate>
+        <cds-control validate>
+          <label>control</label>
+          <input type="text" require />
+          <cds-control-message error="valueMissing">message text</cds-control-message>
+        </cds-control>
+      </form>
+    `);
 
-    await waitForComponent('cds-control');
     message = element.querySelector<CdsControlMessage>('cds-control-message');
   });
 
@@ -195,19 +184,13 @@ describe('cds-control responsive', () => {
   let control: CdsControl;
 
   beforeEach(async () => {
-    element = createTestElement();
-    render(
-      html`
-        <cds-control layout="compact">
-          <label>control</label>
-          <input type="text" />
-          <cds-control-message>message text</cds-control-message>
-        </cds-control>
-      `,
-      element
-    );
-
-    await waitForComponent('cds-control');
+    element = await createTestElement(html`
+      <cds-control layout="compact">
+        <label>control</label>
+        <input type="text" />
+        <cds-control-message>message text</cds-control-message>
+      </cds-control>
+    `);
 
     control = element.querySelector<CdsControl>('cds-control');
   });

--- a/packages/core/src/forms/form-group/form-group.element.spec.ts
+++ b/packages/core/src/forms/form-group/form-group.element.spec.ts
@@ -4,8 +4,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { render, html } from 'lit-html';
-import { removeTestElement, waitForComponent, createTestElement, componentIsStable } from '@clr/core/test/utils';
+import { html } from 'lit-html';
+import { removeTestElement, createTestElement, componentIsStable } from '@clr/core/test/utils';
 import { CdsControl } from '@clr/core/forms';
 import '@clr/core/forms/register.js';
 import { CdsFormGroup } from './form-group.element';
@@ -16,26 +16,19 @@ let controls: CdsControl[];
 
 describe('cds-form-group', () => {
   beforeEach(async () => {
-    element = createTestElement();
-    render(
-      html`
-        <cds-form-group layout="horizontal">
-          <cds-control>
-            <label style="width: 200px">control</label>
-            <input type="text" />
-          </cds-control>
+    element = await createTestElement(html`
+      <cds-form-group layout="horizontal">
+        <cds-control>
+          <label style="width: 200px">control</label>
+          <input type="text" />
+        </cds-control>
 
-          <cds-control>
-            <label>control</label>
-            <input type="text" />
-          </cds-control>
-        </cds-form-group>
-      `,
-      element
-    );
-
-    await waitForComponent('cds-form-group');
-    await waitForComponent('cds-control');
+        <cds-control>
+          <label>control</label>
+          <input type="text" />
+        </cds-control>
+      </cds-form-group>
+    `);
 
     formGroup = element.querySelector<CdsFormGroup>('cds-form-group');
     controls = Array.from(element.querySelectorAll<CdsControl>('cds-control'));

--- a/packages/core/src/forms/utils/index.spec.ts
+++ b/packages/core/src/forms/utils/index.spec.ts
@@ -9,9 +9,9 @@ import { createTestElement, removeTestElement } from '@clr/core/test/utils';
 import { associateInputAndLabel, associateInputToDatalist, getStatusIcon, isVerticalLayout } from './index.js';
 
 describe('form internal utilities', () => {
-  it('associateInputAndLabel', () => {
-    const input = createTestElement() as HTMLInputElement;
-    const label = createTestElement() as HTMLLabelElement;
+  it('associateInputAndLabel', async () => {
+    const input = (await createTestElement()) as HTMLInputElement;
+    const label = (await createTestElement()) as HTMLLabelElement;
     associateInputAndLabel(input, label, 'test-id');
 
     expect(input.id).toBe('test-id');
@@ -20,9 +20,9 @@ describe('form internal utilities', () => {
     removeTestElement(label);
   });
 
-  it('associateInputToDatalist', () => {
-    const input = createTestElement() as HTMLInputElement;
-    const datalist = createTestElement() as HTMLDataListElement;
+  it('associateInputToDatalist', async () => {
+    const input = (await createTestElement()) as HTMLInputElement;
+    const datalist = (await createTestElement()) as HTMLDataListElement;
     input.id = 'test-id';
 
     associateInputToDatalist(input, datalist);
@@ -33,9 +33,8 @@ describe('form internal utilities', () => {
     removeTestElement(datalist);
   });
 
-  it('getStatusIcon', () => {
-    const element = createTestElement() as HTMLInputElement;
-    render(html`${getStatusIcon('neutral')}`, element);
+  it('getStatusIcon', async () => {
+    const element = (await createTestElement(html`${getStatusIcon('neutral')}`)) as HTMLInputElement;
     expect(element.querySelector('cds-control-action')).toBe(null);
 
     render(html`${getStatusIcon('error')}`, element);

--- a/packages/core/src/forms/utils/index.ts
+++ b/packages/core/src/forms/utils/index.ts
@@ -44,7 +44,7 @@ export function getStatusIcon(status: 'error' | 'success' | 'neutral') {
           status="${status === 'error' ? 'danger' : 'success'}"
           shape="${status === 'error' ? 'exclamation-circle' : 'check-circle'}"
           size="16"
-          .innerOffset=${4}
+          inner-offset=${4}
         ></cds-icon>
       </cds-control-action>`
     : ''} `;

--- a/packages/core/src/forms/utils/validate.spec.ts
+++ b/packages/core/src/forms/utils/validate.spec.ts
@@ -4,8 +4,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { render, html } from 'lit-html';
-import { createTestElement, removeTestElement, waitForComponent, componentIsStable } from '@clr/core/test/utils';
+import { html } from 'lit-html';
+import { createTestElement, removeTestElement, componentIsStable } from '@clr/core/test/utils';
 import { CdsControlMessage } from '@clr/core/forms';
 import { CdsInput } from '@clr/core/input';
 import '@clr/core/input/register.js';
@@ -17,19 +17,13 @@ let controlMessage: CdsControlMessage;
 
 describe('syncHTML5Validation', () => {
   beforeEach(async () => {
-    element = createTestElement();
-    render(
-      html`
-        <cds-input validate>
-          <label>input</label>
-          <input type="text" required />
-          <cds-control-message error="valueMissing">required</cds-control-message>
-        </cds-input>
-      `,
-      element
-    );
-
-    await waitForComponent('cds-alert');
+    element = await createTestElement(html`
+      <cds-input validate>
+        <label>input</label>
+        <input type="text" required />
+        <cds-control-message error="valueMissing">required</cds-control-message>
+      </cds-input>
+    `);
 
     control = element.querySelector<CdsInput>('cds-input');
     controlMessage = element.querySelector<CdsControlMessage>('cds-control-message');

--- a/packages/core/src/icon/icon.element.spec.ts
+++ b/packages/core/src/icon/icon.element.spec.ts
@@ -3,9 +3,11 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
+
+import { html } from 'lit-html';
 import '@clr/core/icon/register.js';
 import { CdsIcon } from '@clr/core/icon';
-import { componentIsStable, createTestElement, removeTestElement, waitForComponent } from '@clr/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@clr/core/test/utils';
 import { renderIcon } from './icon.renderer.js';
 import { ClarityIcons } from './icon.service.js';
 
@@ -20,12 +22,7 @@ describe('icon element', () => {
   });
 
   beforeEach(async () => {
-    testElement = createTestElement();
-    testElement.innerHTML = `
-      <cds-icon></cds-icon>
-    `;
-
-    await waitForComponent('cds-icon');
+    testElement = await createTestElement(html`<cds-icon></cds-icon>`);
     component = testElement.querySelector<CdsIcon>('cds-icon');
   });
 

--- a/packages/core/src/icon/utils/icon.classnames.spec.ts
+++ b/packages/core/src/icon/utils/icon.classnames.spec.ts
@@ -4,10 +4,11 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
+import { html } from 'lit-html';
 import '@clr/core/icon/register.js';
 import { CdsIcon } from '@clr/core/icon';
 import { getEnumValues } from '@clr/core/internal';
-import { componentIsStable, createTestElement, removeTestElement, waitForComponent } from '@clr/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@clr/core/test/utils';
 import { renderIcon } from '../icon.renderer.js';
 import { ClarityIcons } from '../icon.service.js';
 
@@ -102,12 +103,7 @@ describe('Icon classname helpers: ', () => {
     });
 
     beforeEach(async () => {
-      testElement = createTestElement();
-      testElement.innerHTML = `
-        <cds-icon></cds-icon>
-      `;
-
-      await waitForComponent('cds-icon');
+      testElement = await createTestElement(html`<cds-icon></cds-icon>`);
       component = testElement.querySelector<CdsIcon>('cds-icon');
     });
 

--- a/packages/core/src/input/input-group.element.spec.ts
+++ b/packages/core/src/input/input-group.element.spec.ts
@@ -4,18 +4,17 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { render, html } from 'lit-html';
+import { html } from 'lit-html';
 import { CdsInputGroup, CdsInput } from '@clr/core/input';
-import { createTestElement, waitForComponent, removeTestElement, componentIsStable } from '@clr/core/test/utils';
+import { createTestElement, removeTestElement, componentIsStable } from '@clr/core/test/utils';
 
 describe('cds-input-group', () => {
   let component: CdsInputGroup;
   let element: HTMLElement;
 
   beforeEach(async () => {
-    element = createTestElement();
-    render(
-      html` <cds-input-group>
+    element = await createTestElement(html`
+      <cds-input-group>
         <label>input group</label>
         <cds-input>
           <label>input 1</label>
@@ -26,11 +25,8 @@ describe('cds-input-group', () => {
           <input type="text" />
         </cds-input>
         <cds-control-message>message text</cds-control-message>
-      </cds-input-group>`,
-      element
-    );
-
-    await waitForComponent('cds-input-group');
+      </cds-input-group>
+    `);
 
     component = element.querySelector<CdsInputGroup>('cds-input-group');
   });

--- a/packages/core/src/input/input.element.spec.ts
+++ b/packages/core/src/input/input.element.spec.ts
@@ -4,25 +4,21 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { render, html } from 'lit-html';
+import { html } from 'lit-html';
 import { CdsInput } from '@clr/core/input';
-import { createTestElement, waitForComponent, removeTestElement, componentIsStable } from '@clr/core/test/utils';
+import { createTestElement, removeTestElement, componentIsStable } from '@clr/core/test/utils';
 
 describe('cds-input', () => {
   let component: CdsInput;
   let element: HTMLElement;
 
   beforeEach(async () => {
-    element = createTestElement();
-    render(
-      html` <cds-input>
+    element = await createTestElement(html`
+      <cds-input>
         <label>input</label>
         <input type="text" />
-      </cds-input>`,
-      element
-    );
-
-    await waitForComponent('cds-input');
+      </cds-input>
+    `);
 
     component = element.querySelector<CdsInput>('cds-input');
   });

--- a/packages/core/src/internal-components/close-button/close-button.element.spec.ts
+++ b/packages/core/src/internal-components/close-button/close-button.element.spec.ts
@@ -4,9 +4,10 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
+import { html } from 'lit-html';
 import '@clr/core/internal-components/close-button/register.js';
 import { CdsInternalCloseButton } from '@clr/core/internal-components/close-button';
-import { componentIsStable, createTestElement, removeTestElement, waitForComponent } from '@clr/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@clr/core/test/utils';
 
 describe('internal close button element', () => {
   let testElement: HTMLElement;
@@ -14,14 +15,11 @@ describe('internal close button element', () => {
   const placeholderText = 'ohai';
 
   beforeEach(async () => {
-    testElement = createTestElement();
-    testElement.innerHTML = `
+    testElement = await createTestElement(html`
       <form>
         <cds-internal-close-button>${placeholderText}</cds-internal-close-button>
       </form>
-    `;
-
-    await waitForComponent('cds-internal-close-button');
+    `);
     component = testElement.querySelector<CdsInternalCloseButton>('cds-internal-close-button');
   });
 

--- a/packages/core/src/internal/base/focus-trap.base.spec.ts
+++ b/packages/core/src/internal/base/focus-trap.base.spec.ts
@@ -3,7 +3,9 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { createTestElement, removeTestElement, waitForComponent, componentIsStable } from '@clr/core/test/utils';
+
+import { html } from 'lit-html';
+import { createTestElement, removeTestElement, componentIsStable } from '@clr/core/test/utils';
 import { registerElementSafely } from '../utils/register.js';
 import { CdsBaseFocusTrap } from './focus-trap.base.js';
 
@@ -23,16 +25,14 @@ describe('modal element', () => {
     const placeholderText = 'Button Placeholder';
 
     beforeEach(async () => {
-      testElement = createTestElement();
-      testElement.innerHTML = `
-              <cds-base-focus-trap>
-                  <cds-button>
-                      <span>${placeholderText}</span>
-                  </cds-button>
-              </cds-base-focus-trap>
-          `;
+      testElement = await createTestElement(html`
+        <cds-base-focus-trap>
+          <cds-button>
+            <span>${placeholderText}</span>
+          </cds-button>
+        </cds-base-focus-trap>
+      `);
 
-      await waitForComponent('cds-base-focus-trap');
       component = testElement.querySelector<CdsBaseFocusTrap>('cds-base-focus-trap');
     });
 
@@ -65,9 +65,7 @@ describe('modal element', () => {
     let component: CdsBaseFocusTrap;
 
     beforeEach(async () => {
-      testElement = createTestElement();
-      testElement.innerHTML = `<cds-base-focus-trap hidden></cds-base-focus-trap>`;
-      await waitForComponent('cds-base-focus-trap');
+      testElement = await createTestElement(html`<cds-base-focus-trap hidden></cds-base-focus-trap>`);
       component = testElement.querySelector<CdsBaseFocusTrap>('cds-base-focus-trap');
     });
 
@@ -87,16 +85,14 @@ describe('modal element', () => {
     const placeholderText = 'Button Placeholder';
 
     beforeEach(async () => {
-      testElement = createTestElement();
-      testElement.innerHTML = `
+      testElement = await createTestElement(html`
         <cds-base-focus-trap __demo-mode>
-            <cds-button>
-                <span>${placeholderText}</span>
-            </cds-button>
+          <cds-button>
+            <span>${placeholderText}</span>
+          </cds-button>
         </cds-base-focus-trap>
-      `;
+      `);
 
-      await waitForComponent('cds-base-focus-trap');
       component = testElement.querySelector<CdsBaseFocusTrap>('cds-base-focus-trap');
     });
 

--- a/packages/core/src/internal/decorators/event.spec.ts
+++ b/packages/core/src/internal/decorators/event.spec.ts
@@ -4,10 +4,11 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
+import { LitElement, html } from 'lit-element';
 import { event, EventEmitter, registerElementSafely } from '@clr/core/internal';
-import { componentIsStable, createTestElement, removeTestElement, waitForComponent } from '@clr/core/test/utils';
-import { LitElement } from 'lit-element';
+import { componentIsStable, createTestElement, removeTestElement } from '@clr/core/test/utils';
 
+/** @element test-event-decorator */
 export class TestElement extends LitElement {
   @event() test: EventEmitter<string>;
 }
@@ -19,10 +20,7 @@ describe('event decorator', () => {
   let component: TestElement;
 
   beforeEach(async () => {
-    testElement = createTestElement();
-    testElement.innerHTML = `<test-event-decorator></test-event-decorator>`;
-
-    await waitForComponent('test-event-decorator');
+    testElement = await createTestElement(html`<test-event-decorator></test-event-decorator>`);
     component = testElement.querySelector<TestElement>('test-event-decorator');
   });
 

--- a/packages/core/src/internal/decorators/global-style.spec.ts
+++ b/packages/core/src/internal/decorators/global-style.spec.ts
@@ -5,7 +5,6 @@
  */
 
 import { LitElement, html, css } from 'lit-element';
-import { render } from 'lit-html';
 import { registerElementSafely } from '@clr/core/internal';
 import { createTestElement, removeTestElement } from '@clr/core/test/utils';
 import { globalStyle } from './global-style.js';
@@ -38,9 +37,8 @@ let element: HTMLElement;
 let testElement: TestElement;
 
 describe('globalStyle decorator', () => {
-  beforeEach(() => {
-    element = createTestElement();
-    render(html`<test-global-style-decorator></test-global-style-decorator>`, element);
+  beforeEach(async () => {
+    element = await createTestElement(html`<test-global-style-decorator></test-global-style-decorator>`);
     testElement = element.querySelector<TestElement>('test-global-style-decorator');
   });
 

--- a/packages/core/src/internal/decorators/query-slot.spec.ts
+++ b/packages/core/src/internal/decorators/query-slot.spec.ts
@@ -6,9 +6,10 @@
 
 import { registerElementSafely } from '@clr/core/internal';
 import { html, LitElement } from 'lit-element';
-import { createTestElement, removeTestElement, waitForComponent } from '@clr/core/test/utils';
+import { createTestElement, removeTestElement } from '@clr/core/test/utils';
 import { querySlot, querySlotAll } from './query-slot.js';
 
+/** @element test-element */
 class TestElement extends LitElement {
   @querySlot('#test') test: HTMLDivElement;
   @querySlotAll('.item') testItems: NodeListOf<HTMLDivElement>;
@@ -25,16 +26,14 @@ describe('query slot decorator', () => {
   let component: TestElement;
 
   beforeEach(async () => {
-    testElement = createTestElement();
-    testElement.innerHTML = `
+    testElement = await createTestElement(html`
       <test-element>
         <div id="test">hi</div>
         <div class="item">item 1</div>
         <div class="item">item 2</div>
         <div class="item">item 3</div>
       </test-element>
-    `;
-    await waitForComponent('test-element');
+    `);
     component = testElement.querySelector<TestElement>('test-element');
   });
 

--- a/packages/core/src/internal/directives/spread-props.spec.ts
+++ b/packages/core/src/internal/directives/spread-props.spec.ts
@@ -27,10 +27,8 @@ registerElementSafely('test-spread-props-directive', TestElement);
 
 describe('spread props directive', () => {
   it('should assign all props to component within template', async () => {
-    const element = createTestElement();
+    const element = await createTestElement(html`<test-spread-props-directive></test-spread-props-directive>`);
     const getTestElement = () => element.querySelector<TestElement>('test-spread-props-directive');
-
-    render(html`<test-spread-props-directive></test-spread-props-directive>`, element);
     expect(getTestElement().test).toBe(false);
     expect(getTestElement().test2).toBe('hello');
 

--- a/packages/core/src/internal/i18n/utils.spec.ts
+++ b/packages/core/src/internal/i18n/utils.spec.ts
@@ -8,8 +8,8 @@ import { getElementLanguageDirection } from './utils.js';
 import { createTestElement } from '@clr/core/test/utils';
 
 describe('getElementLanguageDirection', () => {
-  it('should return the current element level language direction', () => {
-    const element = createTestElement();
+  it('should return the current element level language direction', async () => {
+    const element = await createTestElement();
     expect(getElementLanguageDirection(element)).toBe('ltr');
 
     element.style.direction = 'rtl';

--- a/packages/core/src/internal/utils/a11y.spec.ts
+++ b/packages/core/src/internal/utils/a11y.spec.ts
@@ -8,9 +8,9 @@ import { describeElementByElements } from './a11y.js';
 import { createTestElement } from '@clr/core/test/utils';
 
 describe('a11y utilities', () => {
-  it('describeElementByElements', () => {
-    const element = createTestElement();
-    const descriptions: HTMLElement[] = [createTestElement(), createTestElement()];
+  it('describeElementByElements', async () => {
+    const element = await createTestElement();
+    const descriptions: HTMLElement[] = [await createTestElement(), await createTestElement()];
     describeElementByElements(element, descriptions);
 
     expect(element.getAttribute('aria-describedby').trim()).toBe(`${descriptions[0].id} ${descriptions[1].id}`);

--- a/packages/core/src/internal/utils/css.spec.ts
+++ b/packages/core/src/internal/utils/css.spec.ts
@@ -4,6 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
+import { html } from 'lit-html';
 import { createTestElement, removeTestElement } from './../../test/utils.js';
 import { addClassnames, hasClassnames, removeClassnames, removeClassnamesUnless, updateElementStyles } from './css.js';
 
@@ -11,11 +12,8 @@ describe('Css utility functions - ', () => {
   let testElement: HTMLElement;
   let testDiv: HTMLElement;
 
-  beforeEach(() => {
-    testElement = createTestElement();
-    testElement.innerHTML = `
-      <div id="myTestElement" class="test1 test2">Ohai</div>
-    `;
+  beforeEach(async () => {
+    testElement = await createTestElement(html`<div id="myTestElement" class="test1 test2">Ohai</div>`);
     testDiv = testElement.querySelector<HTMLElement>('#myTestElement');
   });
 

--- a/packages/core/src/internal/utils/dom.spec.ts
+++ b/packages/core/src/internal/utils/dom.spec.ts
@@ -4,6 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
+import { html } from 'lit-html';
 import { createTestElement, removeTestElement } from '@clr/core/test/utils';
 import {
   addAttributeValue,
@@ -25,8 +26,8 @@ describe('Functional Helper: ', () => {
     let testElement: HTMLElement;
     const elementWidth = '100px';
 
-    beforeEach(() => {
-      testElement = createTestElement();
+    beforeEach(async () => {
+      testElement = await createTestElement();
       testElement.style.width = elementWidth;
     });
 
@@ -47,8 +48,8 @@ describe('Functional Helper: ', () => {
     let testElement: HTMLElement;
     const elementWidth = '100px';
 
-    beforeEach(() => {
-      testElement = createTestElement();
+    beforeEach(async () => {
+      testElement = await createTestElement();
       testElement.style.width = elementWidth;
     });
 
@@ -68,8 +69,8 @@ describe('Functional Helper: ', () => {
   describe('isHTMLElement() ', () => {
     let testElement: any;
 
-    it('returns true if it is an HTMLElement', () => {
-      testElement = createTestElement();
+    it('returns true if it is an HTMLElement', async () => {
+      testElement = await createTestElement();
       expect(isHTMLElement(testElement)).toEqual(true);
     });
 
@@ -91,8 +92,8 @@ describe('Functional Helper: ', () => {
     let testElement: HTMLElement;
     const attrName = 'myAttr';
 
-    beforeEach(() => {
-      testElement = createTestElement();
+    beforeEach(async () => {
+      testElement = await createTestElement();
     });
 
     afterEach(() => {
@@ -126,8 +127,8 @@ describe('Functional Helper: ', () => {
       ['data-attr', 'stringified data goes here'],
     ];
 
-    beforeEach(() => {
-      testElement = createTestElement();
+    beforeEach(async () => {
+      testElement = await createTestElement();
     });
 
     afterEach(() => {
@@ -201,8 +202,8 @@ describe('Functional Helper: ', () => {
       ['data-attr', 'stringified data goes here'],
     ];
 
-    beforeEach(() => {
-      testElement = createTestElement();
+    beforeEach(async () => {
+      testElement = await createTestElement();
       setAttributes(testElement, ...testAttrs);
     });
 
@@ -235,10 +236,12 @@ describe('Functional Helper: ', () => {
     let testDiv3: null;
     let testDiv4: HTMLElement;
 
-    beforeEach(() => {
-      testElement = createTestElement();
-      testElement.innerHTML =
-        '<div id="testDiv1">ohai</div><div id="testDiv2">kthxbye</div><div id="testDiv4">omye</div>';
+    beforeEach(async () => {
+      testElement = await createTestElement(
+        html`<div id="testDiv1">ohai</div>
+          <div id="testDiv2">kthxbye</div>
+          <div id="testDiv4">omye</div>`
+      );
       testDiv1 = testElement.querySelector('#testDiv1');
       testDiv2 = testElement.querySelector('#testDiv2');
       testDiv3 = testElement.querySelector('#testDiv3');
@@ -287,8 +290,8 @@ describe('Functional Helper: ', () => {
       ['data-attr', 'stringified data goes here'],
     ];
 
-    beforeEach(() => {
-      testElement = createTestElement();
+    beforeEach(async () => {
+      testElement = await createTestElement();
       setAttributes(testElement, ...testAttrs);
     });
 
@@ -316,8 +319,8 @@ describe('Functional Helper: ', () => {
   });
 
   describe('listenForAttributeChange', () => {
-    it('executes callback when observed attribute changes', done => {
-      const element = createTestElement();
+    it('executes callback when observed attribute changes', async done => {
+      const element = await createTestElement();
       expect(element.getAttribute('name')).toBe(null);
 
       listenForAttributeChange(element, 'name', id => {
@@ -331,8 +334,8 @@ describe('Functional Helper: ', () => {
   });
 
   describe('isVisible', () => {
-    it('determines if element is visible', () => {
-      const element = createTestElement();
+    it('determines if element is visible', async () => {
+      const element = await createTestElement();
       element.style.width = '100px';
       element.style.height = '100px';
 
@@ -346,10 +349,8 @@ describe('Functional Helper: ', () => {
     });
   });
   describe('spanWrapper', () => {
-    it('wraps text nodes in an element', () => {
-      const element: HTMLElement = createTestElement();
-      const text = document.createTextNode('Hello spanWrapper');
-      element.appendChild(text);
+    it('wraps text nodes in an element', async () => {
+      const element = await createTestElement(html`Hello spanWrapper`);
       spanWrapper(element.childNodes);
       expect(element.children[0].tagName).toBe('SPAN');
       expect(element.children[0].textContent).toBe('Hello spanWrapper');

--- a/packages/core/src/internal/utils/focus-trap.spec.ts
+++ b/packages/core/src/internal/utils/focus-trap.spec.ts
@@ -20,8 +20,8 @@ describe('Focus Trap Utilities: ', () => {
     describe('addReboundElementsToFocusTrapElement()', () => {
       let focusTrapElement: FocusTrapElement;
 
-      beforeEach(() => {
-        focusTrapElement = createTestElement() as FocusTrapElement;
+      beforeEach(async () => {
+        focusTrapElement = (await createTestElement()) as FocusTrapElement;
       });
 
       afterEach(() => {
@@ -60,8 +60,8 @@ describe('Focus Trap Utilities: ', () => {
     describe('removeReboundElementsFromFocusTrapElement()', () => {
       let focusTrapElement: FocusTrapElement;
 
-      beforeEach(() => {
-        focusTrapElement = createTestElement() as FocusTrapElement;
+      beforeEach(async () => {
+        focusTrapElement = (await createTestElement()) as FocusTrapElement;
       });
 
       afterEach(() => {
@@ -102,8 +102,8 @@ describe('Focus Trap Utilities: ', () => {
       let focusedElement: HTMLElement;
       let focusTrapElement: FocusTrapElement;
 
-      beforeEach(() => {
-        focusTrapElement = createTestElement() as FocusTrapElement;
+      beforeEach(async () => {
+        focusTrapElement = (await createTestElement()) as FocusTrapElement;
       });
 
       afterEach(() => {
@@ -111,20 +111,20 @@ describe('Focus Trap Utilities: ', () => {
         removeTestElement(focusedElement);
       });
 
-      it('calls focus() if in current focus trap element', () => {
+      it('calls focus() if in current focus trap element', async () => {
         spyOn(focusTrapElement, 'focus');
 
-        focusedElement = createTestElement();
+        focusedElement = await createTestElement();
         FocusTrapTracker.setCurrent(focusTrapElement);
 
         focusElementIfInCurrentFocusTrapElement(focusedElement, focusTrapElement);
         expect(focusTrapElement.focus).toHaveBeenCalled();
       });
 
-      it('does not call focus() if not in current focus trap element', () => {
+      it('does not call focus() if not in current focus trap element', async () => {
         spyOn(focusTrapElement, 'focus');
 
-        focusedElement = createTestElement();
+        focusedElement = await createTestElement();
 
         focusElementIfInCurrentFocusTrapElement(focusedElement, focusTrapElement);
         expect(focusTrapElement.focus).not.toHaveBeenCalled();
@@ -135,8 +135,8 @@ describe('Focus Trap Utilities: ', () => {
       let focusedElement: HTMLElement;
       let focusTrapElement: FocusTrapElement;
 
-      beforeEach(() => {
-        focusTrapElement = createTestElement() as FocusTrapElement;
+      beforeEach(async () => {
+        focusTrapElement = (await createTestElement()) as FocusTrapElement;
       });
 
       afterEach(() => {
@@ -146,19 +146,19 @@ describe('Focus Trap Utilities: ', () => {
         }
       });
 
-      it('returns true if element is outside focus trap element', () => {
-        focusedElement = createTestElement();
+      it('returns true if element is outside focus trap element', async () => {
+        focusedElement = await createTestElement();
         expect(elementIsOutsideFocusTrapElement(focusedElement, focusTrapElement)).toBeTruthy();
       });
 
-      it('returns true if focused element is top rebound element', () => {
-        const focusedElement = createTestElement();
+      it('returns true if focused element is top rebound element', async () => {
+        const focusedElement = await createTestElement();
         focusTrapElement.topReboundElement = focusedElement;
         expect(elementIsOutsideFocusTrapElement(focusedElement, focusTrapElement)).toBeTruthy();
       });
 
-      it('returns true if focused element is bottom rebound element', () => {
-        const focusedElement = createTestElement();
+      it('returns true if focused element is bottom rebound element', async () => {
+        const focusedElement = await createTestElement();
         focusTrapElement.bottomReboundElement = focusedElement;
         expect(elementIsOutsideFocusTrapElement(focusedElement, focusTrapElement)).toBeTruthy();
       });
@@ -176,8 +176,8 @@ describe('Focus Trap Utilities: ', () => {
     let testElement: HTMLElement;
 
     describe('enableFocusTrap()', () => {
-      beforeEach(() => {
-        testElement = createTestElement();
+      beforeEach(async () => {
+        testElement = await createTestElement();
         focusTrap = new FocusTrap(testElement);
         focusTrap.enableFocusTrap();
       });
@@ -216,9 +216,9 @@ describe('Focus Trap Utilities: ', () => {
     describe('removeFocusTrap()', () => {
       let previousFocusedElement: HTMLElement;
 
-      beforeEach(() => {
-        testElement = createTestElement();
-        previousFocusedElement = createTestElement();
+      beforeEach(async () => {
+        testElement = await createTestElement();
+        previousFocusedElement = await createTestElement();
         previousFocusedElement.setAttribute('tabindex', '0');
         previousFocusedElement.focus();
         focusTrap = new FocusTrap(testElement);

--- a/packages/core/src/internal/utils/responsive.spec.ts
+++ b/packages/core/src/internal/utils/responsive.spec.ts
@@ -4,8 +4,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { render, html } from 'lit-html';
-import { createTestElement, removeTestElement, waitForComponent, componentIsStable } from '@clr/core/test/utils';
+import { html } from 'lit-html';
+import { createTestElement, removeTestElement, componentIsStable } from '@clr/core/test/utils';
 import { CdsControl } from '@clr/core/forms/index.js';
 
 describe('responsive utilities', () => {
@@ -13,17 +13,13 @@ describe('responsive utilities', () => {
   let component: CdsControl;
 
   beforeEach(async () => {
-    element = createTestElement();
-    render(
-      html` <cds-control layout="horizontal">
+    element = await createTestElement(html`
+      <cds-control layout="horizontal">
         <label>test</label>
         <input type="text" />
         <cds-control-message>message text</cds-control-message>
-      </cds-control>`,
-      element
-    );
-
-    await waitForComponent('cds-control');
+      </cds-control>
+    `);
 
     component = element.querySelector<CdsControl>('cds-control');
   });

--- a/packages/core/src/internal/utils/size.spec.ts
+++ b/packages/core/src/internal/utils/size.spec.ts
@@ -4,6 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
+import { html } from 'lit-html';
 import { createTestElement, removeTestElement } from './../../test/utils.js';
 import { updateElementStyles } from './css.js';
 import { isTshirtSize, updateEquilateralSizeStyles } from './size.js';
@@ -34,11 +35,8 @@ describe('Functional Helper: ', () => {
     let testElement: HTMLElement;
     let testDiv: HTMLElement;
 
-    beforeEach(() => {
-      testElement = createTestElement();
-      testElement.innerHTML = `
-            <div id="myTestElement" class="test1 test2">Ohai</div>
-          `;
+    beforeEach(async () => {
+      testElement = await createTestElement(html`<div id="myTestElement" class="test1 test2">Ohai</div>`);
       testDiv = testElement.querySelector<HTMLElement>('#myTestElement');
       updateElementStyles(testDiv, ['width', initSize], ['height', initSize]);
     });

--- a/packages/core/src/internal/utils/supports.ts
+++ b/packages/core/src/internal/utils/supports.ts
@@ -23,6 +23,6 @@ export function supportsFlexGap(): boolean {
   // append to the DOM (needed to obtain scrollHeight)
   document.body.appendChild(flex);
   const isSupported = flex.scrollHeight === 1; // flex container should be 1px high from the row-gap
-  flex.parentNode!.removeChild(flex);
+  (flex.parentNode as Element).removeChild(flex);
   return isSupported;
 }

--- a/packages/core/src/modal/modal-actions.element.spec.ts
+++ b/packages/core/src/modal/modal-actions.element.spec.ts
@@ -3,9 +3,11 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
+
+import { html } from 'lit-html';
 import '@clr/core/modal/register.js';
 import { CdsModalActions } from '@clr/core/modal';
-import { componentIsStable, createTestElement, removeTestElement, waitForComponent } from '@clr/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@clr/core/test/utils';
 
 describe('modal-actions element', () => {
   let testElement: HTMLElement;
@@ -13,10 +15,7 @@ describe('modal-actions element', () => {
   const placeholderContent = 'Modal Placeholder';
 
   beforeEach(async () => {
-    testElement = createTestElement();
-    testElement.innerHTML = `<cds-modal-actions>${placeholderContent}</cds-modal-actions>`;
-
-    await waitForComponent('cds-modal-actions');
+    testElement = await createTestElement(html`<cds-modal-actions>${placeholderContent}</cds-modal-actions>`);
     component = testElement.querySelector<CdsModalActions>('cds-modal-actions');
   });
 

--- a/packages/core/src/modal/modal-content.element.spec.ts
+++ b/packages/core/src/modal/modal-content.element.spec.ts
@@ -3,9 +3,11 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
+
+import { html } from 'lit-html';
 import '@clr/core/modal/register.js';
 import { CdsModalContent } from '@clr/core/modal';
-import { componentIsStable, createTestElement, removeTestElement, waitForComponent } from '@clr/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@clr/core/test/utils';
 
 describe('modal-content element', () => {
   let testElement: HTMLElement;
@@ -13,10 +15,7 @@ describe('modal-content element', () => {
   const placeholderContent = 'Modal Placeholder';
 
   beforeEach(async () => {
-    testElement = createTestElement();
-    testElement.innerHTML = `<cds-modal-content>${placeholderContent}</cds-modal-content>`;
-
-    await waitForComponent('cds-modal-content');
+    testElement = await createTestElement(html`<cds-modal-content>${placeholderContent}</cds-modal-content>`);
     component = testElement.querySelector<CdsModalContent>('cds-modal-content');
   });
 

--- a/packages/core/src/modal/modal-header-actions.element.spec.ts
+++ b/packages/core/src/modal/modal-header-actions.element.spec.ts
@@ -3,9 +3,11 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
+
+import { html } from 'lit-html';
 import '@clr/core/modal/register.js';
 import { CdsModalHeaderActions } from '@clr/core/modal';
-import { componentIsStable, createTestElement, removeTestElement, waitForComponent } from '@clr/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@clr/core/test/utils';
 
 describe('modal-header-actions element', () => {
   let testElement: HTMLElement;
@@ -13,10 +15,9 @@ describe('modal-header-actions element', () => {
   const placeholderContent = 'Modal Placeholder';
 
   beforeEach(async () => {
-    testElement = createTestElement();
-    testElement.innerHTML = `<cds-modal-header-actions>${placeholderContent}</cds-modal-header-actions>`;
-
-    await waitForComponent('cds-modal-header-actions');
+    testElement = await createTestElement(
+      html`<cds-modal-header-actions>${placeholderContent}</cds-modal-header-actions>`
+    );
     component = testElement.querySelector<CdsModalHeaderActions>('cds-modal-header-actions');
   });
 

--- a/packages/core/src/modal/modal-header.element.spec.ts
+++ b/packages/core/src/modal/modal-header.element.spec.ts
@@ -3,9 +3,11 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
+
+import { html } from 'lit-html';
 import '@clr/core/modal/register.js';
 import { CdsModalHeader } from '@clr/core/modal';
-import { componentIsStable, createTestElement, removeTestElement, waitForComponent } from '@clr/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@clr/core/test/utils';
 
 describe('modal-header element', () => {
   let testElement: HTMLElement;
@@ -13,10 +15,7 @@ describe('modal-header element', () => {
   const placeholderContent = 'Modal Placeholder';
 
   beforeEach(async () => {
-    testElement = createTestElement();
-    testElement.innerHTML = `<cds-modal-header>${placeholderContent}</cds-modal-header>`;
-
-    await waitForComponent('cds-modal-header');
+    testElement = await createTestElement(html`<cds-modal-header>${placeholderContent}</cds-modal-header>`);
     component = testElement.querySelector<CdsModalHeader>('cds-modal-header');
   });
 

--- a/packages/core/src/modal/modal.element.spec.ts
+++ b/packages/core/src/modal/modal.element.spec.ts
@@ -3,37 +3,30 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
+
+import { html } from 'lit-html';
 import '@clr/core/modal/register.js';
 import { CommonStringsServiceInternal } from '@clr/core/internal';
 import { CdsInternalCloseButton } from '@clr/core/internal-components/close-button';
 import { CdsModal } from '@clr/core/modal';
-import {
-  componentIsStable,
-  createTestElement,
-  getComponentSlotContent,
-  removeTestElement,
-  waitForComponent,
-} from '@clr/core/test/utils';
+import { componentIsStable, createTestElement, getComponentSlotContent, removeTestElement } from '@clr/core/test/utils';
 
 describe('modal element', () => {
   let testElement: HTMLElement;
   let component: CdsModal;
   const placeholderHeader = 'I have a nice title';
-  const placeholderContent = '<p>But not much to say...</p>';
+  const placeholderContent = 'But not much to say...';
   const placeholderActionText = 'Ok';
   const placeholderAction = `<cds-button>${placeholderActionText}</cds-button>`;
 
   beforeEach(async () => {
-    testElement = createTestElement();
-    testElement.innerHTML = `
-    <cds-modal>
+    testElement = await createTestElement(html`
+      <cds-modal>
         <cds-modal-header>${placeholderHeader}</cds-modal-header>
-        <cds-modal-content>${placeholderContent}</cds-modal-content>
+        <cds-modal-content><p>${placeholderContent}</p></cds-modal-content>
         <cds-modal-actions>${placeholderAction}</cds-modal-actions>
-    </cds-modal>
-    `;
-
-    await waitForComponent('cds-modal');
+      </cds-modal>
+    `);
     component = testElement.querySelector<CdsModal>('cds-modal');
   });
 
@@ -44,8 +37,10 @@ describe('modal element', () => {
   it('should create the component', async () => {
     await componentIsStable(component);
     const slots = getComponentSlotContent(component);
-    expect(slots.default).toBe(`<cds-modal-content>${placeholderContent}</cds-modal-content>`);
-    expect(slots['modal-header']).toBe(`<cds-modal-header slot="modal-header">${placeholderHeader}</cds-modal-header>`);
+    expect(slots.default).toBe(`<cds-modal-content><p><!---->${placeholderContent}<!----></p></cds-modal-content>`);
+    expect(slots['modal-header']).toBe(
+      `<cds-modal-header slot="modal-header"><!---->${placeholderHeader}<!----></cds-modal-header>`
+    );
     // since cds-button further adds and modifies the element we simply test that it contains the button text
     expect(slots['modal-actions']).toContain(`${placeholderActionText}`);
   });

--- a/packages/core/src/password/password.element.spec.ts
+++ b/packages/core/src/password/password.element.spec.ts
@@ -4,8 +4,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { render, html } from 'lit-html';
-import { createTestElement, waitForComponent, removeTestElement, componentIsStable } from '@clr/core/test/utils';
+import { html } from 'lit-html';
+import { createTestElement, removeTestElement, componentIsStable } from '@clr/core/test/utils';
 import { CdsPassword } from '@clr/core/password';
 import '@clr/core/password/register.js';
 
@@ -14,17 +14,13 @@ describe('cds-password', () => {
   let element: HTMLElement;
 
   beforeEach(async () => {
-    element = createTestElement();
-    render(
-      html` <cds-password>
+    element = await createTestElement(html`
+      <cds-password>
         <label>password</label>
         <input type="password" />
         <cds-control-message>message text</cds-control-message>
-      </cds-password>`,
-      element
-    );
-
-    await waitForComponent('cds-password');
+      </cds-password>
+    `);
 
     component = element.querySelector<CdsPassword>('cds-password');
   });

--- a/packages/core/src/progress-circle/progress-circle.element.spec.ts
+++ b/packages/core/src/progress-circle/progress-circle.element.spec.ts
@@ -3,9 +3,11 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
+
+import { html } from 'lit-html';
 import '@clr/core/progress-circle/register.js';
 import { CdsProgressCircle } from '@clr/core/progress-circle';
-import { componentIsStable, createTestElement, removeTestElement, waitForComponent } from '@clr/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@clr/core/test/utils';
 
 describe('progress circle element – ', () => {
   let testElementUnset: HTMLElement;
@@ -14,12 +16,10 @@ describe('progress circle element – ', () => {
   let component: CdsProgressCircle;
 
   beforeEach(async () => {
-    testElementUnset = createTestElement();
-    testElement = createTestElement();
-    testElementUnset.innerHTML = `<cds-progress-circle></cds-progress-circle>`;
-    testElement.innerHTML = `<cds-progress-circle status="info" value="49" inverse></cds-progress-circle>`;
-
-    await waitForComponent('cds-progress-circle');
+    testElementUnset = await createTestElement(html`<cds-progress-circle></cds-progress-circle>`);
+    testElement = await createTestElement(
+      html`<cds-progress-circle status="info" value="49" inverse></cds-progress-circle>`
+    );
     componentUnset = testElementUnset.querySelector<CdsProgressCircle>('cds-progress-circle');
     component = testElement.querySelector<CdsProgressCircle>('cds-progress-circle');
   });

--- a/packages/core/src/radio/radio-group.element.spec.ts
+++ b/packages/core/src/radio/radio-group.element.spec.ts
@@ -4,8 +4,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { render, html } from 'lit-html';
-import { createTestElement, waitForComponent, removeTestElement, componentIsStable } from '@clr/core/test/utils';
+import { html } from 'lit-html';
+import { createTestElement, removeTestElement, componentIsStable } from '@clr/core/test/utils';
 import { CdsRadioGroup } from '@clr/core/radio';
 import '@clr/core/radio/register.js';
 
@@ -14,9 +14,8 @@ describe('cds-radio-group', () => {
   let element: HTMLElement;
 
   beforeEach(async () => {
-    element = createTestElement();
-    render(
-      html` <cds-radio-group>
+    element = await createTestElement(html`
+      <cds-radio-group>
         <label>radio group</label>
         <cds-radio>
           <label>radio 1</label>
@@ -27,11 +26,8 @@ describe('cds-radio-group', () => {
           <input type="radio" value="2" />
         </cds-radio>
         <cds-control-message>message text</cds-control-message>
-      </cds-radio-group>`,
-      element
-    );
-
-    await waitForComponent('cds-radio-group');
+      </cds-radio-group>
+    `);
 
     component = element.querySelector<CdsRadioGroup>('cds-radio-group');
   });

--- a/packages/core/src/radio/radio.element.spec.ts
+++ b/packages/core/src/radio/radio.element.spec.ts
@@ -4,8 +4,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { render, html } from 'lit-html';
-import { createTestElement, waitForComponent, removeTestElement, componentIsStable } from '@clr/core/test/utils';
+import { html } from 'lit-html';
+import { createTestElement, removeTestElement, componentIsStable } from '@clr/core/test/utils';
 import { CdsRadio } from '@clr/core/radio';
 import '@clr/core/radio/register.js';
 
@@ -15,25 +15,19 @@ describe('cds-radio', () => {
   let element: HTMLElement;
 
   beforeEach(async () => {
-    element = createTestElement();
-    render(
-      html`
-        <cds-radio-group>
-          <label>radio group</label>
-          <cds-radio>
-            <label>radio 1</label>
-            <input type="radio" />
-          </cds-radio>
-          <cds-radio>
-            <label>radio 2</label>
-            <input type="radio" checked />
-          </cds-radio>
-        </cds-radio-group>
-      `,
-      element
-    );
-
-    await waitForComponent('cds-radio');
+    element = await createTestElement(html`
+      <cds-radio-group>
+        <label>radio group</label>
+        <cds-radio>
+          <label>radio 1</label>
+          <input type="radio" />
+        </cds-radio>
+        <cds-radio>
+          <label>radio 2</label>
+          <input type="radio" checked />
+        </cds-radio>
+      </cds-radio-group>
+    `);
 
     component = element.querySelector<CdsRadio>('cds-radio');
     componentTwo = element.querySelectorAll<CdsRadio>('cds-radio')[1];

--- a/packages/core/src/range/range.element.spec.ts
+++ b/packages/core/src/range/range.element.spec.ts
@@ -4,8 +4,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { render, html } from 'lit-html';
-import { createTestElement, waitForComponent, removeTestElement, componentIsStable } from '@clr/core/test/utils';
+import { html } from 'lit-html';
+import { createTestElement, removeTestElement, componentIsStable } from '@clr/core/test/utils';
 import { CdsRange } from '@clr/core/range';
 import '@clr/core/range/register.js';
 
@@ -14,17 +14,13 @@ describe('cds-range', () => {
   let element: HTMLElement;
 
   beforeEach(async () => {
-    element = createTestElement();
-    render(
-      html` <cds-range>
+    element = await createTestElement(html`
+      <cds-range>
         <label>range</label>
         <input type="range" />
         <cds-control-message>message test</cds-control-message>
-      </cds-range>`,
-      element
-    );
-
-    await waitForComponent('cds-range');
+      </cds-range>
+    `);
 
     component = element.querySelector<CdsRange>('cds-range');
   });

--- a/packages/core/src/search/search.element.spec.ts
+++ b/packages/core/src/search/search.element.spec.ts
@@ -4,8 +4,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { render, html } from 'lit-html';
-import { createTestElement, waitForComponent, removeTestElement, componentIsStable } from '@clr/core/test/utils';
+import { html } from 'lit-html';
+import { createTestElement, removeTestElement, componentIsStable } from '@clr/core/test/utils';
 import { CdsSearch } from '@clr/core/search';
 import '@clr/core/search/register.js';
 
@@ -14,17 +14,13 @@ describe('cds-search', () => {
   let element: HTMLElement;
 
   beforeEach(async () => {
-    element = createTestElement();
-    render(
-      html` <cds-search>
+    element = await createTestElement(html`
+      <cds-search>
         <label>search</label>
         <input type="search" />
         <cds-control-message>message test</cds-control-message>
-      </cds-search>`,
-      element
-    );
-
-    await waitForComponent('cds-search');
+      </cds-search>
+    `);
 
     component = element.querySelector<CdsSearch>('cds-search');
   });

--- a/packages/core/src/select/select.element.spec.ts
+++ b/packages/core/src/select/select.element.spec.ts
@@ -4,8 +4,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { render, html } from 'lit-html';
-import { createTestElement, waitForComponent, removeTestElement, componentIsStable } from '@clr/core/test/utils';
+import { html } from 'lit-html';
+import { createTestElement, removeTestElement, componentIsStable } from '@clr/core/test/utils';
 import { CdsSelect } from '@clr/core/select';
 import '@clr/core/select/register.js';
 
@@ -14,9 +14,8 @@ describe('cds-select', () => {
   let element: HTMLElement;
 
   beforeEach(async () => {
-    element = createTestElement();
-    render(
-      html` <cds-select>
+    element = await createTestElement(html`
+      <cds-select>
         <label>select</label>
         <select>
           <option>option one</option>
@@ -24,11 +23,8 @@ describe('cds-select', () => {
           <option>option three</option>
         </select>
         <cds-control-message>message text</cds-control-message>
-      </cds-select>`,
-      element
-    );
-
-    await waitForComponent('cds-select');
+      </cds-select>
+    `);
 
     component = element.querySelector<CdsSelect>('cds-select');
   });

--- a/packages/core/src/tag/tag.element.spec.ts
+++ b/packages/core/src/tag/tag.element.spec.ts
@@ -3,10 +3,12 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
+
+import { html } from 'lit-html';
 import '@clr/core/tag/register.js';
 import '@clr/core/icon/register.js';
 import { CdsTag } from '@clr/core/tag';
-import { componentIsStable, createTestElement, removeTestElement, waitForComponent } from '@clr/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@clr/core/test/utils';
 
 describe('tag element', () => {
   let testElement: HTMLElement;
@@ -24,14 +26,11 @@ describe('tag element', () => {
   beforeEach(async () => {
     spyOn(console, 'warn').and.callThrough();
 
-    testElement = createTestElement();
-    testElement.innerHTML = `
+    testElement = await createTestElement(html`
       <cds-tag aria-label="test" class="${defaultClassname}">${placeholderText}</cds-tag>
       <cds-tag class="${readonlyClassname}" readonly>Readonly Tag</cds-tag>
       <cds-tag aria-label="test" class="${closableClassname}" closable>Closable Tag</cds-tag>
-    `;
-
-    await waitForComponent('cds-tag');
+    `);
   });
 
   afterEach(() => {
@@ -85,26 +84,18 @@ describe('tag element', () => {
   });
 
   it('should warn if closable but there is no aria-label', async () => {
-    const inaccessibleTestElement = createTestElement();
-    inaccessibleTestElement.innerHTML = `
+    await createTestElement(html`
       <cds-tag class="${readonlyClassname}" readonly>Readonly Tag</cds-tag>
       <cds-tag class="${closableClassname}" closable>Closable Tag</cds-tag>
-    `;
-
-    await waitForComponent('cds-tag');
-
+    `);
     expect(console.warn).toHaveBeenCalledTimes(1);
   });
 
   it('should warn if clickable but there is no aria-label', async () => {
-    const inaccessibleTestElement = createTestElement();
-    inaccessibleTestElement.innerHTML = `
+    await createTestElement(html`
       <cds-tag class="${readonlyClassname}" readonly>Readonly Tag</cds-tag>
       <cds-tag class="${closableClassname}">Clickable Tag</cds-tag>
-    `;
-
-    await waitForComponent('cds-tag');
-
+    `);
     expect(console.warn).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/core/src/test-dropdown/test-dropdown.element.spec.ts
+++ b/packages/core/src/test-dropdown/test-dropdown.element.spec.ts
@@ -4,29 +4,21 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
+import { html } from 'lit-html';
 import '@clr/core/test-dropdown';
 import { CdsTestDropdown } from '@clr/core/test-dropdown';
-import {
-  componentIsStable,
-  createTestElement,
-  getComponentSlotContent,
-  removeTestElement,
-  waitForComponent,
-} from '@clr/core/test/utils';
+import { componentIsStable, createTestElement, getComponentSlotContent, removeTestElement } from '@clr/core/test/utils';
 
 describe('dropdown test element', () => {
   let testElement: HTMLElement;
   let component: CdsTestDropdown;
 
   beforeEach(async () => {
-    testElement = createTestElement();
-    testElement.innerHTML = `
+    testElement = await createTestElement(html`
       <cds-test-dropdown title="custom title">
         <span>hello world</span>
       </cds-test-dropdown>
-    `;
-
-    await waitForComponent('cds-test-dropdown');
+    `);
     component = testElement.querySelector<CdsTestDropdown>('cds-test-dropdown');
   });
 

--- a/packages/core/src/test/utils.ts
+++ b/packages/core/src/test/utils.ts
@@ -4,26 +4,23 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-export const spyOnFunction = <T>(obj: T, func: keyof T) => {
-  // eslint-disable-next-line jasmine/no-unsafe-spy
-  const spy = jasmine.createSpy(func as string);
-  spyOnProperty(obj, func, 'get').and.returnValue(spy);
+import { TemplateResult, render } from 'lit-html';
 
-  return spy;
-};
-
-export function createTestElement(): HTMLElement {
+export function createTestElement(template?: TemplateResult): Promise<HTMLElement> {
   const element = document.createElement('div');
   document.body.appendChild(element);
-  return element;
+
+  if (template) {
+    render(template, element);
+  }
+
+  return Promise.all(
+    Array.from(document.querySelectorAll(':not(:defined)')).map(el => customElements.whenDefined(el.tagName))
+  ).then(() => element);
 }
 
 export function removeTestElement(element: HTMLElement) {
   element.remove();
-}
-
-export function waitForComponent(elementName: string): Promise<void> {
-  return window.customElements.whenDefined(elementName);
 }
 
 export function getComponentSlotContent(component: HTMLElement): { [name: string]: string } {

--- a/packages/core/src/textarea/textarea.element.spec.ts
+++ b/packages/core/src/textarea/textarea.element.spec.ts
@@ -4,8 +4,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { render, html } from 'lit-html';
-import { createTestElement, waitForComponent, removeTestElement, componentIsStable } from '@clr/core/test/utils';
+import { html } from 'lit-html';
+import { createTestElement, removeTestElement, componentIsStable } from '@clr/core/test/utils';
 import { CdsTextarea } from '@clr/core/textarea';
 import '@clr/core/textarea/register.js';
 
@@ -14,17 +14,13 @@ describe('cds-textarea', () => {
   let element: HTMLElement;
 
   beforeEach(async () => {
-    element = createTestElement();
-    render(
-      html` <cds-textarea>
+    element = await createTestElement(html`
+      <cds-textarea>
         <label>textarea</label>
         <textarea></textarea>
         <cds-control-message>message text</cds-control-message>
-      </cds-textarea>`,
-      element
-    );
-
-    await waitForComponent('cds-textarea');
+      </cds-textarea>
+    `);
 
     component = element.querySelector<CdsTextarea>('cds-textarea');
   });

--- a/packages/core/src/time/time.element.spec.ts
+++ b/packages/core/src/time/time.element.spec.ts
@@ -4,8 +4,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { render, html } from 'lit-html';
-import { createTestElement, waitForComponent, removeTestElement, componentIsStable } from '@clr/core/test/utils';
+import { html } from 'lit-html';
+import { createTestElement, removeTestElement, componentIsStable } from '@clr/core/test/utils';
 import { CdsTime } from '@clr/core/time';
 import '@clr/core/time/register.js';
 
@@ -14,18 +14,13 @@ describe('cds-time', () => {
   let element: HTMLElement;
 
   beforeEach(async () => {
-    element = createTestElement();
-    render(
-      html` <cds-time>
+    element = await createTestElement(html`
+      <cds-time>
         <label>time</label>
         <input type="time" />
         <cds-control-message>message text</cds-control-message>
-      </cds-time>`,
-      element
-    );
-
-    await waitForComponent('cds-time');
-
+      </cds-time>
+    `);
     component = element.querySelector<CdsTime>('cds-time');
   });
 

--- a/packages/core/src/toggle/toggle-group.element.spec.ts
+++ b/packages/core/src/toggle/toggle-group.element.spec.ts
@@ -4,8 +4,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { render, html } from 'lit-html';
-import { createTestElement, waitForComponent, removeTestElement, componentIsStable } from '@clr/core/test/utils';
+import { html } from 'lit-html';
+import { createTestElement, removeTestElement, componentIsStable } from '@clr/core/test/utils';
 import { CdsToggleGroup } from '@clr/core/toggle';
 import '@clr/core/toggle/register.js';
 
@@ -14,9 +14,8 @@ describe('cds-toggle-group', () => {
   let element: HTMLElement;
 
   beforeEach(async () => {
-    element = createTestElement();
-    render(
-      html` <cds-toggle-group>
+    element = await createTestElement(html`
+      <cds-toggle-group>
         <label>toggle group</label>
         <cds-toggle>
           <label>toggle 1</label>
@@ -27,11 +26,8 @@ describe('cds-toggle-group', () => {
           <input type="checkbox" />
         </cds-toggle>
         <cds-control-message>message text</cds-control-message>
-      </cds-toggle-group>`,
-      element
-    );
-
-    await waitForComponent('cds-toggle-group');
+      </cds-toggle-group>
+    `);
 
     component = element.querySelector<CdsToggleGroup>('cds-toggle-group');
   });

--- a/packages/core/src/toggle/toggle.element.spec.ts
+++ b/packages/core/src/toggle/toggle.element.spec.ts
@@ -4,8 +4,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { render, html } from 'lit-html';
-import { createTestElement, waitForComponent, removeTestElement, componentIsStable } from '@clr/core/test/utils';
+import { html } from 'lit-html';
+import { createTestElement, removeTestElement, componentIsStable } from '@clr/core/test/utils';
 import { CdsToggle } from '@clr/core/toggle';
 import '@clr/core/toggle/register.js';
 
@@ -14,18 +14,13 @@ describe('cds-toggle', () => {
   let element: HTMLElement;
 
   beforeEach(async () => {
-    element = createTestElement();
-    render(
-      html` <cds-toggle>
+    element = await createTestElement(html`
+      <cds-toggle>
         <label>toggle</label>
         <input type="checkbox" />
         <cds-control-message>message text</cds-control-message>
-      </cds-toggle>`,
-      element
-    );
-
-    await waitForComponent('cds-toggle');
-
+      </cds-toggle>
+    `);
     component = element.querySelector<CdsToggle>('cds-toggle');
   });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?

This cleans up and simplifies our test utils by making the `createTestElement` async. The `createTestElement` function now will automatically wait for all custom elements to be registered, removing the need to manually check with `waitForComponent`.

We also sometimes used `innerHTML` and `render()` from lit element when creating a test element. This simplifies it by allowing `createTestElement` to take a `html` template literal as its parameter and consistently render all test elements the same. By using the `html` template tag from lit we get improved type checking in the build and IDE support thanks to the `ts-lit-plugin` package we use.

![Screen Shot 2020-09-08 at 2 03 23 PM](https://user-images.githubusercontent.com/2021067/92530441-fe0e8c00-f1f1-11ea-9ba6-52a4de0ff578.png)


This PR also adds some additional documentation examples of our unit testing to the contribution guidelines.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
