### PR TITLE
fix(alert): sync child alerts when slot changes in alert group

### DIFF
--- a/packages/core/src/alert/alert-group.element.spec.ts
+++ b/packages/core/src/alert/alert-group.element.spec.ts
@@ -17,6 +17,66 @@ describe('Alert groups – ', () => {
   const placeholderText = 'I am an alert.';
   const alertStatusIconSelector = '.alert-status-icon';
 
+  describe('syncAlerts: ', () => {
+    beforeEach(async () => {
+      testElement = await createTestElement(html`
+        <cds-alert-group id="default" status="success">
+          <cds-alert>ohai</cds-alert>
+          <cds-alert status="loading">not me</cds-alert>
+          <cds-alert>ohai</cds-alert>
+        </cds-alert-group>
+      `);
+
+      alertGroup = testElement.querySelector<CdsAlertGroup>('#default');
+    });
+
+    afterEach(() => {
+      removeTestElement(testElement);
+    });
+
+    it('should sync alerts to alert group when rendered', async () => {
+      await componentIsStable(alertGroup);
+      const alertGroupSize = alertGroup.size;
+      const alertGroupStatus = alertGroup.status;
+      const alertGroupType = alertGroup.type;
+
+      alertGroup.querySelectorAll<CdsAlert>('cds-alert').forEach(a => {
+        expect(a.size).toBe(alertGroupSize);
+        expect(a.type).toBe(alertGroupType);
+        if (a.status !== 'loading') {
+          expect(a.status).toBe(alertGroupStatus);
+        }
+      });
+    });
+
+    it('should sync alerts to alert group when alerts are added to the alerts slot', async () => {
+      await componentIsStable(alertGroup);
+      const alertGroupSize = alertGroup.size;
+      const alertGroupStatus = alertGroup.status;
+      const alertGroupType = alertGroup.type;
+
+      function addNewAlert(grp: CdsAlertGroup) {
+        return new Promise(resolve => {
+          setTimeout(() => {
+            grp.innerHTML = grp.innerHTML + '<cds-alert id="problemchild">Muwahahahaha</cds-alert>';
+            resolve('ok');
+          }, 100);
+        });
+      }
+
+      await addNewAlert(alertGroup);
+      await componentIsStable(alertGroup);
+
+      alertGroup.querySelectorAll<CdsAlert>('cds-alert').forEach(a => {
+        expect(a.size).toBe(alertGroupSize);
+        expect(a.type).toBe(alertGroupType);
+        if (a.status !== 'loading') {
+          expect(a.status).toBe(alertGroupStatus);
+        }
+      });
+    });
+  });
+
   describe('size: ', () => {
     let compactAlertGroup: CdsAlertGroup;
 

--- a/packages/core/src/alert/alert-group.element.ts
+++ b/packages/core/src/alert/alert-group.element.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { html, LitElement } from 'lit-element';
+import { html, LitElement, query } from 'lit-element';
 import { baseStyles, property, querySlot, querySlotAll, syncProps } from '@clr/core/internal';
 import { CdsAlert } from './alert.element.js';
 import { AlertGroupTypes, AlertStatusTypes, AlertSizes } from './alert.interfaces.js';
@@ -81,6 +81,8 @@ export class CdsAlertGroup extends LitElement {
   /** @private */
   @querySlot('.pager', { assign: 'pager' }) pager: HTMLElement;
 
+  @query('.alerts') private alertSlot: HTMLElement;
+
   render() {
     return html`
       <div
@@ -92,6 +94,7 @@ export class CdsAlertGroup extends LitElement {
         </div>
         <div class="alert-group-wrapper">
           <div
+            class="alerts"
             cds-layout="vertical wrap:none align:horizontal-stretch fill ${this.size === 'sm' ? 'gap:none' : 'gap:sm'}"
           >
             <slot></slot>
@@ -101,17 +104,35 @@ export class CdsAlertGroup extends LitElement {
     `;
   }
 
-  async updated(props: Map<string, any>) {
-    super.updated(props);
+  firstUpdated(props: Map<string, any>) {
+    super.firstUpdated(props);
+    this.setupAlertsUpdate();
+  }
+
+  private setupAlertsUpdate() {
+    const propsToSync = { status: true, type: true, size: true };
+    this.alertSlot?.addEventListener('slotchange', () => this.syncAlerts(propsToSync));
+  }
+
+  private async syncAlerts(propsToSync: { status: boolean; type: boolean; size: boolean }) {
     await Promise.all(Array.from(this.alerts).map(a => a.updateComplete));
 
-    Array.from(this.alerts).forEach(alert =>
+    this.alerts.forEach(alert =>
       syncProps(alert, this, {
-        status: props.has('status') && this.type !== 'light' && alert.status !== 'loading',
-        type: props.has('type'),
-        size: props.has('size'),
+        status: propsToSync.status && this.type !== 'light' && alert.status !== 'loading',
+        type: propsToSync.type,
+        size: propsToSync.size,
       })
     );
+  }
+
+  updated(props: Map<string, any>) {
+    super.updated(props);
+    this.syncAlerts({
+      status: props.has('status'),
+      type: props.has('type'),
+      size: props.has('size'),
+    });
   }
 
   static get styles() {


### PR DESCRIPTION
Tested in:
✔︎ Chrome

Fixes: #5023

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Adding an alert to an alert group asynchronously does not align the child alert with the alert group's settings

Issue Number: #5023

## What is the new behavior?

This works now

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
