### PR TITLE
fix(label): updated a11y of tags

### DIFF
--- a/packages/core/src/button/button.element.spec.ts
+++ b/packages/core/src/button/button.element.spec.ts
@@ -9,6 +9,7 @@ import { CdsButton, ClrLoadingState } from '@clr/core/button';
 import '@clr/core/badge/register.js';
 import '@clr/core/button/register.js';
 import { componentIsStable, createTestElement, getComponentSlotContent, removeTestElement } from '@clr/core/test/utils';
+import { listenForAttributeChange } from '@clr/core/internal';
 
 describe('button element', () => {
   let testElement: HTMLElement;
@@ -311,5 +312,67 @@ describe('buttonSlots: ', () => {
     const component = elem.querySelector<CdsButton>('cds-button');
     const slots = getComponentSlotContent(component);
     expect(slots.default).toContain('Text slot');
+  });
+});
+
+describe('button keyboard interaction: ', () => {
+  it('should add active attr on click', async done => {
+    const element = await createTestElement(html`<cds-button>Text slot</cds-button>`);
+    const component = element.querySelector('cds-button');
+    expect(component.hasAttribute('active')).toBe(false);
+
+    listenForAttributeChange(component, 'active', () => {
+      expect(true).toBe(true, 'active attr was added on click');
+      done();
+    });
+
+    component.click();
+    removeTestElement(element);
+  });
+
+  it('should NOT add active attr if button is disabled', async done => {
+    const element = await createTestElement(html`<cds-button>Text slot</cds-button>`);
+    const component = element.querySelector('cds-button');
+    expect(component.hasAttribute('active')).toBe(false);
+    component.disabled = true;
+    await componentIsStable(component);
+
+    listenForAttributeChange(component, 'active', () => {
+      expect(false).toBe(true, 'active attr should not be added on click');
+      done();
+    });
+
+    listenForAttributeChange(component, 'id', () => {
+      expect(component.hasAttribute('active')).toBe(false, 'active attr was not be added');
+      done();
+    });
+
+    component.click();
+    await componentIsStable(component);
+    component.setAttribute('id', 'ohai');
+    removeTestElement(element);
+  });
+
+  it('should NOT add active attr if button is readonly', async done => {
+    const element = await createTestElement(html`<cds-button readonly>Text slot</cds-button>`);
+    const component = element.querySelector('cds-button');
+    await componentIsStable(component);
+    expect(component.hasAttribute('active')).toBe(false);
+    expect(component.hasAttribute('readonly')).toBe(true);
+
+    listenForAttributeChange(component, 'active', () => {
+      expect(false).toBe(true, 'active attr should not be added on click');
+      done();
+    });
+
+    listenForAttributeChange(component, 'id', () => {
+      expect(component.hasAttribute('active')).toBe(false, 'active attr was not be added');
+      done();
+    });
+
+    component.click();
+    await componentIsStable(component);
+    component.setAttribute('id', 'ohai');
+    removeTestElement(element);
   });
 });

--- a/packages/core/src/internal/base/button.base.ts
+++ b/packages/core/src/internal/base/button.base.ts
@@ -31,6 +31,8 @@ export class CdsBaseButton extends LitElement {
 
   @internalProperty({ type: Boolean, reflect: true }) protected focused = false;
 
+  @internalProperty({ type: Boolean, reflect: true }) protected active = false;
+
   @internalProperty({ type: String, reflect: true }) protected role: string | null = 'button';
 
   /** @deprecated slotted anchor deprecated in 4.0 in favor of wrapping element */
@@ -108,6 +110,23 @@ export class CdsBaseButton extends LitElement {
     }
   }
 
+  /** This mimics the mouse-click visual behavior for keyboard only users and screen readers.
+   * Browsers do not apply the CSS psuedo-selector :active in those instances. So we need this
+   * for our :active styles to show.
+   *
+   * Make sure to update a component's CSS to account for the presence of the [active] attribute
+   * in all instance where :active is defined.
+   *
+   * @private
+   */
+  private showClick() {
+    this.active = true;
+    const clickTimer = setTimeout(() => {
+      this.active = false;
+      clearTimeout(clickTimer);
+    }, 300);
+  }
+
   /**
    * We have to append a hidden button outside the web component in the light DOM
    * This allows us to trigger native submit events within a form element.
@@ -122,8 +141,11 @@ export class CdsBaseButton extends LitElement {
     if (!this.readonly) {
       if (this.disabled) {
         stopEvent(event);
-      } else if (event.target === this && !event.defaultPrevented) {
-        this.hiddenButton.dispatchEvent(new MouseEvent('click', { relatedTarget: this, composed: true }));
+      } else {
+        this.showClick();
+        if (event.target === this && !event.defaultPrevented) {
+          this.hiddenButton.dispatchEvent(new MouseEvent('click', { relatedTarget: this, composed: true }));
+        }
       }
     }
   }

--- a/packages/core/src/tag/tag.element.scss
+++ b/packages/core/src/tag/tag.element.scss
@@ -98,6 +98,7 @@
   --color: #{$cds-token-color-neutral-600} !important;
   --border-color: #{$cds-token-color-neutral-600} !important;
 
+  &:host([active]),
   &:host(:active) {
     .private-host {
       box-shadow: none !important;
@@ -111,12 +112,14 @@
 
 :host(:not([readonly])),
 :host([is-anchor]) {
-  &:host(:focus),
+  &:host([active]),
   &:host(:hover),
+  &:host(:focus),
   &:host(:active) {
     --background: #{$cds-token-color-neutral-200};
   }
 
+  &:host([active]),
   &:host(:active) {
     .private-host {
       box-shadow: 0 #{$cds-token-space-size-1-static} 0 0 var(--border-color) inset;
@@ -196,8 +199,9 @@
 
 :host(:not([readonly])),
 :host([is-anchor]) {
-  &:host([status='info']:focus),
+  &:host([status='info'][active]),
   &:host([status='info']:hover),
+  &:host([status='info']:focus),
   &:host([status='info']:active) {
     --background: #{$cds-token-color-action-100};
   }
@@ -221,8 +225,9 @@
 
 :host(:not([readonly])),
 :host([is-anchor]) {
-  &:host([status='success']:focus),
+  &:host([status='success'][active]),
   &:host([status='success']:hover),
+  &:host([status='success']:focus),
   &:host([status='success']:active) {
     --background: #{$cds-token-color-success-100};
   }
@@ -246,8 +251,9 @@
 
 :host(:not([readonly])),
 :host([is-anchor]) {
-  &:host([status='warning']:focus),
+  &:host([status='warning'][active]),
   &:host([status='warning']:hover),
+  &:host([status='warning']:focus),
   &:host([status='warning']:active) {
     --background: #{$cds-token-color-warning-200};
     --border-color: #{$cds-token-color-warning-500};
@@ -283,8 +289,9 @@
 
 :host(:not([readonly])),
 :host([is-anchor]) {
-  &:host([status='danger']:focus),
+  &:host([status='danger'][active]),
   &:host([status='danger']:hover),
+  &:host([status='danger']:focus),
   &:host([status='danger']:active) {
     --background: #{$cds-token-color-danger-200};
     --border-color: #{$cds-token-color-danger-400};

--- a/packages/core/src/tag/tag.stories.mdx
+++ b/packages/core/src/tag/tag.stories.mdx
@@ -51,20 +51,28 @@ import '@clr/core/tag/register.js';
 
 ## Clickable Tags
 
+<cds-alert-group status="warning" cds-layout="m-b:lg">
+  <cds-alert>
+    Indicating that a tag is clickable or closable will make the tag behave as a button. The external-facing behavior is
+    the same for both clickable and closable tags. The difference between the two is that closable tags display a "close
+    X" icon at the end of the tag's content. The distinction between the closable and clickable tags is purely visual.
+  </cds-alert>
+</cds-alert-group>
+
 <Preview>
   <Story id="components-tag-stories--clickable" />
-</Preview>
-
-## Links
-
-<Preview>
-  <Story id="components-tag-stories--links" />
 </Preview>
 
 ## Closable Tags
 
 <Preview>
   <Story id="components-tag-stories--closable" />
+</Preview>
+
+## Links
+
+<Preview>
+  <Story id="components-tag-stories--links" />
 </Preview>
 
 ## API

--- a/packages/core/src/tag/tag.stories.ts
+++ b/packages/core/src/tag/tag.stories.ts
@@ -91,65 +91,43 @@ export const clickable = () => {
   return html`
     <div cds-layout="vertical gap:sm">
       <div cds-layout="horizontal gap:sm">
-        <cds-tag aria-label="Clickable example of a default tag" color="gray">Default</cds-tag>
-        <cds-tag aria-label="Clickable example of a purple tag" color="purple">Purple</cds-tag>
-        <cds-tag aria-label="Clickable example of a blue tag" color="blue">Blue</cds-tag>
-        <cds-tag aria-label="Clickable example of an orange tag" color="orange">Orange</cds-tag>
-        <cds-tag aria-label="Clickable example of a light blue tag" color="light-blue">Light Blue</cds-tag>
+        <cds-tag aria-label="Default" color="gray">Default</cds-tag>
+        <cds-tag aria-label="Purple" color="purple">Purple</cds-tag>
+        <cds-tag aria-label="Blue" color="blue">Blue</cds-tag>
+        <cds-tag aria-label="Orange" color="orange">Orange</cds-tag>
+        <cds-tag aria-label="Light blue" color="light-blue">Light Blue</cds-tag>
       </div>
       <div cds-layout="horizontal gap:sm">
-        <cds-tag aria-label="Clickable example of a tag with the info status" status="info"
-          >Info <cds-badge status="info">1</cds-badge></cds-tag
-        >
-        <cds-tag aria-label="Clickable example of a tag with the success status" status="success"
+        <cds-tag aria-label="Info 1 item" status="info">Info <cds-badge status="info">1</cds-badge></cds-tag>
+        <cds-tag aria-label="Success 2 items" status="success"
           >Success <cds-badge status="success">2</cds-badge></cds-tag
         >
-        <cds-tag aria-label="Clickable example of a tag with the warning status" status="warning"
-          >Warning <cds-badge status="warning">3</cds-badge>
-        </cds-tag>
-        <cds-tag aria-label="Clickable example of a tag with the danger status" status="danger"
-          >Danger <cds-badge status="danger">12</cds-badge></cds-tag
-        >
+        <cds-tag aria-label="Warning 3 items">Warning <cds-badge status="warning">3</cds-badge> </cds-tag>
+        <cds-tag aria-label="Danger 12 items" status="danger">Danger <cds-badge status="danger">12</cds-badge></cds-tag>
       </div>
       <div cds-layout="horizontal gap:sm">
-        <cds-tag aria-label="Clickable example of a default tag with a badge" color="gray"
-          >Default <cds-badge>A</cds-badge></cds-tag
-        >
-        <cds-tag aria-label="Clickable example of a purple tag with a badge" color="purple"
-          >Purple <cds-badge>B</cds-badge></cds-tag
-        >
-        <cds-tag aria-label="Clickable example of a blue tag with a badge" color="blue"
-          >Blue <cds-badge>C</cds-badge></cds-tag
-        >
-        <cds-tag aria-label="Clickable example of an orange tag with a badge" color="orange"
-          >Orange <cds-badge>D</cds-badge></cds-tag
-        >
-        <cds-tag aria-label="Clickable example of a light-blue tag with a badge" color="light-blue"
-          >Light Blue <cds-badge>E</cds-badge></cds-tag
-        >
+        <cds-tag aria-label="Default with letter A" color="gray">Default <cds-badge>A</cds-badge></cds-tag>
+        <cds-tag aria-label="Purple with letter B" color="purple">Purple <cds-badge>B</cds-badge></cds-tag>
+        <cds-tag aria-label="Blue with letter C" color="blue">Blue <cds-badge>C</cds-badge></cds-tag>
+        <cds-tag aria-label="Orange with letter D" color="orange">Orange <cds-badge>D</cds-badge></cds-tag>
+        <cds-tag aria-label="Light blue with letter E" color="light-blue">Light Blue <cds-badge>E</cds-badge></cds-tag>
       </div>
       <div cds-layout="horizontal gap:sm">
-        <cds-tag aria-label="Clickable example of a gray tag with an icon and a badge" color="gray"
+        <cds-tag aria-label="User image, default, with letter A" color="gray"
           ><cds-icon shape="user"></cds-icon>Default <cds-badge>A</cds-badge></cds-tag
         >
-        <cds-tag aria-label="Clickable example of a purple tag with an icon and a badge" color="purple"
-          ><cds-icon shape="user"></cds-icon>Purple</cds-tag
-        >
-        <cds-tag aria-label="Clickable example of a blue tag with an icon and a badge" color="blue"
+        <cds-tag aria-label="User image, purple" color="purple"><cds-icon shape="user"></cds-icon>Purple</cds-tag>
+        <cds-tag aria-label="User image, blue, with letter B" color="blue"
           ><cds-icon shape="user"></cds-icon>Blue <cds-badge>B</cds-badge></cds-tag
         >
-        <cds-tag aria-label="Clickable example of an orange tag with an icon and a badge" color="orange"
-          ><cds-icon shape="user"></cds-icon>Orange</cds-tag
-        >
-        <cds-tag aria-label="Clickable example of a light-blue tag with an icon and a badge" color="light-blue"
+        <cds-tag aria-label="User image, orange" color="orange"><cds-icon shape="user"></cds-icon>Orange</cds-tag>
+        <cds-tag aria-label="User image, light blue, with letter C" color="light-blue"
           ><cds-icon shape="user"></cds-icon>Light Blue <cds-badge>C</cds-badge></cds-tag
         >
-        <cds-tag aria-label="Clickable example of a tag with an icon and a badge and a status of info" status="info"
+        <cds-tag aria-label="Info image, Info, 12,000 items" status="info"
           ><cds-icon shape="info-standard"></cds-icon>Info <cds-badge status="info">12,000</cds-badge></cds-tag
         >
-        <cds-tag
-          aria-label="Clickable example of a tag with an icon and a badge and a status of success"
-          status="success"
+        <cds-tag aria-label="Info image, Success, 23 plus items" status="success"
           ><cds-icon shape="info-standard"></cds-icon>Success <cds-badge status="success">23+</cds-badge></cds-tag
         >
       </div>
@@ -160,21 +138,21 @@ export const clickable = () => {
 export const links = () => {
   return html`
     <div cds-layout="horizontal gap:sm p-b:lg">
-      <a href="javascript:void(0)" aria-label="example of a tag component using an anchor">
+      <a href="javascript:void(0)" aria-label="Link">
         <cds-tag status="info">link</cds-tag>
       </a>
 
-      <a href="javascript:void(0)" aria-label="example of a tag component using an anchor">
+      <a href="javascript:void(0)" aria-label="Link, 1 item">
         <cds-tag status="success">link <cds-badge status="info">1</cds-badge></cds-tag>
       </a>
 
-      <a href="javascript:void(0)" aria-label="example of a tag component using an anchor">
+      <a href="javascript:void(0)" aria-label="User image, link, 1 item">
         <cds-tag status="warning"
           ><cds-icon shape="user"></cds-icon> link <cds-badge status="info">1</cds-badge></cds-tag
         >
       </a>
 
-      <a href="javascript:void(0)" aria-label="example of a tag component using an anchor">
+      <a href="javascript:void(0)" aria-label="Link">
         <cds-tag status="danger">link</cds-tag>
       </a>
     </div>
@@ -189,20 +167,20 @@ export const links = () => {
 export const closable = () => {
   return html`
     <div>
-      <cds-tag aria-label="Closable example of a tag" color="gray" closable>Default</cds-tag>
-      <cds-tag aria-label="Closable example of a purple tag" color="purple" closable>Purple</cds-tag>
-      <cds-tag aria-label="Closable example of a blue tag" color="blue" closable>Blue</cds-tag>
-      <cds-tag aria-label="Closable example of an orange tag" color="orange" closable>Orange</cds-tag>
-      <cds-tag aria-label="Closable example of a light-blue tag" color="light-blue" closable>Light Blue</cds-tag>
+      <cds-tag aria-label="default" color="gray" closable>Default</cds-tag>
+      <cds-tag aria-label="purple" color="purple" closable>Purple</cds-tag>
+      <cds-tag aria-label="blue" color="blue" closable>Blue</cds-tag>
+      <cds-tag aria-label="orange" color="orange" closable>Orange</cds-tag>
+      <cds-tag aria-label="light blue" color="light-blue" closable>Light Blue</cds-tag>
     </div>
     <div>
-      <cds-tag aria-label="Closable example of a tag with an icon" color="gray" closable
+      <cds-tag aria-label="user image, default, close image" color="gray" closable
         ><cds-icon shape="user"></cds-icon>Default</cds-tag
       >
-      <cds-tag aria-label="Closable example of a blue tag with an icon" color="blue" closable
+      <cds-tag aria-label="user image, blue, close image" color="blue" closable
         ><cds-icon shape="user"></cds-icon>Blue</cds-tag
       >
-      <cds-tag aria-label="Closable example of an orange tag with an icon" color="orange" closable
+      <cds-tag aria-label="user image, orange, close image" color="orange" closable
         ><cds-icon shape="user"></cds-icon>Orange</cds-tag
       >
     </div>
@@ -215,42 +193,42 @@ export const tagsAndIcons = () => {
   return html`
     <div cds-layout="vertical gap:sm">
       <div cds-layout="horizontal gap:xs">
-        <cds-tag readonly>No Icon</cds-tag>
-        <cds-tag readonly><cds-icon shape="user"></cds-icon>No Badge</cds-tag>
-        <cds-tag readonly color="gray"
+        <cds-tag readonly aria-label="no icon">No Icon</cds-tag>
+        <cds-tag readonly aria-label="user image, no badge"><cds-icon shape="user"></cds-icon>No Badge</cds-tag>
+        <cds-tag readonly color="gray" aria-label="user image, default, 1 item"
           ><cds-icon shape="user" ?solid=${solidIcon}></cds-icon>Default <cds-badge>1</cds-badge></cds-tag
         >
-        <cds-tag readonly color="purple"
+        <cds-tag readonly color="purple" aria-label="user image, purple, 2 items"
           ><cds-icon shape="user" ?solid=${solidIcon}></cds-icon>Purple <cds-badge>2</cds-badge></cds-tag
         >
-        <cds-tag readonly color="blue"
+        <cds-tag readonly color="blue" aria-label="user image, blue, 3 items"
           ><cds-icon shape="user" ?solid=${solidIcon}></cds-icon>Blue <cds-badge>3</cds-badge></cds-tag
         >
-        <cds-tag readonly color="orange"
+        <cds-tag readonly color="orange" aria-label="user image, orange, 12 items"
           ><cds-icon shape="user" ?solid=${solidIcon}></cds-icon>Orange <cds-badge>12</cds-badge></cds-tag
         >
-        <cds-tag readonly color="light-blue"
+        <cds-tag readonly color="light-blue" aria-label="user image, light blue, 15 items"
           ><cds-icon shape="user" ?solid=${solidIcon}></cds-icon>Light Blue <cds-badge>15</cds-badge></cds-tag
         >
       </div>
       <div cds-layout="horizontal gap:xs">
-        <cds-tag readonly status="info">No Icon</cds-tag>
-        <cds-tag readonly status="info"
+        <cds-tag readonly status="info" aria-label="no icon">No Icon</cds-tag>
+        <cds-tag readonly status="info" aria-label="info image, no badge"
           ><cds-icon shape="info-standard" ?solid=${solidIcon}></cds-icon>No Badge</cds-tag
         >
-        <cds-tag readonly status="info"
+        <cds-tag readonly status="info" aria-label="info image, info, 1 item"
           ><cds-icon shape="info-standard" ?solid=${solidIcon}></cds-icon>Info
           <cds-badge status="info">1</cds-badge></cds-tag
         >
-        <cds-tag readonly status="success"
+        <cds-tag readonly status="success" aria-label="info image, success, 2 items"
           ><cds-icon shape="info-standard" ?solid=${solidIcon}></cds-icon>Success
           <cds-badge status="success">2</cds-badge></cds-tag
         >
-        <cds-tag readonly status="warning"
+        <cds-tag readonly status="warning" aria-label="info image, warning, 3 items"
           ><cds-icon shape="info-standard" ?solid=${solidIcon}></cds-icon>Warning
           <cds-badge status="warning">3</cds-badge>
         </cds-tag>
-        <cds-tag readonly status="danger"
+        <cds-tag readonly status="danger" aria-label="info image, danger, 12 items"
           ><cds-icon shape="info-standard" ?solid=${solidIcon}></cds-icon>Danger
           <cds-badge status="danger">12</cds-badge></cds-tag
         >


### PR DESCRIPTION
• updated tag documentation to clarify relationship of clickable and closable tags per a11y
• updated aria labels of tag examples per a11y
• added active attr behavior so we could use CSS to mimic the :active pseudo-selector when a button is clicked with something other than a mouse
• updated tag :active styles to work with the new active attribute in base button
• use the tags as an example if other button types need this behavior
• added tests for the active attr on base button

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
