### PR TITLE
fix(datagrid): remove column a11y name override (backport)

### DIFF
--- a/src/clr-angular/data/datagrid/datagrid-column.spec.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column.spec.ts
@@ -7,7 +7,6 @@ import { Component, ViewChild, ChangeDetectorRef } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { Subject } from 'rxjs';
-import { commonStringsDefault } from '../../utils/i18n/common-strings.default';
 import { ClrCommonStringsService } from '../../utils/i18n/common-strings.service';
 import { DatagridPropertyComparator } from './built-in/comparators/datagrid-property-comparator';
 import { DatagridStringFilter } from './built-in/filters/datagrid-string-filter';
@@ -331,13 +330,6 @@ export default function(): void {
         title.click();
         context.detectChanges();
         expect(context.clarityDirective.sortOrder).toBe(ClrDatagridSortOrder.DESC);
-      });
-
-      it('add aria-label to button', function() {
-        context.testComponent.comparator = new TestComparator();
-        context.detectChanges();
-        const title = context.clarityElement.querySelector('.datagrid-column-title');
-        expect(title.attributes['aria-label'].value).toBe(commonStringsDefault.sortColumn);
       });
 
       it('adds and removes the correct icon when sorting', function() {

--- a/src/clr-angular/data/datagrid/datagrid-column.ts
+++ b/src/clr-angular/data/datagrid/datagrid-column.ts
@@ -60,7 +60,6 @@ import { ClrPopoverToggleService } from '../../utils/popover/providers/popover-t
 
           <button
             class="datagrid-column-title"
-            [attr.aria-label]="commonStrings.keys.sortColumn"
             *ngIf="sortable"
             (click)="sort()"
             type="button">


### PR DESCRIPTION
fix for a11y-issue-136
Signed-off-by: Ivan Donchev <idonchev@vmware.com>

# Conflicts:
#	src/clr-angular/data/datagrid/datagrid-column.ts

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
