### PR TITLE
docs: add npm version badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 [![Build Status](https://saucelabs.com/browser-matrix/claritydesignsystem.svg)](https://saucelabs.com/beta/builds/b16110e384ce459ab68f10da6e38a285)
 
+[![npm version](https://badge.fury.io/js/%40clr%2Fcore.svg)](https://badge.fury.io/js/%40clr%2Fcore)
+
 Project Clarity is an open source design system that brings together UX
 guidelines, an HTML/CSS framework, Angular components, and Web Components. This
 repository includes everything you need to build, customize, test, and deploy

--- a/packages/angular/projects/clr-angular/README.md
+++ b/packages/angular/projects/clr-angular/README.md
@@ -1,4 +1,4 @@
-## Installing Clarity Angular
+## Installing Clarity Angular [![npm version](https://badge.fury.io/js/%40clr%2Fangular.svg)](https://badge.fury.io/js/%40clr%2Fangular)
 
 The easiest way is to use the Angular CLI to automatically install Angular into your project
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,4 +1,4 @@
-# Clarity Core Web Components
+# Clarity Core Web Components [![npm version](https://badge.fury.io/js/%40clr%2Fcore.svg)](https://badge.fury.io/js/%40clr%2Fcore)
 
 Clarity Core is a suite of Web Components for [Clarity Design System](https://clarity.design/storybook/core).
 

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -1,4 +1,4 @@
-### Installing Clarity Icons
+### Installing Clarity Icons [![npm version](https://badge.fury.io/js/%40clr%2Ficons.svg)](https://badge.fury.io/js/%40clr%2Ficons)
 
 1.  Install Clarity Icons package through npm:
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,4 +1,4 @@
-# Clarity React Wrappers for Core Web Components
+# Clarity React Wrappers for Core Web Components [![npm version](https://badge.fury.io/js/%40clr%2Freact.svg)](https://badge.fury.io/js/%40clr%2Freact)
 
 Clarity Core is a suite of Web Components from the [Clarity Design System](https://clarity.design). Because React [doesn't fully interoperate with custom elements](https://custom-elements-everywhere.com/) we have developed this library of React components that wrap Clarity Web Components
 

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,4 +1,4 @@
-### Installing Clarity UI
+### Installing Clarity UI [![npm version](https://badge.fury.io/js/%40clr%2Fui.svg)](https://badge.fury.io/js/%40clr%2Fui)
 
 1.  Install Clarity UI package through npm:
 


### PR DESCRIPTION
Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently, we do not have a way to navigate to npm packages from GitHub docs.

P.S. I am looking forward to something a little bit more complex like - having badges for every version of the packages we support but generated automatically. 
https://github.com/badges/shields is cool but we will bring a new npm package in the build pipeline in order to reach what I describe in the previous sentence.

## What is the new behavior?

Having a version badge pointing to the latest available version in NPM.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

