### PR TITLE
fix(dropdown): ensured unlisten method is only called when needed

### DIFF
--- a/packages/angular/projects/clr-angular/src/popover/dropdown/dropdown-item.ts
+++ b/packages/angular/projects/clr-angular/src/popover/dropdown/dropdown-item.ts
@@ -80,6 +80,8 @@ export class ClrDropdownItem implements AfterViewInit {
   }
 
   ngOnDestroy() {
-    this.unlisten();
+    if (this.unlisten) {
+      this.unlisten();
+    }
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently, it is possible for a dropdown item to call its `unlisten` method before it is actually assigned. This results in an error at runtime. This can happen when the dropdown item component is being destroyed but hasn't actually had its view initialized by Angular yet.

Issue Number: N/A

## What is the new behavior?
A simple check is performed that will only call the `unlisten` method when needed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No



## Other information

Thank you!
