### PR TITLE
docs(website): add sticky header for docs pages

### DIFF
--- a/apps/website/.vuepress/theme/components/AlgoliaSearchBox.vue
+++ b/apps/website/.vuepress/theme/components/AlgoliaSearchBox.vue
@@ -76,7 +76,7 @@ export default {
 <style lang="scss">
 .algolia-autocomplete .ds-dropdown-menu {
   line-height: 1rem;
-  z-index: 5000 !important;
+  z-index: 10000 !important;
 }
 
 .algolia-autocomplete

--- a/apps/website/.vuepress/theme/components/Home.vue
+++ b/apps/website/.vuepress/theme/components/Home.vue
@@ -116,7 +116,7 @@
             Clarity is all about people, like designers
           </h1>
           <h2 cds-text="heading" cds-layout="m-t:lg">Design with confidence</h2>
-          <p cds-text="subsection expanded" cds-layout="m-t:xl">
+          <p cds-text="section expanded" cds-layout="m-t:xl">
             Our toolkit is Figma. Every component, pattern, and guideline we ship is rooted in real customer
             interactions. As a result, you can rely on Clarity for 30+ components and over 200 icons so you can focus on
             product-specific user problems.
@@ -147,7 +147,7 @@
             Clarity is all about people, like developers
           </h1>
           <h2 cds-text="heading" cds-layout="m-t:lg">Build framework agnostic</h2>
-          <p cds-text="subsection expanded" cds-layout="m-t:xl">
+          <p cds-text="section expanded" cds-layout="m-t:xl">
             The first folx that built Clarity from scratch were a scrappy team of developers, designers, and content
             creators. Clarity has continued to grow on that strong start by supporting the big three: Angular, React and
             Vue. Our latest web components provide support for them all. Clarity provides code examples and detailed API
@@ -177,7 +177,7 @@
             Clarity is all about people, like all of our users
           </h1>
           <h2 cds-text="heading" cds-layout="m-t:lg">Backed by performant components</h2>
-          <p cds-text="subsection expanded" cds-layout="m-t:xl">
+          <p cds-text="section expanded" cds-layout="m-t:xl">
             When Clarity customers speak, we listen. One of our most requested components, datagrid, can support more
             than a dozen features and handle thousands of data entries. Let us build performant components so you can
             focus on building applications.
@@ -200,7 +200,7 @@
           alt="placeholder image"
           cds-layout="col:start-2 col:10 fill m-t:xl"
         />
-        <p cds-text="subsection expanded" cds-layout="m-t:xl">
+        <p cds-text="section expanded" cds-layout="m-t:xl">
           We’ve integrated accessibility into the design and development of the Clarity assets. Accessibility is a
           priority, and we work closely with a dedicated accessibility team following the WCAG 2.1 AA guidelines. Use
           Clarity to leverage all the built-in accessibility features and follow our accessibility guidelines to make
@@ -221,8 +221,8 @@
     <section cds-layout="p-l:md p-l@sm:xl p-r:md p-r@sm:none p-y:lg p-y@sm:xxl" class="tinted action-light">
       <div cds-layout="grid cols:12" class="home-section">
         <h1 cds-text="subsection uppercase expanded" cds-layout="m-t:lg">Together, we are the Clarity community</h1>
-        <h2 cds-text="heading" cds-layout="m-t:md">Join us and we can build better products together</h2>
-        <p cds-text="subsection expanded" cds-layout="m-t:lg">
+        <h2 cds-text="heading" cds-layout="m-t:lg">Join us and we can build better products together</h2>
+        <p cds-text="section expanded" cds-layout="m-t:lg">
           Great design systems have a great community behind it. We open sourced Clarity early in our journey because we
           believe in the importance of community. It is foundational to our story. We are open about our roadmap and
           priorities. We are proud of what we have running under the hood. Check out our Github and take a look at our
@@ -248,19 +248,19 @@
             <p cds-text="body expanded" cds-layout="m-t:lg">releases for new features and continuous improvements</p>
           </div>
         </div>
-        <p cds-text="message" cds-layout="m-t:xl">
+        <p cds-text="section expanded" cds-layout="m-t:xl">
           Clarity firmly believes that the best products are built by those who form a rich, varied community. We invite
           all forms of feedback or ideas that allow us, together, to create better experiences for all users.
         </p>
 
         <div cds-layout="horizontal gap:lg align:center col:start-2 col:10 m-t:lg">
           <cds-button action="outline">
-            <router-link to="/get-started/design">
+            <router-link to="/get-started/angular">
               Get started developing
             </router-link>
           </cds-button>
           <cds-button action="outline">
-            <router-link to="/get-started/angular">
+            <router-link to="/get-started/design">
               Get started designing
             </router-link>
           </cds-button>

--- a/apps/website/.vuepress/theme/components/Page.vue
+++ b/apps/website/.vuepress/theme/components/Page.vue
@@ -27,7 +27,6 @@ export default {
 .page {
   max-width: 48rem;
   width: 100%;
-  height: calc(100vh - 3rem);
   display: flex;
   flex-direction: column;
   position: relative;

--- a/apps/website/.vuepress/theme/components/PageSubnav.vue
+++ b/apps/website/.vuepress/theme/components/PageSubnav.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="subnav && subnav.children">
+  <div v-if="subnav && subnav.children" class="sticky">
     <h1>{{ subnav.title }}</h1>
     <ul class="nav page-subnav" role="nav" v-if="subnav.children.length > 1">
       <li role="presentation" class="nav-item" v-for="item of subnav.children">
@@ -16,6 +16,13 @@
 </template>
 
 <style lang="scss">
+.sticky {
+  position: sticky;
+  top: 0;
+  background-color: var(--clr-global-app-background);
+  z-index: 5000;
+}
+
 h1 {
   margin: 0rem;
 }

--- a/apps/website/.vuepress/theme/global-components/DocIconsPreviewSettings.vue
+++ b/apps/website/.vuepress/theme/global-components/DocIconsPreviewSettings.vue
@@ -55,6 +55,10 @@ export default {
   display: grid;
   grid-template-columns: 8rem auto;
   padding: 0.75rem 0;
+  position: sticky;
+  top: 133px; // height makes it sticky under search input.
+  background-color: var(--clr-global-app-background);
+  z-index: 5000;
 }
 .control-container-title {
   padding-right: 0.5rem;

--- a/apps/website/.vuepress/theme/global-components/DocIconsSearch.vue
+++ b/apps/website/.vuepress/theme/global-components/DocIconsSearch.vue
@@ -1,16 +1,18 @@
 <template>
-  <label for="search-icons-sticky" class="searchbar-label">
-    <cds-icon class="search-icon" shape="search" size="24"></cds-icon>
-    <button aria-label="close" class="close" type="button" @click="resetSearch()" :class="{ active: !!filterValue }">
-      <cds-icon shape="close" size="24"></cds-icon>
-    </button>
-    <input
-      placeholder="Search for Clarity Icons..."
-      type="text"
-      class="searchbar-input clr-input"
-      v-model.trim="filterValue"
-    />
-  </label>
+  <section class="sticky">
+    <label for="search-icons-sticky" class="searchbar-label">
+      <cds-icon class="search-icon" shape="search" size="24"></cds-icon>
+      <button aria-label="close" class="close" type="button" @click="resetSearch()" :class="{ active: !!filterValue }">
+        <cds-icon shape="close" size="24"></cds-icon>
+      </button>
+      <input
+        placeholder="Search for Clarity Icons..."
+        type="text"
+        class="searchbar-input clr-input"
+        v-model.trim="filterValue"
+      />
+    </label>
+  </section>
 </template>
 
 <script>
@@ -35,6 +37,10 @@ export default {
 </script>
 
 <style scoped lang="scss">
+.sticky {
+  position: sticky;
+  top: 84px; // height is to make it sticky under the page title.
+}
 .searchbar-label {
   position: relative;
   display: block;

--- a/apps/website/.vuepress/theme/global-components/DocIconsSet.vue
+++ b/apps/website/.vuepress/theme/global-components/DocIconsSet.vue
@@ -120,6 +120,12 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+h2 {
+  position: sticky;
+  top: 187px;
+  background-color: var(--clr-global-app-background);
+  z-index: 4500;
+}
 .icon {
   margin: 0 0.5rem;
 }

--- a/apps/website/.vuepress/theme/global-components/Release.vue
+++ b/apps/website/.vuepress/theme/global-components/Release.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div v-for="release of item.releases">
-      <h2>
+      <h2 class="sticky">
         {{ release.version }}
         <a class="release-date" :href="commitLink" target="_blank">
           Released {{ release.date }} <cds-icon class="external-link" size="12" shape="pop-out"></cds-icon>
@@ -55,7 +55,12 @@ export default {
 };
 </script>
 
-<style scoped>
+<style scoped lang="scss">
+.sticky {
+  position: sticky;
+  top: 0;
+}
+
 .release-date {
   font-size: 0.75rem;
   margin-left: 1rem;


### PR DESCRIPTION
Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Type

What kind of change does this PR introduce?
1. This makes the website `.page` element/container have a sticky header for its `PageSubnav.vue` content. 
2. There are some Home page typography and spacing changes that content presentation.

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Page title scrolls out of view. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Page title remains visible. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
