### PR TITLE
fix: (combobox) simplify control state management

### DIFF
--- a/packages/angular/projects/clr-angular/src/forms/combobox/combobox.ts
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/combobox.ts
@@ -256,15 +256,7 @@ export class ClrCombobox<T> extends WrappedFormControl<ClrComboboxContainer>
         if (!this.multiSelect && newSelection && !newSelection.isEmpty()) {
           this.toggleService.open = false;
         }
-
         this.updateControlValue();
-        if (this.control && this.control.control) {
-          this.control.control.updateValueAndValidity();
-        }
-        // for the purposes of validation
-        if (this.onChangeCallback) {
-          this.onChangeCallback(this.optionSelectionService.selectionModel.model);
-        }
       })
     );
 
@@ -318,8 +310,8 @@ export class ClrCombobox<T> extends WrappedFormControl<ClrComboboxContainer>
   }
 
   private updateControlValue() {
-    if (this.control && this.control.control) {
-      this.control.control.setValue(this.optionSelectionService.selectionModel.model);
+    if (this.onChangeCallback) {
+      this.onChangeCallback(this.optionSelectionService.selectionModel.model);
     }
   }
 


### PR DESCRIPTION
It was leading to lifecycle calls overhead in incorrect intermediate states.
closes: #5101
Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

There are intermediate pristine state changes, which get caught by the Stepper and it resets itself.

Issue Number: #5101 

## What is the new behavior?

All direct control-manipulations are removed and communication with the forms API goes only through the ControlValueAccessor interface. Stepper does not reset.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
