### PR TITLE
docs: fix metropolis link

### DIFF
--- a/packages/angular/projects/website/src/app/documentation/get-started/get-started.component.html
+++ b/packages/angular/projects/website/src/app/documentation/get-started/get-started.component.html
@@ -19,16 +19,16 @@
   <h3 id="designResources">Using Clarity Design Resources</h3>
   <p>
     Jumpstart your project with one of our Sketch or Figma-based design resources. Start by downloading the
-    <a href="https://github.com/chrismsimpson/Metropolis" target="_blank">Metropolis fonts</a>. Then download your
-    resources of choice. We recommend that with your UI Library selection, that you also select the matching Icon
-    Library as the two work together.
+    <a href="https://github.com/vmware/clarity/files/5425574/Metropolis.zip" target="_blank">Metropolis fonts</a>. Then
+    download your resources of choice. We recommend that with your UI Library selection, that you also select the
+    matching Icon Library as the two work together.
   </p>
   <div class="design-assets">
     <div>
       <h4>Primary Font</h4>
       <a
         class="btn btn-primary btn-sm"
-        href="https://github.com/chrismsimpson/Metropolis/archive/r8.zip"
+        href="https://github.com/vmware/clarity/files/5425574/Metropolis.zip"
         target="_blank"
         rel="noopener"
         (click)="gaClick('font-metropolis')"


### PR DESCRIPTION
The Metropolis project was recently deleted from GitHub, so we have to link to our saved versions of the assets which I've uploaded to GitHub.

closes #5177

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5177 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
