### PR TITLE
fix(stack-view): tab navigation inside stack-block is skipped when not expanded

### DIFF
--- a/packages/angular/projects/clr-angular/src/data/stack-view/stack-block.spec.ts
+++ b/packages/angular/projects/clr-angular/src/data/stack-view/stack-block.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -65,6 +65,27 @@ class DynamicBlock {
   expanded = false;
 }
 
+@Component({
+  template: `
+    <clr-stack-block #main [clrSbExpandable]="true" [(clrSbExpanded)]="expanded">
+      <clr-stack-label id="STACK_LABEL_ID">Label</clr-stack-label>
+      <clr-stack-content>Content</clr-stack-content>
+
+      <clr-stack-block>
+        <clr-stack-label>Inner content</clr-stack-label>
+        <clr-stack-content>
+          <input />
+        </clr-stack-content>
+      </clr-stack-block>
+    </clr-stack-block>
+  `,
+})
+class DynamicBlockWithInput {
+  @ViewChild('main') blockInstance: ClrStackBlock;
+
+  expanded = false;
+}
+
 export default function (): void {
   'use strict';
   describe('StackBlock', () => {
@@ -74,7 +95,7 @@ export default function (): void {
     beforeEach(() => {
       TestBed.configureTestingModule({
         imports: [ClrStackViewModule, NoopAnimationsModule, FormsModule],
-        declarations: [BasicBlock, DynamicBlock, NestedBlocks],
+        declarations: [BasicBlock, DynamicBlock, DynamicBlockWithInput, NestedBlocks],
         providers: [ClrStackView],
       });
     });
@@ -292,6 +313,18 @@ export default function (): void {
       fixture.nativeElement.querySelector('clr-stack-label').click();
       fixture.detectChanges();
       expect(fixture.componentInstance.expanded).toBeFalsy();
+    });
+
+    it('should skip children when block is not expanded', () => {
+      fixture = TestBed.createComponent(DynamicBlockWithInput);
+
+      fixture.detectChanges();
+
+      expect(getBlockInstance(fixture).expanded).toBeFalsy();
+
+      const input = fixture.nativeElement.querySelector('input');
+
+      expect(input).toBeNull();
     });
 
     it('sets aria-controls attribute corresponding to stack-children id', () => {

--- a/packages/angular/projects/clr-angular/src/data/stack-view/stack-block.ts
+++ b/packages/angular/projects/clr-angular/src/data/stack-view/stack-block.ts
@@ -39,7 +39,7 @@ import { UNIQUE_ID, UNIQUE_ID_PROVIDER } from '../../utils/id-generator/id-gener
     </div>
 
     <clr-expandable-animation [clrExpandTrigger]="expanded" class="stack-children" [attr.id]="getStackChildrenId()">
-      <div [style.height]="expanded ? 'auto' : 0" role="region">
+      <div [style.height]="expanded ? 'auto' : 0" role="region" *ngIf="expanded">
         <ng-content select="clr-stack-block"></ng-content>
       </div>
     </clr-expandable-animation>


### PR DESCRIPTION
Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #4718

## What is the new behavior?

When tabbing the focus doesn't go inside unexpanded stack-block.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

