### PR TITLE
fix: checkbox/toggles had wrong label color

### DIFF
--- a/packages/angular/projects/clr-angular/src/forms/styles/_properties.forms.scss
+++ b/packages/angular/projects/clr-angular/src/forms/styles/_properties.forms.scss
@@ -54,7 +54,7 @@
       --clr-forms-select-multiple-error-focus-color: #{lighten($clr-forms-invalid-color, 30%)};
 
       // Checkbox
-      --clr-forms-checkbox-label-color: var(--clr-forms-text-color);
+      --clr-forms-checkbox-label-color: var(--clr-forms-label-color);
       --clr-forms-checkbox-background-color: var(--clr-color-action-600);
       --clr-forms-checkbox-indeterminate-border-color: var(--clr-color-action-600);
       --clr-forms-checkbox-mark-color: var(--clr-color-neutral-0);

--- a/packages/angular/projects/clr-angular/src/forms/styles/_variables.forms.scss
+++ b/packages/angular/projects/clr-angular/src/forms/styles/_variables.forms.scss
@@ -54,7 +54,7 @@ $clr-forms-select-multiple-border-color: $clr-color-neutral-400 !default;
 $clr-forms-select-multiple-option-color: $clr-forms-text-color !default;
 
 // Checkbox
-$clr-forms-checkbox-label-color: $clr-forms-text-color !default;
+$clr-forms-checkbox-label-color: $clr-forms-label-color !default;
 $clr-forms-checkbox-height: $clr-icon-dimension-sm !default;
 $clr-forms-checkbox-background-color: $clr-color-action-600 !default;
 $clr-forms-checkbox-indeterminate-border-color: $clr-color-action-600 !default;


### PR DESCRIPTION
The label colour fallback to #000 (black) we need to use clr-forms-label-color that is used for all labels

Fixes #5226, #4261

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5226

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Need to be backported to v2, v3, v4