### PR TITLE
fix: core icon service sync

### DIFF
--- a/packages/core/src/icon/icon.element.spec.ts
+++ b/packages/core/src/icon/icon.element.spec.ts
@@ -45,12 +45,20 @@ describe('icon element', () => {
       expect(component.shape).toBe('testing');
     });
 
-    it('shape should return unknown if the shape is not in the registry', async () => {
-      // only shape in registry is 'unknown'
+    it('shape should render when a matching shape is updated in the registry', async () => {
+      const shape = 'jabberwocky';
+      const svg = '<svg>jabberwocky</svg>';
+      const unknown = 'M18,22.61a1,1,0,0';
+
       await componentIsStable(component);
-      component.shape = 'jabberwocky';
+      component.shape = shape;
       await componentIsStable(component);
-      expect(component.shape).toBe('unknown');
+      expect(component.shape).toBe(shape);
+      expect(component.shadowRoot.innerHTML).toContain(unknown);
+
+      ClarityIcons.addIcons([shape, svg]);
+      await componentIsStable(component);
+      expect(component.shadowRoot.innerHTML).toContain(svg);
     });
 
     it('shape should not run an update if the shape is assigned the value it already has', async () => {

--- a/packages/core/src/icon/icon.element.ts
+++ b/packages/core/src/icon/icon.element.ts
@@ -15,6 +15,7 @@ import {
   StatusTypes,
   isString,
   pxToRem,
+  EventSubscription,
 } from '@cds/core/internal';
 import { html, LitElement, query, svg } from 'lit-element';
 import { styles } from './icon.element.css.js';
@@ -59,7 +60,7 @@ export class CdsIcon extends LitElement {
    * the specified icon cannot be found in the icon registry.
    */
   set shape(val: string) {
-    if (hasStringPropertyChangedAndNotNil(val, this._shape) && ClarityIcons.registry[val]) {
+    if (hasStringPropertyChangedAndNotNil(val, this._shape)) {
       const oldVal = this._shape;
       this._shape = val;
       this.requestUpdate('shape', oldVal);
@@ -151,6 +152,8 @@ export class CdsIcon extends LitElement {
 
   @query('svg') private svg: SVGElement;
 
+  private subscription: EventSubscription;
+
   updated(props: Map<string, any>) {
     if (props.has('innerOffset') && this.innerOffset > 0) {
       const val = pxToRem(this.innerOffset);
@@ -159,6 +162,20 @@ export class CdsIcon extends LitElement {
       this.svg.style.height = dimension;
       this.svg.style.margin = `-${val} 0 0 -${val}`;
     }
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.subscription = ClarityIcons.iconUpdates.subscribe(shape => {
+      if (shape === this.shape) {
+        this.requestUpdate();
+      }
+    });
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.subscription.unsubscribe();
   }
 
   protected render() {

--- a/packages/core/src/internal/index.ts
+++ b/packages/core/src/internal/index.ts
@@ -37,5 +37,6 @@ export * from './utils/responsive.js';
 export * from './utils/size.js';
 export * from './utils/string.js';
 export * from './utils/supports.js';
+export * from './utils/event-subject.js';
 export * from './interfaces/index.js';
 export { styles as baseStyles } from './base/base.element.css.js';

--- a/packages/core/src/internal/utils/event-subject.spec.ts
+++ b/packages/core/src/internal/utils/event-subject.spec.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { EventSubject } from './event-subject.js';
+
+describe('EventSubject', () => {
+  it('executes callback when calling next', () => {
+    const subject = new EventSubject<number>();
+    let count = 0;
+    subject.subscribe(v => (count = count + v));
+
+    subject.emit(1);
+    subject.emit(1);
+
+    expect(count).toBe(2);
+  });
+
+  it('stops executing when unsubscribed', () => {
+    const subject = new EventSubject<number>();
+    let count = 0;
+    const subscription = subject.subscribe(v => (count = count + v));
+
+    let count2 = 0;
+    const subscription2 = subject.subscribe(v => (count2 = count2 + v));
+
+    subject.emit(1);
+    subject.emit(1);
+
+    expect(count).toBe(2);
+    expect(count2).toBe(2);
+
+    subscription.unsubscribe();
+
+    subject.emit(1);
+    expect(count).toBe(2);
+    expect(count2).toBe(3);
+
+    subscription2.unsubscribe();
+    subject.emit(1);
+    expect(count2).toBe(3);
+  });
+});

--- a/packages/core/src/internal/utils/event-subject.ts
+++ b/packages/core/src/internal/utils/event-subject.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+export interface EventSubscription extends Pick<InternalEventSubscription, 'unsubscribe'> {} // eslint-disable-line @typescript-eslint/no-empty-interface
+
+export interface EventObservable<T> extends Pick<EventSubject<T>, 'subscribe'> {} // eslint-disable-line @typescript-eslint/no-empty-interface
+
+/**
+ * Subscription returned from EventSubject.
+ * Enables subscriber to un-subscribe from source.
+ */
+class InternalEventSubscription {
+  constructor(public fn: (value: any) => void, private subscriptions: InternalEventSubscription[]) {}
+
+  /** Use during disconnectedCallback to stop receiving events */
+  unsubscribe() {
+    const index = this.subscriptions.indexOf(this);
+    if (index !== -1) {
+      this.subscriptions.splice(index, 1);
+    }
+  }
+}
+
+/**
+ * Basic Subject implementing Observer style pattern.
+ * Use to trigger and communicate outgoing async updates.
+ *
+ * Used as a lightweight alternative to rxjs style subject.
+ * RxJS pulls in too much code for our performance standards
+ * and would require additional peer dependencies for the
+ * host application to take on.
+ *
+ * @internal
+ */
+export class EventSubject<T> {
+  private subscriptions: InternalEventSubscription[] = [];
+
+  /** Subscribe to receive event value updates */
+  subscribe(fn: (value: T) => void) {
+    const sub = new InternalEventSubscription(fn, this.subscriptions);
+    this.subscriptions.push(sub);
+    return sub as EventSubscription;
+  }
+
+  /** Use to trigger and send an event to all active subscribers */
+  emit(value: T) {
+    this.subscriptions.forEach(sub => sub.fn(value));
+  }
+
+  /** Cast Subject to Observable subtype to prevent access to `emit` */
+  toEventObservable() {
+    return (this as unknown) as EventObservable<T>;
+  }
+}

--- a/packages/core/test-bundles/bundlesize.json
+++ b/packages/core/test-bundles/bundlesize.json
@@ -37,7 +37,7 @@
     },
     {
       "path": "./dist/test-bundles/webpack.bundle.js",
-      "maxSize": "15.5 kB",
+      "maxSize": "15.6 kB",
       "compression": "brotli"
     }
   ]


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

There is a case where the icons may not render the icon shape dependent on when the icon was added. The problem occurs when an icon shape is added after the icon component has already rendered. The component has no way of knowing that the service has updated or added a new icon because the icon properties only trigger re-render when set. If you add the icons prior to render there is no issue but this can be tricky. Depending on how the application renders, built or how bundles are split there may not be an order guarantee.

I made a small demo of the behavior here in this angular app.  I show two icons with the same user shape. The first renders immediately but I don't add the user icon until one second later. Then I show the second Icon which does get the reference. https://stackblitz.com/edit/angular-qyft15?file=src%2Fapp%2Fapp.component.ts

## What is the new behavior?
The icon service provides a basic observable type for the icon element to subscribe to and get updates about newly added icons. The observable is a small subject implementation in `@cds/core/internal` as we don't want to take on the dependency or performance hit of rxjs.  Performance wise there was no noticeable change. There is a slight increase in JS execution time for the subscriber function calls. But it looks like it would require a few thousand icons before it would start to make a difference. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
