### PR TITLE
feat: add no-clr-alert rule to detect the usage of Clarity Angular alerts

### DIFF
--- a/packages/eslint-plugin-clarity-migration/README.md
+++ b/packages/eslint-plugin-clarity-migration/README.md
@@ -37,11 +37,13 @@ yarn add -D @typescript-eslint/parser eslint
 {
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "sourceType": "module"
+    "sourceType": "module",
+    "ecmaVersion": 2015
   },
   "plugins": ["@clr/clarity-migration"],
   "rules": {
-    "@clr/clarity-migration/no-clr-button": "warn"
+    "@clr/clarity-migration/no-clr-button": "warn",
+    "@clr/clarity-migration/no-clr-alert": "warn"
   },
   "overrides": [
     {

--- a/packages/eslint-plugin-clarity-migration/docs/rules/no-clr-alert.md
+++ b/packages/eslint-plugin-clarity-migration/docs/rules/no-clr-alert.md
@@ -1,0 +1,23 @@
+# Disallows usage of Clarity Angular alerts (no-clr-alert)
+
+The use of Clarity Angular alerts is discouraged. Use Clarity Core alerts instead.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```html
+<clr-alert [clrAlertType]="'warning'" *ngIf="warning" (clrAlertClosedChange)="warning = false">
+  <clr-alert-item>
+    <span class="alert-text">Try closing this alert.</span>
+  </clr-alert-item>
+</clr-alert>
+```
+
+Examples of **correct** code for this rule:
+
+```html
+<cds-alert-group status="warning" *ngIf="warning">
+  <cds-alert closable="true" (closeChange)="warning = false">Try closing this alert</cds-alert>
+</cds-alert-group>
+```

--- a/packages/eslint-plugin-clarity-migration/src/index.ts
+++ b/packages/eslint-plugin-clarity-migration/src/index.ts
@@ -1,7 +1,9 @@
 import noClrButton from './rules/no-clr-button';
+import noClrAlert from './rules/no-clr-alert';
 
 module.exports = {
   rules: {
     'no-clr-button': noClrButton,
+    'no-clr-alert': noClrAlert,
   },
 };

--- a/packages/eslint-plugin-clarity-migration/src/rules/no-clr-alert/index.ts
+++ b/packages/eslint-plugin-clarity-migration/src/rules/no-clr-alert/index.ts
@@ -2,40 +2,42 @@ import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
 import { JSDOM } from 'jsdom';
 import { calculateLocation, getDecoratorTemplate, DomElementLocation } from '../utils';
 import { HTMLElement } from '../../types';
-import { primaryDisallowedClass, additionalDisallowedClasses, disallowedButtonsSelector } from './disallowed-classes';
+
+const disallowedAlertsSelector = ['.alert', 'clr-alert'];
 
 export const createESLintRule = ESLintUtils.RuleCreator(() => ``);
-export type MessageIds = 'clrButtonFailure';
-
-function hasDisallowedClasses(classes: Array<string>): boolean {
-  return classes.includes(primaryDisallowedClass) && additionalDisallowedClasses.some(cls => classes.includes(cls));
-}
-
+export type MessageIds = 'clrAlertFailure';
 export default createESLintRule({
-  name: 'no-clr-button',
+  name: 'no-clr-alert',
   meta: {
     type: 'problem',
     docs: {
-      description: 'Disallow use of clr-button',
+      description: 'Disallow use of clr-alert',
       category: 'Best Practices',
       recommended: 'warn',
     },
     fixable: 'code',
     messages: {
-      clrButtonFailure: 'Using clr-button is not allowed!',
+      clrAlertFailure: 'Using clr-alert is not allowed!',
     },
     schema: [{}],
   },
   defaultOptions: [{}],
   create(context) {
     return {
-      'HTMLElement[tagName="button"]'(node: HTMLElement): void {
+      'HTMLElement[tagName="clr-alert"]'(node: HTMLElement): void {
+        context.report({
+          node: node as any,
+          messageId: 'clrAlertFailure',
+        });
+      },
+      'HTMLElement[tagName="div"]'(node: HTMLElement): void {
         const classNode = node.attributes?.find(attribute => attribute.attributeName.value === 'class');
         const classes = classNode?.attributeValue?.value?.split(' ') || [];
-        if (hasDisallowedClasses(classes)) {
+        if (classes.includes('alert')) {
           context.report({
             node: node as any,
-            messageId: 'clrButtonFailure',
+            messageId: 'clrAlertFailure',
           });
         }
       },
@@ -50,14 +52,14 @@ export default createESLintRule({
         const dom = new JSDOM(templateContent, {
           includeNodeLocations: true,
         });
-        const clrButtons = dom.window.document.querySelectorAll(disallowedButtonsSelector);
+        const clrAlerts = dom.window.document.querySelectorAll(disallowedAlertsSelector);
 
-        for (const button of clrButtons) {
-          const nodeLocation = dom.nodeLocation(button) as DomElementLocation;
+        for (const alert of clrAlerts) {
+          const nodeLocation = dom.nodeLocation(alert) as DomElementLocation;
           const loc = calculateLocation(templateContentNode, nodeLocation);
           context.report({
             node: templateContentNode,
-            messageId: 'clrButtonFailure',
+            messageId: 'clrAlertFailure',
             loc,
           });
         }

--- a/packages/eslint-plugin-clarity-migration/src/rules/no-clr-button/disallowed-classes.ts
+++ b/packages/eslint-plugin-clarity-migration/src/rules/no-clr-button/disallowed-classes.ts
@@ -1,0 +1,7 @@
+export const primaryDisallowedClass = 'btn';
+
+export const additionalDisallowedClasses = ['btn-primary', 'btn-success', 'btn-warning', 'btn-danger'];
+
+export const disallowedButtonsSelector = additionalDisallowedClasses.map(
+  cls => `button.${primaryDisallowedClass}.${cls}`
+);

--- a/packages/eslint-plugin-clarity-migration/test/no-clr-alert.spec.ts
+++ b/packages/eslint-plugin-clarity-migration/test/no-clr-alert.spec.ts
@@ -1,0 +1,229 @@
+import { LineAndColumnData } from '@typescript-eslint/types/dist/ts-estree';
+import rule from '../src/rules/no-clr-alert';
+import { RuleTester } from './test-helper';
+
+interface InvalidTest {
+  code: string;
+  errors: Array<{
+    messageId: string;
+    line?: number;
+    column?: number;
+  }>;
+  output?: string;
+}
+
+const alertFailureMessageId = 'clrAlertFailure';
+
+const tsRuleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+  },
+  parser: '@typescript-eslint/parser',
+});
+
+const htmlRuleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+  },
+  parser: '../src/html-parser',
+});
+
+function getInvalidTest(
+  code: string,
+  locations?: Array<LineAndColumnData>,
+  messageIds?: Array<string>,
+  output?: string
+): InvalidTest {
+  if (!messageIds) {
+    messageIds = [alertFailureMessageId];
+  }
+
+  const invalidTest: InvalidTest = {
+    code,
+    errors: [],
+  };
+
+  messageIds.forEach(messageId => {
+    invalidTest.errors.push({ messageId });
+  });
+
+  locations?.forEach((location, index) => {
+    invalidTest.errors[index].line = location.line;
+    invalidTest.errors[index].column = location.column;
+  });
+
+  if (output) {
+    invalidTest.output = output;
+  }
+
+  return invalidTest;
+}
+
+htmlRuleTester.run('no-clr-alert', rule, {
+  invalid: [
+    getInvalidTest(
+      `
+      <clr-alert [clrAlertType]="'danger'" [clrAlertAppLevel]="true">
+        <clr-alert-item>
+          <span class="alert-text">
+            This is an app level alert.
+          </span>
+          <div class="alert-actions">
+            <button class="btn alert-action">Fix</button>
+          </div>
+        </clr-alert-item>
+      </clr-alert>
+      `,
+      [{ line: 2, column: 7 }]
+    ),
+
+    getInvalidTest(
+      `
+      <clr-alerts>
+        <clr-alert [clrAlertType]="'info'" [clrAlertAppLevel]="true">
+          <clr-alert-item>
+          <span class="alert-text">
+            This is the first app level alert.
+          </span>
+          <div class="alert-actions">
+            <button class="btn alert-action">Fix</button>
+          </div>
+        </clr-alert-item>
+        </clr-alert>
+        <clr-alert [clrAlertType]="'danger'" [clrAlertAppLevel]="true">
+          <clr-alert-item>
+          <span class="alert-text">
+            This is a second app level alert.
+          </span>
+          <div class="alert-actions">
+            <button class="btn alert-action">Fix</button>
+          </div>
+          </clr-alert-item>
+        </clr-alert>
+      </clr-alerts>
+      `,
+      [
+        { line: 3, column: 9 },
+        { line: 13, column: 9 },
+      ],
+      [alertFailureMessageId, alertFailureMessageId]
+    ),
+    getInvalidTest(
+      `
+      <div class="alert alert-danger" role="alert">
+        <div class="alert-items">
+            <div class="alert-item static"></div>
+            <div class="alert-item static"></div>
+        </div>
+      </div>
+
+      <div class="alert alert-warning" role="alert">
+        <div class="alert-items">
+          <div class="alert-item static">
+            <div class="alert-icon-wrapper">
+              <clr-icon class="alert-icon" shape="exclamation-triangle"></clr-icon>
+            </div>
+            <span class="alert-text">...</span>
+            <div class="alert-actions">
+              <div class="alert-action dropdown bottom-right open">
+                <button class="dropdown-toggle">
+                  Actions
+                  <clr-icon shape="caret down"></clr-icon>
+                </button>
+                <div class="dropdown-menu">
+                  <a class="dropdown-item" href="...">Shutdown</a>
+                  <a class="dropdown-item" href="...">Suspend</a>
+                  <a class="dropdown-item" href="...">Reboot</a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <button type="button" class="close" aria-label="Close">
+          <clr-icon aria-hidden="true" shape="close"></clr-icon>
+        </button>
+      </div>
+      `,
+      [
+        { line: 2, column: 7 },
+        { line: 9, column: 7 },
+      ],
+      [alertFailureMessageId, alertFailureMessageId]
+    ),
+  ],
+  valid: [
+    `
+      <div class="my-alert"></div>
+    `,
+    `
+      <cl-alert><cl-alert>
+    `,
+    `
+      <alert></alert>
+    `,
+  ],
+});
+
+tsRuleTester.run('no-clr-alert', rule, {
+  invalid: [
+    getInvalidTest(
+      `
+      @Component({
+        template: \`
+          <clr-alert [clrAlertType]="'warning'">
+            <clr-alert-item>
+              <span class="alert-text">
+                Try closing this alert.
+              </span>
+            </clr-alert-item>
+          </clr-alert>
+        \`
+      })
+      export class CustomAlertComponent {
+
+      }
+      `,
+      [{ line: 4, column: 11 }]
+    ),
+    getInvalidTest(
+      `
+      @Component({
+        template: \`
+          <div class="alert alert-danger" role="alert">
+            <div class="alert-items">
+                <div class="alert-item static"></div>
+                <div class="alert-item static"></div>
+            </div>
+          </div>
+        \`
+      })
+      export class CustomAlertComponent {
+
+      }
+      `,
+      [{ line: 4, column: 11 }]
+    ),
+  ],
+  valid: [
+    `
+    @Component({
+      selector: 'app-custom-alert',
+      template: \`
+        <div></div>
+      \`
+      })
+      export class CustomAlertComponent {
+        // Should we catch that case?
+        const myAlert = \`
+          <clr-alert [clrAlertType]="'warning'">
+            <clr-alert-item>
+              <span class="alert-text">
+                Try closing this alert.
+              </span>
+            </clr-alert-item>
+          </clr-alert>
+        \`;
+      }
+    `,
+  ],
+});

--- a/packages/eslint-plugin-clarity-migration/test/no-clr-button.spec.ts
+++ b/packages/eslint-plugin-clarity-migration/test/no-clr-button.spec.ts
@@ -102,7 +102,7 @@ htmlRuleTester.run('no-clr-button', rule, {
     getInvalidTest(
       `
       <button class="btn btn-primary">Le button</button>
-      <div><ul></ul><button class="btn btn-primary"></button></div>
+      <div><ul></ul><button class="btn btn-success"></button></div>
     `,
       [
         { line: 2, column: 7 },
@@ -136,7 +136,7 @@ tsRuleTester.run('no-clr-button', rule, {
       @Component({
         selector: 'app-custom-button',
         template: \`
-          <button class="btn btn-primary custom-class">Primary</button>
+          <button class="btn btn-warning custom-class">Primary</button>
         \`
       })
       export class CustomButtonComponent {
@@ -151,8 +151,8 @@ tsRuleTester.run('no-clr-button', rule, {
         template: \`
           <button class="btn btn-primary custom-class">Primary</button>
           <div>Text</div>
-          <button class="btn btn-primary custom-class">Primary</button>
-          <div>Text</div><button class="btn btn-primary custom-class">Primary</button><p></p>
+          <button class="btn btn-danger custom-class">Primary</button>
+          <div>Text</div><button class="btn btn-success custom-class">Primary</button><p></p>
         \`
       })
       export class CustomButtonComponent {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3314,6 +3314,10 @@
     tslib "^2.0.0"
   optionalDependencies:
     "@clr/city" "^1.1.0"
+    "@webcomponents/custom-elements" "^1.4.2"
+    "@webcomponents/shadycss" "^1.10.1"
+    "@webcomponents/webcomponentsjs" "^2.4.4"
+    css-vars-ponyfill "^2.3.2"
     normalize.css "^8.0.1"
 
 "@clr/react@./packages/react/dist/react":
@@ -8581,6 +8585,16 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
+"@webcomponents/custom-elements@^1.4.2":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@webcomponents/custom-elements/-/custom-elements-1.4.3.tgz#1800d49f38bb4425ebfd160b50115e62776109d7"
+  integrity sha512-iD0YW46SreUQANGccywK/eC+gZELNHocZZrY2fGwrIlx/biQOTkAF9IohisibHbrmIHmA9pVCIdGwzfO+W0gig==
+
+"@webcomponents/shadycss@^1.10.1":
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@webcomponents/shadycss/-/shadycss-1.10.2.tgz#40e03cab6dc5e12f199949ba2b79e02f183d1e7b"
+  integrity sha512-9Iseu8bRtecb0klvv+WXZOVZatsRkbaH7M97Z+f+Pt909R4lDfgUODAnra23DOZTpeMTAkVpf4m/FZztN7Ox1A==
+
 "@webcomponents/shadycss@^1.9.4":
   version "1.9.6"
   resolved "https://registry.yarnpkg.com/@webcomponents/shadycss/-/shadycss-1.9.6.tgz#a8c5db867e49200a05cf8d5008029c09b7861979"
@@ -8590,6 +8604,11 @@
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.4.3.tgz#384f4f6d54563ba465fb4df21fe89e78a76fc530"
   integrity sha512-cV4+sAmshf8ysU2USutrSRYQkJzEYKHsRCGa0CkMElGpG5747VHtkfsW3NdVIBV/m2MDKXTDydT4lkrysH7IFA==
+
+"@webcomponents/webcomponentsjs@^2.4.4":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.5.0.tgz#61b27785a6ad5bfd68fa018201fe418b118cb38d"
+  integrity sha512-C0l51MWQZ9kLzcxOZtniOMohpIFdCLZum7/TEHv3XWFc1Fvt5HCpbSX84x8ltka/JuNKcuiDnxXFkiB2gaePcg==
 
 "@wessberg/ts-evaluator@0.0.25":
   version "0.0.25"
@@ -13500,6 +13519,11 @@ css-vars-ponyfill@2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/css-vars-ponyfill/-/css-vars-ponyfill-2.3.1.tgz#34831c8b35c021e940d157cd497ae235f4b4238e"
   integrity sha512-LHLFhKKQChkQz6nItHU1ZA/ABYJbw489eF0APx2a2FvjT32fAnbqriTLzKsl4KXowuVXcwoRWh8iQNO7wNzuGA==
+
+css-vars-ponyfill@^2.3.2:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/css-vars-ponyfill/-/css-vars-ponyfill-2.4.1.tgz#c711d71253443b77457ad50a6a21c8cc8a7972fc"
+  integrity sha512-duoN5j10VJPdPUgo/H4PwvxhSxhJWgfymjeIGpTA7+KzQ2AmeFHnlKwrCYC9Ii+HUpC8BrIS5fhwcuaNOs/Hrg==
 
 css-what@2.1:
   version "2.1.3"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The usage of Clarity Angular alerts is not being detected.

## What is the new behavior?

The ESLint plugin (`@clr/eslint-clarity-migration`) now has a rule detecting the usage of Clarity Angular alerts.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
