### PR TITLE
fix: password input a11y improvement

### DIFF
--- a/packages/core/src/password/password.element.spec.ts
+++ b/packages/core/src/password/password.element.spec.ts
@@ -49,4 +49,17 @@ describe('cds-password', () => {
     expect(component.inputControl.type).toBe('password');
     expect(component.shadowRoot.querySelector('cds-icon').shape).toBe('eye');
   });
+
+  it('should focus back on input when show/hide is clicked', async () => {
+    await componentIsStable(component);
+    expect(document.activeElement).not.toEqual(component.inputControl);
+
+    component.shadowRoot.querySelector('cds-control-action').click();
+    await componentIsStable(component);
+    expect(document.activeElement).toEqual(component.inputControl);
+
+    component.shadowRoot.querySelector('cds-control-action').click();
+    await componentIsStable(component);
+    expect(document.activeElement).toEqual(component.inputControl);
+  });
 });

--- a/packages/core/src/password/password.element.ts
+++ b/packages/core/src/password/password.element.ts
@@ -67,5 +67,6 @@ export class CdsPassword extends CdsControl {
   togglePasswordVisibility() {
     this.showPassword = !this.showPassword;
     this.inputControl.type = this.showPassword ? 'text' : 'password';
+    this.inputControl.focus();
   }
 }


### PR DESCRIPTION
Signed-off-by: Jeeyun Lim <jeeyun.lim@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When you click on show/hide password button, the focus remains on the button.

## What is the new behavior?

When you click on show/hide password button, the focus now moves back to the password input field. This allows the SR to read out the password if the user clicked on "show" button. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
