### PR TITLE
fix: adds CI build step for netlify lambda fn

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -21,6 +21,7 @@ jobs:
       - run: yarn build:website
       - run: yarn build:storybook:angular
       - run: yarn build:storybook:core
+      - run: yarn website:functions
       - run: npm run website:deploy # Use NPM as a workaround for npx executing
 
     env:

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "website:preview": "lite-server --baseDir=dist/website",
     "website:start": "yarn --cwd apps/website run start",
     "website:lint": "yarn --cwd app/website run lint",
+    "website:functions": "netlify-lambda build scripts/netlify",
     "tool:audit-website": "yarn --cwd tools/audit-website run start",
     "tool:link-checker": "yarn --cwd tools/link-checker run start"
   },


### PR DESCRIPTION
In order to download icons the lambda function needs to be built and deployed. 
This change will do that. 

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

## PR Type

What kind of change does this PR introduce?
Build and deploy the icons lambda fn for the website. 

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Individual icon download button results in 404. 

## What is the new behavior?
Individual icon download button downloads the correct svg file from github. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No