### PR TITLE
fix: address accessibility items that affect multiple pages

### DIFF
--- a/apps/website/.vuepress/theme/components/Page.vue
+++ b/apps/website/.vuepress/theme/components/Page.vue
@@ -1,12 +1,9 @@
 <template>
   <main class="page">
     <PageSubnav v-bind="{ sidebarItems }" />
-
-    <slot name="nav-toc" />
-
     <Content class="theme-default-content" />
-
     <Footer></Footer>
+    <slot name="nav-toc" />
   </main>
 </template>
 

--- a/apps/website/.vuepress/theme/global-components/DocCode.vue
+++ b/apps/website/.vuepress/theme/global-components/DocCode.vue
@@ -1,13 +1,13 @@
 <template>
-  <div class="code-wrapper" :class="{ expanded: state }">
+  <div class="code-wrapper" :class="{ expanded: state }" v-bind:aria-expanded="state ? 'true' : 'false'">
     <button class="btn btn-primary btn-sm toggle-button" @click="toggleState()" v-if="showToggle">
       {{ state ? 'hide' : 'show' }} code
     </button>
     <div
       class="code"
-      v-bind:aria-expanded="state ? 'true' : 'false'"
       v-bind:style="{ height: this.getHeight() }"
       ref="code-snippet"
+      v-bind:aria-hidden="state ? 'false' : 'true'"
     >
       <slot></slot>
     </div>
@@ -81,7 +81,7 @@ export default {
     position: absolute;
     right: 0;
     top: 0;
-    color: inherit;
+    color: var(--cds-token-color-neutral-800);
     margin: 0;
     padding: 0;
     outline: none 0;

--- a/apps/website/.vuepress/theme/styles/overrides.scss
+++ b/apps/website/.vuepress/theme/styles/overrides.scss
@@ -247,3 +247,16 @@ h4 .header-anchor cds-icon {
 .asset-download-btn cds-icon {
   vertical-align: text-top;
 }
+
+// Target viewports that are scaled (mobile) or zoomed in past 125%
+@media only screen and (max-width: 1433px) {
+  // This should apply to any @clr/ui tables - APIs and releases
+  .table {
+    table-layout: fixed;
+    width: 100%;
+
+    td {
+      word-wrap: break-word;
+    }
+  }
+}


### PR DESCRIPTION
These are a few more targeted fixes for parts of the website that affect multiple pages at a time on the website. 

- moved aria-expanded to the code demo container and made button text darker
- adjust Page child elements for focus order and screen-reader flow
- hide code blocks from screen readers when they are not expanded

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?
Website accessibility fixes for multiple pages on the website. 

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
n/a
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
