### PR TITLE
fix(a11y): improve default core tag accessibility (backport to v4)

### DIFF
--- a/packages/core/src/tag/tag.element.scss
+++ b/packages/core/src/tag/tag.element.scss
@@ -3,12 +3,12 @@
 
 :host {
   --background: none;
-  --color: #{$cds-token-color-neutral-600};
+  --color: #{$cds-token-color-neutral-800};
   --padding: 0 #{$cds-token-space-size-2};
   --size: #{$cds-token-space-size-8-static + $cds-token-space-size-3-static};
   --font-size: #{($cds-token-space-size-8-static + $cds-token-space-size-2-static) / 2 + $cds-token-space-size-1-static};
   --border-radius: calc(var(--size) / 2);
-  --border-color: #{$cds-token-color-neutral-600};
+  --border-color: #{$cds-token-color-neutral-800};
   --border-width: #{$cds-token-global-border-width};
 
   display: inline-block;


### PR DESCRIPTION
• the wrong default color was implemented initially
• the color that was implemented was too light
• this change aligns the core tag text color with the clr/ui label text color

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
