### PR TITLE
[BACKPORT -> v4] fix: clr-input-wrapper max width

### DIFF
--- a/packages/angular/projects/clr-angular/src/forms/styles/_input.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/forms/styles/_input.clarity.scss
@@ -6,6 +6,7 @@
   .clr-input-wrapper {
     white-space: nowrap;
     max-height: $clr-forms-baseline * 4;
+    max-width: fit-content;
   }
 
   .clr-input {


### PR DESCRIPTION
This is a cherry-picked backport of the fix on master into the v4 branch. 


-----------------------------------------------------
The issue reported was the animated blue underline when an input was given focus was going the full width of the inputs parent container (a .clr-input-wrapper element). This is a partial fix for evergreen browsers. I have an idea that might also work for IE11 but we need to set up the dev app to build for ie11 (e.g compile for es5).

As such, this is a partial fix for #5009.

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
