### PR TITLE
fix(datagrid): double event on selection

### DIFF
--- a/packages/angular/projects/clr-angular/src/data/datagrid/providers/selection.spec.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/providers/selection.spec.ts
@@ -193,7 +193,7 @@ export default function (): void {
         expect(currentSelection.sort(numberSort)).toEqual(itemsInstance.displayed);
         selectionInstance.toggleAll();
         expect(currentSelection).toEqual([]);
-        expect(nbChanges).toBe(4);
+        expect(nbChanges).toBe(3);
       });
 
       it('exposes an Observable to follow selection changes in single selection type', function () {

--- a/packages/angular/projects/clr-angular/src/data/datagrid/providers/selection.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/providers/selection.ts
@@ -318,10 +318,8 @@ export class Selection<T = any> {
       case SelectionType.Multi:
         if (index >= 0 && !selected) {
           this.deselectItem(index);
-          this.emitChange();
         } else if (index < 0 && selected) {
           this.selectItem(item);
-          this.emitChange();
         }
         break;
       default:


### PR DESCRIPTION
Caused by fix in the "current selection immutability" fix

Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4528 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
