### PR TITLE
fix(accordion): stop emitting the same event twice

### DIFF
--- a/packages/angular/projects/clr-angular/src/accordion/accordion-panel.ts
+++ b/packages/angular/projects/clr-angular/src/accordion/accordion-panel.ts
@@ -102,7 +102,9 @@ export class ClrAccordionPanel implements OnInit, OnChanges {
   }
 
   private emitPanelChange(panel: AccordionPanelModel) {
-    this.panelOpenChange.emit(panel.open);
+    if (panel.open !== this.panelOpen) {
+      this.panelOpenChange.emit(panel.open);
+    }
 
     if (panel.open) {
       this.ifExpandService.expanded = true;


### PR DESCRIPTION
The accordion was triggering unneeded events on start with the initialized value.

Now only when the state has changed an event will be triggered

fixes #5276

Signed-off-by: Bozhidar Dryanovski <bozhidar.dryanovski@gmail.com>


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5276 

## What is the new behavior?

The event is triggered only when there is a change in value.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Close #5276  