### PR TITLE
fix(combobox): remove placeholder input in unit test

### DIFF
--- a/packages/angular/projects/clr-angular/src/forms/combobox/combobox.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/combobox.spec.ts
@@ -40,7 +40,6 @@ class TestComponent {
   selection: any;
   inputValue: string;
   openState: boolean;
-  placeholder: string;
   disabled = false;
   inputChanged(value: string) {
     this.inputValue = value;
@@ -167,13 +166,6 @@ export default function (): void {
         toggleService.open = true;
         fixture.detectChanges();
         expect(trigger.getAttribute('aria-expanded')).toEqual('true');
-      });
-
-      it('should pass placeholder to internal input', () => {
-        fixture.componentInstance.placeholder = 'hello world';
-        fixture.detectChanges();
-        const combobox: HTMLElement = clarityElement.querySelector('.clr-combobox-input');
-        expect(combobox.getAttribute('placeholder')).toEqual('hello world');
       });
 
       it('should disable openClose button', () =>


### PR DESCRIPTION
For some reason, the `placeholder` input is not included in `v4` branch so the test has to be removed in the branch

Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
