### PR TITLE
fix: icon inheritance (color, cursor)

### DIFF
--- a/packages/core/src/icon/icon.element.scss
+++ b/packages/core/src/icon/icon.element.scss
@@ -16,14 +16,15 @@
 }
 
 :host {
-  --color: #{$cds-alias-object-interaction-color};
+  --color: currentColor;
   display: inline-block;
   @include equilateral(#{$cds-global-space-7});
   margin: 0;
   vertical-align: middle;
   fill: var(--color);
-  color: inherit; // inherit so older clr-icon based themes get currentColor from parent
+  color: var(--color); // See https://github.com/vmware/clarity/issues/5332
   contain: strict;
+  cursor: inherit;
 }
 
 svg {

--- a/packages/core/src/progress-circle/progress-circle.element.scss
+++ b/packages/core/src/progress-circle/progress-circle.element.scss
@@ -9,6 +9,7 @@
   font-size: inherit;
   color: inherit;
   display: block;
+  cursor: inherit;
 }
 
 svg {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: https://github.com/vmware/clarity/issues/5332

Icons do not inherit color or cursor of the element surrounding them. This is particularly true with links:

![link-before](https://user-images.githubusercontent.com/113730/100934369-a57f2000-34bc-11eb-905d-b905d4c33f49.gif)

(This was rendered in Clarity Core's Storybook with `<a href="#" cds-text="link">This is a <cds-icon shape="user" solid></cds-icon> link</a>`)

Additionally, I (temporarily and locally) replaced `cursor: pointer !important;` with `cursor: pointer;` in `packages/core/src/internal/base/base.element.scss` on `:host([role='button'])` to reproduce what I experienced in the linked issue and could confirm I was seeing this as well:

![button-with-icon-before](https://user-images.githubusercontent.com/113730/100935637-59cd7600-34be-11eb-8cb7-126e60ee7b54.gif) ![loading-button-before](https://user-images.githubusercontent.com/113730/100935644-5b973980-34be-11eb-9adb-9cf0e9838d27.gif)

## What is the new behavior?

Respectively, the "after" of all 3 screencasts above:


![link-after](https://user-images.githubusercontent.com/113730/100935748-7d90bc00-34be-11eb-8493-11a4e1a9002c.gif)

![button-with-icon-after](https://user-images.githubusercontent.com/113730/100935742-7c5f8f00-34be-11eb-8862-ded9a6197cf2.gif) ![loading-button-after](https://user-images.githubusercontent.com/113730/100935749-7e295280-34be-11eb-81bc-bcfeeabfb186.gif)


## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

I checked `Yes` because in my understanding, all consumers that do not explicitly set the color or cursor of their icon will see a difference. It is even more prominent with colors, if consumers were letting Clarity define a homogenous (gray) color for all icons, they will now all be colored after their parent element.
I'm not sure what would be a good migration path, happy to talk about it.

## Other information

I did not commit the `cursor: pointer;` change without the `!important` I made locally, as I'm sure there are a lot more consequences to that (e.g. the badge would need the same treatment) but I think it would be beneficial overall if/when it becomes possible to remove it.
I however committed the change on the progress-circle element as it's related, let me know if it's not welcome here.