### PR TITLE
fix(signpost): put header before contents to fix DOM/a11y tree order (backport)

### DIFF
--- a/src/clr-angular/popover/signpost/signpost-content.ts
+++ b/src/clr-angular/popover/signpost/signpost-content.ts
@@ -36,14 +36,14 @@ const POSITIONS: string[] = [
   template: `
       <div class="signpost-wrap">
           <div class="popover-pointer"></div>
-          <div class="signpost-content-body">
-              <ng-content></ng-content>
-          </div>
           <div class="signpost-content-header">
               <button type="button" [attr.aria-label]="commonStrings.keys.signpostClose" class="signpost-action close"
                       (click)="close()" [attr.aria-controls]="signpostContentId">
                   <clr-icon shape="close" [attr.title]="commonStrings.keys.close"></clr-icon>
               </button>
+          </div>
+          <div class="signpost-content-body">
+              <ng-content></ng-content>
           </div>
       </div>
   `,


### PR DESCRIPTION
Backport of #5130

Signed-off-by: Bogdan Bogdanov bbogdanov@vmware.com

Signed-off-by: Alex Mellnik a.r.mellnik@gmail.com

Credits to @amellnik