### PR TITLE
fix: accessibility issues with clr-icon involving title and aria-hidden

### DIFF
--- a/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-column-toggle.spec.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-column-toggle.spec.ts
@@ -142,12 +142,30 @@ export default function (): void {
         );
       }));
 
+      it('toggle switch must include attr.title', fakeAsync(function () {
+        columnToggle.toggleSwitchPanel();
+        context.detectChanges();
+        tick();
+        expect(document.querySelector('button.column-toggle--action').attributes['title'].value).toBe(
+          commonStringsDefault.pickColumns
+        );
+      }));
+
       it('toggle switch close button should have aria-label for close', fakeAsync(function () {
         /* Open it */
         columnToggle.toggleSwitchPanel();
         context.detectChanges();
         tick();
         expect(document.querySelector('button.toggle-switch-close-button').attributes['aria-label'].value).toBe(
+          commonStringsDefault.close
+        );
+      }));
+
+      it('toggle close switch must include attr.title', fakeAsync(function () {
+        columnToggle.toggleSwitchPanel();
+        context.detectChanges();
+        tick();
+        expect(document.querySelector('button.toggle-switch-close-button').attributes['title'].value).toBe(
           commonStringsDefault.close
         );
       }));

--- a/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-column-toggle.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-column-toggle.ts
@@ -32,8 +32,9 @@ import { ClrDatagridColumnToggleButton } from './datagrid-column-toggle-button';
       clrPopoverOpenCloseButton
       [attr.aria-controls]="popoverId"
       [attr.aria-owns]="popoverId"
+      [attr.title]="commonStrings.keys.pickColumns"
     >
-      <clr-icon shape="view-columns" [attr.title]="commonStrings.keys.pickColumns"></clr-icon>
+      <clr-icon shape="view-columns" aria-hidden="true"></clr-icon>
     </button>
     <div
       class="column-switch"
@@ -54,8 +55,9 @@ import { ClrDatagridColumnToggleButton } from './datagrid-column-toggle-button';
           clrPopoverCloseButton
           type="button"
           [attr.aria-label]="commonStrings.keys.close"
+          [attr.title]="commonStrings.keys.close"
         >
-          <clr-icon shape="close" [attr.title]="commonStrings.keys.close"></clr-icon>
+          <clr-icon shape="close" aria-hidden="true"></clr-icon>
         </button>
       </div>
       <ul class="switch-content list-unstyled">

--- a/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-column.spec.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-column.spec.ts
@@ -341,6 +341,15 @@ export default function (): void {
         expect(context.clarityElement.querySelector('.sort-icon')).toBeNull();
       });
 
+      it('should add aria-hidden=true to sort-icon', function () {
+        context.clarityDirective.sortBy = new TestComparator();
+        context.clarityDirective.sort();
+        context.detectChanges();
+
+        const arrowIcon = context.clarityElement.querySelector('.sort-icon');
+        expect(arrowIcon.getAttribute('aria-hidden')).toBe('true');
+      });
+
       it('adds a11y roles to the column', function () {
         expect(context.clarityElement.attributes.role.value).toEqual('columnheader');
         expect(context.clarityElement.attributes['aria-sort'].value).toBe('none');

--- a/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-column.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-column.ts
@@ -46,7 +46,7 @@ import { DetailService } from './providers/detail.service';
     <div class="datagrid-column-flex">
       <button class="datagrid-column-title" *ngIf="sortable" (click)="sort()" type="button">
         <ng-container *ngTemplateOutlet="columnTitle"></ng-container>
-        <clr-icon *ngIf="sortIcon" [attr.shape]="sortIcon" class="sort-icon"></clr-icon>
+        <clr-icon *ngIf="sortIcon" [attr.shape]="sortIcon" aria-hidden="true" class="sort-icon"></clr-icon>
       </button>
       <!-- I'm really not happy with that select since it's not very scalable -->
       <ng-content select="clr-dg-filter, clr-dg-string-filter, clr-dg-numeric-filter"></ng-content>

--- a/packages/angular/projects/clr-angular/src/layout/tabs/tabs.spec.ts
+++ b/packages/angular/projects/clr-angular/src/layout/tabs/tabs.spec.ts
@@ -204,6 +204,13 @@ describe('Tabs', () => {
       expect(compiled.querySelector('.tabs-overflow .tab4')).toBeDefined();
     });
 
+    it('should add attribute title to dropdown-toggle', function () {
+      context.fixture.componentInstance.inOverflow = true;
+      context.fixture.detectChanges();
+      const toggle: HTMLElement = compiled.querySelector('.dropdown-toggle');
+      expect(toggle.getAttribute('aria-hidden')).toBe('true');
+    });
+
     it('does not activate overflow in vertical mode', () => {
       expect(compiled.querySelector('.tabs-overflow')).toBeNull();
 

--- a/packages/angular/projects/clr-angular/src/layout/tabs/tabs.ts
+++ b/packages/angular/projects/clr-angular/src/layout/tabs/tabs.ts
@@ -63,12 +63,9 @@ import { ClrTabOverflowContent } from './tab-overflow-content';
               (mousedown)="_mousedown = true"
               (focus)="openOverflowOnFocus()"
               (click)="toggleOverflowOnClick()"
+              [attr.title]="commonStrings.keys.more"
             >
-              <clr-icon
-                shape="ellipsis-horizontal"
-                [class.is-info]="toggleService.open"
-                [attr.title]="commonStrings.keys.more"
-              ></clr-icon>
+              <clr-icon shape="ellipsis-horizontal" [class.is-info]="toggleService.open"></clr-icon>
             </button>
           </li>
           <!--tab links in overflow menu-->


### PR DESCRIPTION
When icons are part of a button (icon only) it's better to add the
`aria-hidden` and `title` to the button wrapper not to the icon.

This change affects datagrid and tab component

fixes: #4454

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 4454

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
