### PR TITLE
fix(combobox): disable openClose button

### DIFF
--- a/packages/angular/projects/clr-angular/src/forms/combobox/_combobox.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/_combobox.clarity.scss
@@ -145,6 +145,11 @@
   }
 
   .clr-combobox-trigger {
+    &:disabled {
+      color: var(--clr-btn-link-disabled-color, #666);
+      opacity: 0.4;
+    }
+
     //Dimensions
     width: $clr-combobox-trigger-dimensions;
     margin: auto;

--- a/packages/angular/projects/clr-angular/src/forms/combobox/combobox.html
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/combobox.html
@@ -82,6 +82,7 @@
     type="button"
     class="clr-combobox-trigger"
     tabindex="-1"
+    [disabled]="control?.disabled || null"
     [attr.aria-label]="commonStrings.keys.comboboxOpen"
   >
     <clr-icon shape="caret down" size="12"></clr-icon>

--- a/packages/angular/projects/clr-angular/src/forms/combobox/combobox.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/combobox.spec.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { TestBed, ComponentFixture, tick, fakeAsync } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -26,6 +26,7 @@ import { ClrComboboxModule } from './combobox.module';
       [clrMulti]="multi"
       (clrInputChange)="inputChanged($event)"
       (clrOpenChange)="openChanged($event)"
+      [disabled]="disabled"
     >
       <clr-options>
         <clr-option [clrValue]="1">1</clr-option>
@@ -41,6 +42,7 @@ class TestComponent {
   inputValue: string;
   openState: boolean;
   placeholder: string;
+  disabled = false;
   inputChanged(value: string) {
     this.inputValue = value;
   }
@@ -174,6 +176,15 @@ export default function (): void {
         const combobox: HTMLElement = clarityElement.querySelector('.clr-combobox-input');
         expect(combobox.getAttribute('placeholder')).toEqual('hello world');
       });
+
+      it('should disable openClose button', () =>
+        fakeAsync(function () {
+          fixture.componentInstance.disabled = true;
+          fixture.detectChanges();
+          tick();
+          const button: HTMLButtonElement = clarityElement.querySelector('.clr-combobox-trigger');
+          expect(button.disabled).toBeTruthy();
+        }));
     });
   });
 }


### PR DESCRIPTION
Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #4868

## What is the new behavior?

The `openClose` button is disabled when the `combobox` is disabled. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

