### PR TITLE
fix(datagrid): add aria-label to string filter input

### DIFF
--- a/packages/angular/golden/clr-angular.d.ts
+++ b/packages/angular/golden/clr-angular.d.ts
@@ -380,6 +380,7 @@ export interface ClrCommonStrings {
     detailPaneEnd: string;
     detailPaneStart: string;
     expand: string;
+    filterItems: string;
     firstPage: string;
     hide: string;
     info: string;
@@ -2149,6 +2150,7 @@ export declare class DatagridPropertyStringFilter<T = any> implements ClrDatagri
 }
 
 export declare class DatagridStringFilter<T = any> extends DatagridFilterRegistrar<T, DatagridStringFilterImpl<T>> implements CustomFilter, AfterViewInit, OnDestroy {
+    commonStrings: ClrCommonStringsService;
     set customStringFilter(value: ClrDatagridStringFilterInterface<T> | RegisteredFilter<T, DatagridStringFilterImpl<T>>);
     filterContainer: ClrDatagridFilter<T>;
     filterValueChange: EventEmitter<any>;
@@ -2156,7 +2158,7 @@ export declare class DatagridStringFilter<T = any> extends DatagridFilterRegistr
     open: boolean;
     get value(): string;
     set value(value: string);
-    constructor(filters: FiltersProvider<T>, domAdapter: DomAdapter, smartToggleService: ClrPopoverToggleService);
+    constructor(filters: FiltersProvider<T>, domAdapter: DomAdapter, commonStrings: ClrCommonStringsService, smartToggleService: ClrPopoverToggleService);
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
 }

--- a/packages/angular/projects/clr-angular/src/data/datagrid/built-in/filters/datagrid-string-filter.spec.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/built-in/filters/datagrid-string-filter.spec.ts
@@ -117,6 +117,13 @@ export default function (): void {
       expect(context.testComponent.filterValue).toBe('t');
     });
 
+    it('has an aria-label on the input', fakeAsync(function () {
+      openFilter();
+      const input: HTMLInputElement = document.querySelector("input[type='text']");
+      expect(input.getAttribute('aria-label')).toBe('Filter items');
+      tick();
+    }));
+
     xit('closes when the user presses Enter in the input', function () {
       // TODO
       openFilter();

--- a/packages/angular/projects/clr-angular/src/data/datagrid/built-in/filters/datagrid-string-filter.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/built-in/filters/datagrid-string-filter.ts
@@ -11,6 +11,7 @@ import { CustomFilter } from '../../providers/custom-filter';
 import { FiltersProvider, RegisteredFilter } from '../../providers/filters';
 import { DomAdapter } from '../../../../utils/dom-adapter/dom-adapter';
 import { DatagridFilterRegistrar } from '../../utils/datagrid-filter-registrar';
+import { ClrCommonStringsService } from '../../../../utils/i18n/common-strings.service';
 
 import { DatagridStringFilterImpl } from './datagrid-string-filter-impl';
 import { ClrPopoverToggleService } from '../../../../utils/popover/providers/popover-toggle.service';
@@ -20,7 +21,14 @@ import { ClrPopoverToggleService } from '../../../../utils/popover/providers/pop
   providers: [{ provide: CustomFilter, useExisting: DatagridStringFilter }],
   template: `
     <clr-dg-filter [clrDgFilter]="registered" [(clrDgFilterOpen)]="open">
-      <input #input type="text" name="search" [(ngModel)]="value" class="clr-input" />
+      <input
+        #input
+        type="text"
+        name="search"
+        [(ngModel)]="value"
+        class="clr-input"
+        [attr.aria-label]="commonStrings.keys.filterItems"
+      />
     </clr-dg-filter>
   `,
 })
@@ -30,6 +38,7 @@ export class DatagridStringFilter<T = any> extends DatagridFilterRegistrar<T, Da
   constructor(
     filters: FiltersProvider<T>,
     private domAdapter: DomAdapter,
+    public commonStrings: ClrCommonStringsService,
     private smartToggleService: ClrPopoverToggleService
   ) {
     super(filters);

--- a/packages/angular/projects/clr-angular/src/utils/i18n/common-strings.default.ts
+++ b/packages/angular/projects/clr-angular/src/utils/i18n/common-strings.default.ts
@@ -33,6 +33,7 @@ export const commonStringsDefault: ClrCommonStrings = {
   previousPage: 'Previous Page',
   currentPage: 'Current Page',
   totalPages: 'Total Pages',
+  filterItems: 'Filter items',
   minValue: 'Min value',
   maxValue: 'Max value',
   modalContentStart: 'Beginning of Modal Content',

--- a/packages/angular/projects/clr-angular/src/utils/i18n/common-strings.interface.ts
+++ b/packages/angular/projects/clr-angular/src/utils/i18n/common-strings.interface.ts
@@ -117,6 +117,10 @@ export interface ClrCommonStrings {
    */
   totalPages: string;
   /**
+   * Datagrid string filter: filter items
+   */
+  filterItems: string;
+  /**
    * Datagrid numeric filter: min
    */
   minValue: string;

--- a/packages/core/src/internal/services/common-strings.default.ts
+++ b/packages/core/src/internal/services/common-strings.default.ts
@@ -33,6 +33,7 @@ export const commonStringsDefault: ClrCommonStrings = {
   previousPage: 'Previous Page',
   currentPage: 'Current Page',
   totalPages: 'Total Pages',
+  filterItems: 'Filter items',
   minValue: 'Min value',
   maxValue: 'Max value',
   modalCloseButtonAriaLabel: 'Close modal',

--- a/packages/core/src/internal/services/common-strings.interface.ts
+++ b/packages/core/src/internal/services/common-strings.interface.ts
@@ -109,6 +109,10 @@ export interface ClrCommonStrings {
    */
   totalPages: string;
   /**
+   * Datagrid string filter: filter items
+   */
+  filterItems: string;
+  /**
    * Datagrid numeric filter: min
    */
   minValue: string;


### PR DESCRIPTION
Add a new common string for "Search" and use it to add an aria-label to the datagrid default string filter input.  This string can probably be used elsewhere in the future.

Partially closes: #4756

Signed-off-by: Alex Mellnik <a.r.mellnik@gmail.com>

~WIP to resolve some build issues that I think are unrelated.~

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The datagrid default string filter does not have an aria-label or placeholder.  

Issue Number: #4986 

## What is the new behavior?

This adds the aria label via a new common string.  It doesn't populate the placeholder but that would be easy to do.  

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
