### PR TITLE
fix: start value has mixed support, consider using flex-start instead

### DIFF
--- a/src/clr-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clr-angular/data/datagrid/_datagrid.clarity.scss
@@ -441,7 +441,7 @@
         display: flex;
         flex-flow: column nowrap;
         align-items: center;
-        justify-content: start;
+        justify-content: flex-start;
         font-size: $clr-datagrid-placeholder-font-size;
         color: $clr-datagrid-placeholder-color;
       }


### PR DESCRIPTION
Backport fixes #5240 for v2