### PR TITLE
fix: columns popup doesn't keep tab focus

### DIFF
--- a/packages/angular/projects/clr-angular/src/utils/popover/popover-close-button.ts
+++ b/packages/angular/projects/clr-angular/src/utils/popover/popover-close-button.ts
@@ -35,7 +35,6 @@ export class ClrPopoverCloseButton implements OnDestroy, AfterViewInit {
   @Output('clrPopoverOnCloseChange') closeChange: EventEmitter<void> = new EventEmitter<void>();
 
   @HostListener('click', ['$event'])
-  @HostListener('keydown', ['$event'])
   handleClick(event: MouseEvent) {
     this.smartOpenService.toggleWithEvent(event);
     this.smartEventsService.setAnchorFocus();

--- a/packages/angular/projects/clr-angular/src/utils/popover/popover-content.spec.ts
+++ b/packages/angular/projects/clr-angular/src/utils/popover/popover-content.spec.ts
@@ -17,7 +17,6 @@ import { ClrPopoverPositionService } from './providers/popover-position.service'
 import { ClrPopoverToggleService } from './providers/popover-toggle.service';
 import { ClrPopoverPosition } from './interfaces/popover-position.interface';
 import { ClrPopoverModuleNext } from './popover.module';
-import { KeyCodes } from '../../utils/enums/key-codes.enum';
 
 @Component({
   selector: 'test-host',
@@ -177,18 +176,6 @@ export default function (): void {
 
         expect(tick).not.toThrowAnyError();
       }));
-
-      it('prevents event default behavior when open with arrow key', function (this: Context) {
-        const anchorButton = this.eventService.anchorButtonRef.nativeElement;
-        anchorButton.focus();
-        this.fixture.detectChanges();
-        const event = new KeyboardEvent('keydown', { key: KeyCodes.ArrowDown });
-        spyOn(event, 'preventDefault');
-        anchorButton.dispatchEvent(event);
-        this.fixture.detectChanges();
-        expect(this.toggleService.open).toBeTrue();
-        expect(event.preventDefault).toHaveBeenCalled();
-      });
     });
   });
 }

--- a/packages/angular/projects/clr-angular/src/utils/popover/popover-open-close-button.ts
+++ b/packages/angular/projects/clr-angular/src/utils/popover/popover-open-close-button.ts
@@ -29,7 +29,6 @@ export class ClrPopoverOpenCloseButton implements OnDestroy {
   @Output('clrPopoverOpenCloseChange') openCloseChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 
   @HostListener('click', ['$event'])
-  @HostListener('keydown', ['$event'])
   handleClick(event: MouseEvent) {
     this.smartOpenService.toggleWithEvent(event);
   }


### PR DESCRIPTION
closes #5097
Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Unable to navigate inside popovers after the "Close" button is focused. Tab key closes the popover, preventing any attempt to get to popover content.

Issue Number: #5097 

## What is the new behavior?

Popovers content is focusable

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
This was caused by a regression introduced with this fix:
https://github.com/vmware/clarity/pull/4774/files
addressing this issue: #3622
Removing the 2 keydown handlers has no effect on the above fix, as the code removed resides in smart popovers. The test is also irrelevant, as it is also in the smart popovers section, which is unrelated to the dropdown.
The only fix that matters is adding prevendefault in the popover-toggle service. Which I left unchanged. Tested manually that my fix does not break the other.