### PR TITLE
fix: updated a11y of forms and form input groups

### DIFF
--- a/packages/core/src/forms/control-action/control-action.element.spec.ts
+++ b/packages/core/src/forms/control-action/control-action.element.spec.ts
@@ -39,4 +39,31 @@ describe('cds-control-action', () => {
     await componentIsStable(controlAction);
     expect(LogService.warn).toHaveBeenCalled();
   });
+
+  describe('syncAria: ', () => {
+    it('should set aria-hidden on read-only', async () => {
+      const testElement = await createTestElement(html` <cds-control-action readonly>test</cds-control-action>`);
+      const testControlAction = testElement.querySelector<CdsControlAction>('cds-control-action');
+      expect(testControlAction.getAttribute('aria-hidden')).toBe('true');
+      removeTestElement(testElement);
+    });
+
+    it('should not set aria-hidden when aria-label is present', async () => {
+      const testElement = await createTestElement(
+        html` <cds-control-action aria-label="ohai">test</cds-control-action>`
+      );
+      const testControlAction = testElement.querySelector<CdsControlAction>('cds-control-action');
+      expect(testControlAction.hasAttribute('aria-hidden')).toBe(false);
+      removeTestElement(testElement);
+    });
+
+    it('should not set aria-hidden when aria-label is present, even if read-only', async () => {
+      const testElement = await createTestElement(
+        html` <cds-control-action readonly aria-label="ohai">test</cds-control-action>`
+      );
+      const testControlAction = testElement.querySelector<CdsControlAction>('cds-control-action');
+      expect(testControlAction.hasAttribute('aria-hidden')).toBe(false);
+      removeTestElement(testElement);
+    });
+  });
 });

--- a/packages/core/src/forms/control-action/control-action.element.ts
+++ b/packages/core/src/forms/control-action/control-action.element.ts
@@ -6,7 +6,14 @@
 
 import { html, property } from 'lit-element';
 import { CdsIcon } from '@clr/core/icon/icon.element.js';
-import { baseStyles, CdsBaseButton, querySlot, setAttributes, assignSlotNames } from '@clr/core/internal';
+import {
+  assignSlotNames,
+  baseStyles,
+  CdsBaseButton,
+  hasAttributeAndIsNotEmpty,
+  querySlot,
+  setOrRemoveAttribute,
+} from '@clr/core/internal';
 import { styles } from './control-action.element.css.js';
 import { LogService } from '@clr/core/internal';
 
@@ -30,6 +37,10 @@ export class CdsControlAction extends CdsBaseButton {
   /** Set the action type placement within the supporting input control */
   @property({ type: String }) action: 'label' | 'prefix' | 'suffix';
 
+  @property({ type: Boolean }) readonly = false;
+
+  @property({ type: String }) ariaLabel = '';
+
   @querySlot('cds-icon') protected icon: CdsIcon;
 
   static get styles() {
@@ -47,7 +58,16 @@ export class CdsControlAction extends CdsBaseButton {
 
   connectedCallback() {
     super.connectedCallback();
-    setAttributes(this, ['aria-hidden', 'true']);
+    this.syncAria();
+  }
+
+  // TODO: TESTME
+  private syncAria() {
+    const iAmReadonly = this.readonly;
+    const iHaveAriaLabel = hasAttributeAndIsNotEmpty(this, 'aria-label');
+    setOrRemoveAttribute(this, ['aria-hidden', 'true'], () => {
+      return iAmReadonly && !iHaveAriaLabel;
+    });
   }
 
   updated(props: Map<string, any>) {
@@ -56,8 +76,9 @@ export class CdsControlAction extends CdsBaseButton {
       this.setSlotLocation();
     }
 
-    if (props.has('readonly')) {
+    if (props.has('readonly') || props.has('ariaLabel')) {
       this.validateAriaLabel();
+      this.syncAria();
     }
   }
 

--- a/packages/core/src/forms/control-action/control-action.element.ts
+++ b/packages/core/src/forms/control-action/control-action.element.ts
@@ -61,7 +61,6 @@ export class CdsControlAction extends CdsBaseButton {
     this.syncAria();
   }
 
-  // TODO: TESTME
   private syncAria() {
     const iAmReadonly = this.readonly;
     const iHaveAriaLabel = hasAttributeAndIsNotEmpty(this, 'aria-label');

--- a/packages/core/src/forms/forms.stories.mdx
+++ b/packages/core/src/forms/forms.stories.mdx
@@ -101,6 +101,19 @@ To use RTL add the `<html dir="rtl">` to the HTML root element. Learn more at
   <Story id="forms-preview-forms-stories--internationalization" />
 </Preview>
 
+## Fieldsets, Form Groupings, and Accessibility
+
+<cds-alert status="danger">Use of the `fieldset` and `legend` HTML elements inside a form group is discouraged.</cds-alert>
+
+The use of the `fieldset` HTML element and its corresponding `legend` element inside a `cds-form-group` component or inside another element using the `cds-layout` attribute is not recommended.
+
+The `fieldset` element responds erratically to flex and grid CSS layouts. This is a browser rendering issue and not an issue in Clarity.
+
+A recommended workaround is to use the `group` aria role and associate an `aria-labelledby` value with an existing header in the form group.
+
+An example of how this would work <a href="iframe.html?id=forms-preview-forms-stories--checkout-form&amp%3BviewMode=story&viewMode=story" target="_blank">
+can be found in this example form</a>.
+
 ## Form API
 
 <Props of={'cds-form-group'} />

--- a/packages/core/src/forms/forms.stories.ts
+++ b/packages/core/src/forms/forms.stories.ts
@@ -37,7 +37,7 @@ export const nativeHTML5ValidationSingle = () => {
   return html`
     <cds-input validate>
       <label>text input (required)</label>
-      <input placeholder="placeholder text" required />
+      <input placeholder="place holder text" required />
       <cds-control-message error="valueMissing">required</cds-control-message>
     </cds-input>
   `;
@@ -99,7 +99,7 @@ export const form = () => {
       <cds-form-group control-width="shrink">
         <cds-input>
           <label>text label</label>
-          <input placeholder="placeholder text" />
+          <input placeholder="place holder text" />
         </cds-input>
 
         <cds-select>
@@ -114,7 +114,7 @@ export const form = () => {
 
         <cds-datalist>
           <label>datalist label</label>
-          <input placeholder="placeholder text" />
+          <input placeholder="place holder text" />
           <datalist>
             <option value="Item 1"></option>
             <option value="Item 2"></option>
@@ -149,8 +149,18 @@ export const form = () => {
           <cds-input>
             <label>Host Port</label>
             <input placeholder="localhost:8000" type="url" />
-            <cds-control-action action="suffix" readonly aria-label="host status stable" title="host status stable">
-              <cds-icon shape="cloud" badge="success"></cds-icon>
+            <cds-control-action
+              action="suffix"
+              readonly
+              aria-label="Icon indicating that the selected host status is stable"
+              title="Icon indicating that the selected host status is stable"
+            >
+              <cds-icon
+                shape="cloud"
+                badge="success"
+                role="img"
+                aria-label="Icon of host cloud with green badge"
+              ></cds-icon>
             </cds-control-action>
           </cds-input>
           <cds-control-message>Host ID: 123456</cds-control-message>
@@ -241,7 +251,7 @@ export const vertical = () => {
       <cds-form-group layout="vertical">
         <cds-input>
           <label>text label</label>
-          <input placeholder="placeholder text" />
+          <input placeholder="place holder text" />
         </cds-input>
 
         <cds-select>
@@ -256,7 +266,7 @@ export const vertical = () => {
 
         <cds-datalist>
           <label>datalist label</label>
-          <input placeholder="placeholder text" />
+          <input placeholder="place holder text" />
           <datalist>
             <option value="Item 1"></option>
             <option value="Item 2"></option>
@@ -383,7 +393,7 @@ export const verticalInline = () => {
       <cds-form-group layout="vertical-inline">
         <cds-input>
           <label>text label</label>
-          <input placeholder="placeholder text" />
+          <input placeholder="place holder text" />
         </cds-input>
 
         <cds-select>
@@ -398,7 +408,7 @@ export const verticalInline = () => {
 
         <cds-datalist>
           <label>datalist label</label>
-          <input placeholder="placeholder text" />
+          <input placeholder="place holder text" />
           <datalist>
             <option value="Item 1"></option>
             <option value="Item 2"></option>
@@ -525,7 +535,7 @@ export const horizontal = () => {
       <cds-form-group layout="horizontal">
         <cds-input>
           <label>text label</label>
-          <input placeholder="placeholder text" />
+          <input placeholder="place holder text" />
         </cds-input>
 
         <cds-select>
@@ -540,7 +550,7 @@ export const horizontal = () => {
 
         <cds-datalist>
           <label>datalist label</label>
-          <input placeholder="placeholder text" />
+          <input placeholder="place holder text" />
           <datalist>
             <option value="Item 1"></option>
             <option value="Item 2"></option>
@@ -667,7 +677,7 @@ export const horizontalInline = () => {
       <cds-form-group layout="horizontal-inline">
         <cds-input>
           <label>text label</label>
-          <input placeholder="placeholder text" />
+          <input placeholder="place holder text" />
         </cds-input>
 
         <cds-select>
@@ -682,7 +692,7 @@ export const horizontalInline = () => {
 
         <cds-datalist>
           <label>datalist label</label>
-          <input placeholder="placeholder text" />
+          <input placeholder="place holder text" />
           <datalist>
             <option value="Item 1"></option>
             <option value="Item 2"></option>
@@ -809,7 +819,7 @@ export const compact = () => {
       <cds-form-group layout="compact">
         <cds-input>
           <label>text label</label>
-          <input placeholder="placeholder text" />
+          <input placeholder="place holder text" />
         </cds-input>
 
         <cds-select>
@@ -824,7 +834,7 @@ export const compact = () => {
 
         <cds-datalist>
           <label>datalist label</label>
-          <input placeholder="placeholder text" />
+          <input placeholder="place holder text" />
           <datalist>
             <option value="Item 1"></option>
             <option value="Item 2"></option>
@@ -953,7 +963,7 @@ export const compactShrink = () => {
       <cds-form-group layout="compact" control-width="shrink">
         <cds-input>
           <label>text label</label>
-          <input placeholder="placeholder text" />
+          <input placeholder="place holder text" />
         </cds-input>
 
         <cds-select>
@@ -968,7 +978,7 @@ export const compactShrink = () => {
 
         <cds-datalist>
           <label>datalist label</label>
-          <input placeholder="placeholder text" />
+          <input placeholder="place holder text" />
           <datalist>
             <option value="Item 1"></option>
             <option value="Item 2"></option>
@@ -1097,7 +1107,7 @@ export const controlWidth = () => {
       <cds-form-group control-width="shrink">
         <cds-input>
           <label>text label</label>
-          <input placeholder="placeholder text" />
+          <input placeholder="place holder text" />
         </cds-input>
 
         <cds-select>
@@ -1112,7 +1122,7 @@ export const controlWidth = () => {
 
         <cds-datalist>
           <label>datalist label</label>
-          <input placeholder="placeholder text" />
+          <input placeholder="place holder text" />
           <datalist>
             <option value="Item 1"></option>
             <option value="Item 2"></option>
@@ -1428,7 +1438,7 @@ export const responsive = () => {
       <cds-form-group layout="horizontal-inline">
         <cds-input>
           <label>text label</label>
-          <input placeholder="placeholder text" />
+          <input placeholder="place holder text" />
           <cds-control-message>message text</cds-control-message>
         </cds-input>
 
@@ -1500,7 +1510,7 @@ export const longText = () => {
             >Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
             dolore magna aliqua. Ut enim ad minim veniam</label
           >
-          <input placeholder="placeholder text" />
+          <input placeholder="place holder text" />
           <cds-control-message
             >Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
             dolore magna aliqua. Ut enim ad minim veniam</cds-control-message
@@ -1538,7 +1548,7 @@ export const longText = () => {
             >Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
             dolore magna aliqua. Ut enim ad minim veniam</label
           >
-          <input placeholder="placeholder text" />
+          <input placeholder="place holder text" />
           <cds-control-message
             >Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
             dolore magna aliqua. Ut enim ad minim veniam</cds-control-message
@@ -1576,7 +1586,7 @@ export const longText = () => {
             >Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
             dolore magna aliqua. Ut enim ad minim veniam</label
           >
-          <input placeholder="placeholder text" />
+          <input placeholder="place holder text" />
           <cds-control-message status="error"
             >Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
             dolore magna aliqua. Ut enim ad minim veniam</cds-control-message
@@ -1611,7 +1621,7 @@ export const longText = () => {
       <cds-form-group layout="vertical">
         <cds-input>
           <label>Lorem ipsum</label>
-          <input placeholder="placeholder text" />
+          <input placeholder="place holder text" />
           <cds-control-message>Lorem ipsum</cds-control-message>
         </cds-input>
 
@@ -1637,7 +1647,7 @@ export const longText = () => {
       <cds-form-group layout="horizontal">
         <cds-input>
           <label>Lorem ipsum</label>
-          <input placeholder="placeholder text" />
+          <input placeholder="place holder text" />
           <cds-control-message>Lorem ipsum</cds-control-message>
         </cds-input>
 
@@ -1663,7 +1673,7 @@ export const longText = () => {
       <cds-form-group layout="compact">
         <cds-input>
           <label>Lorem ipsum</label>
-          <input placeholder="placeholder text" />
+          <input placeholder="place holder text" />
           <cds-control-message>Lorem ipsum</cds-control-message>
         </cds-input>
 
@@ -1723,125 +1733,130 @@ export const multiColumn = () => {
 export const checkoutForm = () => {
   return html`
     <cds-form-group layout="vertical" cds-layout="container:sm">
-      <p cds-text="section">Billing Address</p>
+      <div cds-layout="vertical gap:xl">
+        <fieldset cds-layout="vertical gap:md">
+          <legend cds-text="section">Billing Address</legend>
 
-      <div cds-layout="grid cols@xs:6 gap:lg">
-        <cds-input>
-          <label>first name</label>
-          <input type="text" />
-        </cds-input>
+          <div cds-layout="grid cols@xs:6 gap:lg p-t:sm">
+            <cds-input>
+              <label>first name</label>
+              <input type="text" />
+            </cds-input>
 
-        <cds-input>
-          <label>last name</label>
-          <input type="text" />
-        </cds-input>
+            <cds-input>
+              <label>last name</label>
+              <input type="text" />
+            </cds-input>
+          </div>
+
+          <cds-input>
+            <label>email</label>
+            <input type="email" placeholder="you@example.com" />
+          </cds-input>
+
+          <div cds-layout="grid cols@xs:6 gap:lg p-t:sm">
+            <cds-input>
+              <label>address</label>
+              <input type="text" placeholder="1234 Main St." />
+            </cds-input>
+
+            <cds-input>
+              <label>address 2</label>
+              <input type="text" placeholder="Apartment or Suite" />
+              <cds-control-message>(optional)</cds-control-message>
+            </cds-input>
+          </div>
+
+          <div cds-layout="grid gap:lg p-t:sm">
+            <cds-select cds-layout="col@xs:6 col@sm:5">
+              <label>Country</label>
+              <select>
+                <option>choose...</option>
+                <option>United States</option>
+              </select>
+            </cds-select>
+
+            <cds-select cds-layout="col@xs:6 col@sm:4">
+              <label>State</label>
+              <select>
+                <option>choose...</option>
+                <option>California</option>
+              </select>
+            </cds-select>
+
+            <cds-input cds-layout="col@sm:3">
+              <label>Postal Code</label>
+              <input type="text" placeholder="" />
+            </cds-input>
+          </div>
+        </fieldset>
+
+        <fieldset cds-layout="vertical gap:md">
+          <legend cds-text="section">Payment</legend>
+          <cds-radio-group cds-layout="p-t:sm">
+            <label>payment type</label>
+            <cds-radio>
+              <label>credit card</label>
+              <input type="radio" value="1" checked />
+            </cds-radio>
+            <cds-radio>
+              <label>debt card</label>
+              <input type="radio" value="2" />
+            </cds-radio>
+            <cds-radio>
+              <label>paypal</label>
+              <input type="radio" value="3" />
+            </cds-radio>
+          </cds-radio-group>
+
+          <cds-checkbox-group cds-layout="p-t:md">
+            <label>Shipping Details</label>
+            <cds-checkbox>
+              <label>Shipping address is the same as my billing address</label>
+              <input type="checkbox" />
+            </cds-checkbox>
+            <cds-checkbox>
+              <label>Save this information for next time</label>
+              <input type="checkbox" />
+            </cds-checkbox>
+          </cds-checkbox-group>
+
+          <div cds-layout="grid cols@xs:6 gap:lg p-t:md">
+            <cds-input>
+              <label>name on card</label>
+              <input type="text" />
+              <cds-control-message>full name as displayed on card</cds-control-message>
+            </cds-input>
+
+            <cds-input>
+              <label>credit card number</label>
+              <input type="number" />
+            </cds-input>
+          </div>
+
+          <div cds-layout="grid gap:lg p-t:md">
+            <cds-input cds-layout="cols@xs:6 col@sm:4">
+              <label>expiration</label>
+              <input type="text" />
+            </cds-input>
+
+            <cds-input cds-layout="cols@xs:6 col@sm:3">
+              <label>CVV</label>
+              <input type="number" />
+            </cds-input>
+
+            <cds-input cds-layout="col@sm:5">
+              <label>promo code</label>
+              <input type="text" />
+              <cds-control-action action="suffix" aria-label="add promo code">
+                <cds-icon shape="add"></cds-icon>
+              </cds-control-action>
+            </cds-input>
+          </div>
+        </fieldset>
+
+        <cds-button cds-layout="m-t:lg">continue to checkout</cds-button>
       </div>
-
-      <cds-input>
-        <label>email</label>
-        <input type="email" placeholder="you@example.com" />
-      </cds-input>
-
-      <div cds-layout="grid cols@xs:6 gap:lg">
-        <cds-input>
-          <label>address</label>
-          <input type="text" placeholder="1234 Main St." />
-        </cds-input>
-
-        <cds-input>
-          <label>address 2</label>
-          <input type="text" placeholder="Apartment or Suite" />
-          <cds-control-message>(optional)</cds-control-message>
-        </cds-input>
-      </div>
-
-      <div cds-layout="grid gap:lg">
-        <cds-select cds-layout="col@xs:6 col@sm:5">
-          <label>Country</label>
-          <select>
-            <option>choose...</option>
-            <option>United States</option>
-          </select>
-        </cds-select>
-
-        <cds-select cds-layout="col@xs:6 col@sm:4">
-          <label>State</label>
-          <select>
-            <option>choose...</option>
-            <option>California</option>
-          </select>
-        </cds-select>
-
-        <cds-input cds-layout="col@sm:3">
-          <label>Postal Code</label>
-          <input type="text" placeholder="" />
-        </cds-input>
-      </div>
-
-      <p cds-text="section" cds-layout="m-t:xl">Payment</p>
-
-      <cds-radio-group>
-        <label>payment type</label>
-        <cds-radio>
-          <label>credit card</label>
-          <input type="radio" value="1" checked />
-        </cds-radio>
-        <cds-radio>
-          <label>debt card</label>
-          <input type="radio" value="2" />
-        </cds-radio>
-        <cds-radio>
-          <label>paypal</label>
-          <input type="radio" value="3" />
-        </cds-radio>
-      </cds-radio-group>
-
-      <cds-checkbox-group>
-        <label>Shipping Details</label>
-        <cds-checkbox>
-          <label>Shipping address is the same as my billing address</label>
-          <input type="checkbox" />
-        </cds-checkbox>
-        <cds-checkbox>
-          <label>Save this information for next time</label>
-          <input type="checkbox" />
-        </cds-checkbox>
-      </cds-checkbox-group>
-
-      <div cds-layout="grid cols@xs:6 gap:lg">
-        <cds-input>
-          <label>name on card</label>
-          <input type="text" />
-          <cds-control-message>full name as displayed on card</cds-control-message>
-        </cds-input>
-
-        <cds-input>
-          <label>credit card number</label>
-          <input type="number" />
-        </cds-input>
-      </div>
-
-      <div cds-layout="grid gap:lg">
-        <cds-input cds-layout="cols@xs:6 col@sm:4">
-          <label>expiration</label>
-          <input type="text" />
-        </cds-input>
-
-        <cds-input cds-layout="cols@xs:6 col@sm:3">
-          <label>CVV</label>
-          <input type="number" />
-        </cds-input>
-
-        <cds-input cds-layout="col@sm:5">
-          <label>promo code</label>
-          <input type="text" />
-          <cds-control-action action="suffix" aria-label="add promo code">
-            <cds-icon shape="add"></cds-icon>
-          </cds-control-action>
-        </cds-input>
-      </div>
-
-      <cds-button>continue to checkout</cds-button>
     </cds-form-group>
   `;
 };

--- a/packages/core/src/forms/forms.stories.ts
+++ b/packages/core/src/forms/forms.stories.ts
@@ -1732,132 +1732,129 @@ export const multiColumn = () => {
 // https://getbootstrap.com/docs/4.5/examples/checkout/
 export const checkoutForm = () => {
   return html`
-    <cds-form-group layout="vertical" cds-layout="container:sm">
-      <div cds-layout="vertical gap:xl">
-        <fieldset cds-layout="vertical gap:md">
-          <legend cds-text="section">Billing Address</legend>
+    <div cds-layout="vertical gap:xl container:sm" role="region" aria-labelledby="checkout-form-title">
+      <p id="checkout-form-title" cds-text="title">Example Payment Form</p>
 
-          <div cds-layout="grid cols@xs:6 gap:lg p-t:sm">
-            <cds-input>
-              <label>first name</label>
-              <input type="text" />
-            </cds-input>
-
-            <cds-input>
-              <label>last name</label>
-              <input type="text" />
-            </cds-input>
-          </div>
-
+      <cds-form-group layout="vertical" cds-layout="vertical" role="group" aria-labelledby="billing-group-title">
+        <p id="billing-group-title" cds-text="section">Billing Information</p>
+        <div cds-layout="grid cols@xs:6 gap:lg p-t:sm">
           <cds-input>
-            <label>email</label>
-            <input type="email" placeholder="you@example.com" />
+            <label>first name</label>
+            <input type="text" />
           </cds-input>
 
-          <div cds-layout="grid cols@xs:6 gap:lg p-t:sm">
-            <cds-input>
-              <label>address</label>
-              <input type="text" placeholder="1234 Main St." />
-            </cds-input>
+          <cds-input>
+            <label>last name</label>
+            <input type="text" />
+          </cds-input>
+        </div>
 
-            <cds-input>
-              <label>address 2</label>
-              <input type="text" placeholder="Apartment or Suite" />
-              <cds-control-message>(optional)</cds-control-message>
-            </cds-input>
-          </div>
+        <cds-input>
+          <label>email</label>
+          <input type="email" placeholder="you@example.com" />
+        </cds-input>
 
-          <div cds-layout="grid gap:lg p-t:sm">
-            <cds-select cds-layout="col@xs:6 col@sm:5">
-              <label>Country</label>
-              <select>
-                <option>choose...</option>
-                <option>United States</option>
-              </select>
-            </cds-select>
+        <div cds-layout="grid cols@xs:6 gap:lg p-t:sm">
+          <cds-input>
+            <label>address</label>
+            <input type="text" placeholder="1234 Main St." />
+          </cds-input>
 
-            <cds-select cds-layout="col@xs:6 col@sm:4">
-              <label>State</label>
-              <select>
-                <option>choose...</option>
-                <option>California</option>
-              </select>
-            </cds-select>
+          <cds-input>
+            <label>address 2</label>
+            <input type="text" placeholder="Apartment or Suite" />
+            <cds-control-message>(optional)</cds-control-message>
+          </cds-input>
+        </div>
 
-            <cds-input cds-layout="col@sm:3">
-              <label>Postal Code</label>
-              <input type="text" placeholder="" />
-            </cds-input>
-          </div>
-        </fieldset>
+        <div cds-layout="grid gap:lg p-t:sm">
+          <cds-select cds-layout="col@xs:6 col@sm:5">
+            <label>Country</label>
+            <select>
+              <option>choose...</option>
+              <option>United States</option>
+            </select>
+          </cds-select>
 
-        <fieldset cds-layout="vertical gap:md">
-          <legend cds-text="section">Payment</legend>
-          <cds-radio-group cds-layout="p-t:sm">
-            <label>payment type</label>
-            <cds-radio>
-              <label>credit card</label>
-              <input type="radio" value="1" checked />
-            </cds-radio>
-            <cds-radio>
-              <label>debt card</label>
-              <input type="radio" value="2" />
-            </cds-radio>
-            <cds-radio>
-              <label>paypal</label>
-              <input type="radio" value="3" />
-            </cds-radio>
-          </cds-radio-group>
+          <cds-select cds-layout="col@xs:6 col@sm:4">
+            <label>State</label>
+            <select>
+              <option>choose...</option>
+              <option>California</option>
+            </select>
+          </cds-select>
 
-          <cds-checkbox-group cds-layout="p-t:md">
-            <label>Shipping Details</label>
-            <cds-checkbox>
-              <label>Shipping address is the same as my billing address</label>
-              <input type="checkbox" />
-            </cds-checkbox>
-            <cds-checkbox>
-              <label>Save this information for next time</label>
-              <input type="checkbox" />
-            </cds-checkbox>
-          </cds-checkbox-group>
+          <cds-input cds-layout="col@sm:3">
+            <label>Postal Code</label>
+            <input type="text" placeholder="" />
+          </cds-input>
+        </div>
+      </cds-form-group>
 
-          <div cds-layout="grid cols@xs:6 gap:lg p-t:md">
-            <cds-input>
-              <label>name on card</label>
-              <input type="text" />
-              <cds-control-message>full name as displayed on card</cds-control-message>
-            </cds-input>
+      <cds-form-group layout="vertical" cds-layout="vertical m-t:md" role="group" aria-labelledby="payment-group-title">
+        <p id="payment-group-title" cds-text="section">Payment</p>
+        <cds-radio-group cds-layout="p-t:sm">
+          <label>payment type</label>
+          <cds-radio>
+            <label>credit card</label>
+            <input type="radio" value="1" checked />
+          </cds-radio>
+          <cds-radio>
+            <label>debt card</label>
+            <input type="radio" value="2" />
+          </cds-radio>
+          <cds-radio>
+            <label>paypal</label>
+            <input type="radio" value="3" />
+          </cds-radio>
+        </cds-radio-group>
 
-            <cds-input>
-              <label>credit card number</label>
-              <input type="number" />
-            </cds-input>
-          </div>
+        <cds-checkbox-group cds-layout="p-t:md">
+          <label>Shipping Details</label>
+          <cds-checkbox>
+            <label>Shipping address is the same as my billing address</label>
+            <input type="checkbox" />
+          </cds-checkbox>
+          <cds-checkbox>
+            <label>Save this information for next time</label>
+            <input type="checkbox" />
+          </cds-checkbox>
+        </cds-checkbox-group>
 
-          <div cds-layout="grid gap:lg p-t:md">
-            <cds-input cds-layout="cols@xs:6 col@sm:4">
-              <label>expiration</label>
-              <input type="text" />
-            </cds-input>
+        <div cds-layout="grid cols@xs:6 gap:lg p-t:md">
+          <cds-input>
+            <label>name on card</label>
+            <input type="text" />
+            <cds-control-message>full name as displayed on card</cds-control-message>
+          </cds-input>
 
-            <cds-input cds-layout="cols@xs:6 col@sm:3">
-              <label>CVV</label>
-              <input type="number" />
-            </cds-input>
+          <cds-input>
+            <label>credit card number</label>
+            <input type="number" />
+          </cds-input>
+        </div>
+        <div cds-layout="grid gap:lg p-t:md">
+          <cds-input cds-layout="cols@xs:6 col@sm:4">
+            <label>expiration</label>
+            <input type="text" />
+          </cds-input>
 
-            <cds-input cds-layout="col@sm:5">
-              <label>promo code</label>
-              <input type="text" />
-              <cds-control-action action="suffix" aria-label="add promo code">
-                <cds-icon shape="add"></cds-icon>
-              </cds-control-action>
-            </cds-input>
-          </div>
-        </fieldset>
+          <cds-input cds-layout="cols@xs:6 col@sm:3">
+            <label>CVV</label>
+            <input type="number" />
+          </cds-input>
 
-        <cds-button cds-layout="m-t:lg">continue to checkout</cds-button>
-      </div>
-    </cds-form-group>
+          <cds-input cds-layout="col@sm:5">
+            <label>promo code</label>
+            <input type="text" />
+            <cds-control-action action="suffix" aria-label="add promo code">
+              <cds-icon shape="add"></cds-icon>
+            </cds-control-action>
+          </cds-input>
+        </div>
+      </cds-form-group>
+      <cds-button cds-layout="m-t:lg">continue to checkout</cds-button>
+    </div>
   `;
 };
 

--- a/packages/core/src/icon/icon.stories.ts
+++ b/packages/core/src/icon/icon.stories.ts
@@ -5,7 +5,7 @@
  */
 
 import '@clr/core/icon/register.js';
-import { CdsIcon, ClarityIcons, imageIcon, userIcon } from '@clr/core/icon';
+import { ClarityIcons, imageIcon, userIcon } from '@clr/core/icon';
 import { boolean, select, text } from '@storybook/addon-knobs';
 import { html } from 'lit-html';
 import { classMap } from 'lit-html/directives/class-map';
@@ -43,13 +43,7 @@ import {
   travelCollectionAliases,
   travelCollectionIcons,
 } from '@clr/core/icon';
-import {
-  propertiesGroup,
-  registerElementSafely,
-  getElementStorybookArgTypes,
-  spreadProps,
-  getElementStorybookArgs,
-} from '@clr/core/internal';
+import { propertiesGroup, getElementStorybookArgTypes, spreadProps, getElementStorybookArgs } from '@clr/core/internal';
 import { ifDefined } from 'lit-html/directives/if-defined';
 
 loadChartIconSet();

--- a/packages/core/src/internal/utils/dom.spec.ts
+++ b/packages/core/src/internal/utils/dom.spec.ts
@@ -19,6 +19,7 @@ import {
   setAttributes,
   listenForAttributeChange,
   isVisible,
+  setOrRemoveAttribute,
   spanWrapper,
 } from './dom.js';
 
@@ -230,6 +231,40 @@ describe('Functional Helper: ', () => {
     });
   });
 
+  describe('setOrRemoveAttribute() ', () => {
+    let testElement: HTMLElement;
+
+    const attrToTest: HTMLAttributeTuple = ['data-attr', 'stringified data goes here'];
+    const [attrToTestName, attrToTestValue] = attrToTest;
+
+    beforeEach(async () => {
+      testElement = await createTestElement();
+    });
+
+    afterEach(() => {
+      removeTestElement(testElement);
+    });
+
+    it('sets attribute if test function returns true', () => {
+      setOrRemoveAttribute(testElement, attrToTest, () => {
+        return true;
+      });
+      expect(testElement.hasAttribute(attrToTestName)).toBe(true);
+      expect(testElement.getAttribute(attrToTestName)).toBe(attrToTestValue as string);
+    });
+
+    it('removes attribute value if function returns false', () => {
+      setAttributes(testElement, attrToTest);
+      expect(testElement.hasAttribute(attrToTestName)).toBe(true);
+      expect(testElement.getAttribute(attrToTestName)).toBe(attrToTestValue as string);
+      setOrRemoveAttribute(testElement, attrToTest, () => {
+        return false;
+      });
+      expect(testElement.hasAttribute(attrToTestName)).toBe(false);
+      expect(testElement.getAttribute(attrToTestName)).toBe(null);
+    });
+  });
+
   describe('assignSlotNames() ', () => {
     let testElement: HTMLElement;
     let testDiv1: HTMLElement;
@@ -344,6 +379,9 @@ describe('Functional Helper: ', () => {
 
       element.setAttribute('hidden', '');
       expect(isVisible(element)).toBe(false);
+
+      removeAttributes(element, 'hidden');
+      expect(isVisible(element)).toBe(true);
 
       removeTestElement(element);
       expect(isVisible(element)).toBe(false);

--- a/packages/core/src/internal/utils/dom.ts
+++ b/packages/core/src/internal/utils/dom.ts
@@ -32,10 +32,8 @@ export function hasAttributeAndIsNotEmpty(element: HTMLElement | null, attribute
   return !!element && element.hasAttribute(attribute) && isStringAndNotNilOrEmpty(element.getAttribute(attribute));
 }
 
-// TODO: TESTME!
 export function setOrRemoveAttribute(element: HTMLElement, attrTuple: HTMLAttributeTuple, test: () => boolean) {
   const [attribute, value] = attrTuple;
-  console.log('ohai: element = ', element, '; tuple = ', attribute, ', ', value, '; did i pass my test? ', test());
   if (test()) {
     setAttributes(element, [attribute, value]);
   } else {
@@ -117,7 +115,7 @@ export function listenForAttributeChange(
 }
 
 export function isVisible(element: HTMLElement) {
-  return element?.offsetHeight > 0 && element?.hasAttribute('hidden') === false;
+  return !!element && element?.offsetHeight > 0 && element?.hasAttribute('hidden') === false;
 }
 
 export function spanWrapper(nodeList: NodeListOf<ChildNode>): void {

--- a/packages/core/src/internal/utils/dom.ts
+++ b/packages/core/src/internal/utils/dom.ts
@@ -32,6 +32,17 @@ export function hasAttributeAndIsNotEmpty(element: HTMLElement | null, attribute
   return !!element && element.hasAttribute(attribute) && isStringAndNotNilOrEmpty(element.getAttribute(attribute));
 }
 
+// TODO: TESTME!
+export function setOrRemoveAttribute(element: HTMLElement, attrTuple: HTMLAttributeTuple, test: () => boolean) {
+  const [attribute, value] = attrTuple;
+  console.log('ohai: element = ', element, '; tuple = ', attribute, ', ', value, '; did i pass my test? ', test());
+  if (test()) {
+    setAttributes(element, [attribute, value]);
+  } else {
+    removeAttributes(element, attribute);
+  }
+}
+
 export function setAttributes(element: HTMLElement, ...attributeTuples: HTMLAttributeTuple[]) {
   if (element) {
     attributeTuples.forEach(([attr, val]) => {

--- a/packages/core/src/styles/layout/_display.scss
+++ b/packages/core/src/styles/layout/_display.scss
@@ -55,3 +55,21 @@
 @media (min-width: $cds-token-layout-width-xl-static) {
   @include display('xl');
 }
+
+// duplicating here b/c the form fields can't pull it in from
+// the reset module
+
+[cds-layout~='display:screen-reader-only'] {
+  position: absolute !important;
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  padding: 0;
+  border: 0;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+  top: 0;
+  left: 0;
+  display: block !important;
+}

--- a/packages/core/src/styles/module.reset.scss
+++ b/packages/core/src/styles/module.reset.scss
@@ -39,3 +39,20 @@ html {
   left: 0;
   display: block !important;
 }
+
+fieldset[cds-layout] {
+  padding: 0 !important;
+  border: 0;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
+  padding-block-start: 0;
+  padding-block-end: 0;
+  padding-inline-start: 0;
+  padding-inline-end: 0;
+
+  & > legend {
+    display: contents;
+    padding-inline-end: 0;
+    padding-inline-start: 0;
+  }
+}

--- a/packages/core/src/styles/module.reset.scss
+++ b/packages/core/src/styles/module.reset.scss
@@ -39,20 +39,3 @@ html {
   left: 0;
   display: block !important;
 }
-
-fieldset[cds-layout] {
-  padding: 0 !important;
-  border: 0;
-  margin-inline-start: 0;
-  margin-inline-end: 0;
-  padding-block-start: 0;
-  padding-block-end: 0;
-  padding-inline-start: 0;
-  padding-inline-end: 0;
-
-  & > legend {
-    display: contents;
-    padding-inline-end: 0;
-    padding-inline-start: 0;
-  }
-}

--- a/packages/core/test-bundles/bundlesize.json
+++ b/packages/core/test-bundles/bundlesize.json
@@ -12,7 +12,7 @@
     },
     {
       "path": "./dist/core/styles/module.reset.min.css",
-      "maxSize": "0.25 kB",
+      "maxSize": "0.3 kB",
       "compression": "brotli"
     },
     {


### PR DESCRIPTION
• updated cds-control-actions so they could be announced by screen readers
• duplicated screen readers styles because reset styles aren't being loaded internally to components
• updated placeholder text values to "place holder text"
• the rationale here was that VoiceOver was pronouncing it "plass-holder text"
• VoiceOver now pronounces the value as intended
• added a reset style for a fieldset that uses cds-layout
• legends inside a reset fieldset are likewise reset
• updated checkout form demo to show expected use of fieldset
• fieldsets + legends behave slightly odd inside a layout; I got it working but :-\
• new reset styles increased reset bundlesize
• removed unused imports from icon.stories.ts

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
