### PR TITLE
docs: addd website a11y for social icons and navigation

### DIFF
--- a/apps/website/.vuepress/theme/components/Footer.vue
+++ b/apps/website/.vuepress/theme/components/Footer.vue
@@ -12,13 +12,28 @@
         </div>
 
         <div class="social-media-links">
-          <a href="https://github.com/vmware/clarity" target="_blank" class="sm-icon-link">
+          <a
+            aria-label="Clarity on GitHub"
+            href="https://github.com/vmware/clarity"
+            target="_blank"
+            class="sm-icon-link"
+          >
             <img src="/images/footer/github.svg" alt="Clarity Github" />
           </a>
-          <a href="https://twitter.com/VMwareClarity" target="_blank" class="sm-icon-link">
+          <a
+            aria-label="Clarity on twitter"
+            href="https://twitter.com/VMwareClarity"
+            target="_blank"
+            class="sm-icon-link"
+          >
             <img src="/images/footer/twitter.svg" alt="Clarity Twitter" />
           </a>
-          <a href="https://medium.com/claritydesignsystem" target="_blank" class="sm-icon-link">
+          <a
+            aria-label="Clarity on Medium"
+            href="https://medium.com/claritydesignsystem"
+            target="_blank"
+            class="sm-icon-link"
+          >
             <img src="/images/footer/medium.svg" alt="Clarity Medium" />
           </a>
         </div>

--- a/apps/website/.vuepress/theme/components/NavToc.vue
+++ b/apps/website/.vuepress/theme/components/NavToc.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="nav-toc-container">
-    <nav class="nav-toc">
+    <nav aria-label="Table of content navigation" class="nav-toc">
       <div class="asset-download-btn-wrapper" cds-layout="m-b:md" v-if="isOnIconsPage">
         <a
           class="btn btn-outline asset-download-btn"

--- a/apps/website/.vuepress/theme/components/Sidebar.vue
+++ b/apps/website/.vuepress/theme/components/Sidebar.vue
@@ -1,7 +1,7 @@
 <template>
   <transition name="slide-fade">
     <div class="side-nav-container" v-show="isOpen" @click="checkOutsideClick($event)">
-      <nav class="clr-vertical-nav has-nav-groups side-nav" ref="nav">
+      <nav aria-label="Sidebar navigation" class="clr-vertical-nav has-nav-groups side-nav" ref="nav">
         <div class="nav-content">
           <template v-for="(item, index) in items">
             <div class="nav-group" v-if="item.children">


### PR DESCRIPTION
## PR Checklist

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

There are two navigations that can appear on the page and the user cannot know which one is using.
The social icons don't have a label so the user can know which one is focused on.

## What is the new behavior?
When tabbing the user will know which navigation is currently using and also when the user gets to the social link will know which one is focused.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
