### PR TITLE
feat: adding cds-divider component to core

### DIFF
--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -48,7 +48,7 @@ export const parameters = {
           'Date (Internal)',
         ],
         'Components (Preview)',
-        ['Circular Progress'],
+        ['Circular Progress', 'Divider'],
         'Utilities (Preview)',
         'Internal',
         [

--- a/packages/core/.storybook/public/demo.css
+++ b/packages/core/.storybook/public/demo.css
@@ -143,35 +143,39 @@ cds-card {
   overflow: hidden;
 }
 
+.demo-divider {
+  --color: var(--cds-token-color-neutral-500);
+}
+
 .demo-header {
   background: var(--cds-token-color-action-1000);
   color: var(--cds-token-color-neutral-0);
 }
 
+.demo-sidenav,
 .demo-content {
   background: var(--cds-token-color-neutral-200);
 }
 
-.demo-footer {
+.demo-subnav,
+.demo-footer,
+.demo-alt-content,
+.demo-alt-content-header {
   background: var(--cds-token-color-neutral-0);
+}
+
+.demo-footer,
+.demo-alt-content-header {
   color: var(--cds-token-color-neutral-700);
-  box-shadow: 0 0.05rem 0 hsl(198, 0%, 70%) inset;
 }
 
 .demo-sidenav {
-  background: var(--cds-token-color-neutral-200);
-  box-shadow: -0.05rem 0 0 rgba(0, 0, 0, 0.2) inset;
   width: 25%;
 }
 
 .demo-sidebar {
   background: var(--cds-token-color-neutral-100);
   width: 25%;
-}
-
-.demo-subnav {
-  background: var(--cds-token-color-neutral-0);
-  box-shadow: 0 -0.05rem 0 hsl(198, 0%, 70%) inset;
 }
 
 .demo-alt-header cds-icon,
@@ -199,14 +203,4 @@ cds-card {
 
 .demo-alt-header-2 {
   background: var(--cds-token-color-neutral-900);
-}
-
-.demo-alt-content {
-  background: var(--cds-token-color-neutral-0);
-}
-
-.demo-alt-content-header {
-  background: var(--cds-token-color-neutral-0);
-  color: var(--cds-token-color-neutral-700);
-  box-shadow: 0 -0.05rem 0 hsl(198, 0%, 70%) inset;
 }

--- a/packages/core/import-map.importmap
+++ b/packages/core/import-map.importmap
@@ -52,6 +52,8 @@
     "@clr/core/datalist/register.js": "/base/dist/core/datalist/register.js",
     "@clr/core/date": "/base/dist/core/date/index.js",
     "@clr/core/date/register.js": "/base/dist/core/date/register.js",
+    "@clr/core/divider": "/base/dist/core/divider/index.js",
+    "@clr/core/divider/register.js": "/base/dist/core/divider/register.js",
     "@clr/core/file": "/base/dist/core/file/index.js",
     "@clr/core/file/register.js": "/base/dist/core/file/register.js",
     "@clr/core/forms": "/base/dist/core/forms/index.js",

--- a/packages/core/src/divider/divider.element.scss
+++ b/packages/core/src/divider/divider.element.scss
@@ -1,0 +1,31 @@
+@import './../styles/tokens/generated/index';
+
+:host {
+  --color: #{$cds-token-color-neutral-300};
+  --size: #{$cds-token-space-size-1};
+  --padding: 0;
+
+  display: block;
+  width: 100%;
+  padding: var(--padding);
+}
+
+.private-host {
+  height: var(--size);
+  background: var(--color);
+}
+
+:host([orientation='vertical']) {
+  // align-self and the height allow the vertical divider to fill up its parent container inside a layout
+  // - height will likely have to be set via CSS if the vertical divider is used outside of a layout
+  // - if a container is set to a smaller height than its contents should allow the vertical divider
+  //   will creep up on the screen above the container.
+  align-self: stretch;
+  height: inherit;
+  width: var(--size);
+}
+
+:host([orientation*='vertical']) .private-host {
+  height: 100%;
+  width: var(--size);
+}

--- a/packages/core/src/divider/divider.element.spec.ts
+++ b/packages/core/src/divider/divider.element.spec.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { html } from 'lit-html';
+import { CdsDivider } from '@clr/core/divider';
+import { componentIsStable, createTestElement, removeTestElement } from '@clr/core/test/utils';
+import '@clr/core/divider/register.js';
+
+describe('divider element', () => {
+  describe('render: ', () => {
+    let testElement: HTMLElement;
+    let component: CdsDivider;
+
+    beforeEach(async () => {
+      testElement = await createTestElement(html`<cds-divider></cds-divider>`);
+      component = testElement.querySelector<CdsDivider>('cds-divider');
+    });
+
+    afterEach(() => {
+      removeTestElement(testElement);
+    });
+
+    it('should create the component', async () => {
+      await componentIsStable(component);
+      expect(component).not.toBe(null);
+    });
+  });
+
+  describe('defaults: ', () => {
+    let testElement: HTMLElement;
+    let component: CdsDivider;
+    let innerComponent: HTMLElement;
+    const containerWidth = 250;
+
+    beforeEach(async () => {
+      testElement = await createTestElement(html`
+        <div id="container" style="height: 60px; width: ${containerWidth}px">
+          <cds-divider></cds-divider>
+        </div>
+      `);
+      component = testElement.querySelector<CdsDivider>('cds-divider');
+      innerComponent = component.shadowRoot.querySelector('.private-host');
+    });
+
+    afterEach(() => {
+      removeTestElement(testElement);
+    });
+
+    it('should set the divider width to the width of the container by default', async () => {
+      await componentIsStable(component);
+      expect(innerComponent.clientWidth).toBe(
+        containerWidth,
+        'dividers should take up the full width of their container by default'
+      );
+    });
+
+    it('should set the divider height to 1px by default', async () => {
+      await componentIsStable(component);
+      expect(innerComponent.clientHeight).toBe(1, 'dividers should be 1px by default');
+    });
+
+    it('should set aria role to "separator" by default', async () => {
+      await componentIsStable(component);
+      expect(innerComponent.getAttribute('role')).toBe('separator');
+    });
+
+    it('should set aria-orientation to "horizontal" by default', async () => {
+      await componentIsStable(component);
+      expect(innerComponent.getAttribute('aria-orientation')).toBe('horizontal');
+    });
+  });
+
+  describe('vertical divider: ', () => {
+    let testElement: HTMLElement;
+    let component: CdsDivider;
+    let innerComponent: HTMLElement;
+    const containerHeight = 250;
+    const containerWidth = 50;
+
+    beforeEach(async () => {
+      testElement = await createTestElement(html`
+        <div
+          id="container"
+          style="display: flex; flex-direction: row; height: ${containerHeight}px; width: ${containerWidth}px"
+        >
+          <cds-divider orientation="vertical"></cds-divider>
+        </div>
+      `);
+      component = testElement.querySelector<CdsDivider>('cds-divider');
+      innerComponent = component.shadowRoot.querySelector('.private-host');
+    });
+
+    afterEach(() => {
+      removeTestElement(testElement);
+    });
+
+    it('should set the divider height to the height of the container', async () => {
+      await componentIsStable(component);
+      expect(innerComponent.clientHeight).toBe(
+        containerHeight,
+        'vertical dividers should take up the full height of their container'
+      );
+    });
+
+    it('should set the vertical divider width to 1px', async () => {
+      await componentIsStable(component);
+      expect(innerComponent.clientWidth).toBe(1);
+    });
+
+    it('should set aria-orientation to "vertical"', async () => {
+      await componentIsStable(component);
+      expect(innerComponent.getAttribute('aria-orientation')).toBe('vertical');
+    });
+  });
+});

--- a/packages/core/src/divider/divider.element.ts
+++ b/packages/core/src/divider/divider.element.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { baseStyles, property } from '@clr/core/internal';
+import { html, LitElement } from 'lit-element';
+import { styles } from './divider.element.css.js';
+
+/**
+ * Dividers are a convenient way to place lined dividers or "rules"
+ * between blocks of content.
+ *
+ * ```typescript
+ * import '@clr/core/divider/register.js';
+ * ```
+ *
+ * ```html
+ * <cds-divider></cds-divider>
+ * ```
+ * @beta
+ * @element cds-divider
+ * @cssprop --color
+ * @cssprop --padding
+ * @cssprop --size
+ */
+export class CdsDivider extends LitElement {
+  @property({ type: String })
+  orientation: 'horizontal' | 'vertical' = 'horizontal';
+
+  render() {
+    return html`<div class="private-host" role="separator" aria-orientation="${this.orientation}"></div>`;
+  }
+
+  static get styles() {
+    return [baseStyles, styles];
+  }
+}

--- a/packages/core/src/divider/divider.stories.mdx
+++ b/packages/core/src/divider/divider.stories.mdx
@@ -1,0 +1,48 @@
+import { Meta, Props, Story, Preview, API } from '@storybook/addon-docs/blocks';
+import { html, LitElement } from 'lit-element';
+
+<Meta title="Components (Preview)/Divider/Getting Started" />
+
+# Dividers
+
+Dividers are a convenient way to place lined dividers or "rules" between blocks of content.
+
+## Installation
+
+To use the divider component import the component in your JavaScript.
+
+```typescript
+import '@clr/core/divider/register.js';
+```
+
+```html
+<cds-divider></cds-divider>
+```
+
+## Divider
+
+<Preview>
+  <Story id="components-preview-divider-stories--horizontal" />
+</Preview>
+
+## Vertical Divider
+
+<Preview>
+  <Story id="components-preview-divider-stories--vertical" />
+</Preview>
+
+## Vertical Dividers Without Layouts
+
+<Preview>
+  <Story id="components-preview-divider-stories--vertical-fill" />
+</Preview>
+
+## Custom Dividers
+
+<Preview>
+  <Story id="components-preview-divider-stories--custom" />
+</Preview>
+
+## API
+
+<Props of={'cds-divider'} />

--- a/packages/core/src/divider/divider.stories.ts
+++ b/packages/core/src/divider/divider.stories.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import '@clr/core/button/register.js';
+import '@clr/core/divider/register.js';
+import { getElementStorybookArgTypes, spreadProps, getElementStorybookArgs } from '@clr/core/internal';
+import { html } from 'lit-html';
+import customElements from '../../dist/core/custom-elements.json';
+
+export default {
+  title: 'Components (Preview)/Divider/Stories',
+  component: 'cds-divider',
+  argTypes: getElementStorybookArgTypes('cds-divider', customElements),
+  parameters: {
+    options: { showPanel: true },
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/v2mkhzKQdhECXOx8BElgdA/Clarity-UI-Library---light-2.2.0?node-id=51%3A673',
+    },
+  },
+};
+
+export const API = (args: any) => {
+  return html`
+    <cds-divider ...="${spreadProps(getElementStorybookArgs(args))}">
+      ${args.default}
+    </cds-divider>
+  `;
+};
+
+export const horizontal = () => {
+  return html`
+    <div cds-layout="vertical gap:md">
+      <p cds-text="body disable-lhe">It is often preferable to use dividers inside of layouts.</p>
+      <cds-divider></cds-divider>
+      <p cds-text="body disable-lhe">This allows them to span the dimensions of their containers as expected.</p>
+    </div>
+  `;
+};
+
+export const vertical = () => {
+  return html`
+    <div cds-layout="horizontal gap:md align:vertical-center p-x:md" style="background:#f9f9f9">
+      <cds-button size="sm" action="outline">Demo Button 1</cds-button>
+      <cds-button size="sm" action="outline">Demo Button 1</cds-button>
+      <cds-divider orientation="vertical"></cds-divider>
+      <cds-button size="sm" action="outline">Demo Button 2</cds-button>
+      <cds-divider orientation="vertical"></cds-divider>
+      <p cds-text="body disable-lhe">Vertical dividers should be used inside horizontal layouts.</p>
+    </div>
+    <p cds-text="body" cds-layout="m-y:lg">
+      A background color has been applied to the section above to demonstrate the divider taking the full height of its
+      container.
+    </p>
+  `;
+};
+
+export const verticalFill = () => {
+  return html`
+    <div style="background:#f9f9f9; width: 100%; height: 80px; padding: 0 49%">
+      <cds-divider orientation="vertical"></cds-divider>
+    </div>
+    <p cds-text="body" cds-layout="m-y:lg">
+      If not using a layout, the vertical divider should still be able to fill the known height of a container. But the
+      container needs to have a height defined on it. Layouts, however, are preferred and recommended.
+    </p>
+  `;
+};
+
+export const custom = () => {
+  return html`
+    <style>
+      cds-divider.app-custom {
+        --color: red;
+        --size: 0.1rem;
+      }
+
+      cds-divider.app-custom-2 {
+        --color: purple;
+        --size: 0.15rem;
+        --padding: 0.3rem 0.2rem;
+      }
+
+      cds-divider.app-custom-3 {
+        --color: green;
+      }
+
+      .old-style-float::after {
+        clear: both;
+        content: '';
+        display: block;
+        height: 0;
+        visibility: hidden;
+      }
+
+      .old-style-float > * {
+        float: left;
+        height: 100%;
+      }
+    </style>
+    <div cds-layout="vertical gap:lg">
+      <div cds-layout="horizontal gap:md align:vertical-center">
+        <cds-button size="sm">Demo Button 1</cds-button>
+        <cds-divider class="app-custom-2" orientation="vertical"></cds-divider>
+        <cds-button size="sm" action="outline">Demo Button 2</cds-button>
+        <cds-button size="sm" action="outline">Demo Button 3</cds-button>
+      </div>
+      <cds-divider class="app-custom"></cds-divider>
+      <div cds-layout="align:stretch">
+        <p cds-text="body disable-lhe">The thickness (size) and color of dividers can be customized.</p>
+      </div>
+    </div>
+  `;
+};

--- a/packages/core/src/divider/entrypoint.tsconfig.json
+++ b/packages/core/src/divider/entrypoint.tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.lib.json",
+  "compilerOptions": {
+    "composite": true
+  },
+  "references": [{ "path": "../internal/entrypoint.tsconfig.json" }]
+}

--- a/packages/core/src/divider/index.ts
+++ b/packages/core/src/divider/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+export * from './divider.element.js';

--- a/packages/core/src/divider/package.json
+++ b/packages/core/src/divider/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "@clr/core/divider",
+    "sideEffects": [
+      "./register.js"
+    ]
+  }
+  

--- a/packages/core/src/divider/register.ts
+++ b/packages/core/src/divider/register.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { registerElementSafely } from '@clr/core/internal';
+import { CdsDivider } from './divider.element.js';
+
+registerElementSafely('cds-divider', CdsDivider);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'cds-divider': CdsDivider;
+  }
+}

--- a/packages/core/src/styles/layout/layout.stories.ts
+++ b/packages/core/src/styles/layout/layout.stories.ts
@@ -5,6 +5,7 @@
  */
 
 import { html } from 'lit-html';
+import '@clr/core/divider/register.js';
 
 export default {
   title: 'Foundation/Layout/Stories',
@@ -1543,12 +1544,14 @@ export const patternsApplicationVerticalLayout = () => {
       </header>
       <div cds-layout="horizontal align:vertical-stretch wrap:none">
         <nav class="demo-sidenav" cds-layout="p:md p@md:lg">sidebar</nav>
+        <cds-divider class="demo-divider" orientation="vertical"></cds-divider>
         <div cds-layout="vertical align:stretch">
           <div class="demo-content demo-scrollable-content">
             <div cds-layout="vertical gap:md p:lg">
               ${scrollableContentHtml}
             </div>
           </div>
+          <cds-divider class="demo-divider"></cds-divider>
           <footer class="demo-footer" cds-layout="p-y:md p-x:lg">footer</footer>
         </div>
       </div>
@@ -1563,12 +1566,15 @@ export const patternsApplicationVerticalLayoutSubnav = () => {
         header
       </header>
       <div class="demo-subnav" cds-layout="p:md">subnav</div>
-      <div cds-layout="horizontal align:stretch">
-        <nav class="demo-sidenav" cds-layout="p:md p@md:lg align:shrink">sidebar</nav>
+      <cds-divider class="demo-divider"></cds-divider>
+      <div cds-layout="horizontal align:vertical-stretch">
+        <nav class="demo-sidenav" cds-layout="p:md p@md:lg">sidebar</nav>
+        <cds-divider class="demo-divider" orientation="vertical"></cds-divider>
         <div class="demo-content demo-scrollable-content" cds-layout="vertical gap:md p:lg align:stretch">
           ${scrollableContentHtml}
         </div>
       </div>
+      <cds-divider class="demo-divider"></cds-divider>
       <footer class="demo-footer" cds-layout="p:md p@md:lg align:shrink">footer</footer>
     </div>
   `;
@@ -1584,15 +1590,18 @@ export const patternsApplicationVerticalIconLayout = () => {
         <cds-icon shape="building" size="lg" inverse></cds-icon>
         <cds-icon shape="cog" size="lg" inverse cds-layout="align:bottom"></cds-icon>
       </header>
-      <div cds-layout="horizontal gap:none align:stretch wrap:none">
+      <div cds-layout="horizontal gap:none align:vertical-stretch wrap:none">
         <nav class="demo-sidenav" cds-layout="p:md align:shrink">
           <p cds-text="section">sidebar</p>
         </nav>
+        <cds-divider class="demo-divider" orientation="vertical"></cds-divider>
         <div cds-layout="vertical align:stretch">
-          <div class="demo-header demo-alt-content-header" cds-layout="p:md align:shrink">header</div>
+          <div class="demo-header demo-alt-content-header" cds-layout="p:md">header</div>
+          <cds-divider class="demo-divider"></cds-divider>
           <div class="demo-content demo-scrollable-content demo-alt-content" cds-layout="vertical gap:md p:lg">
             ${scrollableContentHtml}
           </div>
+          <cds-divider class="demo-divider"></cds-divider>
           <footer class="demo-footer" cds-layout="p:md align:shrink">footer</footer>
         </div>
       </div>
@@ -1611,16 +1620,18 @@ export const patternsApplicationVerticalIconLayoutHybrid = () => {
         <cds-icon shape="cog" size="lg" inverse cds-layout="align:bottom"></cds-icon>
       </header>
       <div cds-layout="vertical align:stretch">
-        <header class="demo-header" cds-layout="p:md p@md:lg align:shrink">
+        <header class="demo-header" cds-layout="p:md p@md:lg">
           header
         </header>
-        <div cds-layout="horizontal align:stretch">
-          <nav class="demo-sidenav" cds-layout="p:md p@md:lg align:shrink">sidebar</nav>
+        <div cds-layout="horizontal align:vertical-stretch">
+          <nav class="demo-sidenav" cds-layout="p:md p@md:lg">sidebar</nav>
+          <cds-divider class="demo-divider" orientation="vertical"></cds-divider>
           <div class="demo-content demo-scrollable-content" cds-layout="vertical gap:md p:lg align:stretch">
             ${scrollableContentHtml}
           </div>
         </div>
-        <footer class="demo-footer" cds-layout="p:md p@md:lg align:shrink">footer</footer>
+        <cds-divider class="demo-divider"></cds-divider>
+        <footer class="demo-footer" cds-layout="p:md p@md:lg">footer</footer>
       </div>
     </div>
   `;
@@ -1628,16 +1639,19 @@ export const patternsApplicationVerticalIconLayoutHybrid = () => {
 
 export const patternsContentSiteThreeColumn = () => {
   return html`
-    <div class="demo-layout" cds-layout="vertical align:stretch" style="height: 100vh">
-      <header class="demo-header" cds-layout="p:md p@md:lg align:shrink">
+    <div class="demo-layout" cds-layout="vertical align:horizontal-stretch" style="height: 100vh">
+      <header class="demo-header" cds-layout="p:md p@md:lg">
         header
       </header>
       <div cds-layout="horizontal align:vertical-stretch" class="demo-content">
         <nav class="demo-sidenav" cds-layout="p:md p@md:lg">sidebar</nav>
+        <cds-divider class="demo-divider" orientation="vertical"></cds-divider>
         <div class="demo-content" cds-layout="p:md p@md:lg align:stretch">content</div>
+        <cds-divider class="demo-divider" orientation="vertical"></cds-divider>
         <section class="demo-sidebar" cds-layout="p:md p@md:lg">sidebar</section>
       </div>
-      <footer class="demo-footer" cds-layout="p:md p@md:lg align:shrink">footer</footer>
+      <cds-divider class="demo-divider"></cds-divider>
+      <footer class="demo-footer" cds-layout="p:md p@md:lg">footer</footer>
     </div>
   `;
 };
@@ -1714,6 +1728,7 @@ export const patternsResponsiveImageGallery = () => {
         <img src="https://dummyimage.com/600x400/000/fff" alt="placeholder image" cds-layout="fill" />
         <img src="https://dummyimage.com/600x400/000/fff" alt="placeholder image" cds-layout="fill" />
       </div>
+      <cds-divider class="demo-divider"></cds-divider>
       <footer class="demo-footer" cds-layout="p:md p@md:lg">footer</footer>
     </div>
   `;

--- a/packages/core/tsconfig.project.json
+++ b/packages/core/tsconfig.project.json
@@ -12,6 +12,7 @@
     { "path": "./src/checkbox/entrypoint.tsconfig.json" },
     { "path": "./src/datalist/entrypoint.tsconfig.json" },
     { "path": "./src/date/entrypoint.tsconfig.json" },
+    { "path": "./src/divider/entrypoint.tsconfig.json" },
     { "path": "./src/file/entrypoint.tsconfig.json" },
     { "path": "./src/forms/entrypoint.tsconfig.json" },
     { "path": "./src/icon/entrypoint.tsconfig.json" },

--- a/packages/react/App.tsx
+++ b/packages/react/App.tsx
@@ -21,6 +21,7 @@ import { CdsTime } from './src/time';
 import { CdsTextarea } from './src/textarea';
 import { CdsToggle, CdsToggleGroup } from './src/toggle';
 import { ClarityIcons, userIcon, timesIcon } from '@clr/core/icon';
+import { CdsDivider } from './src/divider';
 
 ClarityIcons.addIcons(userIcon, timesIcon);
 
@@ -611,6 +612,13 @@ export default class App extends React.Component<{}, AppState> {
             <CdsControlMessage>message text</CdsControlMessage>
           </CdsSelect>
         </CdsFormGroup>
+
+        <h2>Divider</h2>
+        <CdsDivider></CdsDivider>
+
+        <div style={{ height: '140px', marginTop: '24px' }}>
+          <CdsDivider orientation="vertical">1</CdsDivider>
+        </div>
 
         <h2>Progress</h2>
         <h3>Circular</h3>

--- a/packages/react/src/divider/__snapshots__/index.test.tsx.snap
+++ b/packages/react/src/divider/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CdsDivider snapshot 1`] = `
+<div>
+  <CdsDivider>
+    <cds-divider />
+  </CdsDivider>
+  <div
+    style={
+      Object {
+        "height": "140px",
+        "marginTop": "24px",
+      }
+    }
+  >
+    <CdsDivider
+      orientation="vertical"
+    >
+      <cds-divider>
+        1
+      </cds-divider>
+    </CdsDivider>
+  </div>
+</div>
+`;

--- a/packages/react/src/divider/entrypoint.tsconfig.json
+++ b/packages/react/src/divider/entrypoint.tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.lib.json",
+  "compilerOptions": {
+    "composite": true
+  },
+  "references": [{ "path": "../converter/entrypoint.tsconfig.json" }]
+}

--- a/packages/react/src/divider/index.test.tsx
+++ b/packages/react/src/divider/index.test.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { mount, shallow } from 'enzyme';
+import { CdsDivider } from './index';
+
+describe('CdsDivider', () => {
+  it('renders', () => {
+    const wrapper = shallow(
+      <div>
+        <CdsDivider></CdsDivider>
+      </div>
+    );
+    const renderedComponent = wrapper.find('CdsDivider');
+    expect(renderedComponent).toBeDefined();
+  });
+
+  it('snapshot', () => {
+    const vertDivStyle = {
+      height: '140px',
+      marginTop: '24px',
+    };
+    const wrapper = mount(
+      <div>
+        <CdsDivider></CdsDivider>
+        <div style={vertDivStyle}>
+          <CdsDivider orientation="vertical">1</CdsDivider>
+        </div>
+      </div>
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/packages/react/src/divider/index.tsx
+++ b/packages/react/src/divider/index.tsx
@@ -1,0 +1,6 @@
+import { CdsDivider as Divider } from '@clr/core/divider';
+import '@clr/core/divider/register';
+import { createReactComponent } from '../converter/react-wrapper';
+
+type CdsDividerType = Divider;
+export class CdsDivider extends createReactComponent<CdsDividerType>('cds-divider') {}

--- a/packages/react/src/divider/package.json
+++ b/packages/react/src/divider/package.json
@@ -1,0 +1,5 @@
+{
+    "sideEffects": true,
+    "name": "@clr/react/divider"
+  }
+  

--- a/packages/react/tsconfig.project.json
+++ b/packages/react/tsconfig.project.json
@@ -6,8 +6,23 @@
     { "path": "./src/alert/entrypoint.tsconfig.json" },
     { "path": "./src/badge/entrypoint.tsconfig.json" },
     { "path": "./src/button/entrypoint.tsconfig.json" },
+    { "path": "./src/checkbox/entrypoint.tsconfig.json" },
+    { "path": "./src/datalist/entrypoint.tsconfig.json" },
+    { "path": "./src/date/entrypoint.tsconfig.json" },
+    { "path": "./src/divider/entrypoint.tsconfig.json" },
+    { "path": "./src/file/entrypoint.tsconfig.json" },
+    { "path": "./src/forms/entrypoint.tsconfig.json" },
     { "path": "./src/icon/entrypoint.tsconfig.json" },
     { "path": "./src/modal/entrypoint.tsconfig.json" },
-    { "path": "./src/tag/entrypoint.tsconfig.json" }
+    { "path": "./src/password/entrypoint.tsconfig.json" },
+    { "path": "./src/progress-circle/entrypoint.tsconfig.json" },
+    { "path": "./src/radio/entrypoint.tsconfig.json" },
+    { "path": "./src/range/entrypoint.tsconfig.json" },
+    { "path": "./src/search/entrypoint.tsconfig.json" },
+    { "path": "./src/select/entrypoint.tsconfig.json" },
+    { "path": "./src/tag/entrypoint.tsconfig.json" },
+    { "path": "./src/textarea/entrypoint.tsconfig.json" },
+    { "path": "./src/time/entrypoint.tsconfig.json" },
+    { "path": "./src/toggle/entrypoint.tsconfig.json" }
   ]
 }


### PR DESCRIPTION
• needed for menus, cards, datagrid headers, and other components
• added stories
• added horizontal dividers
• added vertical dividers for use within layouts
• added vertical-fill dividers for use within sized containers that aren't using layouts
• added unit tests
• added react wrappers and tests for dividers
• updated project tsconfig to account for all components
• update example app layouts to use dividers
• cleaned up example app layouts as CSS borders are no longer needed

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

People have to use CSS to put dividers between sections. Or use custom stylings on divs to create dividers themselves (see: datagrid header)

Issue Number: N/A

## What is the new behavior?

We have a divider component. It was needed for dropdown menus in any case.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
