### PR TITLE
docs: two small launch fixes for website

### DIFF
--- a/apps/website/.vuepress/theme/components/SkipTo.vue
+++ b/apps/website/.vuepress/theme/components/SkipTo.vue
@@ -1,0 +1,62 @@
+<!--
+  - Copyright (c) 2016-2020 VMware, Inc.
+  - All Rights ReserveThis software is released under MIT license.
+  - The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<template>
+  <cds-button
+    status="danger"
+    size="sm"
+    class="doc-skip-link"
+    :class="{
+      'clr-sr-only': hideSkipLink,
+    }"
+    @click="skipToContent()"
+    @focus="hideSkipLink = false"
+    @blur="hideSkipLink = true"
+    name="Skip to content"
+  >
+    <slot>{{ label }}</slot>
+  </cds-button>
+</template>
+
+<script>
+export default {
+  name: 'SkipTo',
+  hideSkipLink: true,
+  data: function () {
+    return {
+      hideSkipLink: true,
+    };
+  },
+  props: {
+    label: {
+      type: String,
+      default: 'Skip to main content',
+    },
+    toId: {
+      type: String,
+      default: '#content-area',
+    },
+  },
+  methods: {
+    skipToContent() {
+      this.skipTarget.focus();
+    },
+  },
+  computed: {
+    skipTarget: function () {
+      return document.getElementById(this.toId);
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+.doc-skip-link {
+  position: absolute;
+  margin-left: 1.5rem;
+  margin-top: 2.5rem;
+}
+</style>

--- a/apps/website/.vuepress/theme/layouts/Layout.vue
+++ b/apps/website/.vuepress/theme/layouts/Layout.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="main-container" cds-layout="vertical align:stretch">
+    <SkipTo toId="content-area" label="Skip to main content" />
     <Navbar v-if="shouldShowNavbar">
       <template #sidebar-toggle>
         <button
@@ -17,6 +18,7 @@
       <Sidebar :items="sidebarItems" :isSidebarOpen="isSidebarOpen" @isSidebarOpenChange="toggleSidebar()" />
       <div
         id="content-area"
+        tabindex="-1"
         :class="{ 'content-area': true, 'home-page': $page.frontmatter.home }"
         cds-layout="pl@sm:md"
       >
@@ -69,6 +71,7 @@ import Navbar from '@theme/components/Navbar';
 import NavToc from '@theme/components/NavToc';
 import Page from '@theme/components/Page';
 import Sidebar from '@theme/components/Sidebar';
+import SkipTo from '@theme/components/SkipTo';
 import { resolveSidebarItems } from '../util';
 import { scrollToGuard } from '../util/route-guards';
 
@@ -85,6 +88,7 @@ export default {
     Sidebar,
     Navbar,
     NavToc,
+    SkipTo,
   },
 
   data() {

--- a/apps/website/foundation/navigation/api.md
+++ b/apps/website/foundation/navigation/api.md
@@ -1,5 +1,6 @@
 ---
 title: API
+toc: true
 ---
 
 ## Angular Navigation Components and Directives

--- a/apps/website/foundation/navigation/demo.md
+++ b/apps/website/foundation/navigation/demo.md
@@ -1,7 +1,0 @@
----
-title: Demo
----
-
-<!-- TODO: add storybook demo -->
-
-_COMING SOON..._


### PR DESCRIPTION
1. Adds a skip to link for all content pages
2. Removes the demo tab from foundation/navigation

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

I'm adding a skip to link and removing an unused demo tab fro the navigation content. 

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
n/x

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
All pages should show a skip to link similar to the current website that places focus on the #content-area container. 
foundation/navigation should only have usage and api tabs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
