### PR TITLE
fix(datagrid): remove column a11y name override

### DIFF
--- a/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-column.spec.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-column.spec.ts
@@ -324,13 +324,6 @@ export default function (): void {
         expect(context.clarityDirective.sortOrder).toBe(ClrDatagridSortOrder.DESC);
       });
 
-      it('add aria-label to button', function () {
-        context.testComponent.comparator = new TestComparator();
-        context.detectChanges();
-        const title = context.clarityElement.querySelector('.datagrid-column-title');
-        expect(title.attributes['aria-label'].value).toBe(commonStringsDefault.sortColumn);
-      });
-
       it('adds and removes the correct icon when sorting', function () {
         context.clarityDirective.sortBy = new TestComparator();
         context.clarityDirective.sort();

--- a/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-column.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-column.ts
@@ -44,13 +44,7 @@ import { DetailService } from './providers/detail.service';
   selector: 'clr-dg-column',
   template: `
     <div class="datagrid-column-flex">
-      <button
-        class="datagrid-column-title"
-        [attr.aria-label]="commonStrings.keys.sortColumn"
-        *ngIf="sortable"
-        (click)="sort()"
-        type="button"
-      >
+      <button class="datagrid-column-title" *ngIf="sortable" (click)="sort()" type="button">
         <ng-container *ngTemplateOutlet="columnTitle"></ng-container>
         <clr-icon *ngIf="sortIcon" [attr.shape]="sortIcon" class="sort-icon"></clr-icon>
       </button>


### PR DESCRIPTION
fix for a11y-issue-136 (also a11y-issue-176, which is duplicate of 136)
closes #4135 

Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Screan readers read headers of sortable columns as "Sort column", and the cell content is not read at all

Issue Number: #4135

## What is the new behavior?

"Sort column" override is removed and sorting state/action is conveyed by the cell aria-sort attribute, as seen in this W3C example:
https://www.w3.org/TR/wai-aria-practices/examples/grid/dataGrids.html

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
