### PR TITLE
fix(v4 backport): make datagrid header sticky no matter how many rows

### DIFF
--- a/packages/angular/projects/clr-angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/_datagrid.clarity.scss
@@ -40,8 +40,6 @@
     overflow: auto;
     flex: 1 1 auto;
     margin-top: $clr_baselineRem_0_5;
-    // Force content stretch on Safari
-    display: flex;
   }
 
   .datagrid-container {
@@ -645,6 +643,7 @@
   .datagrid-table-wrapper {
     display: flex;
     flex: 1 1 auto;
+    min-height: 100%;
   }
 
   .datagrid-table {
@@ -652,9 +651,7 @@
     flex-direction: column;
     flex: 1 1 auto;
     align-content: flex-start;
-    min-height: $clr_baselineRem_3; // Includes header and space for a single (non existing) row
     position: relative;
-    height: 100%;
 
     .datagrid-body {
       width: auto;


### PR DESCRIPTION
This is a cherry-pick  for this fix: 

- https://github.com/vmware/clarity/commit/ee7cbc562b981c0cb31135aa88178e4e36a7f226

------------------------------------------------------------------------------------------
This change fixes a regression that breaks the sticky behavior of datagrid column headers.

Closes #4889

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4889

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
