### PR TITLE
Topic/website line height tokens

### DIFF
--- a/apps/website/.vuepress/theme/components/Home.vue
+++ b/apps/website/.vuepress/theme/components/Home.vue
@@ -72,7 +72,7 @@
     <section cds-layout="p-l:md p-l@sm:xl p-r:md p-r@sm:xl p-y:lg p-y@sm:xxl" class="hero">
       <div cds-layout="grid align:fill" class="home-section hero-container">
         <h1 class="hero-header" cds-layout="col:12" cds-text="display">Enterprise-Ready Consumer-Simple</h1>
-        <p class="hero-text" cds-layout="col:12 col@md:6 m-t:xl" cds-text="section">
+        <p class="hero-text" cds-layout="col:12 col@md:6 m-t:xl" cds-text="section expanded">
           Clarity is a scalable, customizable, open source design system bolstered by the people that build with it, the
           people we build it for, and the community that makes us who we are.
         </p>
@@ -112,17 +112,19 @@
           <div aria-hidden="true" class="accent-wrapper" cds-layout="grid gap:md">
             <div class="orange-accent" cds-layout="col:3"></div>
           </div>
-          <h1 class="accented" cds-text="subsection uppercase" cds-layout="m-t:lg">
+          <h1 class="accented" cds-text="subsection uppercase expanded" cds-layout="m-t:lg">
             Clarity is all about people, like designers
           </h1>
           <h2 cds-text="heading" cds-layout="m-t:lg">Design with confidence</h2>
-          <p cds-text="subsection" cds-layout="m-t:xl">
+          <p cds-text="subsection expanded" cds-layout="m-t:xl">
             Our toolkit is Figma. Every component, pattern, and guideline we ship is rooted in real customer
             interactions. As a result, you can rely on Clarity for 30+ components and over 200 icons so you can focus on
             product-specific user problems.
           </p>
-          <router-link to="/get-started/design" cds-layout="m-t:lg" cds-text="subsection">Get Started</router-link>
-          <router-link to="/get-started/design#figma-libraries" cds-layout="m-t:md" cds-text="subsection"
+          <router-link to="/get-started/design" cds-layout="m-t:lg" cds-text="subsection expanded"
+            >Get Started</router-link
+          >
+          <router-link to="/get-started/design#figma-libraries" cds-layout="m-t:md" cds-text="subsection expanded"
             >Browse our Figma libraries</router-link
           >
         </div>
@@ -141,16 +143,21 @@
           <div aria-hidden="true" class="accent-wrapper" cds-layout="grid gap:md">
             <div class="orange-accent" cds-layout="col:3"></div>
           </div>
-          <h1 cds-text="subsection uppercase" cds-layout="m-t:lg">Clarity is all about people, like developers</h1>
+          <h1 cds-text="subsection uppercase expanded" cds-layout="m-t:lg">
+            Clarity is all about people, like developers
+          </h1>
           <h2 cds-text="heading" cds-layout="m-t:lg">Build framework agnostic</h2>
-          <p cds-text="subsection" cds-layout="m-t:xl">
+          <p cds-text="subsection expanded" cds-layout="m-t:xl">
             The first folx that built Clarity from scratch were a scrappy team of developers, designers, and content
             creators. Clarity has continued to grow on that strong start by supporting the big three: Angular, React and
             Vue. Our latest web components provide support for them all. Clarity provides code examples and detailed API
             documentation that guide you as you build your next application.
           </p>
-          <router-link to="/get-started/design" cds-layout="m-t:lg" cds-text="subsection">Get Started</router-link>
-          <a target="_blank" href="https://github.com/vmware/clarity" cds-layout="m-t:md" cds-text="subsection"
+          <router-link to="/get-started/angular" cds-layout="m-t:lg" cds-text="subsection expanded"
+            >Get started with Angular</router-link
+          >
+          <a target="_blank" href="/storybook/core" cds-layout="m-t:md">Get started with web components</a>
+          <a target="_blank" href="https://github.com/vmware/clarity" cds-layout="m-t:md" cds-text="subsection expanded"
             >Explore our Github</a
           >
         </div>
@@ -166,16 +173,18 @@
           <div aria-hidden="true" class="accent-wrapper" cds-layout="grid gap:md">
             <div class="orange-accent" cds-layout="col:3"></div>
           </div>
-          <h1 cds-text="subsection uppercase" cds-layout="m-t:lg">
+          <h1 cds-text="subsection uppercase expanded" cds-layout="m-t:lg">
             Clarity is all about people, like all of our users
           </h1>
           <h2 cds-text="heading" cds-layout="m-t:lg">Backed by performant components</h2>
-          <p cds-text="subsection" cds-layout="m-t:xl">
+          <p cds-text="subsection expanded" cds-layout="m-t:xl">
             When Clarity customers speak, we listen. One of our most requested components, datagrid, can support more
             than a dozen features and handle thousands of data entries. Let us build performant components so you can
             focus on building applications.
           </p>
-          <router-link to="/components/" cds-layout="m-t:lg" cds-text="subsection">Browse all components</router-link>
+          <router-link to="/components/" cds-layout="m-t:lg" cds-text="subsection expanded"
+            >Browse all components</router-link
+          >
         </div>
         <div cds-layout="vertical ">
           <img src="/images/home/img_performant_components.svg" alt="placeholder image" cds-layout="fill" />
@@ -191,7 +200,7 @@
           alt="placeholder image"
           cds-layout="col:start-2 col:10 fill m-t:xl"
         />
-        <p cds-text="subsection" cds-layout="m-t:xl">
+        <p cds-text="subsection expanded" cds-layout="m-t:xl">
           We’ve integrated accessibility into the design and development of the Clarity assets. Accessibility is a
           priority, and we work closely with a dedicated accessibility team following the WCAG 2.1 AA guidelines. Use
           Clarity to leverage all the built-in accessibility features and follow our accessibility guidelines to make
@@ -211,9 +220,9 @@
     <!-- Join us -->
     <section cds-layout="p-l:md p-l@sm:xl p-r:md p-r@sm:none p-y:lg p-y@sm:xxl" class="tinted action-light">
       <div cds-layout="grid cols:12" class="home-section">
-        <h1 cds-text="subsection uppercase" cds-layout="m-t:lg">Together, we are the Clarity community</h1>
+        <h1 cds-text="subsection uppercase expanded" cds-layout="m-t:lg">Together, we are the Clarity community</h1>
         <h2 cds-text="heading" cds-layout="m-t:md">Join us and we can build better products together</h2>
-        <p cds-text="subsection" cds-layout="m-t:lg">
+        <p cds-text="subsection expanded" cds-layout="m-t:lg">
           Great design systems have a great community behind it. We open sourced Clarity early in our journey because we
           believe in the importance of community. It is foundational to our story. We are open about our roadmap and
           priorities. We are proud of what we have running under the hood. Check out our Github and take a look at our
@@ -228,15 +237,15 @@
         <div cds-text="center" cds-layout="horizontal gap:lg align:fill col:start-2 col:10 m-t:xl">
           <div>
             <h3 cds-text="display" class="docs-red">2M+</h3>
-            <p cds-text="body" cds-layout="m-t:lg">downloads since the beginning of Clarity</p>
+            <p cds-text="body expanded" cds-layout="m-t:lg">downloads since the beginning of Clarity</p>
           </div>
           <div>
             <h3 cds-text="display" class="docs-red">2700+</h3>
-            <p cds-text="body" cds-layout="m-t:lg">Github repositories depending on Clarity</p>
+            <p cds-text="body expanded" cds-layout="m-t:lg">Github repositories depending on Clarity</p>
           </div>
           <div>
             <h3 cds-text="display" class="docs-red">300+</h3>
-            <p cds-text="body" cds-layout="m-t:lg">releases for new features and continuous improvements</p>
+            <p cds-text="body expanded" cds-layout="m-t:lg">releases for new features and continuous improvements</p>
           </div>
         </div>
         <p cds-text="message" cds-layout="m-t:xl">

--- a/apps/website/.vuepress/theme/global-components/ItemOverview.vue
+++ b/apps/website/.vuepress/theme/global-components/ItemOverview.vue
@@ -1,7 +1,7 @@
 <template>
   <a :href="path" :target="target" :aria-label="`Go to ${title} documentation page`">
     <section cds-layout="vertical" role="link" class="item-overview">
-      <h2 cds-text="section">
+      <h2 cds-text="section expanded">
         <div cds-layout="horizontal gap:md p:lg align:center">
           <a :href="path" :target="target"> {{ title }} </a>
           <span role="status" v-if="isNew" class="badge badge-info">new</span>

--- a/apps/website/.vuepress/theme/global-components/WhatsNew.vue
+++ b/apps/website/.vuepress/theme/global-components/WhatsNew.vue
@@ -1,6 +1,6 @@
 <template>
   <div cds-layout="vertical">
-    <h1 cds-text="title medium">v{{ data.version }} is now available!</h1>
+    <h1 cds-text="title medium expanded">v{{ data.version }} is now available!</h1>
     <p v-if="data.feat.length > 0" cds-text="message medium" cds-layout="m-t:md">
       <span v-if="data.feat[0]">{{ data.feat[0].title }}</span>
       <span v-if="data.feat[1]">, {{ data.feat[1].title }}</span>

--- a/apps/website/.vuepress/theme/styles/index.scss
+++ b/apps/website/.vuepress/theme/styles/index.scss
@@ -2,7 +2,7 @@
 @import '../../../../../dist/core/global.min.css';
 @import './a11y-light.scss';
 
-@import './overrides.scss';
 @import './containers';
 @import './spaces';
 @import './layout';
+@import './overrides.scss';

--- a/apps/website/.vuepress/theme/styles/overrides.scss
+++ b/apps/website/.vuepress/theme/styles/overrides.scss
@@ -252,3 +252,26 @@ h4 .header-anchor cds-icon {
     }
   }
 }
+
+/*
+ * This section is an override for something that doesn't exist in Core yet.
+ * When the expanded is added to core we need to remove this css.
+ * (but leave the html implementing it)
+ *
+ */
+
+[cds-text*='expanded'][cds-text*='title'] {
+  --cds-token-typography-title-line-height: 1.6rem;
+}
+
+[cds-text*='expanded'][cds-text*='section'] {
+  --cds-token-typography-section-line-height: 1.4rem;
+}
+
+[cds-text*='expanded'][cds-text*='subection'] {
+  --cds-token-typography-subsection-line-height: 1.2rem;
+}
+
+[cds-text*='expanded'][cds-text*='body'] {
+  --cds-token-typography-body-line-height: 1.2rem;
+}


### PR DESCRIPTION
# Summary
Per internal discussion the home page line heights for some tokens need to be taller for the website content. This change is a css override specific to the website html. The idea is that once `expanded/compact` line-height's are implemented in core only the css will be removed from the website. 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] If applicable, have a visual design approval - @colinreedmiller @yuxin-ux 

## PR Type

What kind of change does this PR introduce?
Adds css overrides of token line-height so the website theme can implement `expanded` cds-text. 

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Line heights for Theme pages are too short. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Line heights are taller. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
