### PR TITLE
fix(icons): fixing a11y issues related to icons in core

### DIFF
--- a/packages/core/src/alert/alert.element.spec.ts
+++ b/packages/core/src/alert/alert.element.spec.ts
@@ -7,7 +7,7 @@
 import { html } from 'lit-html';
 import '@clr/core/alert/register.js';
 import '@clr/core/icon/register.js';
-import { CdsAlert, getIconStatusTuple, iconShapeIsAlertStatusType, iconTitleIsAlertStatusLabel } from '@clr/core/alert';
+import { CdsAlert, getIconStatusTuple, iconShapeIsAlertStatusType } from '@clr/core/alert';
 import { CdsIcon, infoStandardIcon } from '@clr/core/icon';
 import { CommonStringsService } from '@clr/core/internal';
 import { componentIsStable, createTestElement, getComponentSlotContent, removeTestElement } from '@clr/core/test/utils';
@@ -141,11 +141,6 @@ describe('Alert element – ', () => {
       expect(component.status).toBe('default');
       expect(alertStatusIcon.getAttribute('shape')).toBe(iconName);
       expect(alertStatusIcon.getAttribute('shape')).toBe(iconName);
-      expect(
-        alertStatusIcon.shadowRoot
-          .querySelector('[cds-layout="display:screen-reader-only"]')
-          .innerHTML.includes(CommonStringsService.keys.info)
-      ).toBe(true);
     });
 
     it('should allow users to change statuses', async () => {
@@ -154,17 +149,11 @@ describe('Alert element – ', () => {
       expect(component.shadowRoot.querySelector(alertStatusIconSelector).getAttribute('shape')).toBe(
         infoStandardIcon[0]
       );
-      expect(component.shadowRoot.querySelector(alertStatusIconSelector).getAttribute('title')).toBe(
-        CommonStringsService.keys.info
-      );
       component.setAttribute('status', 'warning');
       await componentIsStable(component);
       expect(component.status).toBe('warning');
       expect(component.shadowRoot.querySelector(alertStatusIconSelector).getAttribute('shape')).toBe(
         'warning-standard'
-      );
-      expect(component.shadowRoot.querySelector(alertStatusIconSelector).getAttribute('title')).toBe(
-        CommonStringsService.keys.warning
       );
     });
 
@@ -436,20 +425,5 @@ describe('iconShapeIsAlertStatusType: ', () => {
     expect(iconShapeIsAlertStatusType('info-standard')).toBe(true);
     expect(iconShapeIsAlertStatusType('success-standard')).toBe(true);
     expect(iconShapeIsAlertStatusType('help')).toBe(true);
-  });
-});
-
-describe('iconTitleIsAlertStatusLabel: ', () => {
-  const commonstrings = CommonStringsService.keys;
-
-  it('should return false as expected', async () => {
-    expect(iconTitleIsAlertStatusLabel('chuul')).toBe(false);
-  });
-
-  it('should return true as expected', async () => {
-    expect(iconTitleIsAlertStatusLabel(commonstrings.info)).toBe(true, 'info returns true');
-    expect(iconTitleIsAlertStatusLabel(commonstrings.success)).toBe(true, 'success returns true');
-    expect(iconTitleIsAlertStatusLabel(commonstrings.warning)).toBe(true, 'warning returns true');
-    expect(iconTitleIsAlertStatusLabel(commonstrings.danger)).toBe(true, 'danger returns true');
   });
 });

--- a/packages/core/src/alert/alert.element.ts
+++ b/packages/core/src/alert/alert.element.ts
@@ -52,21 +52,9 @@ export function iconShapeIsAlertStatusType(shape: string): boolean {
   return statusShapes.indexOf(shape) > -1;
 }
 
-export function iconTitleIsAlertStatusLabel(shape: string): boolean {
-  const statusLabels = ['info', 'success', 'warning', 'danger', 'unknown'].map(s => {
-    return getIconStatusLabel(s);
-  });
-  return statusLabels.indexOf(shape) > -1;
-}
-
 export function getIconStatusShape(status: string): string {
   return getIconStatusTuple(status)[0];
 }
-
-export function getIconStatusLabel(status: string): string {
-  return getIconStatusTuple(status)[1];
-}
-
 export function getAlertContentLayout(
   containerType: 'wrapper' | 'content' | 'actions',
   alertGroupType: AlertGroupTypes,
@@ -222,7 +210,6 @@ export class CdsAlert extends LitElement {
                 ><cds-icon
                   class="alert-status-icon"
                   shape="${getIconStatusShape(this.status)}"
-                  title="${getIconStatusLabel(this.status)}"
                   aria-hidden="true"
                   cds-layout="align:horizontal-center"
                 ></cds-icon

--- a/packages/core/src/icon/icon.element.spec.ts
+++ b/packages/core/src/icon/icon.element.spec.ts
@@ -131,38 +131,6 @@ describe('icon element', () => {
     });
   });
 
-  describe('title and aria label: ', () => {
-    it('should set aria label when a icon title is provided', async () => {
-      await componentIsStable(component);
-      expect(component.shadowRoot.querySelector('svg').getAttribute('aria-labelledby')).toBe(null);
-      expect(component.shadowRoot.querySelector('[cds-layout="display:screen-reader-only"')).toBe(null);
-
-      component.title = 'test';
-      await componentIsStable(component);
-
-      const id = component.shadowRoot.querySelector('[cds-layout="display:screen-reader-only"').getAttribute('id');
-      expect(id.charAt(0)).toBe('_');
-      expect(component.shadowRoot.querySelector('svg').getAttribute('aria-labelledby')).toBe(id);
-    });
-  });
-
-  describe('sr-only: ', () => {
-    it('should contain the sr-only element for screen readers', async () => {
-      await componentIsStable(component);
-      const srOnlyEl = component.shadowRoot.querySelector('[cds-layout="display:screen-reader-only"]');
-      expect(srOnlyEl).toBeDefined();
-    });
-
-    it('should update sr-only element if title is changed', async () => {
-      const testTitle = 'Title Me';
-      await componentIsStable(component);
-      component.setAttribute('title', testTitle);
-      await componentIsStable(component);
-      const srOnlyEl = component.shadowRoot.querySelector('[cds-layout="display:screen-reader-only"]');
-      expect(srOnlyEl.innerHTML).toContain(testTitle);
-    });
-  });
-
   describe('solid: ', () => {
     it('should default to false', async () => {
       await componentIsStable(component);

--- a/packages/core/src/icon/icon.element.ts
+++ b/packages/core/src/icon/icon.element.ts
@@ -13,7 +13,6 @@ import {
   property,
   internalProperty,
   StatusTypes,
-  id,
 } from '@clr/core/internal';
 import { html, LitElement, query } from 'lit-element';
 import { styles } from './icon.element.css.js';
@@ -83,9 +82,21 @@ export class CdsIcon extends LitElement {
     }
   }
 
-  /** If present, customizes the aria-label for the icon for accessibility. */
+  /**
+   * The aria-label attribute is required for accessibility. The icon
+   * will warn if used without the aria-label being set.
+   *
+   * Ideally, the aria-label will be specific to the icon's purpose. Avoid sharing
+   * generic labels across multiple icons on a page.
+   *
+   * To not announce redundant information through screen-readers, consider using
+   * aria-hidden="true" on the cds-icon
+   */
+  @property({ type: String, required: 'warning' })
+  ariaLabel: string;
+
   @property({ type: String })
-  title: string;
+  role = 'img';
 
   /**
    * @type {up | down | left | right}
@@ -154,19 +165,7 @@ export class CdsIcon extends LitElement {
 
   @query('svg') private svg: SVGElement;
 
-  @id()
-  private idForAriaLabel: string;
-
-  firstUpdated(props: Map<string, any>) {
-    super.firstUpdated(props);
-    this.updateSVGAriaLabel();
-  }
-
   updated(props: Map<string, any>) {
-    if (props.has('title')) {
-      this.updateSVGAriaLabel();
-    }
-
     if (props.has('innerOffset') && this.innerOffset > 0) {
       const dimension = `calc(100% + ${this.innerOffset * 2}px)`;
       this.svg.style.width = dimension;
@@ -175,26 +174,7 @@ export class CdsIcon extends LitElement {
     }
   }
 
-  connectedCallback() {
-    super.connectedCallback();
-    this.setAttribute('role', 'none');
-  }
-
   protected render() {
-    return html`
-      <span .innerHTML="${ClarityIcons.registry[this.shape]}"></span>
-      ${this.title
-        ? html`<span id="${this.idForAriaLabel}" cds-layout="display:screen-reader-only">${this.title}</span>`
-        : ''}
-    `;
-  }
-
-  private updateSVGAriaLabel() {
-    if (this.title) {
-      this.svg.removeAttribute('aria-label'); // remove empty label that makes icon decorative by default
-      this.svg.setAttribute('aria-labelledby', this.idForAriaLabel); // use labelledby for better SR support
-    } else {
-      this.svg.removeAttribute('aria-labelledby');
-    }
+    return html` <span aria-hidden="true" .innerHTML="${ClarityIcons.registry[this.shape]}"></span> `;
   }
 }

--- a/packages/core/src/icon/icon.stories.mdx
+++ b/packages/core/src/icon/icon.stories.mdx
@@ -75,17 +75,3 @@ ClarityIcons.addIcons(userIcon);
 ## API
 
 <Props of={'cds-icon'} />
-
-## Legacy API
-
-To create a backwards compatible `clr-icon` import and register the cds-icon
-under a tag alias.
-
-```typescript
-class LegacyIcon extends CdsIcon {}
-customElements.define('clr-icon', LegacyIcon);
-```
-
-<Preview>
-  <Story id="components-icon-stories--legacy" />
-</Preview>

--- a/packages/core/src/icon/icon.stories.ts
+++ b/packages/core/src/icon/icon.stories.ts
@@ -89,7 +89,7 @@ export const all = () => {
     propertiesGroup
   );
   const dir = select(
-    'dir',
+    'direction',
     { 'up (default)': undefined, down: 'down', left: 'left', right: 'right' },
     undefined,
     propertiesGroup
@@ -185,21 +185,25 @@ export const all = () => {
           <div class="dc-icon-boxes ${classMap({ inverse: inverse })}">
             ${iconIndex[k].map(
               i => html`
-            <div class="dc-icon-box" .hidden=${!i.includes(search)}>
-            <cds-icon
-              badge=${badge}
-              status=${iconStatus}
-              ?solid=${solid}
-              size=${size}
-              shape=${i}
-              direction=${ifDefined(dir)}
-              ?inverse=${inverse}
-              flip=${ifDefined(fl)}>
-            </cds-icon>
-            </cds-icon>
-              <p class="dc-icon-name">${i}</p>
-            </div>
-          `
+                <div class="dc-icon-box" .hidden=${!i.includes(search)}>
+                  <cds-icon
+                    aria-label="This is an example of an icon using the ${i} shape"
+                    badge=${badge}
+                    status=${iconStatus}
+                    ?solid=${solid}
+                    size=${size}
+                    shape=${i}
+                    direction=${ifDefined(dir)}
+                    ?inverse=${inverse}
+                    flip=${ifDefined(fl)}
+                  >
+                  </cds-icon>
+                  <span cds-layout="display:screen-reader-only"
+                    >${'The shape needed to display this icon is ' + i}</span
+                  >
+                  <p class="dc-icon-name" aria-hidden="true">${i}</p>
+                </div>
+              `
             )}
           </div>
         </section>
@@ -211,84 +215,208 @@ export const all = () => {
 export const API = (args: any) => {
   return html`
     <cds-demo inline-block>
-      <cds-icon ...="${spreadProps(getElementStorybookArgs(args))}"></cds-icon>
+      <cds-icon
+        ...="${spreadProps(getElementStorybookArgs(args))}"
+        aria-label="This is an icon example that can be used to try out the Clarity icon element's API"
+      ></cds-icon>
     </cds-demo>
   `;
 };
 
 export const icon = () => {
-  return html`<cds-icon shape="user"></cds-icon>`;
+  return html`<cds-icon
+    shape="user"
+    aria-label="This is an icon example that shows how to use the icon element in an application"
+  ></cds-icon>`;
 };
 
 export const sizes = () => {
   return html`
-    <cds-icon size="sm"></cds-icon>
-    <cds-icon size="md"></cds-icon>
-    <cds-icon size="lg"></cds-icon>
-    <cds-icon size="xl"></cds-icon>
-    <cds-icon size="xxl"></cds-icon>
+    <cds-icon size="sm" aria-label="This is an example of an icon using a pre-defined small size"></cds-icon>
+    <cds-icon size="md" aria-label="This is an example of an icon using a pre-defined medium size"></cds-icon>
+    <cds-icon size="lg" aria-label="This is an example of an icon using a pre-defined large size"></cds-icon>
+    <cds-icon size="xl" aria-label="This is an example of an icon using a pre-defined extra large size"></cds-icon>
+    <cds-icon
+      size="xxl"
+      aria-label="This is an example of an icon using a pre-defined extra extra large size"
+    ></cds-icon>
 
-    <cds-icon size="16"></cds-icon>
-    <cds-icon size="24"></cds-icon>
-    <cds-icon size="48"></cds-icon>
-    <cds-icon size="64"></cds-icon>
-    <cds-icon size="128"></cds-icon>
+    <cds-icon
+      size="16"
+      aria-label="This is an example of an icon using a custom size of 16 pixels wide and tall"
+    ></cds-icon>
+    <cds-icon
+      size="24"
+      aria-label="This is an example of an icon using a custom size of 24 pixels wide and tall"
+    ></cds-icon>
+    <cds-icon
+      size="48"
+      aria-label="This is an example of an icon using a custom size of 48 pixels wide and tall"
+    ></cds-icon>
+    <cds-icon
+      size="64"
+      aria-label="This is an example of an icon using a custom size of 64 pixels wide and tall"
+    ></cds-icon>
+    <cds-icon
+      size="128"
+      aria-label="This is an example of an icon using a custom size of 128 pixels wide and tall"
+    ></cds-icon>
   `;
 };
 
 export const badges = () => {
   return html`
-    <cds-icon shape="user" size="lg" badge="info"></cds-icon>
-    <cds-icon shape="user" size="lg" badge="success"></cds-icon>
-    <cds-icon shape="user" size="lg" badge="danger"></cds-icon>
-    <cds-icon shape="user" size="lg" badge="warning"></cds-icon>
-    <cds-icon shape="user" size="lg" badge="warning-triangle"></cds-icon>
+    <cds-icon
+      shape="user"
+      size="lg"
+      badge="info"
+      aria-label="This is an example of an icon of a user with a blue informational badge"
+    ></cds-icon>
+    <cds-icon
+      shape="user"
+      size="lg"
+      badge="success"
+      aria-label="This is an example of an icon of a user with a green badge indicating success"
+    ></cds-icon>
+    <cds-icon
+      shape="user"
+      size="lg"
+      badge="danger"
+      aria-label="This is an example of an icon of a user with a red badge indicating danger or an error"
+    ></cds-icon>
+    <cds-icon
+      shape="user"
+      size="lg"
+      badge="warning"
+      aria-label="This is an example of an icon of a user with a dark orange badge indicating a warning"
+    ></cds-icon>
+    <cds-icon
+      shape="user"
+      size="lg"
+      badge="warning-triangle"
+      aria-label="This is an example of an icon of a user with a dark orange triangle indicating something may be wrong"
+    ></cds-icon>
     <cds-demo inverse inline-block>
-      <cds-icon shape="user" size="lg" badge="inherit-triangle" inverse></cds-icon>
+      <cds-icon
+        shape="user"
+        size="lg"
+        badge="inherit-triangle"
+        inverse
+        aria-label="This is an example of an icon of a user on a dark background with a warning triangle that is the same color as the icon"
+      ></cds-icon>
     </cds-demo>
   `;
 };
 
 export const status = () => {
   return html`
-    <cds-icon shape="user" size="lg"></cds-icon>
-    <cds-icon shape="user" status="info" size="lg"></cds-icon>
-    <cds-icon shape="user" status="success" size="lg"></cds-icon>
-    <cds-icon shape="user" status="warning" size="lg"></cds-icon>
-    <cds-icon shape="user" status="danger" size="lg"></cds-icon>
+    <cds-icon
+      shape="user"
+      size="lg"
+      aria-label="This is an example of an icon of a user with the default color of the surrounding text"
+    ></cds-icon>
+    <cds-icon
+      shape="user"
+      status="info"
+      size="lg"
+      aria-label="This is an example of a blue, informational icon of a user"
+    ></cds-icon>
+    <cds-icon
+      shape="user"
+      status="success"
+      size="lg"
+      aria-label="This is an example of a green icon of a user indicating success"
+    ></cds-icon>
+    <cds-icon
+      shape="user"
+      status="warning"
+      size="lg"
+      aria-label="This is an example of a dark orange icon of a user indicating a warning"
+    ></cds-icon>
+    <cds-icon
+      shape="user"
+      status="danger"
+      size="lg"
+      aria-label="This is an example of a red icon of a user indicating danger or an error"
+    ></cds-icon>
 
-    <cds-icon shape="user" size="lg" solid></cds-icon>
-    <cds-icon shape="user" status="info" size="lg" solid></cds-icon>
-    <cds-icon shape="user" status="success" size="lg" solid></cds-icon>
-    <cds-icon shape="user" status="warning" size="lg" solid></cds-icon>
-    <cds-icon shape="user" status="danger" size="lg" solid></cds-icon>
+    <cds-icon
+      shape="user"
+      size="lg"
+      solid
+      aria-label="This is an example of an icon of a user completely filled in with the default color of the surrounding text"
+    ></cds-icon>
+    <cds-icon
+      shape="user"
+      status="info"
+      size="lg"
+      solid
+      aria-label="This is an example of an icon of a user completely filled in with the blue, informational color"
+    ></cds-icon>
+    <cds-icon
+      shape="user"
+      status="success"
+      size="lg"
+      solid
+      aria-label="This is an example of an icon of a user completely filled in with a green color indicating success"
+    ></cds-icon>
+    <cds-icon
+      shape="user"
+      status="warning"
+      size="lg"
+      solid
+      aria-label="This is an example of an icon of a user completely filled in with a dark orange color indicating warning"
+    ></cds-icon>
+    <cds-icon
+      shape="user"
+      status="danger"
+      size="lg"
+      solid
+      aria-label="This is an example of an icon of a user completely filled in with a red color indicating danger or an error"
+    ></cds-icon>
   `;
 };
 
 export const statusInverse = () => {
   return html`
     <cds-demo inverse inline-block>
-      <cds-icon shape="user" inverse size="lg"></cds-icon>
-      <cds-icon shape="user" inverse status="info" size="lg"></cds-icon>
-      <cds-icon shape="user" inverse status="success" size="lg"></cds-icon>
-      <cds-icon shape="user" inverse status="warning" size="lg"></cds-icon>
-      <cds-icon shape="user" inverse status="danger" size="lg"></cds-icon>
+      <cds-icon shape="user" inverse size="lg" aria-label="This is an example of an icon of a user on a dark background with the default color of the surrounding text"></cds-icon>
+      <cds-icon shape="user" inverse status="info" size="lg" aria-label="This is an example of a blue, informational icon of a user on a dark background"></cds-icon>
+      <cds-icon shape="user" inverse status="success" size="lg" aria-label="This is an example of a green icon of a user on a dark background indicating success"></cds-icon>
+      <cds-icon shape="user" inverse status="warning" size="lg" aria-label="This is an example of a dark orange icon of a user on a dark background indicating a warning"></cds-icon>
+      <cds-icon shape="user" inverse status="danger" size="lg" aria-label="This is an example of a red icon of a user on a dark background indicating danger or an error"></cds-icon>
 
-      <cds-icon shape="user" inverse size="lg" solid></cds-icon>
-      <cds-icon shape="user" inverse status="info" size="lg" solid></cds-icon>
-      <cds-icon shape="user" inverse status="success" size="lg" solid></cds-icon>
-      <cds-icon shape="user" inverse status="warning" size="lg" solid></cds-icon>
-      <cds-icon shape="user" inverse status="danger" size="lg" solid></cds-icon>
+      <cds-icon shape="user" inverse size="lg" solid aria-label="This is an example of an icon of a user completely filled in with the default color of the surrounding text on a dark background"></cds-icon>
+      <cds-icon shape="user" inverse status="info" size="lg" solid aria-label="This is an example of an icon of a user completely filled in with the blue, informational color on a dark background"></cds-icon>
+      <cds-icon shape="user" inverse status="success" size="lg" solid aria-label="This is an example of an icon of a user on a dark background completely filled in with a green color indicating success"></cds-icon>
+      <cds-icon shape="user" inverse status="warning" size="lg" solid aria-label="This is an example of an icon of a user on a dark background completely filled in with a dark orange color indicating warning"></cds-icon>
+      <cds-icon shape="user" inverse status="danger" size="lg" solid aria-label="This is an example of an icon of a user on a dark background completely filled in with a red color indicating danger or an error"></cds-icon>></cds-icon>
     </cds-demo>
   `;
 };
 
 export const direction = () => {
   return html`
-    <cds-icon size="lg" direction="up"></cds-icon>
-    <cds-icon size="lg" direction="left"></cds-icon>
-    <cds-icon size="lg" direction="down"></cds-icon>
-    <cds-icon size="lg" direction="right"></cds-icon>
+    <cds-icon
+      size="lg"
+      direction="up"
+      aria-label="This is an example of an icon whose glyph is directed with its top to point upward. This is the default icon direction."
+    ></cds-icon>
+    <cds-icon
+      size="lg"
+      direction="left"
+      aria-label="This is an example of an icon whose glyph is directed with its top to point to the left."
+    ></cds-icon>
+    <cds-icon
+      size="lg"
+      direction="down"
+      aria-label="This is an example of an icon whose glyph is directed with its top to point downward."
+    ></cds-icon>
+    <cds-icon
+      size="lg"
+      direction="right"
+      aria-label="This is an example of an icon whose glyph is directed with its top to point to the right."
+    ></cds-icon>
   `;
 };
 
@@ -346,84 +474,55 @@ export const customStyles = () => {
       }
     </style>
     <div class="custom-icon-colors a">
-      <cds-icon shape="user" badge class="icon-a"></cds-icon>
+      <cds-icon
+        shape="user"
+        badge
+        class="icon-a"
+        aria-label="This is an example of how an icon can be visually customized."
+      ></cds-icon>
     </div>
     <div class="custom-icon-colors b">
-      <cds-icon shape="user" class="icon-b" badge="warning-triangle"></cds-icon>
+      <cds-icon
+        shape="user"
+        class="icon-b"
+        badge="warning-triangle"
+        aria-label="This is another example of how an icon can be visually customized."
+      ></cds-icon>
     </div>
     <div class="custom-icon-colors c">
-      <cds-icon shape="user" badge class="icon-c"></cds-icon>
+      <cds-icon
+        shape="user"
+        badge
+        class="icon-c"
+        aria-label="This is a third example of how an icon can be visually customized."
+      ></cds-icon>
     </div>
     <p>
-      <i>A should be green with a pink badge</i><br />
-      <i>B should be all pink</i><br />
-      <i>C should be default gray with a yellow badge</i>
+      <i>The first icon should be green with a pink badge</i><br />
+      <i>The second icon should be all pink (even the warning triangle should be pink)</i><br />
+      <i>The third icon should be default gray color with a custom yellow badge</i>
     </p>
   `;
 };
 
 export const flip = () => {
   return html`
-    <cds-icon size="lg" shape="image"></cds-icon>
-    <cds-icon size="lg" flip="vertical" shape="image"></cds-icon>
-    <cds-icon size="lg" flip="horizontal" shape="image"></cds-icon>
-  `;
-};
-
-/** @customElement clr-icon */
-class LegacyIcon extends CdsIcon {}
-registerElementSafely('clr-icon', LegacyIcon);
-
-export const legacy = () => {
-  return html`
-    <h2>Size</h2>
-    <clr-icon shape="info-circle" size="12"></clr-icon>
-    <clr-icon shape="info-circle" size="16"></clr-icon>
-    <clr-icon shape="info-circle" size="36"></clr-icon>
-    <clr-icon shape="info-circle" size="48"></clr-icon>
-    <clr-icon shape="info-circle" size="64"></clr-icon>
-    <clr-icon shape="info-circle" size="72"></clr-icon>
-    <clr-icon shape="info-circle" style="width: 12px; height: 12px;"></clr-icon>
-    <clr-icon shape="info-circle" style="width: 16px; height: 16px;"></clr-icon>
-    <clr-icon shape="info-circle" style="width: 36px; height: 36px;"></clr-icon>
-    <clr-icon shape="info-circle" style="width: 48px; height: 48px;"></clr-icon>
-    <clr-icon shape="info-circle" style="width: 64px; height: 64px;"></clr-icon>
-    <clr-icon shape="info-circle" style="width: 72px; height: 72px;"></clr-icon>
-
-    <h2>Direction</h2>
-    <!-- @ts-ignore -->
-    <div>
-      <clr-icon shape="caret" dir="up"></clr-icon>
-      <clr-icon shape="caret" dir="right"></clr-icon>
-      <clr-icon shape="caret" dir="down"></clr-icon>
-      <clr-icon shape="caret" dir="left"></clr-icon>
-    </div>
-    <clr-icon shape="caret" style="transform: rotate(0deg);"></clr-icon>
-    <clr-icon shape="caret" style="transform: rotate(90deg);"></clr-icon>
-    <clr-icon shape="caret" style="transform: rotate(180deg);"></clr-icon>
-    <clr-icon shape="caret" style="transform: rotate(270deg);"></clr-icon>
-
-    <h2>Flip</h2>
-    <clr-icon shape="floppy"></clr-icon>
-    <clr-icon shape="floppy" flip="horizontal"></clr-icon>
-    <clr-icon shape="floppy" flip="vertical"></clr-icon>
-
-    <h2>Color</h2>
-    <clr-icon shape="info-circle"></clr-icon>
-    <clr-icon shape="info-circle" class="is-highlight"></clr-icon>
-    <clr-icon shape="info-circle" class="is-error"></clr-icon>
-    <clr-icon shape="info-circle" class="is-warning"></clr-icon>
-    <clr-icon shape="info-circle" class="is-success"></clr-icon>
-    <clr-icon shape="info-circle" class="is-info"></clr-icon>
-    <clr-icon shape="info-circle" class="is-inverse"></clr-icon>
-
-    <h2>Badge</h2>
-    <clr-icon shape="user"></clr-icon>
-    <clr-icon shape="user" class="has-alert"></clr-icon>
-    <clr-icon shape="user" class="has-badge"></clr-icon>
-    <clr-icon shape="user" class="is-solid"></clr-icon>
-    <clr-icon shape="user" class="is-solid has-alert"></clr-icon>
-    <clr-icon shape="user" class="is-solid has-badge"></clr-icon>
-    <clr-icon shape="user" class="is-solid has-badge--success"></clr-icon>
+    <cds-icon
+      size="lg"
+      shape="image"
+      aria-label="This is an example of an icon whose glyph is positioned upright. This is the default."
+    ></cds-icon>
+    <cds-icon
+      size="lg"
+      flip="vertical"
+      shape="image"
+      aria-label="This is an example of an icon whose glyph is flipped vertically."
+    ></cds-icon>
+    <cds-icon
+      size="lg"
+      flip="horizontal"
+      shape="image"
+      aria-label="This is an example of an icon whose glyph is flipped horizontally."
+    ></cds-icon>
   `;
 };

--- a/packages/core/test-bundles/bundlesize.json
+++ b/packages/core/test-bundles/bundlesize.json
@@ -27,7 +27,7 @@
     },
     {
       "path": "./dist/core/styles/module.shims.min.css",
-      "maxSize": "4 kB",
+      "maxSize": "3.5 kB",
       "compression": "brotli"
     },
     {
@@ -37,7 +37,7 @@
     },
     {
       "path": "./dist/test-bundles/webpack.bundle.js",
-      "maxSize": "18.5 kB",
+      "maxSize": "17.5 kB",
       "compression": "brotli"
     }
   ]


### PR DESCRIPTION
• removed legacy architecture tying the svg to the icon component via aria-labelledBy
• replaced legacy architecture with aria-labelling on the icon component
• set icon component role to image
• hid the underlying svg inside the icon with aria-hidden because screen readers were "double announcing" it
• fixed unit tests in icons and alerts that were broken by new architecture and still relevant
• updated icon stories to demonstrate accessible use of icons
• fixed 'dir' attr in icons api story to use 'direction'
• verified in voiceover

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Icons in a screen reader are confusing.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Icons in a screen reader make sense now.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

CC: @scroniser