### PR TITLE
fix(signpost): put header before contents to fix DOM/a11y tree order (backport)

### DIFF
--- a/packages/angular/projects/clr-angular/src/popover/signpost/signpost-content.ts
+++ b/packages/angular/projects/clr-angular/src/popover/signpost/signpost-content.ts
@@ -36,9 +36,6 @@ const POSITIONS: string[] = [
   template: `
     <div class="signpost-wrap">
       <div class="popover-pointer"></div>
-      <div class="signpost-content-body">
-        <ng-content></ng-content>
-      </div>
       <div class="signpost-content-header">
         <button
           type="button"
@@ -49,6 +46,9 @@ const POSITIONS: string[] = [
         >
           <clr-icon shape="close" [attr.title]="commonStrings.keys.close"></clr-icon>
         </button>
+      </div>
+      <div class="signpost-content-body">
+        <ng-content></ng-content>
       </div>
     </div>
   `,


### PR DESCRIPTION
Currently the header appears after the contents in the DOM, but is visually positioned absolutely at the beginning.  This breaks screen readers, but fortunately we can just reorder the elements and have the same visual result.

Closes; #4986

Signed-off-by: Alex Mellnik <a.r.mellnik@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
