### PR TITLE
fix: datagrid issue with placeholder position (v3 backport)

### DIFF
--- a/src/clr-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clr-angular/data/datagrid/_datagrid.clarity.scss
@@ -997,7 +997,7 @@
         display: flex;
         flex-flow: column nowrap;
         align-items: center;
-        justify-content: center;
+        justify-content: start;
         @include css-var(
           font-size,
           clr-datagrid-placeholder-font-size,


### PR DESCRIPTION
Fix UI issue that let the placeholder icon and text to be center in both
horizontal and vertical. By design it has to be only horizontal.

fixes #5139