### PR TITLE
fix: datagrid issue with placeholder position (v2 backport)

### DIFF
--- a/src/clr-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clr-angular/data/datagrid/_datagrid.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -441,7 +441,7 @@
         display: flex;
         flex-flow: column nowrap;
         align-items: center;
-        justify-content: center;
+        justify-content: start;
         font-size: $clr-datagrid-placeholder-font-size;
         color: $clr-datagrid-placeholder-color;
       }


### PR DESCRIPTION
Fix UI issue that let the placeholder icon and text to be center in both
horizontal and vertical. By design it has to be only horizontal.

close #5139
