### PR TITLE
fix: add new fallback font for core

### DIFF
--- a/packages/core/build/tokens.ts
+++ b/packages/core/build/tokens.ts
@@ -339,8 +339,8 @@ const typography = {
   },
   baseFontSize: token('125%'),
   baseFontSizePx: token(20),
-  fontFamily: token("'Clarity City', 'Avenir Next', 'Helvetica Neue', Arial, sans-serif"),
-  headerFontFamily: token("'Clarity City', 'Avenir Next', 'Helvetica Neue', Arial, sans-serif"),
+  fontFamily: token("'Clarity City', Metropolis, 'Avenir Next', 'Helvetica Neue', Arial, sans-serif"),
+  headerFontFamily: token("'Clarity City', Metropolis, 'Avenir Next', 'Helvetica Neue', Arial, sans-serif"),
   topGapHeight: token('0.1475em'), // line-height eraser
   ascenderHeight: token('0.1703em'), // line-height eraser
   xHeight: token('0.517em'), // line-height eraser


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?
This adds Metropolis as a fallback font if Clarity City fails to load in Core. Many teams using Clarity Core and Clarity UI will have both available so this will make the fallback more robust.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
