### PR TITLE
safe check clr-icon registry in customElements

### DIFF
--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -24,8 +24,10 @@ if (typeof window !== 'undefined') {
   }
 
   // Defining clr-icon custom element
-  // @ts-ignore
-  customElements.define('clr-icon', ClarityIconElement);
+  if (!customElements.get('clr-icon')) {
+    // @ts-ignore
+    customElements.define('clr-icon', ClarityIconElement);
+  }
 }
 
 export { clarityIcons as ClarityIcons };


### PR DESCRIPTION
Check the customElements registry to avoid `clr-icon` being registered twice.
This could happen in a micro frontend architecture with `clr-icon` being registered in multiple micro Apps.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
