### PR TITLE
fix: auto register cds-icon in Angular

### DIFF
--- a/packages/angular/projects/clr-angular/package.json
+++ b/packages/angular/projects/clr-angular/package.json
@@ -6,7 +6,7 @@
   "keywords": ["ng-add", "clarity", "angular", "components"],
   "repository": {
     "type": "git",
-    "url": "git@github.com:vmware/clarity.git"
+    "url": "https://github.com/vmware/clarity.git"
   },
   "peerDependencies": {
     "@angular/common": "^11.0.0",

--- a/packages/angular/projects/clr-angular/src/clr-angular.module.ts
+++ b/packages/angular/projects/clr-angular/src/clr-angular.module.ts
@@ -25,6 +25,9 @@ import { ClrProgressBarModule } from './progress/progress-bars/progress-bar.modu
 import { ClrPopoverModuleNext } from './utils/popover/popover.module';
 import { ClrTimelineModule } from './timeline/timeline.module';
 
+// Register the icon library
+import '@cds/core/icon/register';
+
 @NgModule({
   exports: [
     ClrEmphasisModule,

--- a/packages/eslint-plugin-clarity-adoption/package.json
+++ b/packages/eslint-plugin-clarity-adoption/package.json
@@ -11,6 +11,10 @@
   ],
   "author": "clarity",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vmware/clarity.git"
+  },
   "scripts": {
     "build": "npm-run-all build:tsc build:package",
     "build:package": "cpy package.json README.md ../../dist/eslint-plugin-clarity-adoption/;",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -17,6 +17,10 @@
     "test:snap:update": "jest --updateSnapshot",
     "clean": "del ./dist .parcel-cache"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vmware/clarity.git"
+  },
   "dependencies": {
     "react": "^16.13.1",
     "react-dom": "^16.13.1"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -12,8 +12,12 @@
     "build:optimize": "csso -i ./dist/clr-ui/clr-ui.css -o ./dist/clr-ui/clr-ui.min.css -s file --no-restructure; csso -i ./dist/clr-ui/clr-ui-dark.css -o ./dist/clr-ui/clr-ui-dark.min.css -s file --no-restructure",
     "build:package": "cpy npm.json README.md ./dist/clr-ui/; mv ./dist/clr-ui/npm.json ./dist/clr-ui/package.json; replace '@VERSION' $npm_package_version ./dist/clr-ui/package.json; "
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vmware/clarity.git"
+  },
   "peerDependencies": {
-    "@clr/icons": "./dist/icons"
+    "@cds/core": "./dist/core"
   },
   "devDependencies": {
     "chokidar-cli": "2.1.0",


### PR DESCRIPTION
We don't register the icons automatically so they won't appear unless the app does it manually. This does it automatically now. It also updates the package files repository urls to be consistent.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
