### PR TITLE
fix: start value has mixed support, consider using flex-start instead

### DIFF
--- a/packages/angular/projects/clr-angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/_datagrid.clarity.scss
@@ -1001,7 +1001,7 @@
         display: flex;
         flex-flow: column nowrap;
         align-items: center;
-        justify-content: start;
+        justify-content: flex-start;
         @include css-var(
           font-size,
           clr-datagrid-placeholder-font-size,


### PR DESCRIPTION
Backport fix for #5240 to v4