### PR TITLE
fix(datagrid): allow apps to disable focus management on page change

### DIFF
--- a/packages/angular/golden/clr-angular.d.ts
+++ b/packages/angular/golden/clr-angular.d.ts
@@ -474,6 +474,7 @@ export declare class ClrDatagrid<T = any> implements AfterContentInit, AfterView
     get allSelected(): boolean;
     set allSelected(_value: boolean);
     clrDetailExpandableAriaLabel: string;
+    clrDgDisablePageFocus: boolean;
     set clrDgPreserveSelection(state: boolean);
     clrDgSingleActionableAriaLabel: string;
     clrDgSingleSelectionAriaLabel: string;

--- a/packages/angular/projects/clr-angular/src/data/datagrid/datagrid.spec.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/datagrid.spec.ts
@@ -37,6 +37,7 @@ import { DetailService } from './providers/detail.service';
       *ngIf="!destroy"
       [(clrDgSelected)]="selected"
       [clrDgLoading]="loading"
+      [clrDgDisablePageFocus]="disableFocus"
       (clrDgRefresh)="refresh($event)"
     >
       <clr-dg-column>
@@ -57,6 +58,7 @@ import { DetailService } from './providers/detail.service';
 class FullTest {
   items = [1, 2, 3];
 
+  disableFocus = false;
   loading = false;
   selected: number[];
 
@@ -618,6 +620,20 @@ export default function (): void {
           const page: Page = context.getClarityProvider(Page);
           page.current = 2;
           expect(() => context.detectChanges()).not.toThrow();
+        });
+
+        it('focuses the datagrid on page change', function () {
+          expect(context.clarityDirective.datagridTable.nativeElement).not.toEqual(document.activeElement);
+          context.getClarityProvider(Page).current = 2;
+          expect(context.clarityDirective.datagridTable.nativeElement).toEqual(document.activeElement);
+        });
+
+        it('does not focus the datagrid on page change when disabled', function () {
+          context.testComponent.disableFocus = true;
+          context.detectChanges();
+          expect(context.clarityDirective.datagridTable.nativeElement).not.toEqual(document.activeElement);
+          context.getClarityProvider(Page).current = 2;
+          expect(context.clarityDirective.datagridTable.nativeElement).not.toEqual(document.activeElement);
         });
 
         // Actually not fixed yet, my bad

--- a/packages/angular/projects/clr-angular/src/data/datagrid/datagrid.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/datagrid.ts
@@ -158,6 +158,8 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
   @Input() clrDgSingleSelectionAriaLabel: string = this.commonStrings.keys.singleSelectionAriaLabel;
   @Input() clrDgSingleActionableAriaLabel: string = this.commonStrings.keys.singleActionableAriaLabel;
   @Input() clrDetailExpandableAriaLabel: string = this.commonStrings.keys.detailExpandableAriaLabel;
+  // Allows disabling of the auto focus on page/state changes (excludes focus management inside of popups)
+  @Input() clrDgDisablePageFocus = false;
 
   @Input()
   set clrDgPreserveSelection(state: boolean) {
@@ -268,7 +270,9 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
         }
       }),
       this.page.change.subscribe(() => {
-        this.datagridTable.nativeElement.focus();
+        if (!this.clrDgDisablePageFocus) {
+          this.datagridTable.nativeElement.focus();
+        }
       }),
       // A subscription that listens for displayMode changes on the datagrid
       this.displayMode.view.subscribe(viewChange => {


### PR DESCRIPTION
This allows an application to disable the focus management on page change in cases where there are unexpected side effects. It is a requirement by default to have it on, so the setting is to disable it.

`<clr-datagrid [clrDgDisablePageFocus]="disableFocus"></clr-datagrid>`

closes #4229
closes #5374

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
