### PR TITLE
fix: remove core icons deprecated styles and methods

### DIFF
--- a/packages/core/src/icon/icon.element.scss
+++ b/packages/core/src/icon/icon.element.scss
@@ -37,121 +37,83 @@ svg {
 }
 
 // sizing
-// DEPRECATED IN 4.0: all legacy sizing classnames
-// will be replaced with [size="sm|md|lg|xl|xxl"] selectors!
-:host(.clr-i-size-sm) {
+:host([size='sm']) {
   // weirdly, the default... 16px
   @include equilateral(#{$cds-token-space-size-7});
 }
 
-:host(.clr-i-size-md) {
+:host([size='md']) {
   // 24px
   @include equilateral(#{$cds-token-space-size-9});
 }
 
-:host(.clr-i-size-lg) {
+:host([size='lg']) {
   // 36px
   @include equilateral(#{$cds-token-space-size-11});
 }
 
-:host(.clr-i-size-xl) {
+:host([size='xl']) {
   // 48px
   @include equilateral(#{$cds-token-space-size-12});
 }
 
-:host(.clr-i-size-xxl) {
+:host([size='xxl']) {
   // 64px
   @include equilateral(calc(#{$cds-token-space-size-13} - #{$cds-token-space-size-5}));
 }
 
 // colors
-// DEPRECATED IN 3.0: is-green, .is-success
-:host(.is-green),
-:host(.is-success),
 :host([status='success']) {
   --color: #{$cds-token-color-success-700};
 }
 
-// DEPRECATED IN 3.0: is-red, is-error, is-danger
-:host(.is-red),
-:host(.is-danger),
-:host(.is-error),
 :host([status='danger']) {
   --color: #{$cds-token-color-danger-700};
 }
 
-// DEPRECATED IN 3.0: is-warning
-:host(.is-warning),
 :host([status='warning']) {
   --color: #{$cds-token-color-warning-900};
 }
 
-// DEPRECATED IN 3.0: is-blue, is-info, is-highlight
-:host(.is-blue),
-:host(.is-info),
-:host(.is-highlight),
 :host([status='info']) {
   --color: #{$cds-token-color-action-600};
 }
 
 // INVERSE COLORS
 
-// DEPRECATED IN 3.0: is-white, is-inverse
-:host(.is-white),
-:host(.is-inverse),
 :host([inverse]) {
   --color: #{$cds-token-color-neutral-0};
 }
 
-// DEPRECATED IN 3.0: is-info, is-inverse
-:host([inverse].is-info),
-:host([status='info'].is-inverse),
 :host([inverse][status='info']) {
   --color: #{$cds-token-color-action-400};
 }
 
-// DEPRECATED IN 3.0: is-success, is-inverse
-:host([inverse].is-success),
-:host([status='success'].is-inverse),
 :host([inverse][status='success']) {
   --color: #{$cds-token-color-success-400};
 }
 
-// DEPRECATED IN 3.0: is-error, is-danger, is-inverse
-:host(.is-inverse.is-error),
-:host(.is-inverse.is-danger),
-:host([status='danger'].is-inverse),
-:host([inverse].is-error),
-:host([inverse].is-danger),
 :host([inverse][status='danger']) {
   --color: #{$cds-token-color-danger-700};
 }
 
-// DEPRECATED IN 3.0: is-warning, is-inverse
-:host(.is-inverse.is-warning),
-:host([status='warning'].is-inverse),
-:host([inverse].is-warning),
 :host([inverse][status='warning']) {
   --color: #{$cds-token-color-warning-500};
 }
 
 // directional
-:host([dir='up']),
 :host([direction='up']) {
   @include rotateSVGIcon(0deg);
 }
 
-:host([dir='down']),
 :host([direction='down']) {
   @include rotateSVGIcon(180deg);
 }
 
-:host([dir='right']),
 :host([direction='right']) {
   @include rotateSVGIcon(90deg);
 }
 
-:host([dir='left']),
 :host([direction='left']) {
   @include rotateSVGIcon(270deg);
 }
@@ -186,8 +148,6 @@ svg {
   }
 }
 
-// DEPRECATED IN 3.0: has-badge
-:host([class*='has-badge']) .can-badge,
 :host([badge]) .can-badge {
   .clr-i-outline--badged {
     display: block;
@@ -198,8 +158,6 @@ svg {
   }
 }
 
-// DEPRECATED IN 3.0: has-alert
-:host([class*='has-alert']) .can-alert,
 :host([badge$='triangle']) .can-alert {
   .clr-i-outline--alerted {
     display: block;
@@ -212,9 +170,6 @@ svg {
 }
 
 // solid
-
-// DEPRECATED IN 3.0: is-solid
-:host(.is-solid) .has-solid,
 :host([solid]) .has-solid {
   .clr-i-solid {
     display: block;
@@ -233,10 +188,6 @@ svg {
   }
 }
 
-// DEPRECATED IN 3.0: is-solid, has-badge
-:host(.is-solid[class*='has-badge']) .can-badge.has-solid,
-:host([solid].has-badge) .can-badge.has-solid,
-:host([badge].is-solid) .can-badge.has-solid,
 :host([badge][solid]) .can-badge.has-solid {
   .clr-i-solid--badged {
     display: block;
@@ -249,10 +200,6 @@ svg {
   }
 }
 
-// DEPRECATED IN 3.0: is-solid, has-alert
-:host(.is-solid[class*='has-alert']) .can-alert.has-solid,
-:host([solid].has-alert) .can-alert.has-solid,
-:host([badge$='triangle'].is-solid) .can-alert.has-solid,
 :host([solid][badge$='triangle']) .can-alert.has-solid {
   .clr-i-solid--alerted {
     display: block;
@@ -268,20 +215,14 @@ svg {
 
 // variant badge colors
 
-// DEPRECATED IN 3.0: has-badge--success
-:host(.has-badge--success),
 :host([badge='success']) {
   --badge-color: #{$cds-token-color-success-700};
 }
 
-// DEPRECATED IN 3.0: has-badge--danger, has-badge--error
-:host(.has-badge--danger),
-:host(.has-badge--error),
 :host([badge='danger']) {
   --badge-color: #{$cds-token-color-danger-700};
 }
 
-// there is no .has-badge--warning classname
 :host([badge='warning']) {
   --badge-color: #{$cds-token-color-warning-900};
 }
@@ -290,15 +231,11 @@ svg {
   --badge-color: inherit;
 }
 
-// DEPRECATED IN 3.0: has-badge--info
-:host(.has-badge--info),
 :host([badge='info']) {
   --badge-color: #{$cds-token-color-action-600};
 }
 
 // alert colors
-// DEPRECATED IN 3.0: has-alert
-:host(.has-alert),
 :host([badge$='triangle']) {
   --badge-color: #{$cds-token-color-warning-800};
 }
@@ -308,29 +245,12 @@ svg {
 }
 
 // inverse + variants
-
-// DEPRECATED IN 3.0: has-badge--error, has-badge--danger, is-inverse
-:host([badge][inverse]),
-:host([badge].is-inverse),
-:host(.has-badge--danger[inverse]),
-:host(.has-badge--error[inverse]),
-:host(.has-badge--danger.is-inverse),
-:host(.has-badge--error.is-inverse) {
+:host([badge][inverse]) {
   --badge-color: #{$cds-token-color-danger-500};
 }
 
-// DEPRECATED IN 3.0: is-highlight, is-inverse
-:host([inverse].is-highlight),
-:host(.is-highlight.is-inverse) {
-  --color: #{$cds-token-color-action-400};
-}
-
 // variant badge colors
-// DEPRECATED IN 3.0: has-badge--success, is-inverse
-:host([badge='success'][inverse]),
-:host([inverse].has-badge--success),
-:host([badge='success'].is-inverse),
-:host(.has-badge--success.is-inverse) {
+:host([badge='success'][inverse]) {
   --badge-color: #{$cds-token-color-success-400};
 }
 
@@ -338,25 +258,16 @@ svg {
   --badge-color: inherit;
 }
 
-// there is no has-badge--warning classname
 :host([badge='warning'][inverse]) {
   --badge-color: #{$cds-token-color-warning-500};
 }
 
-// DEPRECATED IN 3.0: has-badge--info, is-inverse
-:host([badge='info'][inverse]),
-:host(.has-badge--info[inverse]),
-:host([badge='info'].is-inverse),
-:host(.has-badge--info.is-inverse) {
+:host([badge='info'][inverse]) {
   --badge-color: #{$cds-token-color-action-400};
 }
 
 // alert colors
-// DEPRECATED IN 3.0: has-alert, is-inverse
-:host([badge$='triangle'][inverse]),
-:host(.has-alert[inverse]),
-:host(.is-inverse[badge$='triangle']),
-:host(.has-alert.is-inverse) {
+:host([badge$='triangle'][inverse]) {
   --badge-color: #{$cds-token-color-warning-500};
 }
 

--- a/packages/core/src/icon/icon.element.spec.ts
+++ b/packages/core/src/icon/icon.element.spec.ts
@@ -18,7 +18,7 @@ describe('icon element', () => {
   let component: CdsIcon;
 
   beforeAll(() => {
-    ClarityIcons.add({ testing: testIcon });
+    ClarityIcons.addIcons(['testing', testIcon]);
   });
 
   beforeEach(async () => {
@@ -108,13 +108,6 @@ describe('icon element', () => {
       await componentIsStable(component);
       expect(component.requestUpdate).not.toHaveBeenCalled();
     });
-    it('should add classname if passed a t-shirt size', async () => {
-      await componentIsStable(component);
-      expect(component.classList.contains('clr-i-size-xl')).toBe(false);
-      component.setAttribute('size', 'xl');
-      await componentIsStable(component);
-      expect(component.classList.contains('clr-i-size-xl')).toBe(true);
-    });
     it('should add width/height styles if passed numerical value', async () => {
       await componentIsStable(component);
       expect(component.style.width).toBe('');
@@ -124,27 +117,16 @@ describe('icon element', () => {
       expect(component.style.width).toBe('43px');
       expect(component.style.height).toBe('43px');
     });
-    it('should do nothing if passed neither a t-shirt size or numerical value', async () => {
-      await componentIsStable(component);
-      component.setAttribute('size', 'xl');
-      await componentIsStable(component);
-      expect(component.classList.contains('clr-i-size-xl')).toBe(true);
-      component.setAttribute('size', 'jabberwocky');
-      await componentIsStable(component);
-      expect(component.classList.contains('clr-i-size-xl')).toBe(true);
-    });
     it('should remove the size attribute if set to undefined', async () => {
       await componentIsStable(component);
       component.size = void 0;
       await componentIsStable(component);
-      expect(component.classList.contains('clr-i-size-')).toBe(false);
       expect(component.hasAttribute('size')).toBe(false);
     });
     it('should remove the size attribute if set to null', async () => {
       await componentIsStable(component);
       component.size = null;
       await componentIsStable(component);
-      expect(component.classList.contains('clr-i-size-')).toBe(false);
       expect(component.hasAttribute('size')).toBe(false);
     });
   });

--- a/packages/core/src/icon/icon.element.ts
+++ b/packages/core/src/icon/icon.element.ts
@@ -18,7 +18,7 @@ import {
 import { html, LitElement, query } from 'lit-element';
 import { styles } from './icon.element.css.js';
 import { ClarityIcons } from './icon.service.js';
-import { updateIconSizeStyleOrClassnames } from './utils/icon.classnames.js';
+import { updateIconSizeStyle } from './utils/icon.classnames.js';
 import { hasIcon } from './utils/icon.service-helpers.js';
 
 /**
@@ -78,7 +78,7 @@ export class CdsIcon extends LitElement {
     if (hasStringPropertyChanged(val, this._size)) {
       const oldVal = this._size;
       this._size = val;
-      updateIconSizeStyleOrClassnames(this, val);
+      updateIconSizeStyle(this, val);
       this.requestUpdate('size', oldVal);
     }
   }
@@ -86,16 +86,6 @@ export class CdsIcon extends LitElement {
   /** If present, customizes the aria-label for the icon for accessibility. */
   @property({ type: String })
   title: string;
-
-  /**
-   * @deprecated
-   * Takes a directional value (up|down|left|right) that rotates the icon 90° with the
-   * top of the icon pointing in the specified direction.
-   *
-   * Deprecated in 3.0. Use `direction` instead. `dir` will be removed in 4.0!
-   */
-  @property({ type: String })
-  dir: Directions;
 
   /**
    * @type {up | down | left | right}

--- a/packages/core/src/icon/icon.service.spec.ts
+++ b/packages/core/src/icon/icon.service.spec.ts
@@ -6,70 +6,40 @@
 
 import { renderIcon } from './icon.renderer.js';
 import { ClarityIcons } from './icon.service.js';
-import { IconRegistry, IconShapeTuple } from './interfaces/icon.interfaces.js';
+import { IconAlias, IconShapeTuple } from './interfaces/icon.interfaces.js';
 import { testIcons } from './utils/test-icons.js';
 
 describe('ClarityIcons service: ', () => {
-  describe('get: ', () => {
-    let registry: IconRegistry;
-
-    beforeAll(() => {
-      registry = Object.assign({}, ClarityIcons.registry);
-    });
-
-    it('should return the registry on empty string or null', () => {
-      expect(ClarityIcons.get('')).toEqual(registry);
-      expect(ClarityIcons.get(null)).toEqual(registry);
-    });
-
-    it('should have an unknown icon initialized in its registry', () => {
-      expect(ClarityIcons.get('unknown')).toBeDefined();
-    });
-  });
-
-  describe('add: ', () => {
+  describe('addIcons: ', () => {
     it('should add icons to the registry using legacy call signature', () => {
-      ClarityIcons.add({
-        test01: 'testing',
-      });
-      expect(ClarityIcons.get('test01')).toEqual('testing');
+      ClarityIcons.addIcons(['test01', 'testing']);
+      expect(ClarityIcons.registry['test01']).toEqual('testing');
     });
 
     it('should be able to add multiple icons to the registry using legacy call signature', () => {
-      ClarityIcons.add({
-        test02: 'testing',
-        test03: 'ohai',
-      });
-      expect(ClarityIcons.get('test02')).toEqual('testing');
-      expect(ClarityIcons.get('test03')).toEqual('ohai');
+      ClarityIcons.addIcons(['test02', 'testing'], ['test03', 'ohai']);
+      expect(ClarityIcons.registry['test02']).toEqual('testing');
+      expect(ClarityIcons.registry['test03']).toEqual('ohai');
     });
 
     it('should add icons to the registry using icon shapes', () => {
       const [, testShape] = testIcons.justOutline;
       const expected = renderIcon(testShape);
-      ClarityIcons.add({
-        test04: testShape,
-      });
-      expect(ClarityIcons.get('test04')).toEqual(expected);
+      ClarityIcons.addIcons(['test04', testShape]);
+      expect(ClarityIcons.registry['test04']).toEqual(expected);
     });
 
     it('should add icons to the registry using strings', () => {
-      ClarityIcons.add({
-        test05: 'testing',
-      });
-      expect(ClarityIcons.get('test05')).toEqual('testing');
+      ClarityIcons.addIcons(['test05', 'testing']);
+      expect(ClarityIcons.registry['test05']).toEqual('testing');
     });
 
     it('should not overwrite icons that have already been added to the registry (legacy api)', () => {
       const [, testShape] = testIcons.justOutline;
-      ClarityIcons.add({
-        test06: 'testing',
-      });
-      expect(ClarityIcons.get('test06')).toEqual('testing');
-      ClarityIcons.add({
-        test06: testShape,
-      });
-      expect(ClarityIcons.get('test06')).toEqual('testing');
+      ClarityIcons.addIcons(['test06', 'testing']);
+      expect(ClarityIcons.registry['test06']).toEqual('testing');
+      ClarityIcons.addIcons(['test06', testShape]);
+      expect(ClarityIcons.registry['test06']).toEqual('testing');
     });
   });
 
@@ -78,19 +48,19 @@ describe('ClarityIcons service: ', () => {
       const [, testShape] = testIcons.badgedIcon;
       const expected = renderIcon(testShape);
       ClarityIcons.addIcons(['test07', testShape]);
-      expect(ClarityIcons.get('test07')).toEqual(expected);
+      expect(ClarityIcons.registry['test07']).toEqual(expected);
     });
 
     it('should add icons to the registry using string tuples', () => {
       ClarityIcons.addIcons(['test08', 'testing']);
-      expect(ClarityIcons.get('test08')).toEqual('testing');
+      expect(ClarityIcons.registry['test08']).toEqual('testing');
     });
 
     it('should not overwrite icons that have already been added to the registry (legacy api)', () => {
       ClarityIcons.addIcons(['test09', 'ohai']);
-      expect(ClarityIcons.get('test09')).toEqual('ohai');
+      expect(ClarityIcons.registry['test09']).toEqual('ohai');
       ClarityIcons.addIcons(['test09', 'kthxbye']);
-      expect(ClarityIcons.get('test09')).toEqual('ohai');
+      expect(ClarityIcons.registry['test09']).toEqual('ohai');
     });
   });
 
@@ -102,16 +72,20 @@ describe('ClarityIcons service: ', () => {
     });
   });
 
-  describe('alias: ', () => {
+  describe('addAliases: ', () => {
     it('should be able to set an array of aliases', () => {
-      const aliases = {
-        unknown: ['whut', 'huh', 'ItsAMystery'],
-      };
-      const theUnknownIcon = ClarityIcons.get('unknown');
-      ClarityIcons.alias(aliases);
-      expect(ClarityIcons.get(aliases.unknown[0])).toEqual(theUnknownIcon);
-      expect(ClarityIcons.get(aliases.unknown[1])).toEqual(theUnknownIcon);
-      expect(ClarityIcons.get(aliases.unknown[2])).toEqual(theUnknownIcon);
+      const iconName = 'unknown';
+      const aliases: IconAlias[] = [
+        [iconName, ['whut']],
+        [iconName, ['huh']],
+        [iconName, ['ItsAMystery']],
+      ];
+
+      const theUnknownIcon = ClarityIcons.registry[iconName];
+      ClarityIcons.addAliases(...aliases);
+      expect(ClarityIcons.registry['whut']).toEqual(theUnknownIcon);
+      expect(ClarityIcons.registry['huh']).toEqual(theUnknownIcon);
+      expect(ClarityIcons.registry['ItsAMystery']).toEqual(theUnknownIcon);
     });
   });
 });

--- a/packages/core/src/icon/icon.service.ts
+++ b/packages/core/src/icon/icon.service.ts
@@ -4,16 +4,10 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import {
-  IconAlias,
-  IconAliasLegacyObject,
-  IconRegistry,
-  IconShapeSources,
-  IconShapeTuple,
-} from './interfaces/icon.interfaces.js';
+import { IconAlias, IconRegistry, IconShapeTuple } from './interfaces/icon.interfaces.js';
 import { unknownIcon } from './shapes/unknown.js';
 
-import { addIcon, addIcons, getIcon, legacyAlias, setIconAliases } from './utils/icon.service-helpers.js';
+import { addIcons, setIconAliases } from './utils/icon.service-helpers.js';
 
 const iconRegistry: IconRegistry = {
   unknown: unknownIcon[1] as string,
@@ -45,31 +39,19 @@ export class ClarityIcons {
     addIcons(shapes, iconRegistry);
   }
 
+  /**
+   * @description
+   * Use `addIcons` instead of `addAliases`
+   *
+   * This method is a backwords compatibility function to the old API
+   *
+   * The team will revisit this method for possible deprecation.
+   */
   static addAliases(...aliases: IconAlias[]) {
     aliases.forEach(alias => setIconAliases(alias, iconRegistry));
   }
 
   static getIconNameFromShape(iconShape: IconShapeTuple) {
     return iconShape[0];
-  }
-
-  /** @deprecated legacy API */
-  static get(shapeName?: string): string | IconRegistry {
-    return shapeName ? getIcon(shapeName, iconRegistry) : { ...iconRegistry };
-  }
-
-  /** @deprecated legacy API */
-  static add(shapes: IconShapeSources) {
-    for (const shapeName in shapes) {
-      // eslint-disable-next-line no-prototype-builtins
-      if (shapes.hasOwnProperty(shapeName)) {
-        addIcon([shapeName, shapes[shapeName]] as IconShapeTuple, iconRegistry);
-      }
-    }
-  }
-
-  /** @deprecated legacy API */
-  static alias(alias: IconAliasLegacyObject) {
-    legacyAlias(alias, iconRegistry);
   }
 }

--- a/packages/core/src/icon/utils/icon.classnames.spec.ts
+++ b/packages/core/src/icon/utils/icon.classnames.spec.ts
@@ -4,10 +4,10 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { html } from 'lit-html';
 import '@clr/core/icon/register.js';
+
+import { html } from 'lit-html';
 import { CdsIcon } from '@clr/core/icon';
-import { getEnumValues } from '@clr/core/internal';
 import { componentIsStable, createTestElement, removeTestElement } from '@clr/core/test/utils';
 import { renderIcon } from '../icon.renderer.js';
 import { ClarityIcons } from '../icon.service.js';
@@ -15,14 +15,10 @@ import { ClarityIcons } from '../icon.service.js';
 import { IconShapeCollection } from '../interfaces/icon.interfaces.js';
 import {
   getIconSvgClasses,
-  getIconTshirtSizeClassname,
   getUpdateSizeStrategy,
   IconSvgClassnames,
-  iconTshirtSizeClassnamePrefix,
-  IconTshirtSizes,
-  isIconTshirtSizeClassname,
   SizeUpdateStrategies,
-  updateIconSizeStyleOrClassnames,
+  updateIconSizeStyle,
 } from './icon.classnames.js';
 import { testIcons } from './test-icons.js';
 
@@ -99,7 +95,7 @@ describe('Icon classname helpers: ', () => {
     let component: CdsIcon;
 
     beforeAll(() => {
-      ClarityIcons.add({ testing: testIcon });
+      ClarityIcons.addIcons(['testing', testIcon]);
     });
 
     beforeEach(async () => {
@@ -112,15 +108,10 @@ describe('Icon classname helpers: ', () => {
     });
 
     it('should remove classnames and update size styles if passed a numeric string', async () => {
-      await componentIsStable(component);
-      component.classList.add(iconTshirtSizeClassnamePrefix + 'lg');
-      await componentIsStable(component);
-      expect(component.classList.toString().indexOf(iconTshirtSizeClassnamePrefix) > -1).toBe(true);
-      updateIconSizeStyleOrClassnames(component, '15');
+      updateIconSizeStyle(component, '15');
       await componentIsStable(component);
       expect(component.style.width).toEqual('15px');
       expect(component.style.height).toEqual('15px');
-      expect(component.classList.toString().indexOf(iconTshirtSizeClassnamePrefix) > -1).toBe(false);
     });
     it('should remove size styles and add classname if passed a t-shirt size', async () => {
       const myDims = '30';
@@ -129,107 +120,68 @@ describe('Icon classname helpers: ', () => {
       await componentIsStable(component);
       expect(component.style.height).toEqual(`${myDims}px`);
       expect(component.style.width).toEqual(`${myDims}px`);
-      updateIconSizeStyleOrClassnames(component, 'xl');
+      updateIconSizeStyle(component, 'xl');
       await componentIsStable(component);
       expect(component.style.width).toEqual('');
       expect(component.style.height).toEqual('');
-      expect(component.classList.contains(iconTshirtSizeClassnamePrefix + 'xl')).toBe(true);
     });
     it('should replace size styles if passed a new t-shirt size', async () => {
       await componentIsStable(component);
-      updateIconSizeStyleOrClassnames(component, 'lg');
+      updateIconSizeStyle(component, 'lg');
       await componentIsStable(component);
-      updateIconSizeStyleOrClassnames(component, 'sm');
+      updateIconSizeStyle(component, 'sm');
       await componentIsStable(component);
       expect(component.style.width).toEqual('');
       expect(component.style.height).toEqual('');
-      expect(component.classList.contains(iconTshirtSizeClassnamePrefix + 'sm')).toBe(true);
-      expect(component.classList.contains(iconTshirtSizeClassnamePrefix + 'lg')).toBe(false);
     });
     it('should remove classnames and size styles if passed a nil value', async () => {
       await componentIsStable(component);
-      updateIconSizeStyleOrClassnames(component, 'lg');
+      updateIconSizeStyle(component, 'lg');
       await componentIsStable(component);
-      expect(component.classList.contains(iconTshirtSizeClassnamePrefix + 'lg')).toBe(true);
-      updateIconSizeStyleOrClassnames(component, null);
+      updateIconSizeStyle(component, null);
       await componentIsStable(component);
       expect(component.style.width).toEqual('');
       expect(component.style.height).toEqual('');
-      expect(component.classList.toString().indexOf(iconTshirtSizeClassnamePrefix) > -1).toBe(false);
-      updateIconSizeStyleOrClassnames(component, '48');
+      updateIconSizeStyle(component, '48');
       await componentIsStable(component);
       expect(component.style.width).toEqual('48px');
       expect(component.style.height).toEqual('48px');
-      updateIconSizeStyleOrClassnames(component, void 0);
+      updateIconSizeStyle(component, void 0);
       await componentIsStable(component);
       expect(component.style.width).toEqual('');
       expect(component.style.height).toEqual('');
-      expect(component.classList.toString().indexOf(iconTshirtSizeClassnamePrefix) > -1).toBe(false);
     });
     it('should remove classnames and size styles if passed an empty string value', async () => {
       await componentIsStable(component);
-      updateIconSizeStyleOrClassnames(component, 'xl');
+      updateIconSizeStyle(component, 'xl');
       await componentIsStable(component);
-      expect(component.classList.contains(iconTshirtSizeClassnamePrefix + 'xl')).toBe(true);
-      updateIconSizeStyleOrClassnames(component, '');
+      updateIconSizeStyle(component, '');
       await componentIsStable(component);
       expect(component.style.width).toEqual('');
       expect(component.style.height).toEqual('');
-      expect(component.classList.toString().indexOf(iconTshirtSizeClassnamePrefix) > -1).toBe(false);
-      updateIconSizeStyleOrClassnames(component, '48');
+      updateIconSizeStyle(component, '48');
       await componentIsStable(component);
       expect(component.style.width).toEqual('48px');
       expect(component.style.height).toEqual('48px');
-      updateIconSizeStyleOrClassnames(component, '');
+      updateIconSizeStyle(component, '');
       await componentIsStable(component);
       expect(component.style.width).toEqual('');
       expect(component.style.height).toEqual('');
-      expect(component.classList.toString().indexOf(iconTshirtSizeClassnamePrefix) > -1).toBe(false);
     });
     it('should do nothing if passed a string that is not a t-shirt size and is non-numeric', async () => {
       await componentIsStable(component);
-      updateIconSizeStyleOrClassnames(component, 'sm');
+      updateIconSizeStyle(component, 'sm');
       await componentIsStable(component);
-      expect(component.classList.contains(iconTshirtSizeClassnamePrefix + 'sm')).toBe(true);
-      updateIconSizeStyleOrClassnames(component, 'jabberwocky');
+      updateIconSizeStyle(component, 'jabberwocky');
       await componentIsStable(component);
-      expect(component.classList.contains(iconTshirtSizeClassnamePrefix + 'sm')).toBe(true);
-      updateIconSizeStyleOrClassnames(component, '24');
+      updateIconSizeStyle(component, '24');
       await componentIsStable(component);
       expect(component.style.width).toEqual('24px');
       expect(component.style.height).toEqual('24px');
-      expect(component.classList.contains(iconTshirtSizeClassnamePrefix + 'sm')).toBe(false);
-      updateIconSizeStyleOrClassnames(component, '4d9rs');
+      updateIconSizeStyle(component, '4d9rs');
       await componentIsStable(component);
       expect(component.style.width).toEqual('24px');
       expect(component.style.height).toEqual('24px');
-    });
-  });
-
-  describe('getIconTshirtSizeClassname', () => {
-    it('should have last two arguments default', () => {
-      expect(getIconTshirtSizeClassname('xs')).toEqual(iconTshirtSizeClassnamePrefix + 'xs');
-    });
-    it('should return an empty string if passed a string that is not a t-shirt size', () => {
-      expect(getIconTshirtSizeClassname('xxxs')).toEqual('');
-      expect(getIconTshirtSizeClassname('')).toEqual('');
-    });
-    it('should return properly prefixed t-shirt sizes if passed a valid t-shirt size', () => {
-      (getEnumValues(IconTshirtSizes) as any[]).forEach(size => {
-        expect(getIconTshirtSizeClassname(size)).toEqual(iconTshirtSizeClassnamePrefix + size);
-      });
-    });
-  });
-
-  describe('isIconTshirtSizeClassname', () => {
-    it('should return true for known t-shirt sizes', () => {
-      (getEnumValues(IconTshirtSizes) as any[]).forEach(size => {
-        expect(isIconTshirtSizeClassname(size)).toBe(true);
-      });
-    });
-    it('should return false if passed something unexpected', () => {
-      expect(isIconTshirtSizeClassname('jabberwocky')).toBe(false);
-      expect(isIconTshirtSizeClassname('xxxs')).toBe(false);
     });
   });
 });

--- a/packages/core/src/icon/utils/icon.classnames.ts
+++ b/packages/core/src/icon/utils/icon.classnames.ts
@@ -4,15 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import {
-  getEnumValues,
-  isString,
-  transformToSpacedString,
-  updateElementStyles,
-  removeClassnames,
-  addClassnames,
-  removeClassnamesUnless,
-} from '@clr/core/internal';
+import { isTshirtSize, transformToSpacedString, updateElementStyles } from '@clr/core/internal';
 import isNil from 'ramda/es/isNil';
 import { CdsIcon } from '../icon.element.js';
 import { IconShapeCollection } from '../interfaces/icon.interfaces.js';
@@ -66,38 +58,6 @@ export function getShapeClassname(shapeType: string) {
   return className;
 }
 
-export enum IconTshirtSizes {
-  ExtraSmall = 'xs',
-  Small = 'sm',
-  Medium = 'md',
-  Large = 'lg',
-  ExtraLarge = 'xl',
-  ExtraExtraLarge = 'xxl',
-}
-
-export const iconTshirtSizeClassnamePrefix = 'clr-i-size-';
-
-export function getIconTshirtSizeClassname(
-  sizeToLookup: string,
-  prefix = iconTshirtSizeClassnamePrefix,
-  sizes = IconTshirtSizes
-): string {
-  const tshirtSizesVals = getEnumValues(sizes);
-  const indexOfSize = tshirtSizesVals.indexOf(sizeToLookup);
-  if (indexOfSize > -1) {
-    return prefix + tshirtSizesVals[indexOfSize];
-  }
-  return '';
-}
-
-export function getAllIconTshirtSizeClassnames(prefix = iconTshirtSizeClassnamePrefix, sizes = IconTshirtSizes) {
-  return getEnumValues(sizes).map(sz => prefix + sz);
-}
-
-export function isIconTshirtSizeClassname(classname: string, sizes = IconTshirtSizes) {
-  return getEnumValues(sizes).indexOf(classname) > -1;
-}
-
 export function getIconSvgClasses(icon: IconShapeCollection): string {
   const testSolid = (i: IconShapeCollection) => (iconHasSolidShapes(i) ? IconSvgClassnames.Solid : '');
   const testBadged = (i: IconShapeCollection) => (iconHasBadgedShapes(i) ? IconSvgClassnames.Badged : '');
@@ -118,7 +78,7 @@ export function getUpdateSizeStrategy(size: string) {
     return SizeUpdateStrategies.NilSizeValue;
   }
 
-  if (isString(size) && isIconTshirtSizeClassname(size)) {
+  if (isTshirtSize(size)) {
     return SizeUpdateStrategies.ValidSizeString;
   }
 
@@ -129,22 +89,17 @@ export function getUpdateSizeStrategy(size: string) {
   return SizeUpdateStrategies.BadSizeValue;
 }
 
-export function updateIconSizeStyleOrClassnames(el: CdsIcon, size: string) {
+export function updateIconSizeStyle(el: CdsIcon, size: string) {
   const updateStrategy = getUpdateSizeStrategy(size);
-  const newTshirtSize = getIconTshirtSizeClassname(size);
 
   switch (updateStrategy) {
     case SizeUpdateStrategies.ValidNumericString:
       updateElementStyles(el, ['width', `${size}px`], ['height', `${size}px`]);
-      removeClassnames(el, ...getAllIconTshirtSizeClassnames());
       return;
     case SizeUpdateStrategies.ValidSizeString:
-      addClassnames(el, newTshirtSize);
-      removeClassnamesUnless(el, getAllIconTshirtSizeClassnames(), [newTshirtSize]);
       updateElementStyles(el, ['width', ''], ['height', '']);
       return;
     case SizeUpdateStrategies.NilSizeValue: // nil values empty out all sizing
-      removeClassnames(el, ...getAllIconTshirtSizeClassnames());
       updateElementStyles(el, ['width', ''], ['height', '']);
       return;
     case SizeUpdateStrategies.BadSizeValue:


### PR DESCRIPTION
Removing the deprecated methods and styles introduced in previous versions and marked as deprecated for v5 in Icons.

Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #4925

## What is the new behavior?

Removed deprecated code

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Anybody who uses the old icon sizes styles, `dir` property of `cds-icon` and `get`, `add` and `alias` methods from `icon.service` will be affected.
