### PR TITLE
Revert "feat(a11y): deprecate aria live service"

### DIFF
--- a/apps/website/components/alert/api.md
+++ b/apps/website/components/alert/api.md
@@ -3,6 +3,13 @@ title: API
 toc: true
 ---
 
+<cds-alert-group type="default" status="warning">
+ <cds-alert closable><strong>Deprecation</strong>: Since v4, we will no longer handle setting `aria-live` and announcing the message for you by default. Based on the application use case, you can use the new `ClrAriaLiveService` to make announcements when they make sense for a user to hear about updates or loading status changes. This will result in of removing few inputs provided by the component such as `clrPolite`, `clrAssertive`, `clrOff`.
+ <cds-alert-actions>
+ </cds-alert-actions>
+ </cds-alert>
+ </cds-alert-group>
+
 ## Angular Components
 
 {.section-header}

--- a/apps/website/components/form/README.md
+++ b/apps/website/components/form/README.md
@@ -153,6 +153,8 @@ Without the `clr-CONTROL-container` parent the forms and form controls are not a
 
 Finally, for screen readers, if there are any controls with errors after the submit action an `aria-live` region will be updated with the associated labels for each control in the error state.
 
+Deprecation: Since v4, we will no longer handle setting `aria-live` and announcing the message for you by default. Based on the application use case, you can use the new `ClrAriaLiveService` to make announcements when they make sense for a user to hear about updates or loading status changes.
+
 ## Forms Using Angular
 
 Clarity has created a set of directives to help manage forms with minimal effort by developers. The structure is more condensed and easier to implement, so it is the recommended approach to use the following if you are using Angular. More form controls are being added regularly.

--- a/apps/website/foundation/accessibility/README.md
+++ b/apps/website/foundation/accessibility/README.md
@@ -3,4 +3,81 @@ title: Accessibility
 toc: true
 ---
 
-Clarity tries to cover as many best practices for accessibility out of the box. However, some things are too application specific for Clarity to provide and here is where we will be providing some tools and recommendations to make it easier for you to implement custom accessibility.
+Clarity tries to cover as many best practices for accessibility out of the box. However, some things are too application specific for Clarity to provide and we've provided some tools to make it easier when you need to implement custom accessibility.
+
+## Aria live region
+
+When content changed dynamically on the page outside of the current focus, a screen reader user would not be aware of those changes. In these scenarios, the browser supports the `aria-live` attribute to make important announcements. You might announce errors in a form, status updates for long running tasks, or alert messages.
+
+There are limitations to how different screen readers and assistive technologies support `aria-live`, and we've provided a service `ClrAriaLiveService` for your Angular application to use anytime you need to make an announcement in a fully compatible way.
+
+Clarity will not make any announcements by default in version 4, it is up to the application to do this when it makes sense. Here are a few examples of how the service works and could be used.
+
+<doc-code>
+
+```javascript
+import { Component, AfterViewInit, ClrAriaLiveService } from '@angular/core';
+
+@Component({
+  selector: 'my-component',
+  providers: [ClrAriaLiveService],
+  template: '...',
+})
+class MyComponent implements AfterViewInit {
+  constructor(public ariaLiveService: ClrAriaLiveService) {}
+
+  ngAfterViewInit() {
+    this.ariaLiveService.announce('Message to broadcast to screen reader');
+  }
+}
+```
+
+</doc-code>
+
+Aria live regions have three levels, `off` to disable it, `polite` to announce to the user at the next opportunity (default), and `assertive` to alert the user immediately and interrupt any other announcements in progress.
+
+<doc-code>
+
+```javascript
+import { ClrAriaLiveService, ClrAriaLivePoliteness } from '@clr/angular';
+
+// ...
+this.ariaLiveService.announce('Message to broadcast to screen reader', ClrAriaLivePoliteness.assertive);
+```
+
+</doc-code>
+
+### Integration
+
+A working example of using `ClrAriaLiveService` with a download, asynchronous process is below. You start by injecting the service, and based on changes in the progress state it will announce updates of the percentage updates. You might also want to debounce messages if you expect to get them very quickly so you don't have too many rapid announcements and annoy the users.
+
+<doc-code>
+
+```javascript
+import { Component, AfterViewInit, ClrAriaLiveService } from '@angular/core';
+import { download } from 'my-code';
+
+@Component({
+  selector: 'download-progress',
+  providers: [ClrAriaLiveService],
+  template: `
+    <button (click)="startDownload()">Start download</button>
+    <clr-progress-bar *ngIf="progressValue > 0" clrValue="progressValue" clrMax="100"></clr-progress-bar>
+  `,
+})
+class MyComponent implements AfterViewInit {
+  public progressValue: number = 0;
+
+  constructor(public ariaLiveService: ClrAriaLiveService) {}
+
+  startDownload() {
+    // Do some work and return progress value as number.
+    download().then(progress => {
+      this.progressValue = progress;
+      this.ariaLiveService.announce(`Download progress is ${progress} proccent done.`);
+    });
+  }
+}
+```
+
+</doc-code>

--- a/packages/angular/projects/clr-angular/src/utils/a11y/aria-live.service.ts
+++ b/packages/angular/projects/clr-angular/src/utils/a11y/aria-live.service.ts
@@ -21,13 +21,6 @@ export enum ClrAriaLivePoliteness {
 const ARIA_LIVE_TICK = 100;
 
 /**
- * @deprecated
- *
- * -- ClrAriaLiveService is deprecated in 5.0 to be removed in 6.0 --
- * Please consider using the LiveAnnouncer in the Angular Material CDK
- * if your project needs this functionality.
- * More info: https://material.angular.io/cdk/a11y/overview#example-1
- *
  * This service handle `aria-live` accessibility attribute. The issue is that you need
  * to have the DOM Element with attribute `aria-live` before you could insert content
  * and SR (Screen Reader) pick the change and announce it.


### PR DESCRIPTION
Reverts vmware/clarity#5108

I understand that, ClrAriaLiveService was depreciated and decided to remove based on bug #5083, Got a recommendation to use LiveAnnouncer from @angular/cdk, However, i found that the LiveAnnouncer from @angular/cdk behaves the same way as ClrAriaLiveService. (You can check here https://stackblitz.com/edit/clarity-v4-dark-theme-wizard )

There is a workaround to make this work, Take a look at this https://stackblitz.com/edit/clarity-v4-dark-theme-wizard-ktrnvg?file=src%2Fapp%2Fapp.component.html