### PR TITLE
Allow className to be passed down to the underlying component

### DIFF
--- a/packages/react/src/converter/react-wrapper.test.tsx
+++ b/packages/react/src/converter/react-wrapper.test.tsx
@@ -79,4 +79,16 @@ describe('CdsTestComponent', () => {
     );
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('correctly passes down className to the underlying web component', () => {
+    const wrapper = mount(
+      <div>
+        <CdsTestComponent className="test-classname">Hello World</CdsTestComponent>
+      </div>
+    );
+
+    const { classList } = wrapper.find('ReactWrapperComponent').getDOMNode();
+    expect(classList).toHaveLength(1);
+    expect(classList).toContain('test-classname');
+  });
 });

--- a/packages/react/src/converter/react-wrapper.tsx
+++ b/packages/react/src/converter/react-wrapper.tsx
@@ -44,7 +44,7 @@ export function createReactComponent<BaseComponent extends HTMLElement>(elementN
     }
 
     _propIsReservedReactProp(prop) {
-      const reactProperties = ['children', 'localName', 'ref', 'style', 'className'];
+      const reactProperties = ['children', 'localName', 'ref', 'style'];
       return reactProperties.indexOf(prop) !== -1;
     }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The [Storybook page about the Icon API](https://clarity.design/storybook/core/?path=/story/components-icon-getting-started--page#api) shows that it should be possible to change the color with `--color`.

In practice, I could not find a way to apply a `className` to the `CdsIcon` React component because the `className` property was being swallowed. [Here is a sandbox](https://codesandbox.io/s/great-swanson-kdb39?file=/src/App.tsx) to demonstrate the issue.

Issue Number: N/A

## What is the new behavior?

After removing this, this would be the expected behavior:

<img width="185" alt="Screen Shot 2020-09-09 at 4 00 05 PM" src="https://user-images.githubusercontent.com/113730/92647251-915cc580-f2b5-11ea-84fe-db6d0bfb5a7b.png">

(I couldn't figure out how to patch dependencies on CodeSandbox)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] Probably?
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I'm not sure if this is the right way to do that, and I'm more than happy to edit my PR if there is a better way, but I figured I would share what I tried and what worked in my specific use case.
Hopefully this is just a PEBCAK and there is a simple way to pass down a CSS class that I missed. Let me know how I can help!