### PR TITLE
fix: updated a11y of alerts and alert groups

### DIFF
--- a/packages/core/src/alert/alert-group.element.spec.ts
+++ b/packages/core/src/alert/alert-group.element.spec.ts
@@ -34,6 +34,11 @@ describe('Alert groups – ', () => {
       removeTestElement(testElement);
     });
 
+    it('should have an aria role of "region" by default', async () => {
+      await componentIsStable(alertGroup);
+      expect(alertGroup.getAttribute('role')).toBe('region');
+    });
+
     it('should sync alerts to alert group when rendered', async () => {
       await componentIsStable(alertGroup);
       const alertGroupSize = alertGroup.size;

--- a/packages/core/src/alert/alert-group.element.ts
+++ b/packages/core/src/alert/alert-group.element.ts
@@ -70,6 +70,12 @@ export class CdsAlertGroup extends LitElement {
   type: AlertGroupTypes = 'default';
 
   /**
+   * Autosets the alert groups aria role to 'region'
+   */
+  @property({ type: String })
+  role = 'region';
+
+  /**
    * @type {default | info | success | warning | danger | unknown | loading}
    * Sets the status of the alerts inside the alert group
    */

--- a/packages/core/src/alert/alert-group.stories.ts
+++ b/packages/core/src/alert/alert-group.stories.ts
@@ -42,13 +42,14 @@ export const API = (args: any) => {
 export const alertGroup = () => {
   return html`
     <div cds-layout="vertical gap:sm">
-      <cds-alert-group status="info">
+      <cds-alert-group status="info" aria-label="This is an example info alert group">
         <cds-alert closable>
-          This example is a closable alert inside an alert group with a status of "info".
+          This example is an alert a user may be able to close inside an alert group with a status of "info".
         </cds-alert>
         <cds-alert closable>
-          <cds-icon shape="node-group" aria-hidden="true"></cds-icon>
-          This example is a closable alert with a custom icon shape inside an alert group with a status of "info".
+          <cds-icon shape="node-group" aria-label="Custom icon of a node group" role="img"></cds-icon>
+          This example is an alert a user may be able to close with a custom icon shape inside an alert group with a
+          status of "info".
         </cds-alert>
         <cds-alert status="loading" closable>
           This example is an alert with a "loading" status and alert action buttons inside an alert group with a status
@@ -62,12 +63,13 @@ export const alertGroup = () => {
         </cds-alert>
       </cds-alert-group>
 
-      <cds-alert-group status="success">
+      <cds-alert-group status="success" aria-label="This is an example success alert group">
         <cds-alert closable>
-          This example is a closable alert inside an alert group with a status of "success".
+          This example is an alert a user may be able to close inside an alert group with a status of "success".
         </cds-alert>
         <cds-alert closable>
-          This example is a closable alert with alert action buttons inside an alert group with a status of "success".
+          This example is an alert a user may be able to close with alert action buttons inside an alert group with a
+          status of "success".
           <cds-alert-actions>
             <cds-button>Button 1</cds-button>
             <cds-button>
@@ -77,12 +79,13 @@ export const alertGroup = () => {
         </cds-alert>
       </cds-alert-group>
 
-      <cds-alert-group status="warning">
+      <cds-alert-group status="warning" aria-label="This is an example warning alert group">
         <cds-alert closable>
-          This example is a closable alert inside an alert group with a status of "warning".
+          This example is an alert a user may be able to close inside an alert group with a status of "warning".
         </cds-alert>
         <cds-alert closable>
-          This example is a closable alert with alert action buttons inside an alert group with a status of "warning".
+          This example is an alert a user may be able to close with alert action buttons inside an alert group with a
+          status of "warning".
           <cds-alert-actions>
             <cds-button>Button 1</cds-button>
             <cds-button>
@@ -92,12 +95,13 @@ export const alertGroup = () => {
         </cds-alert>
       </cds-alert-group>
 
-      <cds-alert-group status="danger">
+      <cds-alert-group status="danger" aria-label="This is an example error or danger alert group">
         <cds-alert closable>
-          This example is a closable alert inside an alert group with a status of "danger".
+          This example is an alert a user may be able to close inside an alert group with a status of "danger".
         </cds-alert>
         <cds-alert closable>
-          This example is a closable alert with alert action buttons inside an alert group with a status of "danger".
+          This example is an alert a user may be able to close with alert action buttons inside an alert group with a
+          status of "danger".
           <cds-alert-actions>
             <cds-button>Button 1</cds-button>
             <cds-button>
@@ -107,15 +111,15 @@ export const alertGroup = () => {
         </cds-alert>
       </cds-alert-group>
 
-      <cds-alert-group>
+      <cds-alert-group aria-label="This is an example alert group">
         <cds-alert>
           This example is an alert inside an alert group.
         </cds-alert>
         <cds-alert closable>
-          This example is a closable alert inside an alert group.
+          This example is an alert a user may be able to close inside an alert group.
         </cds-alert>
         <cds-alert>
-          <cds-icon shape="headphones" aria-hidden="true"></cds-icon>
+          <cds-icon shape="headphones" aria-label="Headphones" role="img"></cds-icon>
           This example is an alert with alert action buttons and a custom icon shape inside an alert group.
           <cds-alert-actions>
             <cds-button>Button 1</cds-button>
@@ -125,13 +129,13 @@ export const alertGroup = () => {
           </cds-alert-actions>
         </cds-alert>
         <cds-alert closable>
-          This example is a closable alert with alert action buttons and multiple lines of text inside an alert group. A
-          block of lorem ipsum sample text follows: Drake Equation take root and flourish culture rings of Uranus quasar
-          hundreds of thousands? Cambrian explosion gathered by gravity of brilliant syntheses vanquish the impossible
-          finite but unbounded not a sunrise but a galaxyrise. Intelligent beings two ghostly white figures in coveralls
-          and helmets are soflty dancing something incredible is waiting to be known vanquish the impossible vastness is
-          bearable only through love concept of the number one and billions upon billions upon billions upon billions
-          upon billions upon billions upon billions.
+          This example is an alert a user may be able to close with alert action buttons and multiple lines of text
+          inside an alert group. A block of lorem ipsum sample text follows: Drake Equation take root and flourish
+          culture rings of Uranus quasar hundreds of thousands? Cambrian explosion gathered by gravity of brilliant
+          syntheses vanquish the impossible finite but unbounded not a sunrise but a galaxyrise. Intelligent beings two
+          ghostly white figures in coveralls and helmets are soflty dancing something incredible is waiting to be known
+          vanquish the impossible vastness is bearable only through love concept of the number one and billions upon
+          billions upon billions upon billions upon billions upon billions upon billions.
           <cds-alert-actions>
             <cds-button>Button 1</cds-button>
           </cds-alert-actions>
@@ -144,21 +148,21 @@ export const alertGroup = () => {
 export const bannerGroupStatus = () => {
   return html`
     <div cds-layout="vertical gap:sm">
-      <cds-alert-group type="banner" status="info">
+      <cds-alert-group type="banner" status="info" aria-label="This is an example banner alert group with a status of info">
         <cds-alert closable>
-          This example is a closable banner alert inside a banner alert group with a status of "info".
+          This example is a banner alert a user may be able to close inside a banner alert group with a status of "info".
         </cds-alert>
       </cds-alert-group>
 
-      <cds-alert-group type="banner" status="success">
+      <cds-alert-group type="banner" status="success" aria-label="This is an example banner alert group with a status of success"></cds-alert-group>
         <cds-alert closable>
-          This example is a closable alert with a status of "success" inside a banner alert group.
+          This example is an alert a user may be able to close with a status of "success" inside a banner alert group.
         </cds-alert>
       </cds-alert-group>
 
-      <cds-alert-group type="banner" status="warning">
+      <cds-alert-group type="banner" status="warning" aria-label="This is an example banner alert group with a status of warning">
         <cds-alert closable>
-          This example is a closable alert with alert action buttons and a status of "warning" inside a banner alert
+          This example is an alert a user may be able to close with alert action buttons and a status of "warning" inside a banner alert
           group.
           <cds-alert-actions>
             <cds-button>Button 1</cds-button>
@@ -169,9 +173,9 @@ export const bannerGroupStatus = () => {
         </cds-alert>
       </cds-alert-group>
 
-      <cds-alert-group type="banner" status="danger">
+      <cds-alert-group type="banner" status="danger" aria-label="This is an example banner alert group with a status of danger or error">
         <cds-alert closable>
-          This example is a closable alert with a status of "danger" inside a banner alert group.
+          This example is an alert a user may be able to close with a status of "danger" inside a banner alert group.
           <cds-alert-actions>
             <cds-button>Button 1</cds-button>
             <cds-button>
@@ -181,7 +185,7 @@ export const bannerGroupStatus = () => {
         </cds-alert>
       </cds-alert-group>
 
-      <cds-alert-group type="banner" status="unknown">
+      <cds-alert-group type="banner" status="unknown" aria-label="This is an example banner alert group with an unknown or undetermined status">
         <cds-alert>
           This example is a non-closable alert with alert actions and a status of "unknown" inside a banner alert group.
           <cds-alert-actions>
@@ -193,7 +197,7 @@ export const bannerGroupStatus = () => {
         </cds-alert>
       </cds-alert-group>
 
-      <cds-alert-group type="banner" status="info">
+      <cds-alert-group type="banner" status="info" aria-label="This is an example banner alert group with a status of info and a loading alert within it">
         <cds-alert status="loading">
           This example is an alert with alert actions and a status of "loading" inside a banner alert group.
           <cds-alert-actions>
@@ -208,30 +212,33 @@ export const bannerGroupStatus = () => {
 export const bannerGroup = () => {
   return html`
     <div cds-layout="vertical gap:sm">
-      <cds-alert-group type="banner">
+      <cds-alert-group type="banner" aria-label="This is an example banner alert group">
         <cds-alert closable>
-          <cds-icon shape="node-group" aria-hidden="true"></cds-icon>
-          This example is a closable alert with a custom icon shape inside a banner alert group.
+          <cds-icon shape="node-group" aria-label="Custom icon of a node group" role="img"></cds-icon>
+          This example is an alert a user may be able to close with a custom icon shape inside a banner alert group.
         </cds-alert>
       </cds-alert-group>
 
-      <cds-alert-group type="banner">
+      <cds-alert-group
+        type="banner"
+        aria-label="This is an example banner alert group with an alert whose text is really long"
+      >
         <cds-alert closable>
-          <cds-icon shape="headphones" aria-hidden="true"></cds-icon>
-          This example is a closable alert with alert action buttons, a custom icon, and multiple lines of text inside a
-          banner alert group. A block of lorem ipsum sample text follows: Drake Equation take root and flourish culture
-          rings of Uranus quasar hundreds of thousands? Cambrian explosion gathered by gravity of brilliant syntheses
-          vanquish the impossible finite but unbounded not a sunrise but a galaxyrise. Intelligent beings two ghostly
-          white figures in coveralls and helmets are soflty dancing something incredible is waiting to be known vanquish
-          the impossible vastness is bearable only through love concept of the number one and billions upon billions
-          upon billions upon billions upon billions upon billions upon billions.
+          <cds-icon shape="headphones" aria-label="Headphones" role="img"></cds-icon>
+          This example is an alert a user may be able to close with alert action buttons, a custom icon, and multiple
+          lines of text inside a banner alert group. A block of lorem ipsum sample text follows: Drake Equation take
+          root and flourish culture rings of Uranus quasar hundreds of thousands? Cambrian explosion gathered by gravity
+          of brilliant syntheses vanquish the impossible finite but unbounded not a sunrise but a galaxyrise.
+          Intelligent beings two ghostly white figures in coveralls and helmets are soflty dancing something incredible
+          is waiting to be known vanquish the impossible vastness is bearable only through love concept of the number
+          one and billions upon billions upon billions upon billions upon billions upon billions upon billions.
           <cds-alert-actions>
             <cds-button>Button 1</cds-button>
           </cds-alert-actions>
         </cds-alert>
       </cds-alert-group>
 
-      <cds-alert-group size="sm" type="banner">
+      <cds-alert-group size="sm" type="banner" aria-label="This is an example banner alert group">
         <cds-alert>
           This example shows that a banner alert group should ignore compact sizing.
           <cds-alert-actions>
@@ -345,7 +352,7 @@ export const compactAlertGroup = () => {
           This example is a closable alert inside a compact alert group with a status of "info".
         </cds-alert>
         <cds-alert closable>
-          <cds-icon shape="node-group" aria-hidden="true"></cds-icon>
+          <cds-icon shape="node-group" aria-label="Custom icon of a node group" role="img"></cds-icon>
           This example is a closable alert with alert actions and a custom icon shape inside a compact alert group with
           a status of "info".
           <cds-alert-actions>
@@ -378,7 +385,7 @@ export const compactAlertGroup = () => {
           This example is a closable alert inside a compact alert group with a status of "warning".
         </cds-alert>
         <cds-alert closable>
-          <cds-icon shape="headphones" aria-hidden="true"></cds-icon>
+          <cds-icon shape="headphones" aria-label="Headphones" role="img"></cds-icon>
           This example is a closable alert with alert actions and a custom icon shape inside a compact alert group with
           a status of "warning".
           <cds-alert-actions>

--- a/packages/core/src/alert/alert.element.spec.ts
+++ b/packages/core/src/alert/alert.element.spec.ts
@@ -357,17 +357,17 @@ describe('Alert element – ', () => {
       expect(component.getAttribute('role')).toBe('region', 'role is set to "region" on alert element');
     });
 
-    it('should use "aria-hidden" on the alert icon', async () => {
+    it('should use "aria-label" on the alert icon', async () => {
       await componentIsStable(component);
       let alertIcon = component.shadowRoot.querySelector('cds-icon.alert-status-icon');
-      expect(alertIcon.getAttribute('aria-hidden')).toBe('true', 'default alert has aria-hidden true');
+      expect(alertIcon.getAttribute('aria-label')).toBe('Info', 'default alert has aria-label "Info"');
 
       component.setAttribute('status', 'danger');
       await componentIsStable(component);
       expect(alertIcon.getAttribute('shape')).toBe('error-standard', 'verify status has changed');
-      expect(alertIcon.getAttribute('aria-hidden')).toBe(
-        'true',
-        'icon shapes have aria-hidden true after status change'
+      expect(alertIcon.getAttribute('aria-label')).toBe(
+        'Error',
+        'icon shapes have aria-label "Error" after status change'
       );
 
       component.setAttribute('status', 'loading');
@@ -375,9 +375,9 @@ describe('Alert element – ', () => {
       alertIcon = component.shadowRoot.querySelector('.alert-spinner');
       expect(component.shadowRoot.querySelector('cds-icon.alert-icon')).toBeNull('verify loading status pt. 1');
       expect(alertIcon).not.toBeNull('verify loading status pt. 2');
-      expect(alertIcon.getAttribute('aria-hidden')).toBe(
-        'true',
-        'loading spinner has aria-hidden true after status changed to loading'
+      expect(alertIcon.getAttribute('aria-label')).toBe(
+        'Loading',
+        'loading spinner has aria-label "Loading" after status changed to loading'
       );
     });
   });

--- a/packages/core/src/alert/alert.element.ts
+++ b/packages/core/src/alert/alert.element.ts
@@ -52,9 +52,14 @@ export function iconShapeIsAlertStatusType(shape: string): boolean {
   return statusShapes.indexOf(shape) > -1;
 }
 
+export function getIconStatusLabel(status: string): string {
+  return getIconStatusTuple(status)[1];
+}
+
 export function getIconStatusShape(status: string): string {
   return getIconStatusTuple(status)[0];
 }
+
 export function getAlertContentLayout(
   containerType: 'wrapper' | 'content' | 'actions',
   alertGroupType: AlertGroupTypes,
@@ -164,6 +169,10 @@ export class CdsAlert extends LitElement {
   @property({ type: String })
   status: AlertStatusTypes = 'default';
 
+  /**
+   * @deprecated
+   * TODO: replace this with commonstrings when that work is ready
+   */
   @property({ type: String })
   closeIconTitle = CommonStringsService.keys.alertCloseButtonAriaLabel;
 
@@ -198,19 +207,21 @@ export class CdsAlert extends LitElement {
         ${this.type === 'banner' && !this.parentGroupHasPager
           ? html`<span class="alert-spacer" cds-layout="align:stretch">&nbsp;</span>`
           : html``}
-        <span class="alert-icon-wrapper" aria-hidden="true" cds-layout="horizontal">
+        <span class="alert-icon-wrapper" cds-layout="horizontal">
           ${this.status === 'loading'
             ? html`<cds-progress-circle
                 class="alert-spinner"
                 size="${this.type === 'banner' ? '20' : '18'}"
-                aria-hidden="true"
+                aria-label="${getIconStatusLabel(this.status)}"
+                role="img"
                 cds-layout="align:horizontal-center"
               ></cds-progress-circle>`
             : html`<slot name="alert-icon"
                 ><cds-icon
                   class="alert-status-icon"
                   shape="${getIconStatusShape(this.status)}"
-                  aria-hidden="true"
+                  role="img"
+                  aria-label="${getIconStatusLabel(this.status)}"
                   cds-layout="align:horizontal-center"
                 ></cds-icon
               ></slot>`}

--- a/packages/core/src/alert/alert.stories.ts
+++ b/packages/core/src/alert/alert.stories.ts
@@ -92,11 +92,12 @@ export const status = () => {
       <cds-alert status="loading">This is an alert with a status of "loading"</cds-alert>
       <cds-alert status="unknown">This is an alert with a status of "unknown"</cds-alert>
       <cds-alert status="danger"
-        ><cds-icon shape="times-circle" solid></cds-icon>This is an alert with a status of "danger" and a custom
-        icon</cds-alert
+        ><cds-icon shape="times-circle" aria-label="Warning" role="img" solid></cds-icon>This is an alert with a status
+        of "danger" and a custom icon</cds-alert
       >
       <cds-alert
-        ><cds-icon shape="user" solid badge></cds-icon>This is an alert with a badged, solid custom icon</cds-alert
+        ><cds-icon shape="user" aria-label="User" role="img" solid badge></cds-icon>This is an alert with a badged,
+        solid custom icon</cds-alert
       >
     </div>
   `;

--- a/packages/core/src/progress-circle/progress-circle.element.spec.ts
+++ b/packages/core/src/progress-circle/progress-circle.element.spec.ts
@@ -80,7 +80,7 @@ describe('progress circle element – ', () => {
     it('should not have aria attrs if value is not set', async () => {
       await componentIsStable(componentUnset);
       expect(componentUnset.hasAttribute('aria-valuenow')).toBe(false, 'aria-valuenow should not be present');
-      expect(componentUnset.hasAttribute('role')).toBe(false, 'role should not be present');
+      expect(componentUnset.getAttribute('role')).toBe('img', 'role should be set to "img"');
       expect(componentUnset.hasAttribute('aria-valuemin')).toBe(false, 'aria-valuenow should not be present');
       expect(componentUnset.hasAttribute('aria-valuemax')).toBe(false, 'aria-valuenow should not be present');
     });
@@ -118,7 +118,7 @@ describe('progress circle element – ', () => {
       component.value = undefined;
       await componentIsStable(component);
       expect(component.hasAttribute('aria-valuenow')).toBe(false, 'aria-valuenow should not be present');
-      expect(component.hasAttribute('role')).toBe(false, 'role should not be present');
+      expect(component.getAttribute('role')).toBe('img', 'role should be "img"');
       expect(component.hasAttribute('aria-valuemin')).toBe(false, 'aria-valuenow should not be present');
       expect(component.hasAttribute('aria-valuemax')).toBe(false, 'aria-valuenow should not be present');
     });

--- a/packages/core/src/progress-circle/progress-circle.element.ts
+++ b/packages/core/src/progress-circle/progress-circle.element.ts
@@ -116,17 +116,19 @@ export class CdsProgressCircle extends LitElement {
 
   private setAriaAttributes() {
     const currentValue = this.value;
-    const ariaAttrs: HTMLAttributeTuple[] = [
+    const ariaAttrsIfValue: HTMLAttributeTuple[] = [
       ['role', 'progressbar'],
       ['aria-valuemin', '0'],
       ['aria-valuemax', '100'],
       ['aria-valuenow', currentValue + ''],
     ];
-
-    const attrsToSet: HTMLAttributeTuple[] = ariaAttrs.map(valTuple => {
-      // remove progressbar aria when value is nil; it's a spinner not a progressbar
-      return isNil(currentValue) ? ([valTuple[0], false] as HTMLAttributeTuple) : (valTuple as HTMLAttributeTuple);
-    });
+    const ariaAttrsNoValue: HTMLAttributeTuple[] = [
+      ['role', 'img'],
+      ['aria-valuemin', false],
+      ['aria-valuemax', false],
+      ['aria-valuenow', false],
+    ];
+    const attrsToSet = isNil(currentValue) ? ariaAttrsNoValue : ariaAttrsIfValue;
 
     setAttributes(this, ...attrsToSet);
   }


### PR DESCRIPTION
• improved a11y of progress circles and icons in alerts
• made alert groups into regions so that SR rotors can pick them up and it is clearer what they are
• updated unit tests to account for aria changes
• updated stories to give better code examples of accessible alerts and alert groups

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

this PR addresses two line items in our a11y audit.

## Does this PR introduce a breaking change?

- [x] Yes* (debatably. i'm not certain it present public-facing breaking changes)
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
