### PR TITLE
fix: combobox selection issues fixes and a11y improvements

### DIFF
--- a/packages/angular/projects/clr-angular/src/forms/combobox/combobox.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/combobox.spec.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { TestBed, ComponentFixture, tick, fakeAsync } from '@angular/core/testing';
+import { TestBed, ComponentFixture, tick, async, fakeAsync } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -103,6 +103,43 @@ export default function (): void {
       it('has associated form control', () => {
         expect(clarityDirective.control).toBeTruthy();
       });
+
+      it('does not close panel on clear', () => {
+        toggleService.open = true;
+        clarityDirective.writeValue(null);
+        expect(clarityDirective.openState).toBeTrue();
+      });
+
+      it('closes panel on selection', () => {
+        toggleService.open = true;
+        selectionService.select('test');
+        expect(clarityDirective.openState).toBeFalse();
+      });
+
+      it('does not close panel on selection if multiselect', () => {
+        clarityDirective.multiSelect = true;
+        toggleService.open = true;
+        selectionService.select('test');
+        expect(clarityDirective.openState).toBeTrue();
+      });
+
+      // The forms framework has some inner asychronisity, which requires the async/whenStable
+      // approach in the following tests
+      it('sets selection model based on selection binding', async(() => {
+        fixture.componentInstance.selection = 'test';
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          expect(selectionService.selectionModel.containsItem('test')).toBeTrue();
+        });
+      }));
+
+      it('clears selection model', async(() => {
+        fixture.componentInstance.selection = null;
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          expect(selectionService.selectionModel.isEmpty()).toBeTrue();
+        });
+      }));
     });
 
     describe('Template API', function () {

--- a/packages/angular/projects/clr-angular/src/forms/combobox/combobox.ts
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/combobox.ts
@@ -252,13 +252,10 @@ export class ClrCombobox<T> extends WrappedFormControl<ClrComboboxContainer>
   private initializeSubscriptions(): void {
     this.subscriptions.push(
       this.optionSelectionService.selectionChanged.subscribe((newSelection: ComboboxModel<T>) => {
-        if (!this.multiSelect) {
-          this.searchText = this.getDisplayNames(newSelection.model)[0];
-          if (this.searchText) {
-            this.optionSelectionService.currentInput = this.searchText;
-          }
+        this.updateInputValue(newSelection);
+        if (!this.multiSelect && newSelection && !newSelection.isEmpty()) {
+          this.toggleService.open = false;
         }
-        this.toggleService.open = false;
 
         this.updateControlValue();
         if (this.control && this.control.control) {
@@ -311,6 +308,15 @@ export class ClrCombobox<T> extends WrappedFormControl<ClrComboboxContainer>
     this.focusHandler.focusFirstActive();
   }
 
+  private updateInputValue(model: ComboboxModel<T>) {
+    if (!this.multiSelect) {
+      this.searchText = model.model ? this.getDisplayNames(model.model)[0] : '';
+      if (this.searchText) {
+        this.optionSelectionService.currentInput = this.searchText;
+      }
+    }
+  }
+
   private updateControlValue() {
     if (this.control && this.control.control) {
       this.control.control.setValue(this.optionSelectionService.selectionModel.model);
@@ -319,7 +325,8 @@ export class ClrCombobox<T> extends WrappedFormControl<ClrComboboxContainer>
 
   // ControlValueAccessor implementation methods
   writeValue(value: T | T[]): void {
-    this.optionSelectionService.setSelectionValue(value);
+    this.optionSelectionService.selectionModel.model = value;
+    this.updateInputValue(this.optionSelectionService.selectionModel);
   }
 
   registerOnChange(onChange: any): void {
@@ -358,6 +365,11 @@ export class ClrCombobox<T> extends WrappedFormControl<ClrComboboxContainer>
   // Lifecycle methods
   ngAfterContentInit() {
     this.initializeSubscriptions();
+
+    // Initialize with preselected value
+    if (!this.optionSelectionService.selectionModel.isEmpty()) {
+      this.updateInputValue(this.optionSelectionService.selectionModel);
+    }
   }
 
   ngAfterViewInit() {

--- a/packages/angular/projects/clr-angular/src/forms/combobox/option.ts
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/option.ts
@@ -70,16 +70,13 @@ export class ClrOption<T> implements OnInit {
     }
   }
 
-  /**
-   * This behavior is only for single select. Multi select will keep the menu open on option click.
-   * We will handle that later.
-   */
   @HostListener('click')
   onClick() {
-    // We call render here without checking the value because even if the user hasn't
-    // assigned a value to the option, we should at least display the selection on the input.
-    // This is what the native select does.
-    this.optionSelectionService.select(this.value);
+    if (this.optionSelectionService.multiselectable) {
+      this.optionSelectionService.toggle(this.value);
+    } else {
+      this.optionSelectionService.select(this.value);
+    }
   }
 
   @HostBinding('class.clr-focus')

--- a/packages/angular/projects/clr-angular/src/forms/combobox/options.ts
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/options.ts
@@ -126,7 +126,11 @@ export class ClrOptions<T> implements AfterViewInit, LoadingListener, OnDestroy 
 
     this.subscriptions.push(
       fromEvent(this.document, 'scroll', { capture: true }).subscribe(event => {
-        if (this.toggleService.open && (event as Event).target !== this.el.nativeElement) {
+        if (
+          this.toggleService.open &&
+          (event as Event).target !== this.el.nativeElement &&
+          (event as Event).target !== this.focusHandler.textInput
+        ) {
           this.toggleService.open = false;
         }
       })

--- a/packages/angular/projects/clr-angular/src/forms/combobox/providers/combobox-focus-handler.service.ts
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/providers/combobox-focus-handler.service.ts
@@ -113,7 +113,11 @@ export class ComboboxFocusHandler<T> {
       switch (key) {
         case KeyCodes.Enter:
           if (this.toggleService.open && this.pseudoFocus.model) {
-            this.selectionService.select(this.pseudoFocus.model.value);
+            if (this.selectionService.multiselectable) {
+              this.selectionService.toggle(this.pseudoFocus.model.value);
+            } else {
+              this.selectionService.select(this.pseudoFocus.model.value);
+            }
             preventDefault = true;
           }
           break;
@@ -137,7 +141,8 @@ export class ComboboxFocusHandler<T> {
           // Any other keypress
           if (
             event.key !== KeyCodes.Tab &&
-            !(this.selectionService.multiselectable && event.key === KeyCodes.Backspace)
+            !(this.selectionService.multiselectable && event.key === KeyCodes.Backspace) &&
+            !this.toggleService.open
           ) {
             this.toggleService.open = true;
           }

--- a/packages/angular/projects/clr-angular/src/forms/combobox/providers/option-selection.service.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/providers/option-selection.service.spec.ts
@@ -53,6 +53,20 @@ export default function () {
       subscription.unsubscribe();
     });
 
+    it('can toggle an option and emits selection events', () => {
+      let selectedOption: string;
+      const subscription: Subscription = optionSelectionService.selectionChanged.subscribe(
+        (option: ComboboxModel<string>) => {
+          selectedOption = option.model as string;
+        }
+      );
+      optionSelectionService.toggle('Option 1');
+      expect(selectedOption).toBe('Option 1');
+      optionSelectionService.toggle('Option 1');
+      expect(selectedOption).toBeNull();
+      subscription.unsubscribe();
+    });
+
     it('does not notify when the value remains the same', () => {
       let count = 0;
       const sub: Subscription = optionSelectionService.inputChanged.subscribe(() => {

--- a/packages/angular/projects/clr-angular/src/forms/combobox/providers/option-selection.service.ts
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/providers/option-selection.service.ts
@@ -46,6 +46,18 @@ export class OptionSelectionService<T> {
     this._selectionChanged.next(this.selectionModel);
   }
 
+  toggle(item: T) {
+    if (!item) {
+      return;
+    }
+    if (this.selectionModel.containsItem(item)) {
+      this.selectionModel.unselect(item);
+    } else {
+      this.selectionModel.select(item);
+    }
+    this._selectionChanged.next(this.selectionModel);
+  }
+
   unselect(item: T) {
     if (!item || !this.selectionModel.containsItem(item)) {
       return;


### PR DESCRIPTION
closes #5307, closes #5275, closes #5282, closes #5199
Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

- Form dirty on init
- Clicking on selected option does nothing, popover stays open
- Option filter not reset on model change
- Popover gets closes on each select in multi-selection mode

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:  #5307, #5275, #5282, #5199

## What is the new behavior?

- Form clean on init
- Clicking on selected option in multi-mode toggles it
- Option filter reset on model change
- Popover stays open on select in multi-selection mode, allowing multiple items to be selected/toggled at once

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
