### PR TITLE
fix(datagrid): give all action-item items the menuitem role

### DIFF
--- a/apps/website/.vuepress/public/demos/datagrid/single-action.html
+++ b/apps/website/.vuepress/public/demos/datagrid/single-action.html
@@ -10,8 +10,8 @@
   this pattern in both selectable and non-selectable datagrids. Add a
   <code class="clr-code">clr-dg-action-overflow</code> inside a <code class="clr-code">clr-dg-row</code>. The content
   inside of it will be projected as an action menu which will toggle when the user clicks on the ellipsis icon as shown
-  below. We recommend that the menu items be buttons with a class <code class="clr-code">.action-item</code> as in the
-  example.
+  below. We recommend that the menu items be buttons with the <code class="clr-code">clrDgActionItem</code> directive as
+  in the example.
 </p>
 
 <p>
@@ -41,8 +41,8 @@
 
   <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
     <clr-dg-action-overflow>
-      <button class="action-item" (click)="onEdit(user)">Edit</button>
-      <button class="action-item" (click)="onDelete(user)">Delete</button>
+      <button clrDgActionItem (click)="onEdit(user)">Edit</button>
+      <button clrDgActionItem (click)="onDelete(user)">Delete</button>
     </clr-dg-action-overflow>
     <clr-dg-cell>{{user.id}}</clr-dg-cell>
     <clr-dg-cell>{{user.name}}</clr-dg-cell>

--- a/apps/website/components/datagrid/README.md
+++ b/apps/website/components/datagrid/README.md
@@ -674,7 +674,7 @@ Depending on the role of certain batch actions, you can choose to break button b
 
 ### Single Action
 
-You can allow actions on an item in a single row, in the cases where batch operation is not applicable. You can use this pattern in both selectable and non-selectable datagrids. Add a `clr-dg-action-overflow` inside a `clr-dg-row`. The content inside of it will be projected as an action menu which will toggle when the user clicks on the ellipsis icon as shown below. We recommend that the menu items be buttons with a class `.action-item` as in the example.
+You can allow actions on an item in a single row, in the cases where batch operation is not applicable. You can use this pattern in both selectable and non-selectable datagrids. Add a `clr-dg-action-overflow` inside a `clr-dg-row`. The content inside of it will be projected as an action menu which will toggle when the user clicks on the ellipsis icon as shown below. We recommend that the menu items be buttons with the `clrDgActionItem` directive as in the example.
 
 In the following example, we simply display the names of the selected users, but since we have access to the full objects, we could perform any operation we want on them.
 
@@ -687,8 +687,8 @@ In the following example, we simply display the names of the selected users, but
   <!-- ... -->
   <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
     <clr-dg-action-overflow>
-      <button class="action-item" (click)="onEdit(user)">Edit</button>
-      <button class="action-item" (click)="onDelete(user)">Delete</button>
+      <button clrDgActionItem (click)="onEdit(user)">Edit</button>
+      <button clrDgActionItem (click)="onDelete(user)">Delete</button>
     </clr-dg-action-overflow>
     <!-- ... -->
   </clr-dg-row>

--- a/apps/website/components/datagrid/api.md
+++ b/apps/website/components/datagrid/api.md
@@ -56,7 +56,7 @@ operate on a single row item.
   ...
   <clr-dg-row *clrDgItems="let item of items" [clrDgItem]="item">
     <clr-dg-action-overflow (clrDgActionOverflowOpenChange)="openChangeFn($event)">
-      <button class="action-item">
+      <button clrDgActionItem>
         <clr-icon shape="note"></clr-icon>
         Action
       </button>

--- a/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-action-item.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-action-item.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Directive } from '@angular/core';
+
+/**
+ * @remark
+ * This directive is used to identify action buttons within the single row action menu and to give
+ * them the 'menuitem' aria role.
+ */
+@Directive({
+  selector: '[clrDgActionItem]',
+  host: {
+    '[class.action-item]': 'true',
+    role: 'menuitem',
+  },
+})
+export class ClrDatagridActionItem {}

--- a/packages/angular/projects/clr-angular/src/data/datagrid/datagrid.module.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/datagrid.module.ts
@@ -27,6 +27,7 @@ import { DatagridWillyWonka } from './chocolate/datagrid-willy-wonka';
 import { ExpandableOompaLoompa } from './chocolate/expandable-oompa-loompa';
 import { ClrDatagrid } from './datagrid';
 import { ClrDatagridActionBar } from './datagrid-action-bar';
+import { ClrDatagridActionItem } from './datagrid-action-item';
 import { ClrDatagridActionOverflow } from './datagrid-action-overflow';
 import { ClrDatagridCell } from './datagrid-cell';
 import { ClrDatagridColumn } from './datagrid-column';
@@ -61,6 +62,7 @@ export const CLR_DATAGRID_DIRECTIVES: Type<any>[] = [
   // Core
   ClrDatagrid,
   ClrDatagridActionBar,
+  ClrDatagridActionItem,
   ClrDatagridActionOverflow,
   ClrDatagridColumn,
   ClrDatagridColumnSeparator,

--- a/packages/angular/projects/clr-angular/src/data/datagrid/render/main-renderer.spec.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/render/main-renderer.spec.ts
@@ -331,7 +331,7 @@ export default function (): void {
         <clr-dg-column>Column</clr-dg-column>
         <clr-dg-row>
           <clr-dg-action-overflow *ngIf="hasActions">
-            <button class="action-item" (click)="(return)">
+            <button clrDgActionItem (click)="(return)">
               Edit
             </button>
           </clr-dg-action-overflow>

--- a/packages/angular/projects/clr-angular/src/utils/popover/popover-open-close-button.ts
+++ b/packages/angular/projects/clr-angular/src/utils/popover/popover-open-close-button.ts
@@ -30,7 +30,7 @@ export class ClrPopoverOpenCloseButton implements OnDestroy {
 
   @HostListener('click', ['$event'])
   @HostListener('keydown', ['$event'])
-  handleClick(event: MouseEvent) {
+  handleClick(event: MouseEvent | KeyboardEvent) {
     this.smartOpenService.toggleWithEvent(event);
   }
 

--- a/packages/angular/projects/dev/src/app/datagrid/compact/compact.html
+++ b/packages/angular/projects/dev/src/app/datagrid/compact/compact.html
@@ -143,11 +143,11 @@
 
     <clr-dg-row *clrDgItems="let user of nonPaginatedUsers" [clrDgItem]="user">
       <clr-dg-action-overflow>
-        <button class="action-item" (click)="onEdit(user)">
+        <button clrDgActionItem (click)="onEdit(user)">
           <clr-icon shape="note"></clr-icon>
           Edit
         </button>
-        <button class="action-item" (click)="onDelete(user)">
+        <button clrDgActionItem (click)="onDelete(user)">
           <clr-icon shape="trash"></clr-icon>
           Delete
         </button>
@@ -193,8 +193,7 @@
       <clr-dg-cell>{{user.id}}</clr-dg-cell>
       <clr-dg-cell>{{user.name}}</clr-dg-cell>
       <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
-      <clr-dg-cell
-        >{{user.pokemon.name}}
+      <clr-dg-cell>{{user.pokemon.name}}
         <span class="badge badge-5">#{{user.pokemon.number}}</span>
       </clr-dg-cell>
       <clr-dg-cell>

--- a/packages/angular/projects/dev/src/app/datagrid/detail/detail.html
+++ b/packages/angular/projects/dev/src/app/datagrid/detail/detail.html
@@ -18,19 +18,22 @@
   </clr-dg-action-bar>
 
   <clr-dg-column [clrDgField]="'id'">User ID</clr-dg-column>
-  <clr-dg-column [clrDgField]="'name'"><ng-container *clrDgHideableColumn>Name</ng-container></clr-dg-column>
-  <clr-dg-column [clrDgField]="'creation'"
-    ><ng-container *clrDgHideableColumn>Creation date</ng-container></clr-dg-column
-  >
-  <clr-dg-column [clrDgField]="'pokemon.name'"><ng-container *clrDgHideableColumn>Pokemon</ng-container></clr-dg-column>
-  <clr-dg-column [clrDgField]="'color'"><ng-container *clrDgHideableColumn>Favorite color</ng-container></clr-dg-column>
+  <clr-dg-column [clrDgField]="'name'">
+    <ng-container *clrDgHideableColumn>Name</ng-container>
+  </clr-dg-column>
+  <clr-dg-column [clrDgField]="'creation'">
+    <ng-container *clrDgHideableColumn>Creation date</ng-container>
+  </clr-dg-column>
+  <clr-dg-column [clrDgField]="'pokemon.name'">
+    <ng-container *clrDgHideableColumn>Pokemon</ng-container>
+  </clr-dg-column>
+  <clr-dg-column [clrDgField]="'color'">
+    <ng-container *clrDgHideableColumn>Favorite color</ng-container>
+  </clr-dg-column>
 
-  <clr-dg-row
-    *clrDgItems="let user of users"
-    [clrDgItem]="user"
+  <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user"
     [clrDgDetailOpenLabel]="'Open row details for ' + user.name"
-    [clrDgDetailCloseLabel]="'Open row details for ' + user.name"
-  >
+    [clrDgDetailCloseLabel]="'Open row details for ' + user.name">
     <clr-dg-cell>{{user.id}}</clr-dg-cell>
     <clr-dg-cell>{{user.name}}</clr-dg-cell>
     <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
@@ -49,10 +52,9 @@
 
   <!-- Simple API for most cases -->
   <clr-dg-detail *clrIfDetail="let detail">
-    <clr-dg-detail-header
-      >{{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}}
-      {{detail.name}} {{detail.name}}</clr-dg-detail-header
-    >
+    <clr-dg-detail-header>{{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}}
+      {{detail.name}} {{detail.name}}
+      {{detail.name}} {{detail.name}}</clr-dg-detail-header>
     <clr-dg-detail-body>
       <pre>{{detail | json}}</pre>
       <pre>{{detail | json}}</pre>
@@ -73,12 +75,18 @@
 
 <clr-datagrid id="change-event" [(clrDgSingleSelected)]="singleSelection">
   <clr-dg-column [clrDgField]="'id'">User ID</clr-dg-column>
-  <clr-dg-column [clrDgField]="'name'"><ng-container *clrDgHideableColumn>Name</ng-container></clr-dg-column>
-  <clr-dg-column [clrDgField]="'creation'"
-    ><ng-container *clrDgHideableColumn>Creation date</ng-container></clr-dg-column
-  >
-  <clr-dg-column [clrDgField]="'pokemon.name'"><ng-container *clrDgHideableColumn>Pokemon</ng-container></clr-dg-column>
-  <clr-dg-column [clrDgField]="'color'"><ng-container *clrDgHideableColumn>Favorite color</ng-container></clr-dg-column>
+  <clr-dg-column [clrDgField]="'name'">
+    <ng-container *clrDgHideableColumn>Name</ng-container>
+  </clr-dg-column>
+  <clr-dg-column [clrDgField]="'creation'">
+    <ng-container *clrDgHideableColumn>Creation date</ng-container>
+  </clr-dg-column>
+  <clr-dg-column [clrDgField]="'pokemon.name'">
+    <ng-container *clrDgHideableColumn>Pokemon</ng-container>
+  </clr-dg-column>
+  <clr-dg-column [clrDgField]="'color'">
+    <ng-container *clrDgHideableColumn>Favorite color</ng-container>
+  </clr-dg-column>
 
   <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
     <clr-dg-cell>{{user.id}}</clr-dg-cell>
@@ -100,10 +108,9 @@
   <!--  Desugared option for change event -->
   <ng-template clrIfDetail let-detail (clrIfDetailChange)="stateEvent = $event">
     <clr-dg-detail>
-      <clr-dg-detail-header
-        >{{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}}
-        {{detail.name}} {{detail.name}}</clr-dg-detail-header
-      >
+      <clr-dg-detail-header>{{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}}
+        {{detail.name}} {{detail.name}}
+        {{detail.name}} {{detail.name}}</clr-dg-detail-header>
       <clr-dg-detail-body>
         <pre>{{detail | json}}</pre>
         <pre>{{detail | json}}</pre>
@@ -125,20 +132,26 @@
 
 <clr-datagrid id="two-way">
   <clr-dg-column [clrDgField]="'id'">User ID</clr-dg-column>
-  <clr-dg-column [clrDgField]="'name'"><ng-container *clrDgHideableColumn>Name</ng-container></clr-dg-column>
-  <clr-dg-column [clrDgField]="'creation'"
-    ><ng-container *clrDgHideableColumn>Creation date</ng-container></clr-dg-column
-  >
-  <clr-dg-column [clrDgField]="'pokemon.name'"><ng-container *clrDgHideableColumn>Pokemon</ng-container></clr-dg-column>
-  <clr-dg-column [clrDgField]="'color'"><ng-container *clrDgHideableColumn>Favorite color</ng-container></clr-dg-column>
+  <clr-dg-column [clrDgField]="'name'">
+    <ng-container *clrDgHideableColumn>Name</ng-container>
+  </clr-dg-column>
+  <clr-dg-column [clrDgField]="'creation'">
+    <ng-container *clrDgHideableColumn>Creation date</ng-container>
+  </clr-dg-column>
+  <clr-dg-column [clrDgField]="'pokemon.name'">
+    <ng-container *clrDgHideableColumn>Pokemon</ng-container>
+  </clr-dg-column>
+  <clr-dg-column [clrDgField]="'color'">
+    <ng-container *clrDgHideableColumn>Favorite color</ng-container>
+  </clr-dg-column>
 
   <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
     <clr-dg-action-overflow>
-      <button class="action-item">
+      <button clrDgActionItem>
         <clr-icon shape="note"></clr-icon>
         Edit
       </button>
-      <button class="action-item">
+      <button clrDgActionItem>
         <clr-icon shape="trash"></clr-icon>
         Delete
       </button>
@@ -163,10 +176,9 @@
   <!--  Desugared option for two way binding -->
   <ng-template [(clrIfDetail)]="state" let-detail>
     <clr-dg-detail>
-      <clr-dg-detail-header
-        >{{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}}
-        {{detail.name}} {{detail.name}}</clr-dg-detail-header
-      >
+      <clr-dg-detail-header>{{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}}
+        {{detail.name}} {{detail.name}}
+        {{detail.name}} {{detail.name}}</clr-dg-detail-header>
       <clr-dg-detail-body>
         <pre>{{detail | json}}</pre>
         <pre>{{detail | json}}</pre>
@@ -188,19 +200,22 @@
 
 <clr-datagrid id="overlay" class="datagrid-detail-overlay">
   <clr-dg-column [clrDgField]="'id'">User ID</clr-dg-column>
-  <clr-dg-column [clrDgField]="'name'"><ng-container *clrDgHideableColumn>Name</ng-container></clr-dg-column>
-  <clr-dg-column [clrDgField]="'creation'"
-    ><ng-container *clrDgHideableColumn>Creation date</ng-container></clr-dg-column
-  >
-  <clr-dg-column [clrDgField]="'pokemon.name'"><ng-container *clrDgHideableColumn>Pokemon</ng-container></clr-dg-column>
-  <clr-dg-column [clrDgField]="'color'"><ng-container *clrDgHideableColumn>Favorite color</ng-container></clr-dg-column>
+  <clr-dg-column [clrDgField]="'name'">
+    <ng-container *clrDgHideableColumn>Name</ng-container>
+  </clr-dg-column>
+  <clr-dg-column [clrDgField]="'creation'">
+    <ng-container *clrDgHideableColumn>Creation date</ng-container>
+  </clr-dg-column>
+  <clr-dg-column [clrDgField]="'pokemon.name'">
+    <ng-container *clrDgHideableColumn>Pokemon</ng-container>
+  </clr-dg-column>
+  <clr-dg-column [clrDgField]="'color'">
+    <ng-container *clrDgHideableColumn>Favorite color</ng-container>
+  </clr-dg-column>
 
-  <clr-dg-row
-    *clrDgItems="let user of users"
-    [clrDgItem]="user"
+  <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user"
     [clrDgDetailOpenLabel]="'Open row details for ' + user.name"
-    [clrDgDetailCloseLabel]="'Open row details for ' + user.name"
-  >
+    [clrDgDetailCloseLabel]="'Open row details for ' + user.name">
     <clr-dg-cell>{{user.id}}</clr-dg-cell>
     <clr-dg-cell>{{user.name}}</clr-dg-cell>
     <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
@@ -212,10 +227,9 @@
 
   <!-- Simple API for most cases -->
   <clr-dg-detail *clrIfDetail="let detail">
-    <clr-dg-detail-header
-      >{{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}}
-      {{detail.name}} {{detail.name}}</clr-dg-detail-header
-    >
+    <clr-dg-detail-header>{{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}}
+      {{detail.name}} {{detail.name}}
+      {{detail.name}} {{detail.name}}</clr-dg-detail-header>
     <clr-dg-detail-body>
       <pre>{{detail | json}}</pre>
       <pre>{{detail | json}}</pre>
@@ -236,19 +250,22 @@
 
 <clr-datagrid id="simple" [(clrDgSelected)]="selection" style="height: 500px;">
   <clr-dg-column [clrDgField]="'id'">User ID</clr-dg-column>
-  <clr-dg-column [clrDgField]="'name'"><ng-container *clrDgHideableColumn>Name</ng-container></clr-dg-column>
-  <clr-dg-column [clrDgField]="'creation'"
-    ><ng-container *clrDgHideableColumn>Creation date</ng-container></clr-dg-column
-  >
-  <clr-dg-column [clrDgField]="'pokemon.name'"><ng-container *clrDgHideableColumn>Pokemon</ng-container></clr-dg-column>
-  <clr-dg-column [clrDgField]="'color'"><ng-container *clrDgHideableColumn>Favorite color</ng-container></clr-dg-column>
+  <clr-dg-column [clrDgField]="'name'">
+    <ng-container *clrDgHideableColumn>Name</ng-container>
+  </clr-dg-column>
+  <clr-dg-column [clrDgField]="'creation'">
+    <ng-container *clrDgHideableColumn>Creation date</ng-container>
+  </clr-dg-column>
+  <clr-dg-column [clrDgField]="'pokemon.name'">
+    <ng-container *clrDgHideableColumn>Pokemon</ng-container>
+  </clr-dg-column>
+  <clr-dg-column [clrDgField]="'color'">
+    <ng-container *clrDgHideableColumn>Favorite color</ng-container>
+  </clr-dg-column>
 
-  <clr-dg-row
-    *clrDgItems="let user of users | slice:0:4"
-    [clrDgItem]="user"
+  <clr-dg-row *clrDgItems="let user of users | slice:0:4" [clrDgItem]="user"
     [clrDgDetailOpenLabel]="'Open row details for ' + user.name"
-    [clrDgDetailCloseLabel]="'Open row details for ' + user.name"
-  >
+    [clrDgDetailCloseLabel]="'Open row details for ' + user.name">
     <clr-dg-cell>{{user.id}}</clr-dg-cell>
     <clr-dg-cell>{{user.name}}</clr-dg-cell>
     <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
@@ -261,10 +278,9 @@
   <!-- Desugared with pre-selection -->
   <ng-template [(clrIfDetail)]="preState" let-detail>
     <clr-dg-detail>
-      <clr-dg-detail-header
-        >{{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}}
-        {{detail.name}} {{detail.name}}</clr-dg-detail-header
-      >
+      <clr-dg-detail-header>{{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}} {{detail.name}}
+        {{detail.name}} {{detail.name}}
+        {{detail.name}} {{detail.name}}</clr-dg-detail-header>
       <clr-dg-detail-body>
         <pre>{{detail | json}}</pre>
         <pre>{{detail | json}}</pre>

--- a/packages/angular/projects/dev/src/app/datagrid/full/full.html
+++ b/packages/angular/projects/dev/src/app/datagrid/full/full.html
@@ -96,11 +96,11 @@
     <clr-dg-placeholder>No users found</clr-dg-placeholder>
     <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
       <clr-dg-action-overflow (clrDgActionOverflowOpenChange)="clrDgActionOverflowOpenChangeFn($event)">
-        <button class="action-item">
+        <button clrDgActionItem>
           <clr-icon shape="note"></clr-icon>
           Edit
         </button>
-        <button class="action-item">
+        <button clrDgActionItem>
           <clr-icon shape="trash"></clr-icon>
           Delete
         </button>
@@ -125,12 +125,8 @@
     </clr-dg-footer>
   </clr-datagrid>
 
-  <clr-datagrid
-    *ngIf="isServerDriven"
-    [(clrDgSelected)]="selected"
-    (clrDgRefresh)="refresh($event)"
-    [clrDgLoading]="loading"
-  >
+  <clr-datagrid *ngIf="isServerDriven" [(clrDgSelected)]="selected" (clrDgRefresh)="refresh($event)"
+    [clrDgLoading]="loading">
     <clr-dg-column>User ID</clr-dg-column>
     <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
     <clr-dg-column [clrDgField]="'creation'">Creation date</clr-dg-column>

--- a/packages/angular/projects/dev/src/app/datagrid/kitchen-sink/kitchen-sink.html
+++ b/packages/angular/projects/dev/src/app/datagrid/kitchen-sink/kitchen-sink.html
@@ -196,11 +196,11 @@
 
     <clr-dg-row *clrDgItems="let user of nonPaginatedUsers" [clrDgItem]="user">
       <clr-dg-action-overflow>
-        <button class="action-item" (click)="onEdit(user)">
+        <button clrDgActionItem (click)="onEdit(user)">
           <clr-icon shape="note"></clr-icon>
           Edit
         </button>
-        <button class="action-item" (click)="onDelete(user)">
+        <button clrDgActionItem (click)="onDelete(user)">
           <clr-icon shape="trash"></clr-icon>
           Delete
         </button>


### PR DESCRIPTION
Currently the documentation shows adding buttons with this class, but not giving them the `menuitem` role which is required since the wrapping container has a `menu role`.  We could update the documentation to do this, but this approach adds a tiny directive that does it for the user.  Also added a test for this.

Partially fixes:  #4756

Signed-off-by: Alex Mellnik <a.r.mellnik@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Documentation for the datagrid single action shows adding buttons to the menu, but they don't have the `menuitem` role which is a 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

