### PR TITLE
fix(a11y): removing restriction for banner/app alerts to be one line

### DIFF
--- a/packages/core/src/alert/alert.element.scss
+++ b/packages/core/src/alert/alert.element.scss
@@ -117,16 +117,7 @@ cds-internal-close-button {
 
 :host([type='banner']) .alert-content-wrapper {
   transform: none;
-  overflow: hidden;
-  height: #{$cds-token-space-size-10};
-}
-
-:host([type='banner']) {
-  .alert-content {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
+  min-height: #{$cds-token-space-size-10};
 }
 
 :host([type='banner']) .spinner {


### PR DESCRIPTION
• removed height restrictions forcing banner alerts to be one line
• removed truncation on banner alerts from CSS
• it is recommended that apps NOT wrap the content inside a banner alert but sometimes that is not realistic
• given the current implementation of banner alerts it is recommended that paging through multiple alerts uses either opacity or visibility instead of display: none CSS styles so that content jumping can be avoided <= @Shijir for app-alert pagination demo!!!

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Banner alerts are forced to remain one-line tall and truncate any content overflow

Issue Number: In a11y backlog

## What is the new behavior?

Banner alert content wraps.

<img width="681" alt="Screen Shot 2020-10-30 at 1 57 29 PM" src="https://user-images.githubusercontent.com/2728359/97748013-c833a880-1aba-11eb-9c17-05d6521c2d0b.png">

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

CC: @scroniser