### PR TITLE
fix(accordion): updated panel property to match stepper panel for TS 4

### DIFF
--- a/packages/angular/golden/clr-angular.d.ts
+++ b/packages/angular/golden/clr-angular.d.ts
@@ -89,12 +89,13 @@ export declare class ClrAccordionPanel implements OnInit, OnChanges {
     accordionDescription: QueryList<ClrAccordionDescription>;
     commonStrings: ClrCommonStringsService;
     disabled: boolean;
-    id: string;
+    get id(): string;
+    set id(value: string);
     isAccordion: boolean;
     panel: Observable<AccordionPanelModel>;
     panelOpen: boolean;
     panelOpenChange: EventEmitter<boolean>;
-    constructor(commonStrings: ClrCommonStringsService, accordionService: AccordionService, ifExpandService: IfExpandService, id: string);
+    constructor(commonStrings: ClrCommonStringsService, accordionService: AccordionService, ifExpandService: IfExpandService, _id: string);
     collapsePanelOnAnimationDone(panel: AccordionPanelModel): void;
     getAccordionContentId(id: string): string;
     getAccordionHeaderId(id: string): string;

--- a/packages/angular/projects/clr-angular/src/accordion/accordion-panel.ts
+++ b/packages/angular/projects/clr-angular/src/accordion/accordion-panel.ts
@@ -47,11 +47,19 @@ export class ClrAccordionPanel implements OnInit, OnChanges {
   readonly AccordionStatus = AccordionStatus;
   isAccordion = true;
 
+  get id(): string {
+    return this._id;
+  }
+
+  set id(value: string) {
+    this._id = value;
+  }
+
   constructor(
     public commonStrings: ClrCommonStringsService,
     private accordionService: AccordionService,
     private ifExpandService: IfExpandService,
-    @Inject(UNIQUE_ID) public id: string
+    @Inject(UNIQUE_ID) private _id: string
   ) {}
 
   ngOnInit() {


### PR DESCRIPTION
There was an inconsistency in how the `id` property of the accordion panel and stepper panels were implemented that Typescript 4 did not like. This resolves the inconsistency and should work fine on TS 3.9 or 4. Angular bumped support to TS 4 and this is an unexpected side effect.

fixes #5015

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
