### PR TITLE
fix: local build packages prototype WIP

### DIFF
--- a/apps/core-angular-cli/package.json
+++ b/apps/core-angular-cli/package.json
@@ -22,7 +22,7 @@
     "@angular/platform-browser-dynamic": "~10.0.3",
     "@angular/router": "~10.0.3",
     "@clr/city": "^1.1.0",
-    "@clr/core": "./packages/core/dist/core",
+    "@clr/core": "./dist/core",
     "normalize.css": "^8.0.1",
     "rxjs": "~6.5.5",
     "tslib": "^2.0.0",

--- a/apps/core-angular-js/package.json
+++ b/apps/core-angular-js/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@clr/city": "^1.1.0",
-    "@clr/core": "./packages/core/dist/core",
+    "@clr/core": "./dist/core",
     "angular": "^1.8.0",
     "normalize.css": "^8.0.1"
   },

--- a/apps/core-angular-universal/package.json
+++ b/apps/core-angular-universal/package.json
@@ -25,7 +25,7 @@
     "@angular/platform-server": "~10.0.3",
     "@angular/router": "~10.0.3",
     "@clr/city": "^1.1.0",
-    "@clr/core": "./packages/core/dist/core",
+    "@clr/core": "./dist/core",
     "@nguniversal/express-engine": "^10.0.1",
     "normalize.css": "^8.0.1",
     "express": "^4.15.2",

--- a/apps/core-create-react-app/package.json
+++ b/apps/core-create-react-app/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "dependencies": {
     "@clr/city": "^1.1.0",
-    "@clr/core": "./packages/core/dist/core",
-    "@clr/react": "./packages/react/dist/react",
+    "@clr/core": "./dist/core",
+    "@clr/react": "./dist/react",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.4.1",
     "@testing-library/user-event": "^7.2.1",

--- a/apps/core-ie/package.json
+++ b/apps/core-ie/package.json
@@ -7,7 +7,7 @@
     "start": "lite-server"
   },
   "dependencies": {
-    "@clr/core": "./packages/core/dist/core"
+    "@clr/core": "./dist/core"
   },
   "devDependencies": { }
 }

--- a/apps/core-parcel-js/package.json
+++ b/apps/core-parcel-js/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@clr/city": "^1.1.0",
-    "@clr/core": "./packages/core/dist/core",
+    "@clr/core": "./dist/core",
     "normalize.css": "^8.0.1"
   },
   "devDependencies": {

--- a/apps/core-rollup-js/package.json
+++ b/apps/core-rollup-js/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@clr/city": "1.1.0",
-    "@clr/core": "./packages/core/dist/core",
+    "@clr/core": "./dist/core",
     "normalize.css": "8.0.1"
   },
   "devDependencies": {

--- a/apps/core-snowpack/package.json
+++ b/apps/core-snowpack/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "normalize.css": "^8.0.1",
     "@clr/city": "^1.1.0",
-    "@clr/core": "./packages/core/dist/core"
+    "@clr/core": "./dist/core"
   },
   "devDependencies": {
     "snowpack": "^2.7.6"

--- a/apps/core-vue-cli/package.json
+++ b/apps/core-vue-cli/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@clr/city": "^1.1.0",
-    "@clr/core": "./packages/core/dist/core",
+    "@clr/core": "./dist/core",
     "core-js": "^3.6.4",
     "normalize.css": "^8.0.1",
     "vue": "^2.6.11"

--- a/apps/website/.vuepress/config.js
+++ b/apps/website/.vuepress/config.js
@@ -102,46 +102,5 @@ module.exports = {
         changeOrigin: true,
       },
     },
-  },
-  configureWebpack: {
-    resolve: {
-      alias: {
-        // Note: paths to dist/core/register.js are from website root, not .vuepress/register.js
-        // Mono repo constraints mak us reference these assets that aren't installed directly in project node_modules
-        '@clr/core': path.resolve('../../dist/core'),
-        '@clr/core/alert': path.resolve('../../dist/core/alert'),
-        '@clr/core/badge': path.resolve('../../dist/core/badge'),
-        '@clr/core/button': path.resolve('../../dist/core/button'),
-        '@clr/core/checkbox': path.resolve('../../dist/core/checkbox'),
-        '@clr/core/datalist': path.resolve('../../dist/core/datalist'),
-        '@clr/core/date': path.resolve('../../dist/core/date'),
-        '@clr/core/file': path.resolve('../../dist/core/file'),
-        '@clr/core/forms': path.resolve('../../dist/core/forms'),
-        '@clr/core/icon': path.resolve('../../dist/core/icon'),
-        '@clr/core/input': path.resolve('../../dist/core/input'),
-        '@clr/core/modal': path.resolve('../../dist/core/modal'),
-        '@clr/core/password': path.resolve('../../dist/core/password'),
-        '@clr/core/radio': path.resolve('../../dist/core/radio'),
-        '@clr/core/range': path.resolve('../../dist/core/range'),
-        '@clr/core/search': path.resolve('../../dist/core/search'),
-        '@clr/core/select': path.resolve('../../dist/core/select'),
-        '@clr/core/tag': path.resolve('../../dist/core/tag'),
-        '@clr/core/textarea': path.resolve('../../dist/core/textarea'),
-        '@clr/core/time': path.resolve('../../dist/core/time'),
-        '@clr/core/toggle': path.resolve('../../dist/core/toggle'),
-        // @TODO Would like to be able to remove these
-        'ramda': path.resolve('../../packages/core/node_modules/ramda'),
-        'ramda/es/anyPass': path.resolve('../../packages/core/node_modules/ramda/es/anyPass.js'),
-        'ramda/es/equals': path.resolve('../../packages/core/node_modules/ramda/es/equals.js'),
-        'ramda/es/isNil': path.resolve('../../packages/core/node_modules/ramda/es/isNil.js'),
-        'ramda/es/includes': path.resolve('../../packages/core/node_modules/ramda/es/includes.js'),
-        'ramda/es/curryN': path.resolve('../../packages/core/node_modules/ramda/es/curryN.js'),
-        'ramda/es/path': path.resolve('../../packages/core/node_modules/ramda/es/path.js'),
-        'ramda/es/has': path.resolve('../../packages/core/node_modules/ramda/es/has.js'),
-        'ramda/es/is': path.resolve('../../packages/core/node_modules/ramda/es/is.js'),
-        'ramda/es/isEmpty': path.resolve('../../packages/core/node_modules/ramda/es/isEmpty.js'),
-        'ramda/es/without': path.resolve('../../packages/core/node_modules/ramda/es/without.js'),
-      },
-    },
-  },
+  }
 };

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -12,6 +12,7 @@
     "lint": "markdownlint '**/*.md' --ignore 'node_modules'"
   },
   "dependencies": {
+    "@clr/core": "./dist/core",
     "@sentry/browser": "5.15.5",
     "@sentry/integrations": "5.15.5",
     "markdown-it-attrs": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "react:build": "yarn --cwd packages/react run build",
     "react:lint": "yarn --cwd packages/react run lint",
     "react:test": "yarn --cwd packages/react run test",
-    "preinstall": "mkdir -p ./packages/core/dist/core/ && mkdir -p ./packages/react/dist/react/",
+    "preinstall": "yarn --cwd packages/core build:preinstall && yarn --cwd packages/react build:preinstall",
     "website:deploy": "scripts/website.sh",
     "website:build": "yarn --cwd apps/website run build",
     "website:storybook": "yarn --cwd packages/angular run start:storybook",

--- a/packages/angular/.storybook/tsconfig.json
+++ b/packages/angular/.storybook/tsconfig.json
@@ -3,8 +3,6 @@
   "compilerOptions": {
     "types": ["node"],
     "paths": {
-      "@clr/core": ["./dist/core"],
-      "@clr/core/*": ["./dist/core/*"],
       "@clr/icons": ["./dist/clr-icons"],
       "@clr/icons/*": ["./dist/clr-icons/*"],
       "@clr/angular": ["./dist/clr-angular"],

--- a/packages/angular/projects/clr-angular/package.json
+++ b/packages/angular/projects/clr-angular/package.json
@@ -11,6 +11,7 @@
   "peerDependencies": {
     "@angular/common": "^11.0.0",
     "@angular/core": "^11.0.0",
+    "@clr/core": "./dist/core",
     "@clr/ui": "@VERSION"
   },
   "author": "Clarity Design System",

--- a/packages/angular/tsconfig.json
+++ b/packages/angular/tsconfig.json
@@ -22,9 +22,7 @@
       "@clr/angular": ["./projects/clr-angular/src/index.ts"],
       "@clr/angular/*": ["./projects/clr-angular/src/*"],
       "@clr/icons": ["../../dist/clr-icons"],
-      "@clr/icons/shapes/*": ["../../dist/clr-icons/shapes/*"],
-      "@clr/core": ["../../dist/core"],
-      "@clr/core/*": ["../../dist/core/*"]
+      "@clr/icons/shapes/*": ["../../dist/clr-icons/shapes/*"]
     }
   },
   "angularCompilerOptions": {

--- a/packages/core/package.js
+++ b/packages/core/package.js
@@ -78,26 +78,7 @@ function generateAPIMetaData() {
 }
 
 function distributeBuild() {
-  return Promise.all([
-    // make copy into root dist for publishing
-    cpy(['./core'], '../../../dist', { cwd: './dist', parents: true }),
-
-    // copy latest for react wrapper dev app
-    cpy(['./core'], '../../react/node_modules/@clr', { cwd: './dist', parents: true }),
-
-    // copy latest for demo apps (many tools don't support symlinks so this is a workaround of sorts)
-    ...[
-      'core-angular-cli',
-      'core-angular-js',
-      'core-angular-universal',
-      'core-create-react-app',
-      'core-ie',
-      'core-parcel-js',
-      'core-rollup-js',
-      'core-snowpack',
-      'core-vue-cli',
-    ].map(app => cpy(['./core'], `../../../apps/${app}/node_modules/@clr`, { cwd: './dist', parents: true })),
-  ]);
+  return cpy(['./core'], '../../../dist', { cwd: './dist', parents: true });
 }
 
 (async () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,8 @@
     "test:unit": "tsc --b ./tsconfig.spec.json --force && karma start ./karma.conf.js && yarn run build:package",
     "test:performance": "webpack --config ./test-bundles/webpack.config.js && bundlesize --config ./test-bundles/bundlesize.json",
     "test:bundles": "source-map-explorer dist/test-bundles/webpack.bundle.js",
-    "build": "npm-run-all -s build:tokens build:sass build:ts build:package",
+    "build": "npm-run-all -s build:tokens build:sass build:ts build:package build:distribute",
+    "build:distribute": "cd ../../scripts/ && node ./package-distribute.js @clr/core",
     "build:watch": "npm-run-all -p build:sass:watch build:ts:watch",
     "build:package": "node ./package-css.js && node ./package.js",
     "build:ts": "tsc --b ./tsconfig.project.json --force",
@@ -21,7 +22,8 @@
     "build:sass": "npm-run-all 'build:sass:modules' -p 'build:sass:components'",
     "build:sass:watch": "npm-run-all 'build:sass' -p 'build:sass:components -- -w' 'build:sass:modules -- --watch' & chokidar './dist/core/**/*.css' -c 'node ./package-css.js' -i './dist/core/**/*.min.css'",
     "build:sass:modules": "sass --no-source-map ./src/styles:./dist/core/styles ./src/styles/global.scss:./dist/core/global.css ./src/list:./dist/core/list",
-    "build:sass:components": "sass-render --q --suffix '.css.ts' -t ./sass-template.js './**/*.element.scss' './**/*.global.scss'"
+    "build:sass:components": "sass-render --q --suffix '.css.ts' -t ./sass-template.js './**/*.element.scss' './**/*.global.scss'",
+    "build:preinstall": "mkdir -p ../../dist/core/ && cp ./package.json ../../dist/core/"
   },
   "description": "Clarity Design System Web Components",
   "homepage": "https://clarity.design",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,10 +4,12 @@
   "scripts": {
     "start": "npm-run-all core:build dev:start",
     "dev:start": "yarn run clean && parcel index.html --cache-dir=./.parcel-cache",
-    "build": "npm-run-all -s build:ts build:package build:copy",
+    "build": "npm-run-all -s build:ts build:package build:copy build:distribute",
+    "build:distribute": "cd ../../scripts/ && node ./package-distribute.js @clr/react",
     "build:copy": "cpy './react' '../../../dist' --cwd=./dist --parents",
     "build:package": "cpy '**/package.json' '../dist/react/' --cwd=./src --parents && cpy ./package.json ./dist/react/ && cpy ./README.md ./dist/react/ && node ./package.js",
     "build:ts": "tsc --b ./tsconfig.project.json --force",
+    "build:preinstall": "mkdir -p ../../dist/react/ && cp ./package.json ../../dist/react/",
     "core:build": "yarn --cwd ../core run build",
     "lint": "eslint \"*/**/*.{ts,tsx}\" --ignore-pattern \"dist\"",
     "lint:fix": "eslint --fix \"*/**/*.{ts,tsx}\" --ignore-pattern \"dist\"",
@@ -17,9 +19,11 @@
     "clean": "del ./dist .parcel-cache"
   },
   "dependencies": {
-    "@clr/core": "./packages/core/dist/core",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
+  },
+  "peerDependencies": {
+    "@clr/core": "./dist/core"
   },
   "devDependencies": {
     "@babel/core": "7.10.2",

--- a/scripts/package-distribute.js
+++ b/scripts/package-distribute.js
@@ -1,0 +1,51 @@
+'use strict';
+const fs = require('fs-extra');
+const path = require('path');
+const packageName = process.argv.slice(2)[0];
+
+function read(dir) {
+  return fs
+    .readdirSync(dir)
+    .reduce(
+      (files, file) =>
+        fs.statSync(path.join(dir, file)).isDirectory() && !dir.includes('node_modules')
+          ? files.concat(read(path.join(dir, file)))
+          : files.concat(path.join(dir, file)),
+      []
+    );
+}
+
+function getProjects() {
+  return [...read('../packages'), ...read('../apps')]
+    .filter(
+      f => f.endsWith('/package.json') && !f.includes('node_modules') && !f.includes('dist') && !f.includes('src')
+    )
+    .map(f => ({ path: f, json: fs.readJsonSync(f) }));
+}
+
+function packageHasDependency(packageJSON, dependency) {
+  return (
+    (packageJSON.dependencies && packageJSON.dependencies[dependency]) ||
+    (packageJSON.peerDependencies && packageJSON.peerDependencies[dependency])
+  );
+}
+
+const projects = getProjects();
+const packages = projects
+  .filter(p => (packageName ? p.json.name.includes(packageName) : true))
+  .filter(project => project.path.includes('packages/') && project.json.name.includes('@clr/'));
+
+Promise.all(
+  packages.map(pkg =>
+    projects
+      .filter(p => packageHasDependency(p.json, pkg.json.name))
+      .forEach(dep => {
+        const distName = pkg.json.name.replace('@clr/', '');
+        const dest = `./${dep.path.replace('/package.json', `/node_modules/@clr/${distName}`)}`;
+        const src = `./${pkg.path.replace('/package.json', `/dist/${distName}/`)}`;
+        return fs.copy(src, dest);
+      })
+  )
+)
+  .then(() => console.log(`Local package ${packageName} distributed.`))
+  .catch(err => console.error(err));

--- a/yarn.lock
+++ b/yarn.lock
@@ -3323,7 +3323,7 @@
   resolved "https://registry.yarnpkg.com/@clr/city/-/city-1.1.0.tgz#4a444cd12c626d66ffadab27e9d09bb3c8eca352"
   integrity sha512-R+C4uywmXoTD01LINOt3O0cBRviQdbAVNxdVvOyuO3+rM9bvFroF7UZY0R1ue/xvKXlqJrEkNKZQODeKjzaAhA==
 
-"@clr/core@./packages/core/dist/core":
+"@clr/core@./dist/core":
   version "4.0.0"
   dependencies:
     "@types/resize-observer-browser" "^0.1.3"
@@ -3335,7 +3335,7 @@
     "@clr/city" "^1.1.0"
     normalize.css "^8.0.1"
 
-"@clr/react@./packages/react/dist/react":
+"@clr/react@./dist/react":
   version "4.0.0"
   dependencies:
     react "^16.13.1"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

This is a very similar but slightly different option to the solution in https://github.com/vmware/clarity/pull/5310 in case the yarn link does not work out. This still needs more testing to be sure but I wanted to put up what code I had so far as I wont be able look into this until tomorrow or next Monday.

We need a way to resolve and install locally built dependencies in the monorepo. This issue is a blocker for 5.0. Some examples of these new and existing dependency chains:

- core-react-app => @clr/react => @clr/core => lit-element, lit-html...
- angular-dev-app => @clr/angular => @cds/angular => @clr/core => lit-element, lit-html...
- website => @clr/core => lit-element, lit-html...

We have gotten around this so far with inconsistent build scripts copying files (@clr/core/react) or custom webpack setups (website). However with Angular packages now depending on Core there are new issues.

We cannot copy the build of Core for the Angular CLI projects to use like we do with other projects. Angular CLI has not worked well with the package hoisting feature that yarn has provided. Because of this every Angular project installs all
of its dependencies in isolation, dependencies like lit-html are not available unless explicitly listed and installed by yarn. However our library should not be listing upstream dependencies only direct dependencies like `@clr/core`.
This can cause dependency mismatch issues by not allowing normal dependency resolution by npm and yarn.

So this leaves two possible solutions that I am aware of. The first is outlined in https://github.com/vmware/clarity/pull/5310. Yarn link is how yarn would handle local package linking without using features of yarn 2. This would make some local development easier as we can help ensure consistency between the dependencies as they all point to the same local build output directory. We have had issues with yarn link with the Angular CLI in the past but some of those seem to have been improved.

This PR is what I had come up with that is a bit less than ideal but may be the option if yarn does not work. This uses a copy build strategy similar to what core does today but in a generic way like https://github.com/vmware/clarity/pull/5310.

The trick to making this work is two steps. First, we must copy the package.json files of our packages (@clr/react, @clr/core) into the root dist during the yarn preinstall.

```json
mkdir -p ../../dist/core/ && cp ./package.json ../../dist/core/
```

This will allow projects to refer to them locally in their package.json.

```json
{
  "@clr/core": "./dist/core"
}
```

This step is important as it allows yarn to install without building and ensure all upstream dependencies are installed. Example clr-angular needs core which needs lit-html installed.

The second step is after a package builds it calls a generic script which finds all the projects in the repo that have a dependency on the package and copies the build output into the node_modules directory of the project.

This strategy will allow all projects to refer dependencies in a consistent way and remove custom copy scripts, webpack configs and tsconfig mappings. This is similar to https://github.com/vmware/clarity/pull/5310 but swapping yarn link for a copy step. There may be a better way to do this as this is just extending what Core does today in a generic way for all packages.

- [ ] Yes
- [x] No
