### PR TITLE
build: prevent dependency installs on netlify infrastructure

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,13 +1,9 @@
 # Default build settings
 [build]
-  command = "yarn website:build && yarn website:deploy"
+  ignore = "./scripts/netlify-build.sh"
   functions = "dist/netlify"
   publish = "dist/website"
   environment = { CI = "true", NPM_FLAGS = '--no-optional', CYPRESS_INSTALL_BINARY = "false" }
-
-# Override for PRs to deploy the dev app
-[context.deploy-preview]
-  command = "yarn build:libs && yarn angular:dev:preview && yarn website:build && cp -R dist/dev dist/website/dev"
 
 # Legacy Website Redirects
 

--- a/scripts/netlify-build.sh
+++ b/scripts/netlify-build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2016-2020 VMware, Inc.
+# All Rights ReserveThis software is released under MIT license.
+# The full license information can be found in LICENSE in the root directory of this project.
+#
+
+echo "Clarity Netlify Build Script"
+exit 0


### PR DESCRIPTION
Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?
Prevent (yarn) installs on netlify for now because they keep timing out. 

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Yarn installs time out on netlify infrastructure. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Run a simple ignore script and exit with 0 on netlify infrastructure. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
