### PR TITLE
fix(form): input width issue introduced for a fix to datepicker

### DIFF
--- a/packages/angular/projects/clr-angular/src/forms/datepicker/_datepicker.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/forms/datepicker/_datepicker.clarity.scss
@@ -67,6 +67,9 @@
     cursor: not-allowed;
   }
   .clr-form-control {
+    .clr-input-wrapper {
+      max-width: fit-content;
+    }
     .datepicker-trigger {
       line-height: $clr_baselineRem_1 - $clr_baselineRem_2px;
       height: $clr_baselineRem_1 - $clr_baselineRem_2px;

--- a/packages/angular/projects/clr-angular/src/forms/styles/_input.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/forms/styles/_input.clarity.scss
@@ -6,7 +6,6 @@
   .clr-input-wrapper {
     white-space: nowrap;
     max-height: $clr-forms-baseline * 4;
-    max-width: fit-content;
   }
 
   .clr-input {


### PR DESCRIPTION
Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #5146 

## What is the new behavior?

The fix doesn't affect other inputs than `date-picker`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Now the `max-width` is set only from `datepicker.clarity` instead of `input.clarity` file.

![image](https://user-images.githubusercontent.com/15037947/97572770-6fe4a400-19f1-11eb-8ab6-44fb68623dd8.png)
