### PR TITLE
feat: add schematic for updating to Clarity 5.0

### DIFF
--- a/packages/schematics/package.json
+++ b/packages/schematics/package.json
@@ -16,7 +16,7 @@
     "clean": "del src/**/*.{js,js.map}",
     "schematics:build:ts": "tsc -p tsconfig.json",
     "schematics:build:collection": "cpy --parents --cwd='src/' '**/*.json' ../../../dist/clr-angular/schematics",
-    "test": "yarn run build:test && jasmine **/*_spec.js"
+    "test": "yarn run build:test && jasmine **/*.spec.js"
   },
   "keywords": [
     "angular",

--- a/packages/schematics/src/add/index.spec.ts
+++ b/packages/schematics/src/add/index.spec.ts
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 import { Tree, HostTree, SchematicsException } from '@angular-devkit/schematics';
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
 import { join } from 'path';

--- a/packages/schematics/src/migration-collection.json
+++ b/packages/schematics/src/migration-collection.json
@@ -10,6 +10,11 @@
       "version": "3.0.0",
       "factory": "./update/update-3.0.0",
       "description": "Updates for Clarity 3.0.0"
+    },
+    "migration-5.0": {
+      "version": "5.0.0",
+      "factory": "./update/update-5.0.0",
+      "description": "Updates for Clarity 5.0.0"
     }
   }
 }

--- a/packages/schematics/src/update/update-5.0.0.spec.ts
+++ b/packages/schematics/src/update/update-5.0.0.spec.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+import { HostTree } from '@angular-devkit/schematics';
+import { setupProject } from '../utility/setup-project';
+import { getFileContent } from '../utility/get-file-content';
+
+const clarityCorePackageName = '@clr/core';
+
+describe('Migration to version 5.0', () => {
+  let runner: SchematicTestRunner;
+  let workspaceTree: UnitTestTree;
+
+  beforeEach(async () => {
+    runner = new SchematicTestRunner('migrations', require.resolve('../migration-collection.json'));
+    workspaceTree = await setupProject(new UnitTestTree(new HostTree()), runner, 'foo');
+  });
+
+  it('should add the @clr/core package to the project dependencies', async () => {
+    const packageJsonPath = '/package.json';
+    const packageJsonString = workspaceTree.read(packageJsonPath)?.toString();
+    if (packageJsonString === undefined) {
+      fail('Could not read package.json');
+    }
+    const packageJson = JSON.parse(packageJsonString!);
+    packageJson.dependencies['@clr/angular'] = '4.0.0';
+    workspaceTree.overwrite(packageJsonPath, JSON.stringify(packageJson));
+
+    const tree = await runner.runSchematicAsync('migration-5.0', {}, workspaceTree).toPromise();
+    expect(tree.files).toContain(packageJsonPath);
+    const { dependencies } = JSON.parse(getFileContent(tree, packageJsonPath));
+
+    expect(dependencies).toBeDefined();
+    expect(dependencies[clarityCorePackageName]).toEqual('^5.0.0');
+  });
+
+  it('should not modify the project dependencies if @clr/angular is not a dependency', async () => {
+    const tree = await runner.runSchematicAsync('migration-5.0', {}, workspaceTree).toPromise();
+    const packageJsonPath = '/package.json';
+    expect(tree.files).toContain(packageJsonPath);
+    const { dependencies } = JSON.parse(getFileContent(tree, packageJsonPath));
+
+    expect(dependencies).toBeDefined();
+    expect(dependencies[clarityCorePackageName]).not.toBeDefined();
+  });
+
+  it('should not modify the project dependencies if @clr/core is already a dependency', async () => {
+    const packageJsonPath = '/package.json';
+    const predefinedClarityCoreVersion = 'latest';
+    const packageJsonString = workspaceTree.read(packageJsonPath)?.toString();
+    if (packageJsonString === undefined) {
+      fail('Could not read package.json');
+    }
+    const packageJson = JSON.parse(packageJsonString!);
+    packageJson.dependencies[clarityCorePackageName] = predefinedClarityCoreVersion;
+    workspaceTree.overwrite(packageJsonPath, JSON.stringify(packageJson));
+
+    const tree = await runner.runSchematicAsync('migration-5.0', {}, workspaceTree).toPromise();
+    expect(tree.files).toContain(packageJsonPath);
+    const { dependencies } = JSON.parse(getFileContent(tree, packageJsonPath));
+
+    expect(dependencies).toBeDefined();
+    expect(dependencies[clarityCorePackageName]).toEqual(predefinedClarityCoreVersion);
+  });
+});

--- a/packages/schematics/src/update/update-5.0.0.ts
+++ b/packages/schematics/src/update/update-5.0.0.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Rule, Tree, SchematicContext } from '@angular-devkit/schematics';
+import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
+import { updateJsonFile } from '../utility/update-json-file';
+
+const clarityCorePackageName = '@clr/core';
+const clarityAngularPackageName = '@clr/angular';
+const clarityCorePackageUpdateVersion = '^5.0.0';
+
+export default function (): Rule {
+  return (host: Tree, context: SchematicContext): void => {
+    updateJsonFile(host, 'package.json', json => {
+      // Do nothing if @clr/core is already a dependency
+      const deps = json?.dependencies || {};
+      if (Object.keys(deps).includes(clarityCorePackageName)) {
+        return;
+      }
+
+      if (!json.dependencies) {
+        json.dependencies = {};
+      }
+      const clarityAngularVersion = json.dependencies[clarityAngularPackageName];
+      // Do nothing if @clr/angular is not a dependency
+      if (!clarityAngularVersion) {
+        return;
+      }
+      // Add the same version of @clr/core as
+      // the version of @clr/angular that's in the package.json
+      json.dependencies[clarityCorePackageName] = clarityCorePackageUpdateVersion;
+    });
+
+    context.addTask(new NodePackageInstallTask());
+  };
+}

--- a/packages/schematics/src/utility/update-json-file.ts
+++ b/packages/schematics/src/utility/update-json-file.ts
@@ -1,8 +1,14 @@
+/*
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
 import { Tree } from '@angular-devkit/schematics';
 import { getJsonFile } from './get-json-file';
 
 // Writes changes to a JSON file
-export function updateJsonFile(tree: Tree, path: string, callback: (a: any) => any) {
+export function updateJsonFile(tree: Tree, path: string, callback: (a: any) => any): void {
   const json = getJsonFile(tree, path);
   callback(json);
   tree.overwrite(path, JSON.stringify(json, null, 2));


### PR DESCRIPTION
This PR adds a schematic script for updating to Clarity 5.0. The script does the following:
- Adds the `@clr/core` package to the project dependencies;
- Runs `npm install` or `yarn install` depending on what's configured by the project.

**Note** The script does nothing if `@clr/core` is already a dependency.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
