### PR TITLE
fix(datagrid): add an aria-label to the column chooser dialog

### DIFF
--- a/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-column-toggle.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-column-toggle.ts
@@ -38,14 +38,12 @@ import { ClrDatagridColumnToggleButton } from './datagrid-column-toggle-button';
     <div
       class="column-switch"
       role="dialog"
+      [attr.aria-label]="commonStrings.keys.showColumnsMenuDescription"
       [id]="popoverId"
       clrFocusTrap
       *clrPopoverContent="openState; at: smartPosition; outsideClickToClose: true; scrollToClose: true"
     >
       <div class="switch-header">
-        <div class="clr-sr-only" tabindex="-1" #menuDescription>
-          {{ commonStrings.keys.showColumnsMenuDescription }}
-        </div>
         <div class="clr-sr-only" tabindex="-1" #allSelected>{{ commonStrings.keys.allColumnsSelected }}</div>
         <ng-container *ngIf="!customToggleTitle">{{ commonStrings.keys.showColumns }}</ng-container>
         <ng-content select="clr-dg-column-toggle-title"></ng-content>
@@ -100,8 +98,6 @@ export class ClrDatagridColumnToggle {
 
   @ContentChild(ClrDatagridColumnToggleTitle) customToggleTitle: ClrDatagridColumnToggleTitle;
   @ContentChild(ClrDatagridColumnToggleButton) customToggleButton: ClrDatagridColumnToggleButton;
-  @ViewChild('menuDescription', { read: ElementRef })
-  private menuDescriptionElement: ElementRef<HTMLElement>;
   @ViewChild('allSelected', { read: ElementRef })
   private allSelectedElement: ElementRef<HTMLElement>;
 
@@ -145,13 +141,6 @@ export class ClrDatagridColumnToggle {
 
   toggleSwitchPanel() {
     this.openState = !this.openState;
-    if (this.openState && isPlatformBrowser(this.platformId) && this.menuDescriptionElement) {
-      this.zone.runOutsideAngular(() => {
-        setTimeout(() => {
-          this.menuDescriptionElement.nativeElement.focus();
-        });
-      });
-    }
   }
 
   allColumnsSelected() {


### PR DESCRIPTION
Add an aria-label to the column chooser dialog.

Closes: #4754

Signed-off-by: Alex Mellnik <a.r.mellnik@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The column chooser dialog has the dialog role, but there's no label associated with it.  There is a invisible div inside the dialog that describes it, but since it's not an aria-label its not read again as the screen reader virtual focus exits the dialog.

## What is the new behavior?

Removes the invisible div and moves the message to the aria-label of the dialog.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
