### PR TITLE
fix(stack-view): use normal outline focus indicators

### DIFF
--- a/packages/angular/projects/clr-angular/src/data/stack-view/_stack-view.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/data/stack-view/_stack-view.clarity.scss
@@ -136,10 +136,6 @@ $styledInputs: 'input[type=text], input[type=password], input[type=number], inpu
     }
 
     .stack-block-label {
-      outline: none;
-    }
-
-    .stack-block-label {
       padding: $clr_baselineRem_0_25 $clr_baselineRem_0_5;
       @include css-var(
         background-color,
@@ -182,6 +178,10 @@ $styledInputs: 'input[type=text], input[type=password], input[type=number], inpu
         @include equilateral($clr_baselineRem_0_583);
         margin: ($clr_baselineRem_0_25 + $clr_baselineRem_1px) $clr_baselineRem_0_2 0 0;
         text-align: center;
+      }
+
+      &:focus {
+        outline: $clr_baselineRem_5px auto -webkit-focus-ring-color;
       }
     }
 
@@ -267,7 +267,6 @@ $styledInputs: 'input[type=text], input[type=password], input[type=number], inpu
         transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out;
       }
 
-      &.on-focus:not(.stack-block-expanded),
       &:hover:not(.stack-block-expanded) {
         > .stack-block-label {
           @include css-var(


### PR DESCRIPTION
Removes custom focus styles for the row triggers in stack grids.  It adds the default outline that's used for buttons and other elements, keeping hover behavior the same.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

Issue Number: #4899

## What is the new behavior?

Standardizes the focus indicator.  

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

