### PR TITLE
fix(alert): sync child alerts when slot changes in alert group (v4 backport)

### DIFF
--- a/packages/core/src/alert/alert-group.element.spec.ts
+++ b/packages/core/src/alert/alert-group.element.spec.ts
@@ -21,6 +21,68 @@ describe('Alert groups – ', () => {
   const placeholderText = 'I am an alert.';
   const alertStatusIconSelector = '.alert-status-icon';
 
+  describe('syncAlerts: ', () => {
+    beforeEach(async () => {
+      testElement = createTestElement();
+      testElement.innerHTML = `
+        <cds-alert-group id="default" status="success">
+          <cds-alert>ohai</cds-alert>
+          <cds-alert status="loading">not me</cds-alert>
+          <cds-alert>ohai</cds-alert>
+        </cds-alert-group>
+      `;
+
+      await waitForComponent('cds-alert');
+      alertGroup = testElement.querySelector<CdsAlertGroup>('#default');
+    });
+
+    afterEach(() => {
+      removeTestElement(testElement);
+    });
+
+    it('should sync alerts to alert group when rendered', async () => {
+      await componentIsStable(alertGroup);
+      const alertGroupSize = alertGroup.size;
+      const alertGroupStatus = alertGroup.status;
+      const alertGroupType = alertGroup.type;
+
+      alertGroup.querySelectorAll<CdsAlert>('cds-alert').forEach(a => {
+        expect(a.size).toBe(alertGroupSize);
+        expect(a.type).toBe(alertGroupType);
+        if (a.status !== 'loading') {
+          expect(a.status).toBe(alertGroupStatus);
+        }
+      });
+    });
+
+    it('should sync alerts to alert group when alerts are added to the alerts slot', async () => {
+      await componentIsStable(alertGroup);
+      const alertGroupSize = alertGroup.size;
+      const alertGroupStatus = alertGroup.status;
+      const alertGroupType = alertGroup.type;
+
+      function addNewAlert(grp: CdsAlertGroup) {
+        return new Promise(resolve => {
+          setTimeout(() => {
+            grp.innerHTML = grp.innerHTML + '<cds-alert id="problemchild">Muwahahahaha</cds-alert>';
+            resolve('ok');
+          }, 100);
+        });
+      }
+
+      await addNewAlert(alertGroup);
+      await componentIsStable(alertGroup);
+
+      alertGroup.querySelectorAll<CdsAlert>('cds-alert').forEach(a => {
+        expect(a.size).toBe(alertGroupSize);
+        expect(a.type).toBe(alertGroupType);
+        if (a.status !== 'loading') {
+          expect(a.status).toBe(alertGroupStatus);
+        }
+      });
+    });
+  });
+
   describe('size: ', () => {
     let compactAlertGroup: CdsAlertGroup;
 

--- a/packages/core/src/alert/alert-group.element.ts
+++ b/packages/core/src/alert/alert-group.element.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { html, LitElement } from 'lit-element';
+import { html, LitElement, query } from 'lit-element';
 import { baseStyles, property, querySlot, querySlotAll, syncProps } from '@clr/core/internal';
 import { CdsAlert } from './alert.element.js';
 import { AlertGroupTypes, AlertStatusTypes, AlertSizes } from './alert.interfaces.js';
@@ -81,6 +81,8 @@ export class CdsAlertGroup extends LitElement {
   /** @private */
   @querySlot('.pager', { assign: 'pager' }) pager: HTMLElement;
 
+  @query('.alerts') private alertSlot: HTMLElement;
+
   render() {
     return html`
       <div
@@ -92,6 +94,7 @@ export class CdsAlertGroup extends LitElement {
         </div>
         <div class="alert-group-wrapper">
           <div
+            class="alerts"
             cds-layout="vertical wrap:none align:horizontal-stretch fill ${this.size === 'sm' ? 'gap:none' : 'gap:sm'}"
           >
             <slot></slot>
@@ -101,17 +104,35 @@ export class CdsAlertGroup extends LitElement {
     `;
   }
 
-  async updated(props: Map<string, any>) {
-    super.updated(props);
+  firstUpdated(props: Map<string, any>) {
+    super.firstUpdated(props);
+    this.setupAlertsUpdate();
+  }
+
+  private setupAlertsUpdate() {
+    const propsToSync = { status: true, type: true, size: true };
+    this.alertSlot?.addEventListener('slotchange', () => this.syncAlerts(propsToSync));
+  }
+
+  private async syncAlerts(propsToSync: { status: boolean; type: boolean; size: boolean }) {
     await Promise.all(Array.from(this.alerts).map(a => a.updateComplete));
 
-    Array.from(this.alerts).forEach(alert =>
+    this.alerts.forEach(alert =>
       syncProps(alert, this, {
-        status: props.has('status') && this.type !== 'light' && alert.status !== 'loading',
-        type: props.has('type'),
-        size: props.has('size'),
+        status: propsToSync.status && this.type !== 'light' && alert.status !== 'loading',
+        type: propsToSync.type,
+        size: propsToSync.size,
       })
     );
+  }
+
+  updated(props: Map<string, any>) {
+    super.updated(props);
+    this.syncAlerts({
+      status: props.has('status'),
+      type: props.has('type'),
+      size: props.has('size'),
+    });
   }
 
   static get styles() {


### PR DESCRIPTION
Tested in:
✔︎ Chrome

Fixes: #5023

Signed-off-by: Scott Mathis <smathis@vmware.com>

Backport of #5026 