### PR TITLE
fix: improve clr-angular dev app build and run-time

### DIFF
--- a/packages/angular/tsconfig.json
+++ b/packages/angular/tsconfig.json
@@ -19,8 +19,8 @@
     "lib": ["es2018", "dom"],
     "typeRoots": ["node_modules/@types"],
     "paths": {
-      "@clr/angular": ["./dist/clr-angular"],
-      "@clr/angular/*": ["./dist/clr-angular/*"],
+      "@clr/angular": ["./projects/clr-angular/src/index.ts"],
+      "@clr/angular/*": ["./projects/clr-angular/src/*"],
       "@clr/icons": ["../../dist/clr-icons"],
       "@clr/icons/shapes/*": ["../../dist/clr-icons/shapes/*"],
       "@clr/core": ["../../dist/core"],


### PR DESCRIPTION
Letting the dev app link directly to the source files of the `clr-angular` and compile them when dev-app start let us not run two tasks and manage how they start-sync-build (the tasks)

I did not notice any errors or issues - at least I don't know for them. 

Changes inside `clr-angular` will trigger the rebuild inside the `dev` app.

I did not link in the same way the `icons` or `core` - they are built and work in a whole different way so this pattern is not suitable there. 

now running the dev app is just running 

```bash
npm run serve
# or
yarn run serve
```



## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
