### PR TITLE
fix: (eslint) report warning/error for all disallowed buttons

### DIFF
--- a/packages/eslint-plugin-clarity-migration/src/rules/no-clr-button/disallowed-classes.ts
+++ b/packages/eslint-plugin-clarity-migration/src/rules/no-clr-button/disallowed-classes.ts
@@ -1,0 +1,7 @@
+export const primaryDisallowedClass = 'btn';
+
+export const additionalDisallowedClasses = ['btn-primary', 'btn-success', 'btn-warning', 'btn-danger'];
+
+export const disallowedButtonsSelector = additionalDisallowedClasses.map(
+  cls => `button.${primaryDisallowedClass}.${cls}`
+);

--- a/packages/eslint-plugin-clarity-migration/test/no-clr-button.spec.ts
+++ b/packages/eslint-plugin-clarity-migration/test/no-clr-button.spec.ts
@@ -102,7 +102,7 @@ htmlRuleTester.run('no-clr-button', rule, {
     getInvalidTest(
       `
       <button class="btn btn-primary">Le button</button>
-      <div><ul></ul><button class="btn btn-primary"></button></div>
+      <div><ul></ul><button class="btn btn-success"></button></div>
     `,
       [
         { line: 2, column: 7 },
@@ -136,7 +136,7 @@ tsRuleTester.run('no-clr-button', rule, {
       @Component({
         selector: 'app-custom-button',
         template: \`
-          <button class="btn btn-primary custom-class">Primary</button>
+          <button class="btn btn-warning custom-class">Primary</button>
         \`
       })
       export class CustomButtonComponent {
@@ -151,8 +151,8 @@ tsRuleTester.run('no-clr-button', rule, {
         template: \`
           <button class="btn btn-primary custom-class">Primary</button>
           <div>Text</div>
-          <button class="btn btn-primary custom-class">Primary</button>
-          <div>Text</div><button class="btn btn-primary custom-class">Primary</button><p></p>
+          <button class="btn btn-danger custom-class">Primary</button>
+          <div>Text</div><button class="btn btn-success custom-class">Primary</button><p></p>
         \`
       })
       export class CustomButtonComponent {


### PR DESCRIPTION
Signed-off-by: Stanimira Vlaeva <svlaeva@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Previously, the ESLint rule was detecting only elements with the classes `btn` and `btn-primary`.

## What is the new behavior?

No, the ESLint rule detects the following buttons:
- `<button class="btn btn-primary></button>`
- `<button class="btn btn-success></button>`
- `<button class="btn btn-warning></button>`
- `<button class="btn btn-danger></button>`

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

