### PR TITLE
fix: update json for sketch link

### DIFF
--- a/packages/angular/projects/website/src/releases/release-list.json
+++ b/packages/angular/projects/website/src/releases/release-list.json
@@ -3,7 +3,8 @@
   "all": {
     "4.0.0": {
       "date": "August 19, 2020",
-      "figma": "2.2.0"
+      "figma": "2.2.0",
+      "sketch": "2.2.0"
     },
     "4.0.1": {
       "date": "August 27, 2020",
@@ -11,186 +12,196 @@
     },
     "4.0.2": {
       "date": "September 17, 2020",
-      "figma": "2.2.0"
+      "figma": "2.2.0",
+      "sketch": "2.2.0"
     },
     "4.0.3": {
       "date": "October 1, 2020",
-      "figma": "2.2.0"
+      "figma": "2.2.0",
+      "sketch": "2.2.0"
     },
     "4.0.4": {
       "date": "October 15, 2020",
-      "figma": "2.2.0"
+      "figma": "2.2.0",
+      "sketch": "2.2.0"
     },
     "4.0.5": {
       "date": "October 29, 2020",
-      "figma": "2.2.0"
+      "figma": "2.2.0",
+      "sketch": "2.2.0"
     },
     "4.0.6": {
       "date": "November 12, 2020",
-      "figma": "2.2.0"
+      "figma": "2.2.0",
+      "sketch": "2.2.0"
     },
     "4.0.7": {
       "date": "November 26, 2020",
-      "figma": "2.2.0"
+      "figma": "2.2.0",
+      "sketch": "2.2.0"
     },
     "4.0.8": {
       "date": "December 7, 2020",
-      "figma": "2.2.0"
+      "figma": "2.2.0",
+      "sketch": "2.2.0"
     },
     "4.0.0-rc.1": {
       "date": "July 15, 2020",
-      "figma": "2.2.0"
+      "figma": "2.2.0",
+      "sketch": "2.2.0"
     },
     "4.0.0-rc.0": {
       "date": "July 7, 2020",
-      "figma": "2.2.0"
+      "figma": "2.2.0",
+      "sketch": "2.2.0"
     },
     "4.0.0-next.0": {
       "date": "June 17, 2020",
-      "figma": "2.2.0"
+      "figma": "2.2.0",
+      "sketch": "2.2.0"
     },
     "3.1.14": {
       "date": "November 26, 2020",
       "figma": "2.2.0",
-      "sketch": ""
+      "sketch": "2.2.0"
     },
     "3.1.13": {
       "date": "December 7, 2020",
       "figma": "2.2.0",
-      "sketch": ""
+      "sketch": "2.2.0"
     },
     "3.1.12": {
       "date": "November 12, 2020",
       "figma": "2.2.0",
-      "sketch": ""
+      "sketch": "2.2.0"
     },
     "3.1.11": {
       "date": "October 29, 2020",
       "figma": "2.2.0",
-      "sketch": ""
+      "sketch": "2.2.0"
     },
     "3.1.10": {
       "date": "October 15, 2020",
       "figma": "2.2.0",
-      "sketch": ""
+      "sketch": "2.2.0"
     },
     "3.1.9": {
       "date": "October 1, 2020",
       "figma": "2.2.0",
-      "sketch": ""
+      "sketch": "2.2.0"
     },
     "3.1.8": {
       "date": "September 17, 2020",
       "figma": "2.2.0",
-      "sketch": ""
+      "sketch": "2.2.0"
     },
     "3.1.7": {
       "date": "August 27, 2020",
       "figma": "2.2.0",
-      "sketch": ""
+      "sketch": "2.2.0"
     },
     "3.1.6": {
       "date": "August 19, 2020",
       "figma": "2.2.0",
-      "sketch": ""
+      "sketch": "2.2.0"
     },
     "3.1.5": {
       "date": "July 23, 2020",
       "figma": "2.2.0",
-      "sketch": "",
+      "sketch": "2.2.0",
       "commit": "5d4b86b2711e9035e55058de2a008ea913f1791e"
     },
     "3.1.4": {
       "date": "June 17, 2020",
       "figma": "2.2.0",
-      "sketch": "",
+      "sketch": "2.2.0",
       "commit": "c58814772a1a8155d684273effbc004078096d26"
     },
     "3.1.3": {
       "date": "May 22, 2020",
       "figma": "2.2.0",
-      "sketch": "",
+      "sketch": "2.2.0",
       "commit": "2b90820c0b467d5fdcf5cb3817bf665f0b4845cd"
     },
     "3.1.2": {
       "date": "May 7, 2020",
       "figma": "2.2.0",
-      "sketch": "",
+      "sketch": "2.2.0",
       "commit": "a58e8087f57386a5c6d121e06811922a3ceb93ea"
     },
     "3.1.1": {
       "date": "Apr 23, 2020",
       "figma": "2.2.0",
-      "sketch": "",
+      "sketch": "2.2.0",
       "commit": "95963194bb09baa57a133aa0bcd6be67673a2c2e"
     },
     "3.1.0": {
       "date": "Apr 2, 2020",
       "figma": "2.2.0",
-      "sketch": "",
+      "sketch": "2.2.0",
       "commit": "6da155d7f33ca4875748819782bb7053979868d0"
     },
     "3.0.1": {
       "date": "Mar 12, 2020",
       "figma": "2.2.0",
-      "sketch": "",
+      "sketch": "2.2.0",
       "commit": "da8a565eb73927242676441ab74fda13771c73ff"
     },
     "3.0.0": {
       "date": "Feb 27, 2020",
       "figma": "2.2.0",
-      "sketch": "",
+      "sketch": "2.2.0",
       "commit": "d452f2f3e606c9394ce7d1f1495802fd7c45cb7c"
     },
     "3.0.0-rc.1": {
       "date": "Feb 21, 2020",
       "figma": "2.2.0",
-      "sketch": "",
+      "sketch": "2.2.0",
       "commit": "0d7374c71473d0d6eda29899612afaa900de6c3d"
     },
     "3.0.0-next.8": {
       "date": "Feb 8, 2020",
       "figma": "2.2.0",
-      "sketch": "",
+      "sketch": "2.2.0",
       "commit": "4f2757704664ad5d136432f326b3a241c298d5a2"
     },
     "3.0.0-next.7": {
       "date": "Jan 23, 2020",
       "figma": "2.2.0",
-      "sketch": "",
+      "sketch": "2.2.0",
       "commit": "93c094e769cb556d8ce2af0230d5fa259f3bb452"
     },
     "3.0.0-next.6": {
       "date": "Jan 9, 2020",
       "figma": "2.2.0",
-      "sketch": "",
+      "sketch": "2.2.0",
       "commit": "6ead3ef681168ace68ce5884e85643f8f21e8184"
     },
     "3.0.0-next.5": {
       "date": "Dec 19, 2019",
       "figma": "2.2.0",
-      "sketch": "",
+      "sketch": "2.2.0",
       "commit": "c822fc934bd88ba28e9eb8cd3a8b0ca014e4ea36"
     },
     "3.0.0-next.4": {
       "date": "Dec 5, 2019",
-      "sketch": "",
+      "sketch": "2.2.0",
       "commit": "3be4137e363a40e783067602f70a282a08880555"
     },
     "3.0.0-next.3": {
       "date": "Nov 19, 2019",
       "figma": "2.2.0",
-      "sketch": ""
+      "sketch": "2.2.0"
     },
     "3.0.0-next.2": {
       "date": "Oct 18, 2019",
       "figma": "2.2.0",
-      "sketch": ""
+      "sketch": "2.2.0"
     },
     "3.0.0-next.1": {
       "date": "Oct 3, 2019",
       "figma": "2.2.0",
-      "sketch": ""
+      "sketch": "2.2.0"
     },
     "2.4.10": {
       "date": "November 26, 2020",


### PR DESCRIPTION
the skecth link is broken on the news page for several releases. This fixes the json and populates it so that sketch is downloadable from the website.

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
On several release pages the sketch link is broken. 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Sketch links owrk on recent release pages. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
