### PR TITLE
fix: (datagrid) filtering not working well with Ivy off

### DIFF
--- a/packages/angular/projects/clr-angular/src/data/datagrid/datagrid.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/datagrid.ts
@@ -226,6 +226,13 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
         if (!this.items.smart) {
           this.items.all = this.rows.map((row: ClrDatagridRow<T>) => row.item);
         }
+        // Remove any projected rows from the displayedRows container
+        // Necessary with Ivy off. See https://github.com/vmware/clarity/issues/4692
+        for (let i = this._displayedRows.length - 1; i >= 0; i--) {
+          if (this._displayedRows.get(i).destroyed) {
+            this._displayedRows.remove(i);
+          }
+        }
         this.rows.forEach(row => {
           this._displayedRows.insert(row._view);
         });


### PR DESCRIPTION
issue #5085

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When Ivy is turned off, the displayedRows list accumulates old ghost items, which mess the proper child views visualization. Thus, after been filtered out, rows are not shown back when the filter is removed.

Issue Number: #5085 

## What is the new behavior?

Works fine both with and without Ivy

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Please note, that because of the complicated setup we can't make a test for the no-Ivy scenario. We can't have a test run with and without Ivy unless we run a new task with new test setup.
