### PR TITLE
feat: allow env flag set for core logging

### DIFF
--- a/packages/core/src/internal/services/log.service.spec.ts
+++ b/packages/core/src/internal/services/log.service.spec.ts
@@ -39,4 +39,22 @@ describe('LogService', () => {
 
     window.jasmine = jasmine;
   });
+
+  it('should log when not in a production environment', () => {
+    window.CDS.environment.production = true;
+
+    spyOn(console, 'log');
+    spyOn(console, 'warn');
+    spyOn(console, 'error');
+
+    LogService.log('test log...');
+    LogService.warn('test warn...');
+    LogService.error('test error...');
+
+    expect(console.log).not.toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
+
+    window.CDS.environment.production = false;
+  });
 });

--- a/packages/core/src/internal/services/log.service.ts
+++ b/packages/core/src/internal/services/log.service.ts
@@ -8,19 +8,19 @@ import { existsInWindow } from '../utils/exists.js';
 
 export class LogService {
   static log(...args: any) {
-    if (notTestingEnvironment()) {
+    if (notProductionEnvironment() && notTestingEnvironment()) {
       console.log(...args);
     }
   }
 
   static warn(...args: any) {
-    if (notTestingEnvironment()) {
+    if (notProductionEnvironment() && notTestingEnvironment()) {
       console.warn(...args);
     }
   }
 
   static error(...args: any) {
-    if (notTestingEnvironment()) {
+    if (notProductionEnvironment() && notTestingEnvironment()) {
       console.error(...args);
     }
   }
@@ -28,4 +28,8 @@ export class LogService {
 
 function notTestingEnvironment() {
   return !existsInWindow(['jasmine']);
+}
+
+function notProductionEnvironment() {
+  return !window.CDS.environment.production;
 }

--- a/packages/core/src/internal/utils/global.ts
+++ b/packages/core/src/internal/utils/global.ts
@@ -10,9 +10,13 @@ import { getAngularVersion, getReactVersion, getVueVersion, getAngularJSVersion 
 export interface CDSGlobal {
   _version: string[];
   _loadedElements: string[];
-  _react: { version: string }; // set by @clr/react
+  _react: { version: string }; // set by @cds/react
   getVersion: () => CDSLog;
   logVersion: () => void;
+  environment: {
+    /** Set to true for production env to disable dev time logging and tooling */
+    production: boolean;
+  };
 }
 
 export interface CDSLog {
@@ -23,6 +27,9 @@ export interface CDSLog {
   angularJSVersion?: string | undefined;
   reactVersion?: string | undefined;
   vueVersion?: string | undefined;
+  environment: {
+    production: boolean;
+  };
 }
 
 declare global {
@@ -34,12 +41,13 @@ declare global {
 function getVersion() {
   const log: CDSLog = {
     versions: window.CDS._version,
-    loadedElements: window.CDS._loadedElements,
+    environment: window.CDS.environment,
     userAgent: navigator.userAgent,
     angularVersion: getAngularVersion(false),
     angularJSVersion: getAngularJSVersion(false),
     reactVersion: getReactVersion(false),
     vueVersion: getVueVersion(false),
+    loadedElements: window.CDS._loadedElements,
   };
   return log;
 }
@@ -53,6 +61,9 @@ function initializeCDSGlobal() {
     _version: [],
     _loadedElements: [],
     _react: { version: undefined },
+    environment: {
+      production: false,
+    },
     getVersion,
     logVersion,
   };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?
This is a small feature that allows a production env flag to be set on the global CDS object so teams can disable our dev time specific logging. The logs can create a lot of noise in a production environment when logs are recorded. This would allow teams to disable when deploying their applications similar to Angular.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
