### PR TITLE
fix: file input a11y improvement

### DIFF
--- a/packages/core/src/file/file.element.spec.ts
+++ b/packages/core/src/file/file.element.spec.ts
@@ -62,15 +62,15 @@ describe('cds-file', () => {
     expect(button.innerText.toLocaleLowerCase()).toBe('browse');
 
     // cast to test method as its not possible to trigger file upload in test due to browser security reasons
-    (component as any).updateLabel([{ name: 'test.png' }]);
+    (component as any).updateLabelAndFocus([{ name: 'test.png' }]);
     await componentIsStable(component);
     expect(button.innerText.toLocaleLowerCase()).toBe('test.png');
 
-    (component as any).updateLabel([{ name: 'test.png' }, { name: 'test2.png' }]);
+    (component as any).updateLabelAndFocus([{ name: 'test.png' }, { name: 'test2.png' }]);
     await componentIsStable(component);
     expect(button.innerText.toLocaleLowerCase()).toBe('2 files');
 
-    (component as any).updateLabel();
+    (component as any).updateLabelAndFocus();
     await componentIsStable(component);
     expect(button.innerText.toLocaleLowerCase()).toBe('browse');
   });
@@ -85,5 +85,6 @@ describe('cds-file', () => {
     component.shadowRoot.querySelector('cds-control-action').click();
     await componentIsStable(component);
     expect(button.innerText.toLocaleLowerCase()).toBe('browse');
+    expect(document.activeElement).toBe(component);
   });
 });

--- a/packages/core/src/file/file.element.ts
+++ b/packages/core/src/file/file.element.ts
@@ -55,7 +55,7 @@ export class CdsFile extends CdsControl {
 
   protected get clearFiles() {
     return this.inputControl.files?.length
-      ? html` <cds-control-action @click="${() => this.updateLabel()}" aria-label="${this.i18n.removeFile}">
+      ? html` <cds-control-action @click="${() => this.updateLabelAndFocus()}" aria-label="${this.i18n.removeFile}">
           <cds-icon shape="times"></cds-icon>
         </cds-control-action>`
       : html``;
@@ -63,15 +63,21 @@ export class CdsFile extends CdsControl {
 
   firstUpdated(props: Map<string, any>) {
     super.firstUpdated(props);
-    this.inputControl.addEventListener('change', e => this.updateLabel((e.target as any).files));
+    this.inputControl.addEventListener('change', e => this.updateLabelAndFocus((e.target as any).files));
   }
 
-  private updateLabel(files?: FileList) {
+  private updateLabelAndFocus(files?: FileList) {
     if (files && files.length) {
       this.buttonLabel = files.length > 1 ? `${files.length} ${this.i18n.files}` : files[0].name;
     } else {
       this.buttonLabel = this.i18n.browse;
       this.inputControl.value = '';
+
+      const browseButton = this.shadowRoot?.querySelector('cds-button');
+
+      if (browseButton) {
+        browseButton.focus();
+      }
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Jeeyun Lim <jeeyun.lim@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When you click on the "X" button to clear the file chosen, there's no shift in focus.

## What is the new behavior?

When you click on the "X" button to clear the file chosen, the focus moves back to the "browse" button. This allows the SR to read out the button informing that the previously chosen file is no longer there.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
