### PR TITLE
[v4 BACKPORT] fix(form): mark only blurred control as touched instead of whole form

### DIFF
--- a/packages/angular/projects/clr-angular/src/forms/common/wrapped-control.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/common/wrapped-control.spec.ts
@@ -55,14 +55,7 @@ class TestControl2 extends WrappedFormControl<TestWrapper2> {
 @Component({
   selector: 'test-wrapper3',
   template: `<div id="wrapper"><ng-content></ng-content></div>`,
-  providers: [
-    ControlIdService,
-    MarkControlService,
-    NgControlService,
-    IfControlStateService,
-    ControlClassService,
-    LayoutService,
-  ],
+  providers: [ControlIdService, NgControlService, IfControlStateService, ControlClassService],
 })
 class TestWrapper3 implements DynamicWrapper {
   _dynamic = false;
@@ -75,11 +68,18 @@ class TestControl3 extends WrappedFormControl<TestWrapper3> {
   }
 }
 
+@Component({
+  selector: 'form-wrapper',
+  template: `<div id="form-wrapper"><ng-content></ng-content></div>`,
+  providers: [MarkControlService, LayoutService],
+})
+class FormWrapper {}
+
 @NgModule({
   imports: [ClrHostWrappingModule, FormsModule],
-  declarations: [TestWrapper, TestControl, TestWrapper2, TestControl2, TestControl3, TestWrapper3],
-  exports: [TestWrapper, TestControl, TestWrapper2, TestControl2, TestControl3, TestWrapper3],
-  entryComponents: [TestWrapper, TestWrapper2, TestWrapper3],
+  declarations: [TestWrapper, TestControl, TestWrapper2, TestControl2, TestControl3, TestWrapper3, FormWrapper],
+  exports: [TestWrapper, TestControl, TestWrapper2, TestControl2, TestControl3, TestWrapper3, FormWrapper],
+  entryComponents: [TestWrapper, TestWrapper2, TestWrapper3, FormWrapper],
 })
 class WrappedFormControlTestModule {}
 
@@ -101,13 +101,22 @@ class WithWrapperWithId {}
 @Component({ template: `<test-wrapper2><input testControl id="hello" /></test-wrapper2>` })
 class WithMultipleNgContent {}
 
-@Component({ template: `<test-wrapper3><input testControl3 [(ngModel)]="model" required /></test-wrapper3>` })
+@Component({
+  template: ` <form-wrapper>
+    <test-wrapper3><input testControl3 [(ngModel)]="model" required /></test-wrapper3>
+  </form-wrapper>`,
+})
 class WithControl {
   model = '';
 }
 
 @Component({
-  template: `<test-wrapper3><input type="number" testControl3 [(ngModel)]="model" required /></test-wrapper3>`,
+  template: `
+    <form-wrapper>
+      <test-wrapper3><input type="number" testControl3 [(ngModel)]="model" required /></test-wrapper3>
+      <test-wrapper3><input type="number" testControl3 [(ngModel)]="model" required id="control2" /></test-wrapper3>
+    </form-wrapper>
+  `,
 })
 class WithNumberControl {
   model = '';
@@ -250,6 +259,7 @@ export default function (): void {
         this.input.blur();
         this.fixture.detectChanges();
         expect(this.input.className).toContain('ng-touched');
+        expect(this.fixture.nativeElement.querySelector('#control2').className).toContain('ng-untouched');
       });
 
       it('implements ngOnDestroy', function (this: TestContext) {

--- a/packages/angular/projects/clr-angular/src/forms/common/wrapped-control.ts
+++ b/packages/angular/projects/clr-angular/src/forms/common/wrapped-control.ts
@@ -73,8 +73,7 @@ export class WrappedFormControl<W extends DynamicWrapper> implements OnInit, Aft
     if (this.markControlService) {
       this.subscriptions.push(
         this.markControlService.touchedChange.subscribe(() => {
-          this.ngControl.control.markAsTouched();
-          this.ngControl.control.updateValueAndValidity();
+          this.markAsTouched();
         })
       );
     }
@@ -100,10 +99,15 @@ export class WrappedFormControl<W extends DynamicWrapper> implements OnInit, Aft
        * This one is a workaround to provide the control to be 'touched' on blur and fix #4480.
        */
       if (this.ngControl && !this.ngControl.touched) {
-        this.markControlService.markAsTouched();
+        this.markAsTouched();
       }
       this.ifControlStateService.triggerStatusChange();
     }
+  }
+
+  private markAsTouched(): void {
+    this.ngControl.control.markAsTouched();
+    this.ngControl.control.updateValueAndValidity();
   }
 
   private _containerInjector: Injector;


### PR DESCRIPTION
Back port for a v4 issue that was fixed with this commit. 

Signed-off-by: Wallabeng <marcel@ring-mail.at>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
