### PR TITLE
fix(signpost): put header before contents to fix DOM/a11y tree order

### DIFF
--- a/packages/angular/projects/clr-angular/src/popover/signpost/signpost-content.ts
+++ b/packages/angular/projects/clr-angular/src/popover/signpost/signpost-content.ts
@@ -36,9 +36,6 @@ const POSITIONS: string[] = [
   template: `
     <div class="signpost-wrap">
       <div class="popover-pointer"></div>
-      <div class="signpost-content-body">
-        <ng-content></ng-content>
-      </div>
       <div class="signpost-content-header">
         <button
           type="button"
@@ -49,6 +46,9 @@ const POSITIONS: string[] = [
         >
           <clr-icon shape="close" [attr.title]="commonStrings.keys.close"></clr-icon>
         </button>
+      </div>
+      <div class="signpost-content-body">
+        <ng-content></ng-content>
       </div>
     </div>
   `,


### PR DESCRIPTION
Currently the header appears after the contents in the DOM, but is visually positioned absolutely at the beginning.  This breaks screen readers, but fortunately we can just reorder the elements and have the same visual result.

Closes: #4986

Signed-off-by: Alex Mellnik <a.r.mellnik@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

Signpost headers correctly appear before the contents on the screen, but are after the contents in the DOM and a11y tree.  This makes all three match.  

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
