### PR TITLE
fix(checkbox): poc for setting checkbox values in react - DO NOT MERGE

### DIFF
--- a/packages/core/src/checkbox/checkbox.element.ts
+++ b/packages/core/src/checkbox/checkbox.element.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { internalProperty, listenForAttributeChange } from '@cds/core/internal';
+import { property, listenForAttributeChange, syncProps } from '@cds/core/internal';
 import { CdsInternalControlInline } from '@cds/core/forms';
 import { styles } from './checkbox.element.css.js';
 
@@ -31,12 +31,24 @@ import { styles } from './checkbox.element.css.js';
  * @cssprop --border-radius
  */
 export class CdsCheckbox extends CdsInternalControlInline {
-  @internalProperty({ type: Boolean, reflect: true }) protected checked = false;
+  @property({ type: Boolean }) checked = false;
 
-  @internalProperty({ type: Boolean, reflect: true }) protected indeterminate = false;
+  @property({ type: Boolean }) indeterminate = false;
 
   static get styles() {
     return [...super.styles, styles];
+  }
+
+  updated(props: Map<string, any>) {
+    super.updated(props);
+
+    if (props.has('checked') && this.inputControl.checked !== this.checked) {
+      syncProps(this.inputControl, this, { checked: true });
+    }
+
+    if (props.has('indeterminate') && this.inputControl.indeterminate !== this.indeterminate) {
+      syncProps(this.inputControl, this, { indeterminate: true });
+    }
   }
 
   firstUpdated(props: Map<string, any>) {

--- a/packages/react/App.tsx
+++ b/packages/react/App.tsx
@@ -31,12 +31,19 @@ interface AppState {
   modal2Open: boolean;
 }
 
+let isInd = false;
+
+function toggleIndeterminate(self: React.Component) {
+  isInd = !isInd;
+  self.setState({ isInd: isInd });
+}
+
 export default class App extends React.Component<{}, AppState> {
   buttonRef: React.RefObject<CdsButton>;
 
   constructor(props: any) {
     super(props);
-    this.state = { modalOpen: false, modal2Open: false };
+    this.state = { modalOpen: false, modal2Open: false, isInd: false };
     this.buttonRef = React.createRef<CdsButton>();
   }
 
@@ -282,6 +289,14 @@ export default class App extends React.Component<{}, AppState> {
             <label>checked disabled</label>
             <input type="checkbox" disabled checked />
             <CdsControlMessage>disabled message</CdsControlMessage>
+          </CdsCheckbox>
+
+          <CdsDivider></CdsDivider>
+          <CdsButton onClick={() => toggleIndeterminate(this)}>Toggle Indeterminate</CdsButton>
+          <CdsCheckbox indeterminate={isInd}>
+            <label>Setting indeterminate</label>
+            <input type="checkbox" />
+            <CdsControlMessage>indeterminate message</CdsControlMessage>
           </CdsCheckbox>
         </CdsFormGroup>
 


### PR DESCRIPTION
• DO NOT MERGE
• if this is the way to fix this, we have a bigger refactor ahead with form controls
• opened up access to checked/indeterminate properties on CdsCheckbox
• Added syncProps to CdsCheckbox to sync incoming values on the wrapped input
• Added a manual test on the cds/react demo app to verify
• verified against code in the stackblitz of the reporting issue as well

Signed-off-by: Scott Mathis <smathis@vmware.com>

Fixes: #5397 

I've verified this addresses the issue in Clarity React (#5397 ). But it makes some big changes to the underlying CdsCheckbox architecture and I want to make sure that @coryrylan has a chance to look into it before we decide to go this route.

Because these changes would likely impact other form controls at an architectural level...