### PR TITLE
fix: (eslint-plugin-clarity-migration) catch multiple root elements in HTML file

### DIFF
--- a/packages/eslint-plugin-clarity-migration/README.md
+++ b/packages/eslint-plugin-clarity-migration/README.md
@@ -26,7 +26,7 @@ yarn link @clr/eslint-plugin-clarity-migration
 4. Install the other linter dependencies
 
 ```bash
-yarn add -D @typescript-eslint/parser eslint-html-parser eslint
+yarn add -D @typescript-eslint/parser eslint
 ```
 
 5. Add ESLint configuration for TypeScript and HTML.
@@ -46,7 +46,7 @@ yarn add -D @typescript-eslint/parser eslint-html-parser eslint
   "overrides": [
     {
       "files": ["*.html"],
-      "parser": "eslint-html-parser"
+      "parser": "@clr/eslint-plugin-clarity-migration/src/dist/eslint-html-parser"
     }
   ]
 }

--- a/packages/eslint-plugin-clarity-migration/package.json
+++ b/packages/eslint-plugin-clarity-migration/package.json
@@ -30,12 +30,15 @@
   },
   "dependencies": {
     "@typescript-eslint/experimental-utils": "^4.1.1",
-    "node-html-parser": "^1.2.20"
+    "node-html-parser": "^1.2.20",
+    "htmlparser2": "^5.0.0",
+    "eslint-scope": "^5.1.1"
   },
   "devDependencies": {
     "@types/eslint": "^7.2.2",
     "@types/jest": "^26.0.13",
     "@types/node": "^14.0.2",
+    "@types/htmlparser2": "^3.10.2",
     "@typescript-eslint/eslint-plugin": "^4.1.1",
     "@typescript-eslint/eslint-plugin-tslint": "^4.1.1",
     "@typescript-eslint/parser": "^4.1.1",

--- a/packages/eslint-plugin-clarity-migration/src/html-parser.ts
+++ b/packages/eslint-plugin-clarity-migration/src/html-parser.ts
@@ -1,0 +1,473 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable @typescript-eslint/ban-ts-ignore */
+import { AST, SourceCode } from 'eslint';
+import { extname } from 'path';
+import { ScopeManager, Scope } from 'eslint-scope';
+import { Parser, DomHandler } from 'htmlparser2';
+
+import {
+  ESLintHTMLParserToken,
+  HTMLElement,
+  HTMLAttribute,
+  HTMLWhitespace,
+  HTMLText,
+  HTMLComment,
+  HTMLProcessingInstruction,
+  ESLintHtmlParseResult,
+  HTMLSyntaxTree,
+} from './types';
+
+const startsWithHtmlTag = /^\s*</;
+
+function isHtmlFile(code: string, options): boolean {
+  const filePath: string = (options.filePath as string | undefined) || 'unknown.js';
+
+  return options.htmlFileExtensions.indexOf(extname(filePath)) !== -1 || startsWithHtmlTag.test(code);
+}
+
+function parseScript(code: string, options): ESLintHtmlParseResult {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const fallbackParser = require(options.parser);
+
+  if (typeof fallbackParser.parseForESLint === 'function') {
+    return fallbackParser.parseForESLint(code, options);
+  } else {
+    return {
+      ast: fallbackParser.parse(code, options),
+      visitorKeys: fallbackParser.VisitorKeys,
+    };
+  }
+}
+
+export function parseForESLint(code: string, options = {}): ESLintHtmlParseResult {
+  options = {
+    htmlFileExtensions: ['.htm', '.html'],
+    parser: 'espree',
+    comment: true,
+    loc: true,
+    range: true,
+    tokens: true,
+    ...options,
+  };
+
+  if (!isHtmlFile(code, options)) {
+    return parseScript(code, options);
+  }
+
+  const lineBreakIndices: Array<number> = [-1];
+  let currentIndex = code.indexOf('\n');
+
+  while (currentIndex !== -1) {
+    lineBreakIndices.push(currentIndex);
+    currentIndex = code.indexOf('\n', currentIndex + 1);
+  }
+
+  const tabIndices: Array<number> = [];
+  currentIndex = code.indexOf('\t');
+
+  while (currentIndex !== -1) {
+    tabIndices.push(currentIndex);
+    currentIndex = code.indexOf('\t', currentIndex + 1);
+  }
+
+  function getLineAndColumn(index: number): { line: number; column: number } {
+    let lineNumber = 0;
+
+    for (; lineNumber < lineBreakIndices.length; lineNumber++) {
+      if (index < lineBreakIndices[lineNumber]) {
+        break;
+      }
+    }
+
+    let column: number = index - lineBreakIndices[lineNumber - 1] - 1;
+    let tabNumber = -1;
+
+    while (++tabNumber < tabIndices.length) {
+      if (tabIndices[tabNumber] < lineBreakIndices[lineNumber - 1]) {
+        continue;
+      }
+
+      if (tabIndices[tabNumber] < index) {
+        column += 4;
+      } else {
+        break;
+      }
+    }
+
+    return {
+      line: lineNumber,
+      column,
+    };
+  }
+
+  const visitorKeys: SourceCode.VisitorKeys = {
+    Program: ['root'],
+    HTMLAttribute: ['attributeName', 'attributeValue'],
+    HTMLAttributeName: [],
+    HTMLAttributeValue: [],
+    HTMLElement: ['children', 'attributes'],
+    HTMLText: [],
+    HTMLWhitespace: [],
+    HTMLComment: [],
+    HTMLProcessingInstruction: [],
+  };
+
+  const tokens: Array<ESLintHTMLParserToken> = [];
+  const root: HTMLElement = {
+    type: 'HTMLElement',
+    comments: [],
+    children: [],
+    loc: {
+      start: {
+        line: 1,
+        column: 0,
+      },
+      end: { line: -1, column: -1 },
+    },
+    tagName: '',
+    value: '',
+    range: [0, -1],
+  };
+  let currentElement: HTMLElement;
+  let currentAttribute: HTMLAttribute;
+
+  const onattribdata: (value: string) => void = (value: string) => {
+    // @ts-ignore
+    const startIndex: number = htmlParser.tokenizer.sectionStart;
+
+    currentAttribute.attributeValue = {
+      type: 'HTMLAttributeValue',
+      value,
+      parent: currentAttribute,
+      range: [startIndex, startIndex + value.length],
+      loc: {
+        start: getLineAndColumn(startIndex),
+        end: getLineAndColumn(startIndex + value.length),
+      },
+    };
+
+    currentAttribute.range[1] = startIndex + value.length + 1;
+    currentAttribute.value = code.substr(
+      currentAttribute.range[0],
+      currentAttribute.range[1] - currentAttribute.range[0]
+    );
+    currentAttribute.loc.end = getLineAndColumn(currentAttribute.range[1]);
+
+    tokens.push(currentAttribute.attributeValue);
+  };
+
+  const onopentagname: (name: string) => void = (name: string) => {
+    const element: HTMLElement = {
+      comments: [],
+      type: 'HTMLElement',
+      tagName: name,
+      parent: currentElement,
+      value: '',
+      range: [htmlParser.startIndex, -1],
+      loc: {
+        start: getLineAndColumn(htmlParser.startIndex),
+        end: getLineAndColumn(htmlParser.startIndex),
+      },
+    };
+
+    if (currentElement) {
+      if (!currentElement.children) {
+        currentElement.children = [];
+      }
+
+      currentElement.children.push(element);
+    } else {
+      element.parent = root;
+      root.children?.push(element);
+    }
+
+    currentElement = element;
+  };
+
+  const onattribname: (name: string) => void = (name: string) => {
+    const attribute: Partial<HTMLAttribute> = {
+      type: 'HTMLAttribute',
+      // @ts-ignore
+      range: [htmlParser.tokenizer.sectionStart, -1],
+      parent: currentElement,
+      value: '',
+      loc: {
+        // @ts-ignore
+        start: getLineAndColumn(htmlParser.tokenizer.sectionStart),
+        // @ts-ignore
+        end: getLineAndColumn(htmlParser.tokenizer.sectionStart),
+      },
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const start = attribute.range![0];
+    const end = start + name.length;
+    attribute.attributeName = {
+      type: 'HTMLAttributeName',
+      value: name,
+      parent: attribute as HTMLAttribute,
+      range: [start, end],
+      loc: {
+        start: getLineAndColumn(start),
+        end: getLineAndColumn(end),
+      },
+    };
+
+    currentAttribute = attribute as HTMLAttribute;
+
+    if (!currentElement.attributes) {
+      currentElement.attributes = [];
+    }
+
+    currentElement.attributes.push(attribute as HTMLAttribute);
+
+    tokens.push(attribute as HTMLAttribute);
+    tokens.push(attribute.attributeName);
+  };
+
+  const parseHandler: Partial<DomHandler> = {
+    onopentag: () => {
+      currentElement.loc.start = getLineAndColumn(htmlParser.startIndex);
+      tokens.push(currentElement);
+    },
+
+    onclosetag: () => {
+      currentElement.range[1] = (htmlParser.endIndex || 0) + 1;
+      currentElement.loc.end = getLineAndColumn((htmlParser.endIndex || 0) + 1);
+      currentElement.value = code.substr(currentElement.range[0], currentElement.range[1] - currentElement.range[0]);
+
+      currentElement = currentElement.parent as HTMLElement;
+    },
+
+    ontext: (text: string) => {
+      if (currentElement?.tagName?.toLowerCase() === 'script') {
+        const scriptParseResult: ESLintHtmlParseResult = parseScript(text, options);
+
+        if (scriptParseResult.ast) {
+          const scriptProgram: AST.Program = scriptParseResult.ast as AST.Program;
+
+          if (scriptProgram.tokens) {
+            const textStartLoc: { line: number; column: number } = getLineAndColumn(htmlParser.startIndex);
+
+            for (const token of scriptProgram.tokens) {
+              if (token.range) {
+                token.range[0] += htmlParser.startIndex;
+                token.range[1] += htmlParser.startIndex;
+              }
+
+              if (token.loc) {
+                if (token.loc.start.line === 1) {
+                  token.loc.start.column += textStartLoc.column;
+                }
+
+                if (token.loc.end.line === 1) {
+                  token.loc.end.column += textStartLoc.column;
+                }
+
+                token.loc.start.line += textStartLoc.line - 1;
+                token.loc.end.line += textStartLoc.line - 1;
+              }
+            }
+          }
+
+          if (scriptProgram.body) {
+            if (!currentElement.children) {
+              currentElement.children = [];
+            }
+
+            // eslint-disable-next-line prefer-spread
+            currentElement.children.push.apply(currentElement.children, scriptProgram.body);
+          }
+
+          if (scriptParseResult.visitorKeys) {
+            for (const visitorKey in scriptParseResult.visitorKeys) {
+              if (!visitorKeys[visitorKey]) {
+                visitorKeys[visitorKey] = scriptParseResult.visitorKeys[visitorKey];
+              } else {
+                for (const childKey of scriptParseResult.visitorKeys[visitorKey]) {
+                  if (visitorKeys[visitorKey].indexOf(childKey) === -1) {
+                    visitorKeys[visitorKey].push(childKey);
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        return;
+      }
+
+      const leadingWhitespace: string = (text.match(/^\s+/) || [''])[0];
+      const trailingWhitespace: string =
+        leadingWhitespace.length === text.length ? '' : (text.match(/\s+$/) || [''])[0];
+      const actualText: string =
+        leadingWhitespace.length === text.length
+          ? ''
+          : text.substr(leadingWhitespace.length, text.length - leadingWhitespace.length - trailingWhitespace.length);
+
+      if (leadingWhitespace) {
+        const leadingWhitespaceToken: HTMLWhitespace = {
+          type: 'HTMLWhitespace',
+          parent: currentElement,
+          value: leadingWhitespace,
+          range: [htmlParser.startIndex, htmlParser.startIndex + leadingWhitespace.length],
+          loc: {
+            start: getLineAndColumn(htmlParser.startIndex),
+            end: getLineAndColumn(htmlParser.startIndex + leadingWhitespace.length),
+          },
+        };
+
+        if (currentElement) {
+          if (!currentElement.children) {
+            currentElement.children = [];
+          }
+
+          currentElement.children.push(leadingWhitespaceToken);
+        }
+
+        tokens.push(leadingWhitespaceToken);
+      }
+
+      if (actualText) {
+        const htmlText: HTMLText = {
+          type: 'HTMLText',
+          parent: currentElement,
+          value: actualText,
+          range: [
+            htmlParser.startIndex + leadingWhitespace.length,
+            htmlParser.startIndex + leadingWhitespace.length + actualText.length,
+          ],
+          loc: {
+            start: getLineAndColumn(htmlParser.startIndex + leadingWhitespace.length),
+            end: getLineAndColumn(htmlParser.startIndex + leadingWhitespace.length + actualText.length),
+          },
+        };
+
+        if (currentElement) {
+          if (!currentElement.children) {
+            currentElement.children = [];
+          }
+
+          currentElement.children.push(htmlText);
+        }
+
+        tokens.push(htmlText);
+      }
+
+      if (trailingWhitespace) {
+        const trailingWhitespaceToken: HTMLWhitespace = {
+          type: 'HTMLWhitespace',
+          parent: currentElement,
+          value: trailingWhitespace,
+          range: [htmlParser.startIndex + leadingWhitespace.length + actualText.length, htmlParser.endIndex || 0],
+          loc: {
+            start: getLineAndColumn(htmlParser.startIndex + leadingWhitespace.length + actualText.length),
+            end: getLineAndColumn(htmlParser.endIndex || 0),
+          },
+        };
+
+        if (currentElement) {
+          if (!currentElement.children) {
+            currentElement.children = [];
+          }
+
+          currentElement.children.push(trailingWhitespaceToken);
+        }
+
+        tokens.push(trailingWhitespaceToken);
+      }
+    },
+
+    oncomment: (text: string) => {
+      const comment: HTMLComment = {
+        type: 'HTMLComment',
+        parent: currentElement,
+        text,
+        value: code.substr(htmlParser.startIndex, (htmlParser.endIndex || 0) - htmlParser.startIndex + 1),
+        range: [htmlParser.startIndex, (htmlParser.endIndex || 0) + 1],
+        loc: {
+          start: getLineAndColumn(htmlParser.startIndex),
+          end: getLineAndColumn((htmlParser.endIndex || 0) + 1),
+        },
+      };
+
+      if (currentElement) {
+        if (!currentElement.children) {
+          currentElement.children = [];
+        }
+
+        currentElement.children.push(comment);
+      }
+
+      tokens.push(comment);
+    },
+
+    onprocessinginstruction: (name: string, entireText: string) => {
+      const data: string = entireText.substr(name.length).replace(/^\s+/, '');
+
+      const processingInstruction: HTMLProcessingInstruction = {
+        type: 'HTMLProcessingInstruction',
+        target: entireText.substr(1, name.length - 1),
+        data,
+        value: code.substr(htmlParser.startIndex, entireText.length + 2),
+        range: [htmlParser.startIndex, htmlParser.startIndex + entireText.length + 2],
+        loc: {
+          start: getLineAndColumn(htmlParser.startIndex),
+          end: getLineAndColumn((htmlParser.endIndex || 0) + 1),
+        },
+      };
+
+      tokens.push(processingInstruction);
+    },
+  };
+
+  const htmlParser = new Parser(parseHandler);
+  root.range = [htmlParser.startIndex, htmlParser.endIndex || -1];
+  const originalOnattribname = htmlParser.onattribname;
+  htmlParser.onattribname = function (...args): void {
+    originalOnattribname.apply(this, args);
+    onattribname(args[0]);
+  };
+
+  const originalOnattribdata = htmlParser.onattribdata;
+  htmlParser.onattribdata = function (...args): void {
+    originalOnattribdata.apply(this, args);
+    onattribdata(args[0]);
+  };
+
+  const originalOnopentagname = htmlParser.onopentagname;
+  htmlParser.onopentagname = function (...args): void {
+    originalOnopentagname.apply(this, args);
+    onopentagname(args[0]);
+  };
+
+  htmlParser.parseComplete(code);
+
+  const syntaxTree: HTMLSyntaxTree = {
+    type: 'Program',
+    comments: [],
+    tokens,
+    root,
+    loc: root.loc,
+    range: root.range,
+    value: code.substr(root.range[0], root.range[1] - root.range[0]),
+  };
+
+  const scopeManager: ScopeManager = new ScopeManager({});
+  // DO NOT REMOVE! This code has side-effects, even though the variable is unused.
+  /* tslint:disable no-unused-expression */
+  new Scope(scopeManager, 'module', null, syntaxTree, false);
+
+  const result: ESLintHtmlParseResult = {
+    ast: syntaxTree,
+    visitorKeys,
+    scopeManager,
+    services: {},
+  };
+
+  return result;
+}
+
+export function parse(code: string, options): HTMLSyntaxTree | AST.Program {
+  return parseForESLint(code, options).ast;
+}

--- a/packages/eslint-plugin-clarity-migration/src/types/index.d.ts
+++ b/packages/eslint-plugin-clarity-migration/src/types/index.d.ts
@@ -1,0 +1,87 @@
+import { AST, SourceCode } from 'eslint';
+import { Statement, ModuleDeclaration } from 'estree';
+import { ScopeManager } from 'eslint-scope';
+
+export type HTMLTokenType =
+  | 'HTMLAttributeName'
+  | 'HTMLAttributeValue'
+  | 'HTMLAttribute'
+  | 'HTMLText'
+  | 'HTMLWhitespace'
+  | 'HTMLElement'
+  | 'HTMLComment'
+  | 'HTMLProcessingInstruction'
+  | 'Program';
+
+export interface ESLintHTMLParserToken {
+  type: HTMLTokenType | AST.TokenType;
+  value: string;
+  range: AST.Range;
+  loc: AST.SourceLocation;
+}
+
+export interface HTMLAttributeName extends ESLintHTMLParserToken {
+  type: 'HTMLAttributeName';
+  parent: HTMLAttribute;
+}
+
+export interface HTMLAttributeValue extends ESLintHTMLParserToken {
+  type: 'HTMLAttributeValue';
+  parent: HTMLAttribute;
+}
+
+export interface HTMLAttribute extends ESLintHTMLParserToken {
+  type: 'HTMLAttribute';
+  parent: HTMLElement;
+  attributeName: HTMLAttributeName;
+  attributeValue: HTMLAttributeValue;
+}
+
+export interface HTMLText extends ESLintHTMLParserToken {
+  type: 'HTMLText';
+  parent: HTMLElement;
+}
+
+export interface HTMLWhitespace extends ESLintHTMLParserToken {
+  type: 'HTMLWhitespace';
+  parent: HTMLElement;
+}
+
+export interface HTMLComment extends ESLintHTMLParserToken {
+  type: 'HTMLComment';
+  parent: HTMLElement;
+  text: string;
+}
+
+export interface HTMLProcessingInstruction extends ESLintHTMLParserToken {
+  type: 'HTMLProcessingInstruction';
+  target: string;
+  data: string;
+}
+
+export interface HTMLElement extends ESLintHTMLParserToken {
+  comments: Array<string>;
+  type: 'HTMLElement';
+  tagName: string;
+  parent?: HTMLElement;
+  attributes?: Array<HTMLAttribute>;
+  children?: Array<HTMLElement | HTMLText | HTMLWhitespace | HTMLComment | Statement | ModuleDeclaration>;
+}
+
+export interface HTMLSyntaxTree extends ESLintHTMLParserToken {
+  comments: Array<any>;
+  tokens: Array<ESLintHTMLParserToken>;
+  root: HTMLElement;
+  type: 'Program';
+}
+
+export interface ESLintHtmlParseResult {
+  ast: HTMLSyntaxTree | AST.Program;
+  services?: Record<string, any>;
+  scopeManager?: ScopeManager;
+  visitorKeys?: SourceCode.VisitorKeys;
+}
+
+export function parseForESLint(code: string, options?: any): ESLintHtmlParseResult;
+
+export function parse(code: string, options: any): HTMLSyntaxTree | AST.Program;

--- a/packages/eslint-plugin-clarity-migration/test/no-clr-button.spec.ts
+++ b/packages/eslint-plugin-clarity-migration/test/no-clr-button.spec.ts
@@ -18,7 +18,7 @@ const htmlRuleTester = new RuleTester({
   parserOptions: {
     sourceType: 'module',
   },
-  parser: 'eslint-html-parser',
+  parser: '../src/html-parser',
 });
 
 function getInvalidTest(code: string, output?: string): InvalidTest {
@@ -37,67 +37,68 @@ function getInvalidTest(code: string, output?: string): InvalidTest {
 htmlRuleTester.run('no-clr-button', rule, {
   invalid: [
     getInvalidTest(`
-            <button class="btn btn-primary">Shalqlq</button>
-        `),
+      <button class="btn btn-primary">Shalqlq</button>
+    `),
     getInvalidTest(`
-            <div>
-                <button class="btn btn-primary">Shalqlq</button>
-            </div>
-        `),
-    // TODO: The HTML parser can't handle this case.
-    // It traverses only the first tag.
-    // getInvalidTest(`
-    //     <div></div>
-    //     <button class="btn btn-primary">Shalqlq</button>
-    // `),
+      <div>
+        <button class="btn btn-primary">Shalqlq</button>
+        </div>
+    `),
+    getInvalidTest(`
+      <div></div>
+      <button class="btn btn-primary">Shalqlq</button>
+    `),
+    getInvalidTest(`
+      <div></div>
+      <button id="#button" class="btn btn-primary">Shalqlq</button>
+    `),
+    getInvalidTest(`
+      <div><ul></ul><button class="btn btn-primary"></button></div>
+    `),
   ],
   valid: [`<button class="shalqlq">Le button</button>`, `<div></div>`],
 });
 
 tsRuleTester.run('no-clr-button', rule, {
   invalid: [
-    getInvalidTest(
-      `
-            @Component({
-                selector: 'app-custom-button',
-                template: \`
-                    <div>
-                        <button class="btn btn-primary custom-class">Primary</button>
-                    </div>
-                \`
-              })
-              export class CustomButtonComponent {
-              }
-            `
-    ),
-    getInvalidTest(
-      `
-            @Component({
-                selector: 'app-custom-button',
-                template: \`
-                    <button class="btn btn-primary custom-class">Primary</button>
-                \`
-              })
-              export class CustomButtonComponent {
-              }
-            `
-    ),
+    getInvalidTest(`
+      @Component({
+        selector: 'app-custom-button',
+        template: \`
+          <div>
+            <button class="btn btn-primary custom-class">Primary</button>
+          </div>
+        \`
+      })
+      export class CustomButtonComponent {
+      }
+    `),
+    getInvalidTest(`
+      @Component({
+        selector: 'app-custom-button',
+        template: \`
+          <button class="btn btn-primary custom-class">Primary</button>
+        \`
+      })
+      export class CustomButtonComponent {
+      }
+    `),
   ],
 
   valid: [
     `
-            @Component({
-                selector: 'app-custom-button',
-                template: \`
-                    <div></div>
-                \`
-              })
-              export class CustomButtonComponent {
-                  // Should we catch that case?
-                  const myButton = \`
-                    <button class="btn btn-primary custom-class">Primary</button>
-                  \`;
-              }
-            `,
+      @Component({
+        selector: 'app-custom-button',
+        template: \`
+          <div></div>
+        \`
+        })
+        export class CustomButtonComponent {
+          // Should we catch that case?
+          const myButton = \`
+            <button class="btn btn-primary custom-class">Primary</button>
+          \`;
+        }
+      `,
   ],
 });

--- a/packages/eslint-plugin-clarity-migration/test/test-helper.ts
+++ b/packages/eslint-plugin-clarity-migration/test/test-helper.ts
@@ -3,14 +3,13 @@ import { TSESLint } from '@typescript-eslint/experimental-utils';
 import * as path from 'path';
 
 const parser = '@typescript-eslint/parser';
-const htmlParser = 'eslint-html-parser';
 
 function getFixturesRootDir(): string {
   return path.join(process.cwd(), 'tests/fixtures/');
 }
 
 type RuleTesterConfig = Omit<TSESLint.RuleTesterConfig, 'parser'> & {
-  parser: typeof parser | typeof htmlParser;
+  parser: string;
 };
 
 export class RuleTester extends TSESLint.RuleTester {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2627,7 +2627,7 @@
   integrity sha512-R+C4uywmXoTD01LINOt3O0cBRviQdbAVNxdVvOyuO3+rM9bvFroF7UZY0R1ue/xvKXlqJrEkNKZQODeKjzaAhA==
 
 "@clr/core@./packages/core/dist/core":
-  version "4.0.0"
+  version "4.0.2"
   dependencies:
     "@types/resize-observer-browser" "^0.1.3"
     lit-element "^2.3.1"
@@ -2643,7 +2643,7 @@
     normalize.css "^8.0.1"
 
 "@clr/react@./packages/react/dist/react":
-  version "4.0.0"
+  version "4.0.2"
   dependencies:
     react "^16.13.1"
     react-dom "^16.13.1"
@@ -6187,6 +6187,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/domutils@*":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@types/domutils/-/domutils-1.7.3.tgz#890de5a79d86896e9e6a7445a43c9512e62d6f04"
+  integrity sha512-EucnS75OnnEdypNt+UpARisSF8eJBq4no+aVOis3Bs5kyABDXm1hEDv6jJxcMJPjR+a2YCrEANaW+BMT2QVG2Q==
+  dependencies:
+    domhandler "^2.4.0"
+
 "@types/download@^6.2.4":
   version "6.2.4"
   resolved "https://registry.yarnpkg.com/@types/download/-/download-6.2.4.tgz#d9fb74defe20d75f59a38a9b5b0eb5037d37161a"
@@ -6323,6 +6330,15 @@
     "@types/clean-css" "*"
     "@types/relateurl" "*"
     "@types/uglify-js" "*"
+
+"@types/htmlparser2@^3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@types/htmlparser2/-/htmlparser2-3.10.2.tgz#bd43702eaf2f15c2d26784c8427352a0a4aa75eb"
+  integrity sha512-81vjuO800UMoHjYbCbqtBmfC3iCsrROKpqndo0acKiN6k/cpW+YOw9FzRP0ghujHeUNCOox2AQPrrMy6+j5UpQ==
+  dependencies:
+    "@types/domutils" "*"
+    "@types/node" "*"
+    domhandler "^2.4.0"
 
 "@types/http-assert@*":
   version "1.5.1"
@@ -13731,7 +13747,7 @@ domexception@^2.0.1:
   dependencies:
     webidl-conversions "^5.0.0"
 
-domhandler@^2.3.0:
+domhandler@^2.3.0, domhandler@^2.4.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
   integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
@@ -13766,7 +13782,7 @@ domutils@^1.5.1, domutils@^1.7.0:
     dom-serializer "0"
     domelementtype "1"
 
-domutils@^2.0.0:
+domutils@^2.0.0, domutils@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.4.2.tgz#7ee5be261944e1ad487d9aa0616720010123922b"
   integrity sha512-NKbgaM8ZJOecTZsIzW5gSuplsX2IWW2mIK7xVr8hTQF2v1CJWTmLZ1HOCh5sH+IzVPAGE5IucooOkvwBRAdowA==
@@ -17580,6 +17596,16 @@ htmlparser2@^4.1.0:
     domelementtype "^2.0.1"
     domhandler "^3.0.0"
     domutils "^2.0.0"
+    entities "^2.0.0"
+
+htmlparser2@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-5.0.0.tgz#78454bc782599291d9fefd7b48ef2058dc62eb89"
+  integrity sha512-/Cvz5RTj9q71kCL9No1u2jhFaAdoMtxpNy0YTwjmQB3iX2TZXfCojTm7tp3rM4NxcwaX1iAzvNgo8OFectXmrQ==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^3.3.0"
+    domutils "^2.4.2"
     entities "^2.0.0"
 
 http-assert@^1.3.0:


### PR DESCRIPTION
This PR fixes the case when the traversed HTML file has multiple root
elements, e.g.:

```
<div></div>
<button class="btn btn-primary"></button>
```

The `eslint-plugin-clarity-migration` package now has a custom HTML
parser. The parser is a patched version of [eslint-html-parser](https://github.com/medicomp/eslint-html-parser).

Signed-off-by: Stanimira Vlaeva <stanimira.vlaeva@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently, the plugin uses `eslint-html-parser` to traverse HTML files. However, that package cannot handle the case with multiple root elements in one file.

Issue Number: N/A

## What is the new behavior?

Now, the plugin has its own HTML parser based on `eslint-html-parser`. The current HTML parser creates an empty `HTMLElement` for a root element. Any other elements are then added as children of that root element.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
