### PR TITLE
fix: report correct location of ESLint error in component templates

### DIFF
--- a/packages/eslint-plugin-clarity-migration/package.json
+++ b/packages/eslint-plugin-clarity-migration/package.json
@@ -30,9 +30,9 @@
   },
   "dependencies": {
     "@typescript-eslint/experimental-utils": "^4.1.1",
-    "node-html-parser": "^1.2.20",
     "htmlparser2": "^5.0.0",
-    "eslint-scope": "^5.1.1"
+    "eslint-scope": "^5.1.1",
+    "jsdom": "^16.4.0"
   },
   "devDependencies": {
     "@types/eslint": "^7.2.2",
@@ -45,7 +45,6 @@
     "@typescript-eslint/typescript-estree": "^4.1.1",
     "conventional-changelog-cli": "^2.0.25",
     "eslint": "^7.9.0",
-    "eslint-html-parser": "^6.8.0",
     "jest": "^26.4.2",
     "ts-jest": "^26.3.0",
     "tslint": "^6.1.3",

--- a/packages/eslint-plugin-clarity-migration/src/rules/no-clr-button/index.ts
+++ b/packages/eslint-plugin-clarity-migration/src/rules/no-clr-button/index.ts
@@ -1,11 +1,25 @@
 import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
-import { parse } from 'node-html-parser';
+import { JSDOM } from 'jsdom';
+import { SourceLocation } from '@typescript-eslint/eslint-plugin';
 import { getDecoratorPropertyValue } from '../utils';
-import { HTMLElement } from 'eslint-html-parser';
+import { HTMLElement } from '../../types';
 
 export const createESLintRule = ESLintUtils.RuleCreator(() => ``);
 
 export type MessageIds = 'clrButtonFailure';
+
+function calculateLocation(templateContent: TSESTree.TemplateElement, buttonLocation: any): SourceLocation {
+  const start = {
+    line: buttonLocation.startLine + templateContent.loc.start.line - 1,
+    column: buttonLocation.startCol - 1,
+  };
+  const end = {
+    line: buttonLocation.endLine + templateContent.loc.start.line - 1,
+    column: buttonLocation.endCol - 1,
+  };
+
+  return { start, end };
+}
 
 export default createESLintRule({
   name: 'no-clr-button',
@@ -25,17 +39,17 @@ export default createESLintRule({
   defaultOptions: [{}],
   create(context) {
     return {
-      'HTMLElement[tagName="button"]'(node: HTMLElement) {
+      'HTMLElement[tagName="button"]'(node: HTMLElement): void {
         const classNode = node.attributes?.find(attribute => attribute.attributeName.value === 'class');
         const classes = classNode?.attributeValue?.value?.split(' ');
         if (classes?.includes('btn') && classes.includes('btn-primary')) {
           context.report({
-            node: <any>node,
+            node: node as any,
             messageId: 'clrButtonFailure',
           });
         }
       },
-      'ClassDeclaration > Decorator'(node: TSESTree.Decorator) {
+      'ClassDeclaration > Decorator'(node: TSESTree.Decorator): void {
         const template = getDecoratorPropertyValue(node, 'template');
         if (template?.type !== 'TemplateLiteral') {
           return;
@@ -47,12 +61,18 @@ export default createESLintRule({
           return;
         }
 
-        const root = parse(templateContent);
-        const clrButton = root.querySelector('button.btn.btn-primary');
-        if (clrButton) {
+        const dom = new JSDOM(templateContent, {
+          includeNodeLocations: true,
+        });
+        const clrButtons = dom.window.document.querySelectorAll('button.btn.btn-primary');
+
+        for (const button of clrButtons) {
+          const nodeLocation = dom.nodeLocation(button);
+          const loc = calculateLocation(templateContentNode, nodeLocation);
           context.report({
             node: templateContentNode,
             messageId: 'clrButtonFailure',
+            loc,
           });
         }
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13782,7 +13782,7 @@ domutils@^1.5.1, domutils@^1.7.0:
     dom-serializer "0"
     domelementtype "1"
 
-domutils@^2.0.0, domutils@^2.4.2:
+domutils@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.4.2.tgz#7ee5be261944e1ad487d9aa0616720010123922b"
   integrity sha512-NKbgaM8ZJOecTZsIzW5gSuplsX2IWW2mIK7xVr8hTQF2v1CJWTmLZ1HOCh5sH+IzVPAGE5IucooOkvwBRAdowA==
@@ -14667,15 +14667,6 @@ eslint-config-react-app@^5.2.1:
   dependencies:
     confusing-browser-globals "^1.0.9"
 
-eslint-html-parser@^6.8.0:
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/eslint-html-parser/-/eslint-html-parser-6.8.0.tgz#cf477d93185228833158829273ea3fd3516bb5dd"
-  integrity sha512-Uv2V9axjdd1MLvElMNR5offN9f8hFR493npSbi2ipdf1jh/EowjWt3NVfc5eI0gcLXU5GFagqFv5PYrz8x4ciA==
-  dependencies:
-    eslint "^6.8.0"
-    espree "^6.1.2"
-    htmlparser2 "^4.1.0"
-
 eslint-import-resolver-node@^0.3.2:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz#dbaa52b6b2816b50bc6711af75422de808e98404"
@@ -14856,7 +14847,7 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
-eslint@6.8.0, eslint@^6.6.0, eslint@^6.7.2, eslint@^6.8.0:
+eslint@6.8.0, eslint@^6.6.0, eslint@^6.7.2:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.8.0.tgz#62262d6729739f9275723824302fb227c8c93ffb"
   integrity sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==
@@ -17298,7 +17289,7 @@ hastscript@^5.0.0:
     property-information "^5.0.0"
     space-separated-tokens "^1.0.0"
 
-he@1.2.0, he@1.2.x, he@^1.1.0, he@^1.2.0:
+he@1.2.x, he@^1.1.0, he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
@@ -17587,16 +17578,6 @@ htmlparser2@^3.10.0, htmlparser2@^3.3.0, htmlparser2@^3.9.1, htmlparser2@^3.9.2:
     entities "^1.1.1"
     inherits "^2.0.1"
     readable-stream "^3.1.1"
-
-htmlparser2@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-4.1.0.tgz#9a4ef161f2e4625ebf7dfbe6c0a2f52d18a59e78"
-  integrity sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==
-  dependencies:
-    domelementtype "^2.0.1"
-    domhandler "^3.0.0"
-    domutils "^2.0.0"
-    entities "^2.0.0"
 
 htmlparser2@^5.0.0:
   version "5.0.0"
@@ -23502,13 +23483,6 @@ node-gyp@^3.8.0:
     semver "~5.3.0"
     tar "^2.0.0"
     which "1"
-
-node-html-parser@^1.2.20:
-  version "1.2.21"
-  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-1.2.21.tgz#93b074d877007c7148d594968a642cd65d254daa"
-  integrity sha512-6vDhgen6J332syN5HUmeT4FfBG7m6bFRrPN+FXY8Am7FGuVpsIxTASVbeoO5PF2IHbX2s+WEIudb1hgxOjllNQ==
-  dependencies:
-    he "1.2.0"
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Signed-off-by: Stanimira Vlaeva <svlaeva@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently, when the ESLint rule finds `<button class="btn btn-primary"></button>` in a component template, it reports the error/warning for the template node. That means that the IDE will underline the whole template instead of the specific button node within the template.

## What is the new behavior?

I switched `node-html-parser` for `jsdom`. We use `jsdom` to create an AST out of the template content. Thanks to the `jsdom` API, we can find the location (line and column) of the buttons within the template. Then, we can calculate the correct location in the full source and report it. The result is that now the IDE underlines the button node within the template instead of the whole template.


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
