### PR TITLE
fix: refactor focus-traps

### DIFF
--- a/packages/core/src/internal-components/close-button/close-button.stories.ts
+++ b/packages/core/src/internal-components/close-button/close-button.stories.ts
@@ -8,7 +8,7 @@ import '@clr/core/internal-components/close-button/register.js';
 import { angleIcon, ClarityIcons, timesCircleIcon, userIcon } from '@clr/core/icon';
 import { getElementStorybookArgTypes, spreadProps, getElementStorybookArgs } from '@clr/core/internal';
 import { html } from 'lit-html';
-import customElements from '../../dist/core/custom-elements.json';
+import customElements from '../../../dist/core/custom-elements.json';
 
 ClarityIcons.addIcons(angleIcon, userIcon, timesCircleIcon);
 

--- a/packages/core/src/internal/base/focus-trap.base.spec.ts
+++ b/packages/core/src/internal/base/focus-trap.base.spec.ts
@@ -18,7 +18,7 @@ declare global {
   }
 }
 
-describe('modal element', () => {
+describe('focus trap element', () => {
   describe('basic', () => {
     let testElement: HTMLElement;
     let component: CdsBaseFocusTrap;
@@ -43,6 +43,8 @@ describe('modal element', () => {
     it('should create the component', async () => {
       await componentIsStable(component);
       expect(component.innerText).toBe(placeholderText.toUpperCase());
+      expect(component.focusTrapId).toBeDefined('should have a focus trap id');
+      expect(component.focusTrap).toBeDefined('should have a focus trap');
     });
 
     it('should enable focus trap', async () => {

--- a/packages/core/src/internal/base/focus-trap.base.ts
+++ b/packages/core/src/internal/base/focus-trap.base.ts
@@ -7,9 +7,13 @@
 import { html, LitElement } from 'lit-element';
 import { FocusTrap } from '../utils/focus-trap.js';
 import { internalProperty, property } from '../decorators/property.js';
+import { createId } from '../utils/identity.js';
 
 export class CdsBaseFocusTrap extends LitElement {
-  protected focusTrap = new FocusTrap(this);
+  focusTrap: FocusTrap;
+
+  topReboundElement: HTMLElement;
+  bottomReboundElement: HTMLElement;
 
   /**
    * Its recommended to remove or add a focus trap element from the DOM
@@ -20,6 +24,16 @@ export class CdsBaseFocusTrap extends LitElement {
 
   @internalProperty({ type: Boolean, reflect: true })
   protected __demoMode = false;
+
+  @property({ type: String }) focusTrapId: string;
+
+  constructor() {
+    super();
+    this.focusTrapId = createId();
+    // if we see issues instantiating here, we should consider moving to
+    // firstUpdated()
+    this.focusTrap = new FocusTrap(this);
+  }
 
   connectedCallback() {
     super.connectedCallback();

--- a/packages/core/src/internal/services/focus-trap-tracker.service.spec.ts
+++ b/packages/core/src/internal/services/focus-trap-tracker.service.spec.ts
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { html } from 'lit-html';
+import { createTestElement, removeTestElement } from '@clr/core/test/utils';
+import {
+  CDS_FOCUS_TRAP_DOCUMENT_ATTR,
+  CDS_FOCUS_TRAP_ID_ATTR,
+  FocusTrapTracker,
+} from './focus-trap-tracker.service.js';
+import { arrayTail } from '../utils/array.js';
+
+describe('Focus Trap Tracker Service - ', () => {
+  const service = FocusTrapTracker;
+  const testTrapIds = ['abcd', 'efg', 'hijk', 'lmnop'];
+
+  afterEach(() => {
+    // reset
+    service.getDocroot().removeAttribute(CDS_FOCUS_TRAP_DOCUMENT_ATTR);
+  });
+
+  describe('getDocroot(): ', () => {
+    it('should return something', () => {
+      const myDocroot: HTMLElement = service.getDocroot();
+      expect(myDocroot).not.toBeNull('Docroot node should exist');
+      expect(myDocroot.tagName.toLowerCase()).toBe('body', 'should return the body node');
+    });
+  });
+
+  describe('getTrapIds(): ', () => {
+    it('should return empty array if docroot attr is not present', () => {
+      expect(service.getTrapIds()).toEqual([]);
+    });
+
+    it('should return the trap ids if present', () => {
+      service.setTrapIds(testTrapIds);
+      expect(service.getTrapIds()).toEqual(testTrapIds);
+    });
+
+    it('should return empty array if docroot attr is present but empty', () => {
+      const myDocroot: HTMLElement = service.getDocroot();
+      myDocroot.setAttribute(CDS_FOCUS_TRAP_DOCUMENT_ATTR, '');
+      expect(service.getTrapIds()).toEqual([]);
+    });
+  });
+
+  describe('setTrapIds(): ', () => {
+    it('should not set anything to docroot if passed no ids', () => {
+      const myDocroot: HTMLElement = service.getDocroot();
+      service.setTrapIds([]);
+      expect(myDocroot.hasAttribute(CDS_FOCUS_TRAP_DOCUMENT_ATTR)).toBe(
+        false,
+        'Focus trap attr should not be added to docroot'
+      );
+    });
+
+    it('should set the trap ids to docroot', () => {
+      const myDocroot: HTMLElement = service.getDocroot();
+      service.setTrapIds(testTrapIds);
+      expect(myDocroot.hasAttribute(CDS_FOCUS_TRAP_DOCUMENT_ATTR)).toBe(true, 'Docroot should have focus trap attr');
+      expect(myDocroot.getAttribute(CDS_FOCUS_TRAP_DOCUMENT_ATTR)).toBe(
+        testTrapIds.join(' '),
+        'should return the html node'
+      );
+    });
+
+    it('should unset the trap ids to docroot', () => {
+      const myDocroot: HTMLElement = service.getDocroot();
+      service.setTrapIds(testTrapIds);
+      expect(myDocroot.hasAttribute(CDS_FOCUS_TRAP_DOCUMENT_ATTR)).toBe(true, 'Docroot should have focus trap attr');
+      expect(myDocroot.getAttribute(CDS_FOCUS_TRAP_DOCUMENT_ATTR)).toBe(
+        testTrapIds.join(' '),
+        'should return the html node'
+      );
+      service.setTrapIds([]);
+      expect(myDocroot.hasAttribute(CDS_FOCUS_TRAP_DOCUMENT_ATTR)).toBe(
+        false,
+        'Focus trap attr should not be added to docroot'
+      );
+    });
+  });
+
+  describe('activatePreviousCurrent(): ', () => {
+    it('should set id passed as the tail of the docroot attr', () => {
+      service.setTrapIds(testTrapIds);
+      const previousCurrent = service.getCurrentTrapId();
+      const myTestId = 'qrstuv';
+      service.setCurrent(myTestId);
+      expect(arrayTail(service.getTrapIds())).toBe(myTestId, 'should set id as expected');
+      service.activatePreviousCurrent();
+      expect(arrayTail(service.getTrapIds())).toBe(previousCurrent, 'should have previous id at tail of docroot ids');
+      expect(service.getCurrentTrapId()).toBe(previousCurrent, 'should reflect previous id as the current one now');
+    });
+  });
+
+  describe('getCurrentTrapId(): ', () => {
+    it('should retrieve id at the tail of the docroot attr', () => {
+      const myTestId = 'ohai';
+      service.setCurrent(myTestId);
+      expect(arrayTail(service.getTrapIds())).toBe(myTestId, 'should have id at the head of the docroot ids');
+      expect(service.getCurrentTrapId()).toBe(myTestId, 'should have id at the head of the docroot ids');
+    });
+
+    it('should not die if the docroot attr is empty', () => {
+      expect(service.getTrapIds().length).toBe(0, 'should not have any ids');
+      expect(service.getCurrentTrapId()).toBe('', 'should return an empty string if there are no ids');
+    });
+  });
+
+  describe('getCurrent(): ', () => {
+    it('should retrieve id element at the tail of the docroot attr', async () => {
+      const element = await createTestElement(
+        html`<div focus-trap-id="ohai">howdy</div>
+          <div focus-trap-id="lmnop"></div>`
+      );
+      service.setTrapIds(testTrapIds);
+      const myTestId = 'ohai';
+      service.setCurrent(myTestId);
+      const myCurrent = service.getCurrent();
+      expect(myCurrent).not.toBeNull('should retrieve element as expected');
+      expect(myCurrent.getAttribute(CDS_FOCUS_TRAP_ID_ATTR)).toBe(
+        'ohai',
+        'should retrieve correct current element as expected'
+      );
+      service.activatePreviousCurrent();
+      const newCurrent = service.getCurrent();
+      expect(newCurrent).not.toBeNull('should retrieve previous element as expected');
+      expect(newCurrent.getAttribute(CDS_FOCUS_TRAP_ID_ATTR)).toBe('lmnop', 'should get previous element as expected');
+      removeTestElement(element);
+    });
+
+    it('should not die if id of element does not exist', async () => {
+      const element = await createTestElement(
+        html`<div focus-trap-id="ohai">howdy</div>
+          <div focus-trap-id="lmnop"></div>`
+      );
+
+      const myTestId = 'jabberwocky';
+      service.setCurrent(myTestId);
+      const myCurrent = service.getCurrent();
+      expect(myCurrent).toBeNull('should return null if there is no element that can be retreived');
+      removeTestElement(element);
+    });
+
+    it('should not die if the docroot attr is empty', () => {
+      expect(service.getCurrent()).toBe(null, 'should return an empty string if there are no ids');
+    });
+  });
+
+  describe('setCurrent(): ', () => {
+    it('should set id passed as the tail of the docroot attr', () => {
+      const myDocroot: HTMLElement = service.getDocroot();
+      const myTestId = 'qrstuv';
+
+      service.setTrapIds(testTrapIds);
+      service.setCurrent(myTestId);
+
+      expect(myDocroot.getAttribute(CDS_FOCUS_TRAP_DOCUMENT_ATTR)).toContain(
+        myTestId,
+        'should add id to the docroot attr'
+      );
+      expect(arrayTail(service.getTrapIds())).toBe(myTestId, 'should have id at the tail of the docroot ids');
+    });
+
+    it('should do nothing if passed nothing', () => {
+      service.setTrapIds(testTrapIds);
+      service.setCurrent('');
+      expect(arrayTail(service.getTrapIds())).toBe(
+        arrayTail(testTrapIds),
+        'should not have changed the id at the tail of the docroot ids'
+      );
+    });
+
+    it('should keep id passed as the tail of the docroot attr if it already is', () => {
+      const myDocroot: HTMLElement = service.getDocroot();
+      const myTestId = 'lmnop';
+
+      service.setTrapIds(testTrapIds);
+      service.setCurrent(myTestId);
+
+      expect(myDocroot.getAttribute(CDS_FOCUS_TRAP_DOCUMENT_ATTR)).toContain(
+        myTestId,
+        'should keep id at head of docroot attr'
+      );
+      expect(arrayTail(service.getTrapIds())).toBe(myTestId, 'should have id at the tail of the docroot ids');
+    });
+
+    it('should move id passed to the tail of the docroot attr if it is already present but not current', () => {
+      const myDocroot: HTMLElement = service.getDocroot();
+      const myTestId = 'abcd';
+      const myTestId2 = 'hijk';
+
+      // trying from the front
+      service.setTrapIds(testTrapIds);
+      service.setCurrent(myTestId);
+
+      let updatedIds = service.getTrapIds();
+
+      expect(myDocroot.getAttribute(CDS_FOCUS_TRAP_DOCUMENT_ATTR)).toContain(
+        myTestId,
+        'should include id in the docroot attr (1)'
+      );
+      expect(updatedIds[0]).not.toBe(myTestId, 'should remove id from previous place (1)');
+      expect(arrayTail(updatedIds)).toBe(myTestId, 'should remove id from previous place (1)');
+      let filteredIds = service.getTrapIds().filter(id => id === myTestId);
+      expect(filteredIds.length).toBe(1, 'should only have one instance of an id (1)');
+
+      // pulling id from the middle
+      service.setCurrent(myTestId2);
+
+      updatedIds = service.getTrapIds();
+
+      expect(myDocroot.getAttribute(CDS_FOCUS_TRAP_DOCUMENT_ATTR)).toContain(
+        myTestId2,
+        'should include id in the docroot attr (2)'
+      );
+      expect(updatedIds[1]).not.toBe(myTestId2, 'should remove id from previous place (2)');
+      expect(arrayTail(updatedIds)).toBe(myTestId2, 'should remove id from previous place (2)');
+      filteredIds = service.getTrapIds().filter(id => id === myTestId2);
+      expect(filteredIds.length).toBe(1, 'should only have one instance of an id (2)');
+    });
+  });
+});

--- a/packages/core/src/internal/services/focus-trap-tracker.service.ts
+++ b/packages/core/src/internal/services/focus-trap-tracker.service.ts
@@ -4,22 +4,81 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
+import { hasAttributeAndIsNotEmpty, setAttributes } from '../utils/dom.js';
+import { arrayTail } from '../utils/array.js';
+
 /**
  * FocusTrapTracker is a static class that keeps track of the active element with focus trap,
  * in case there are multiple in a given page.
  */
+
+export const CDS_FOCUS_TRAP_ID_ATTR = 'focus-trap-id';
+export const CDS_FOCUS_TRAP_DOCUMENT_ATTR = 'cds-focus-trap-ids';
+
 export class FocusTrapTracker {
-  private static focusTrapElements: Element[] = [];
-
-  static setCurrent(el: Element) {
-    this.focusTrapElements.unshift(el);
+  static getDocroot(): HTMLElement {
+    return document.body as HTMLElement;
   }
 
-  static activatePreviousCurrent() {
-    this.focusTrapElements.shift();
+  static getTrapIds(): string[] {
+    const docroot = this.getDocroot();
+
+    if (hasAttributeAndIsNotEmpty(docroot, CDS_FOCUS_TRAP_DOCUMENT_ATTR)) {
+      // the function in the conditional handles all nil references. zero chance of null making it through here.
+      const myAttribute = docroot.getAttribute(CDS_FOCUS_TRAP_DOCUMENT_ATTR) || '';
+      // TS forcing us to write an unreachable codepath. this is where monads would be useful.
+      return myAttribute === '' ? [] : myAttribute.split(' ');
+    } else {
+      return [];
+    }
   }
 
-  static getCurrent() {
-    return this.focusTrapElements[0];
+  static setTrapIds(trapIds: string[]): void {
+    const myTrapIds = trapIds.length > 0 ? trapIds.join(' ') : false;
+    setAttributes(this.getDocroot(), [CDS_FOCUS_TRAP_DOCUMENT_ATTR, myTrapIds]);
+  }
+
+  static setCurrent(myTrapId: string): void {
+    if (myTrapId === '') {
+      return;
+    }
+
+    const trapIds = this.getTrapIds();
+
+    // this is a just-in-case situation. we should never encounter it.
+    // but in the event that we do, this guard will ensure no id is in the
+    // focus trap list more than once.
+    if (arrayTail(trapIds) === myTrapId) {
+      return;
+    }
+
+    const existingIndex = trapIds.indexOf(myTrapId);
+    if (existingIndex > -1) {
+      trapIds.splice(existingIndex, 1);
+    }
+
+    trapIds.push(myTrapId);
+    this.setTrapIds(trapIds);
+  }
+
+  static activatePreviousCurrent(): void {
+    const trapIds = this.getTrapIds();
+    trapIds.pop();
+    this.setTrapIds(trapIds);
+  }
+
+  static getCurrentTrapId(): string {
+    return arrayTail(this.getTrapIds()) || '';
+  }
+
+  static getCurrent(): HTMLElement | null {
+    const docroot = this.getDocroot();
+    const currentId = this.getCurrentTrapId();
+
+    if (currentId !== '') {
+      return docroot.querySelector(`[${CDS_FOCUS_TRAP_ID_ATTR}="${currentId}"]`);
+    } else {
+      return null;
+    }
   }
 }

--- a/packages/core/src/internal/utils/array.spec.ts
+++ b/packages/core/src/internal/utils/array.spec.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { arrayToObject } from './array.js';
+import { arrayTail, arrayToObject } from './array.js';
 
 describe('array utils', () => {
   it('arrayToObject', () => {
@@ -19,5 +19,14 @@ describe('array utils', () => {
     expect(obj.one.value).toBe('value 1');
     expect(obj.two.value).toBe('value 2');
     expect(obj.three.value).toBe('value 3');
+  });
+
+  describe('arrayTail: ', () => {
+    it('returns undefined if array is empty', () => {
+      expect(arrayTail([])).toBeUndefined();
+    });
+    it('returns tail of array as expected', () => {
+      expect(arrayTail([0, 1, 2, 3, 4, 5])).toBe(5);
+    });
   });
 });

--- a/packages/core/src/internal/utils/array.ts
+++ b/packages/core/src/internal/utils/array.ts
@@ -10,3 +10,7 @@ export function arrayToObject(arr: any[], key: string) {
     return obj;
   }, {});
 }
+
+export function arrayTail(arr: any[]) {
+  return arr.length ? arr[arr.length - 1] : void 0;
+}

--- a/packages/core/src/internal/utils/dom.spec.ts
+++ b/packages/core/src/internal/utils/dom.spec.ts
@@ -11,6 +11,7 @@ import {
   assignSlotNames,
   getElementWidth,
   getElementWidthUnless,
+  hasAttributeAndIsNotEmpty,
   HTMLAttributeTuple,
   isHTMLElement,
   removeAttributes,
@@ -348,12 +349,35 @@ describe('Functional Helper: ', () => {
       expect(isVisible(element)).toBe(false);
     });
   });
+
   describe('spanWrapper', () => {
     it('wraps text nodes in an element', async () => {
       const element = await createTestElement(html`Hello spanWrapper`);
       spanWrapper(element.childNodes);
       expect(element.children[0].tagName).toBe('SPAN');
       expect(element.children[0].textContent).toBe('Hello spanWrapper');
+    });
+  });
+
+  describe('hasAttributeAndIsNotEmpty', () => {
+    it('should return false if element does not exist', () => {
+      const nope = document.getElementById('ohai');
+      expect(hasAttributeAndIsNotEmpty(nope, 'id')).toBe(false);
+    });
+    it('should return true if element has attribute', async () => {
+      const element = await createTestElement(html`<div id="ohai" data-test-value="false">howdy</div>`);
+      expect(hasAttributeAndIsNotEmpty(document.getElementById('ohai'), 'data-test-value')).toBe(true);
+      removeTestElement(element);
+    });
+    it('should return false if element has attribute but it is an empty string', async () => {
+      const element = await createTestElement(html`<div id="ohai" data-test-value="">howdy</div>`);
+      expect(hasAttributeAndIsNotEmpty(document.getElementById('ohai'), 'data-test-value')).toBe(false);
+      removeTestElement(element);
+    });
+    it('should return false if element has attribute but there is no value in the attribute', async () => {
+      const element = await createTestElement(html`<div id="ohai" data-test-value>howdy</div>`);
+      expect(hasAttributeAndIsNotEmpty(document.getElementById('ohai'), 'data-test-value')).toBe(false);
+      removeTestElement(element);
     });
   });
 });

--- a/packages/core/src/internal/utils/dom.ts
+++ b/packages/core/src/internal/utils/dom.ts
@@ -6,6 +6,8 @@
 import includes from 'ramda/es/includes';
 import without from 'ramda/es/without';
 
+import { isStringAndNotNilOrEmpty } from './identity.js';
+
 export function getElementWidth(element: HTMLElement, unit = 'px') {
   if (element) {
     return element.getBoundingClientRect ? element.getBoundingClientRect().width + unit : '';
@@ -25,6 +27,10 @@ export function isHTMLElement(el: any) {
 }
 
 export type HTMLAttributeTuple = [string, string | boolean];
+
+export function hasAttributeAndIsNotEmpty(element: HTMLElement | null, attribute: string) {
+  return !!element && element.hasAttribute(attribute) && isStringAndNotNilOrEmpty(element.getAttribute(attribute));
+}
 
 export function setAttributes(element: HTMLElement, ...attributeTuples: HTMLAttributeTuple[]) {
   if (element) {

--- a/packages/core/src/styles/layout/_container.scss
+++ b/packages/core/src/styles/layout/_container.scss
@@ -2,8 +2,9 @@
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
+body[cds-focus-trap-ids*='_'],
 body[cds-layout='no-scrolling'] {
-  overflow: hidden;
+  overflow: hidden !important;
 }
 
 [cds-layout~='fill'],

--- a/packages/react/App.tsx
+++ b/packages/react/App.tsx
@@ -27,6 +27,7 @@ ClarityIcons.addIcons(userIcon, timesIcon);
 
 interface AppState {
   modalOpen: boolean;
+  modal2Open: boolean;
 }
 
 export default class App extends React.Component<{}, AppState> {
@@ -34,7 +35,7 @@ export default class App extends React.Component<{}, AppState> {
 
   constructor(props: any) {
     super(props);
-    this.state = { modalOpen: false };
+    this.state = { modalOpen: false, modal2Open: false };
     this.buttonRef = React.createRef<CdsButton>();
   }
 
@@ -50,6 +51,7 @@ export default class App extends React.Component<{}, AppState> {
 
   render() {
     const isModalOpen = this.state.modalOpen;
+    const isModal2Open = this.state.modal2Open;
     return (
       <div>
         <h1>Rendered by React!</h1>
@@ -64,6 +66,9 @@ export default class App extends React.Component<{}, AppState> {
             <CdsModalContent>
               <div cds-layout="vertical gap:md p-y:xs">
                 <p cds-text="body">Lorem Ipsum</p>
+                <CdsButton ref={this.buttonRef} onClick={() => this.setState({ modal2Open: true })}>
+                  Open Modal 2
+                </CdsButton>
               </div>
             </CdsModalContent>
             <CdsModalActions>
@@ -74,6 +79,21 @@ export default class App extends React.Component<{}, AppState> {
                 <CdsButton onClick={() => this.setState({ modalOpen: false })}>Ok</CdsButton>
               </div>
             </CdsModalActions>
+            <CdsModal hidden={!isModal2Open} onCloseChange={() => this.setState({ modal2Open: false })}>
+              <CdsModalHeader>
+                <h3 cds-text="title">My Modal</h3>
+              </CdsModalHeader>
+              <CdsModalContent>
+                <div cds-layout="vertical gap:md p-y:xs">
+                  <p cds-text="body">Focus trap inception!</p>
+                </div>
+              </CdsModalContent>
+              <CdsModalActions>
+                <div cds-layout="horizontal gap:sm align:right">
+                  <CdsButton onClick={() => this.setState({ modal2Open: false })}>Ok</CdsButton>
+                </div>
+              </CdsModalActions>
+            </CdsModal>
           </CdsModal>
         ) : (
           <br />


### PR DESCRIPTION
• refactored focus traps
• decoupled scroll lockdown from layouts
• allows end-users to use the layout lockdown without getting stomped on by focus traps
• made focus trap tracker 100% static
• now no longer keeps track of focus traps, just asks dom for them
• allows for more than one instance to exist if that sort of thing happens in the wild
• guarding against focus trap tracker being passed the same id more than once
• added focus-trap inception to react dev app
• manually verifies that focus traps can be layered and work as expected
• can be replaced with a dropdown in the modal once overlays are ready
• unit test to validate focus-trap inception
• decoupling focus trap refactor from the overlay component

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Focus traps now rely on a layout attribute value that can be used by consumers. The focus trap has no way of knowing whether it has set the value or something else has.

This refactor removes the focus trap's reliance on that attribute in favor of an attribute on the body that "tracks" the state of focus traps as a list.

Presently, the focus trap is only used and entirely contained within the modal. There were some concerns over whether multiple focus traps could be active on the same page. These changes ensure that is possible and viable.

This effort clears the way for overlays.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
