### PR TITLE
feat(icons): [core] allow for custom icons to be added from icon templates

### DIFF
--- a/packages/core/src/icon/index.ts
+++ b/packages/core/src/icon/index.ts
@@ -6,6 +6,7 @@
 
 export * from './icon.element.js';
 export * from './icon.service.js';
+export { renderIcon } from './icon.renderer.js';
 
 // SHAPES
 export { unknownIcon } from './shapes/unknown.js';


### PR DESCRIPTION
• it was our intent to allow users to create their own icons using our icon template format
• we do not export the code to convert an icon template into an SVG
• this change exposes that code
• the renderIcon() function was not rolled up into the icon service because I wanted it to remain tree shakable and not bundled in with the icons API
• using render icon is an advanced use case; most users would not import it and use it.
• this will be back ported to 4.0

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes*
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Users cannot create bonafide clarity icons using the icon templates that @clr/core uses

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

the renderIcon() function is exported so that advanced users can now build outlined, solid, badged, and alerted icons the same way Clarity does

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
