### PR TITLE
fix: start value has mixed support, consider using flex-start instead

### DIFF
--- a/src/clr-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clr-angular/data/datagrid/_datagrid.clarity.scss
@@ -997,7 +997,7 @@
         display: flex;
         flex-flow: column nowrap;
         align-items: center;
-        justify-content: start;
+        justify-content: flex-start;
         @include css-var(
           font-size,
           clr-datagrid-placeholder-font-size,


### PR DESCRIPTION
Backport fixes for #5240 for v3