### PR TITLE
Topic/website build deploy next

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,5 @@
 # Default build settings
 [build]
-  command = "yarn website:build && yarn website:deploy"
   functions = "dist/netlify"
   publish = "dist/website"
   environment = { CI = "true", NPM_FLAGS = '--no-optional', CYPRESS_INSTALL_BINARY = "false" }

--- a/scripts/website.sh
+++ b/scripts/website.sh
@@ -10,4 +10,7 @@ curl -g https://us-central1-clarity-design-system.cloudfunctions.net/actions -o 
 find . -type f -name "*.html" -print0 -path ./website/storybook -prune | xargs -0 perl -pi -e 's/\/localhost:6006\//storybook\/angular\/index.html/g'
 find . -type f -name "*.js" -print0 -path ./website/storybook -prune | xargs -0 perl -pi -e 's/\/localhost:6006\//storybook\/angular\/index.html/g'
 
-node -r dotenv/config -- ./node_modules/.bin/netlify deploy --dir=./dist/website --message="Website - $GITHUB_REF@$GITHUB_SHA"
+# Deploy a preview that can be promoted to production when we are ready
+node -r dotenv/config -- ./node_modules/.bin/netlify deploy --dir=./dist/website --message="Website - $GITHUB_REF@$GITHUB_SHA" --site "clarity.design"
+# Deploy a version to https://next.clarity.design as 'production'
+node -r dotenv/config -- ./node_modules/.bin/netlify deploy --dir=./dist/website --message="Website - $GITHUB_REF@$GITHUB_SHA" --site "next.clarity.design"


### PR DESCRIPTION
## PR Checklist

## PR Type

What kind of change does this PR introduce?

This is a change to the build scripts for deploying the website. 
It adds the ability to build the website with a PR and deploy it to both clarity.design domain and the next.clarity.design subdomain. Netlify has some restrictions around how subdomains are built and deployed that the Clarity repo is running up against.

1. Our website build needs to build a vuepress site for prod, build an angular storybook app and build a core storybook app
2. The build complexity goes past the 15 minute time limit for builds 
3. We need to build and deploy with a github action 

This does mean it might be harder to determine differences between deploys in the netlify UI. That might be helped with a better message? 

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [x] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
n/a
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
After the website is built the script will upload files to the cdn for next.clarity.design ℗eview) and clarity.design (preview). 
This allows us to deploy (previews) that can be promoted to production for both https://clarity.design and https:next.clarity.design. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
