### PR TITLE
fix: unable to unselect from combobox for single select

### DIFF
--- a/packages/angular/projects/clr-angular/src/forms/combobox/providers/option-selection.service.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/providers/option-selection.service.spec.ts
@@ -85,5 +85,13 @@ export default function () {
       optionSelectionService.loading = false;
       expect(optionSelectionService.loading).toBeFalse();
     });
+
+    it('clears selection in single selection mode when input empty', () => {
+      optionSelectionService.currentInput = 'Option 1';
+      optionSelectionService.setSelectionValue('Test value');
+      expect(optionSelectionService.selectionModel.isEmpty()).toBeFalse();
+      optionSelectionService.currentInput = '';
+      expect(optionSelectionService.selectionModel.isEmpty()).toBeTrue();
+    });
   });
 }

--- a/packages/angular/projects/clr-angular/src/forms/combobox/providers/option-selection.service.ts
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/providers/option-selection.service.ts
@@ -20,6 +20,10 @@ export class OptionSelectionService<T> {
     return this._currentInput;
   }
   set currentInput(input) {
+    // clear value in single selection model when input is empty
+    if (!input && !this.multiselectable) {
+      this.setSelectionValue(null);
+    }
     this._currentInput = input;
     this._inputChanged.next(input);
   }


### PR DESCRIPTION
closes #5128
Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Can't unselect in single-seleciton-mode

Issue Number: #5128

## What is the new behavior?

Selection is removed if the input field is cleared

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

