### PR TITLE
chore: add back no-unused-imports lint rule

### DIFF
--- a/packages/angular/.eslintrc.js
+++ b/packages/angular/.eslintrc.js
@@ -17,6 +17,7 @@ const rules = {
   '@typescript-eslint/no-unused-vars': OFF, // TypeScript is catching this
   '@typescript-eslint/no-var-requires': OFF, // Using raw-loader in Storybook
   '@typescript-eslint/ban-ts-ignore': OFF, // There are some quirks where we do want to use ts-ignore, but should be rare
+  'unused-imports/no-unused-imports-ts': ERROR, // It's not covered by default checks; needs external plug-in
   'clarity/no-barrel-imports': ERROR, // Custom check to ensure we only import directly from files
   'jasmine/no-focused-tests': ERROR, // Prevent focused tests
   'no-irregular-whitespace': [ERROR, { skipTemplates: true }], // Turn of whitespace checking inside of `` templates
@@ -28,6 +29,7 @@ const overrides = [
     rules: {
       '@typescript-eslint/no-var-requires': 1,
     },
+    plugins: ['unused-imports'],
   },
 ];
 

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -81,6 +81,7 @@
     "eslint": "6.8.0",
     "eslint-config-prettier": "6.11.0",
     "eslint-plugin-jasmine": "4.1.1",
+    "eslint-plugin-unused-imports": "0.1.3",
     "jasmine": "3.5.0",
     "jasmine-core": "~3.5.0",
     "jasmine-expect": "4.0.3",

--- a/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-column.spec.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-column.spec.ts
@@ -8,7 +8,6 @@ import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { Subject } from 'rxjs';
 
-import { commonStringsDefault } from './../../utils/i18n/common-strings.default';
 import { DatagridPropertyComparator } from './built-in/comparators/datagrid-property-comparator';
 import { DatagridNumericFilterImpl } from './built-in/filters/datagrid-numeric-filter-impl';
 import { DatagridStringFilter } from './built-in/filters/datagrid-string-filter';

--- a/packages/angular/projects/clr-angular/src/deprecations.spec.ts
+++ b/packages/angular/projects/clr-angular/src/deprecations.spec.ts
@@ -4,7 +4,6 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { ClrForm } from './forms/common/form';
 import { ClrDatagrid } from './data/datagrid/datagrid';
 import { ClrDatagridColumnToggle } from './data/datagrid/datagrid-column-toggle';
 import { ClrDatagridColumnToggleTitle } from './data/datagrid/datagrid-column-toggle-title';

--- a/packages/angular/projects/clr-angular/src/forms/common/if-control-state/if-success.ts
+++ b/packages/angular/projects/clr-angular/src/forms/common/if-control-state/if-success.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { Directive, Optional, TemplateRef, ViewContainerRef, Input } from '@angular/core';
+import { Directive, Optional, TemplateRef, ViewContainerRef } from '@angular/core';
 import { NgControlService } from '../providers/ng-control.service';
 import { IfControlStateService, CONTROL_STATE } from './if-control-state.service';
 import { AbstractIfState } from './abstract-if-state';

--- a/packages/angular/projects/clr-angular/src/utils/popover/popover-close-button.spec.ts
+++ b/packages/angular/projects/clr-angular/src/utils/popover/popover-close-button.spec.ts
@@ -12,7 +12,6 @@ import { ClrPopoverEventsService } from './providers/popover-events.service';
 import { ClrPopoverPositionService } from './providers/popover-position.service';
 import { ClrPopoverCloseButton } from './popover-close-button';
 import { ClrPopoverModuleNext } from './popover.module';
-import { KeyCodes } from '../../utils/enums/key-codes.enum';
 
 @Component({
   selector: 'test-host',

--- a/packages/angular/src/stories/combobox/combobox.stories.ts
+++ b/packages/angular/src/stories/combobox/combobox.stories.ts
@@ -5,7 +5,6 @@
  */
 
 import { moduleMetadata } from '@storybook/angular';
-import { boolean } from '@storybook/addon-knobs';
 import { ClarityModule } from '@clr/angular';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 

--- a/packages/angular/src/stories/signpost/signpost.stories.ts
+++ b/packages/angular/src/stories/signpost/signpost.stories.ts
@@ -5,7 +5,7 @@
  */
 
 import { moduleMetadata } from '@storybook/angular';
-import { boolean, select } from '@storybook/addon-knobs';
+import { select } from '@storybook/addon-knobs';
 import { ClarityModule } from '@clr/angular';
 const basicTemplate = require('!!raw-loader!./basic.html'); // eslint-disable-line
 


### PR DESCRIPTION
and fix files that break the rule
Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

Add back rule that used to be in tslint, but is not applied in eslint

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Can merge files with unused imports

Issue Number: N/A

Won't be able to merge files with unused imports

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
