### PR TITLE
fix: prevent core and ui text collisions

### DIFF
--- a/packages/angular/projects/clr-angular/src/typography/_lists.scss
+++ b/packages/angular/projects/clr-angular/src/typography/_lists.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -9,8 +9,8 @@
     list-style: none;
   }
 
-  ul,
-  ol {
+  ul:not([cds-list]),
+  ol:not([cds-list]) {
     list-style-position: inside;
     margin-left: 0;
     margin-top: 0;
@@ -18,8 +18,8 @@
     padding-left: 0;
   }
 
-  ul.list,
-  ol.list {
+  ul.list:not([cds-list]),
+  ol.list:not([cds-list]) {
     list-style-position: outside;
     margin-left: $clr-list-style-padding;
 
@@ -39,28 +39,28 @@
   // right now this causes no problems. but watch out in the future because it may
   // cause issues with nested tabs, list-groups of sidenav lists or something.
   // just be aware that this may need to be overridden down the line.
-  ul:not(.list-unstyled),
-  ol {
+  ul:not(.list-unstyled):not([cds-list]),
+  ol:not([cds-list]) {
     & > li > ul.list-unstyled {
       margin-left: $clr-list-style-padding;
     }
   }
 
-  ul.list-unstyled {
+  ul.list-unstyled:not([cds-list]) {
     @extend %kill-list-styles;
   }
 
-  li > ul {
+  li > ul:not([cds-list]) {
     margin-top: 0;
     margin-left: $clr-list-style-padding;
   }
 
-  ul.list-group {
+  ul.list-group:not([cds-list]) {
     margin-top: 0;
   }
 
-  ul,
-  ol {
+  ul:not([cds-list]),
+  ol:not([cds-list]) {
     &.list-spacer {
       margin-top: $clr_baselineRem_1;
     }

--- a/packages/angular/projects/clr-angular/src/typography/_typography.scss
+++ b/packages/angular/projects/clr-angular/src/typography/_typography.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -7,7 +7,7 @@
 
 @include exports('typography.clarity') {
   //Headings
-  h1 {
+  h1:not([cds-text]) {
     @include css-var(color, clr-h1-color, $clr-h1-color, $clr-use-custom-properties);
     @include css-var(font-weight, clr-h1-font-weight, $clr-h1-font-weight, $clr-use-custom-properties);
     @include css-var(font-family, clr-h1-font-family, $clr-h1-font-family, $clr-use-custom-properties);
@@ -18,7 +18,7 @@
     margin-bottom: $clr-global-typography-margin-bottom;
   }
 
-  h2 {
+  h2:not([cds-text]) {
     @include css-var(color, clr-h2-color, $clr-h2-color, $clr-use-custom-properties);
     @include css-var(font-weight, clr-h2-font-weight, $clr-h2-font-weight, $clr-use-custom-properties);
     @include css-var(font-family, clr-h2-font-family, $clr-h2-font-family, $clr-use-custom-properties);
@@ -29,7 +29,7 @@
     margin-bottom: $clr-global-typography-margin-bottom;
   }
 
-  h3 {
+  h3:not([cds-text]) {
     @include css-var(color, clr-h3-color, $clr-h3-color, $clr-use-custom-properties);
     @include css-var(font-weight, clr-h3-font-weight, $clr-h3-font-weight, $clr-use-custom-properties);
     @include css-var(font-family, clr-h3-font-family, $clr-h3-font-family, $clr-use-custom-properties);
@@ -40,7 +40,7 @@
     margin-bottom: $clr-global-typography-margin-bottom;
   }
 
-  h4 {
+  h4:not([cds-text]) {
     @include css-var(color, clr-h4-color, $clr-h4-color, $clr-use-custom-properties);
     @include css-var(font-weight, clr-h4-font-weight, $clr-h4-font-weight, $clr-use-custom-properties);
     @include css-var(font-family, clr-h4-font-family, $clr-h4-font-family, $clr-use-custom-properties);
@@ -51,7 +51,7 @@
     margin-bottom: $clr-global-typography-margin-bottom;
   }
 
-  h5 {
+  h5:not([cds-text]) {
     @include css-var(color, clr-h5-color, $clr-h5-color, $clr-use-custom-properties);
     @include css-var(font-weight, clr-h5-font-weight, $clr-h5-font-weight, $clr-use-custom-properties);
     @include css-var(font-family, clr-h5-font-family, $clr-h5-font-family, $clr-use-custom-properties);
@@ -62,7 +62,7 @@
     margin-bottom: $clr-global-typography-margin-bottom;
   }
 
-  h6 {
+  h6:not([cds-text]) {
     @include css-var(color, clr-h6-color, $clr-h6-color, $clr-use-custom-properties);
     @include css-var(font-weight, clr-h6-font-weight, $clr-h6-font-weight, $clr-use-custom-properties);
     @include css-var(font-family, clr-h6-font-family, $clr-h6-font-family, $clr-use-custom-properties);
@@ -74,7 +74,7 @@
   }
 
   //Body.
-  body {
+  body:not([cds-text]) {
     @include css-var(color, clr-p1-color, $clr-p1-color, $clr-use-custom-properties);
     @include css-var(font-weight, clr-p1-font-weight, $clr-p1-font-weight, $clr-use-custom-properties);
     font-size: $clr-p1-font-size;
@@ -92,7 +92,7 @@
   // that are overriding these styles. i'm using specificity below to try and force the issue.
 
   body {
-    p {
+    p:not([cds-text]) {
       @include css-var(color, clr-p1-color, $clr-p1-color, $clr-use-custom-properties);
       @include css-var(font-weight, clr-p1-font-weight, $clr-p1-font-weight, $clr-use-custom-properties);
       font-size: $clr-p1-font-size;
@@ -102,8 +102,8 @@
       margin-bottom: $clr-global-typography-margin-bottom;
     }
 
-    .p0,
-    p.p0 {
+    .p0:not([cds-text]),
+    p.p0:not([cds-text]) {
       @include css-var(color, clr-p0-color, $clr-p0-color, $clr-use-custom-properties);
       @include css-var(font-weight, clr-p0-font-weight, $clr-p0-font-weight, $clr-use-custom-properties);
       font-size: $clr-p0-font-size;
@@ -113,8 +113,8 @@
       margin-bottom: $clr-global-typography-margin-bottom;
     }
 
-    .p2,
-    p.p2 {
+    .p2:not([cds-text]),
+    p.p2:not([cds-text]) {
       @include css-var(color, clr-p2-color, $clr-p2-color, $clr-use-custom-properties);
       @include css-var(font-weight, clr-p2-font-weight, $clr-p2-font-weight, $clr-use-custom-properties);
       font-size: $clr-p2-font-size;
@@ -124,8 +124,8 @@
       margin-bottom: $clr-global-typography-margin-bottom;
     }
 
-    .p3,
-    p.p3 {
+    .p3:not([cds-text]),
+    p.p3:not([cds-text]) {
       @include css-var(color, clr-p3-color, $clr-p3-color, $clr-use-custom-properties);
       @include css-var(font-weight, clr-p3-font-weight, $clr-p3-font-weight, $clr-use-custom-properties);
       font-size: $clr-p3-font-size;
@@ -135,8 +135,8 @@
       margin-bottom: $clr-global-typography-margin-bottom;
     }
 
-    .p4,
-    p.p4 {
+    .p4:not([cds-text]),
+    p.p4:not([cds-text]) {
       @include css-var(color, clr-p4-color, $clr-p4-color, $clr-use-custom-properties);
       @include css-var(font-weight, clr-p4-font-weight, $clr-p4-font-weight, $clr-use-custom-properties);
       font-size: $clr-p4-font-size;
@@ -146,8 +146,8 @@
       margin-bottom: $clr-global-typography-margin-bottom;
     }
 
-    .p5,
-    p.p5 {
+    .p5:not([cds-text]),
+    p.p5:not([cds-text]) {
       @include css-var(color, clr-p5-color, $clr-p5-color, $clr-use-custom-properties);
       @include css-var(font-weight, clr-p5-font-weight, $clr-p5-font-weight, $clr-use-custom-properties);
       font-size: $clr-p5-font-size;
@@ -157,8 +157,8 @@
       margin-bottom: $clr-global-typography-margin-bottom;
     }
 
-    .p6,
-    p.p6 {
+    .p6:not([cds-text]),
+    p.p6:not([cds-text]) {
       @include css-var(color, clr-p6-color, $clr-p6-color, $clr-use-custom-properties);
       @include css-var(font-weight, clr-p6-font-weight, $clr-p6-font-weight, $clr-use-custom-properties);
       font-size: $clr-p6-font-size;
@@ -168,8 +168,8 @@
       margin-bottom: $clr-global-typography-margin-bottom;
     }
 
-    .p7,
-    p.p7 {
+    .p7:not([cds-text]),
+    p.p7:not([cds-text]) {
       @include css-var(color, clr-p7-color, $clr-p7-color, $clr-use-custom-properties);
       @include css-var(font-weight, clr-p7-font-weight, $clr-p7-font-weight, $clr-use-custom-properties);
       font-size: $clr-p7-font-size;
@@ -179,8 +179,8 @@
       margin-bottom: $clr-global-typography-margin-bottom;
     }
 
-    .p8,
-    p.p8 {
+    .p8:not([cds-text]),
+    p.p8:not([cds-text]) {
       @include css-var(color, clr-p8-color, $clr-p8-color, $clr-use-custom-properties);
       @include css-var(font-weight, clr-p8-font-weight, $clr-p8-font-weight, $clr-use-custom-properties);
       font-size: $clr-p8-font-size;
@@ -212,7 +212,7 @@
   }
 
   //HTML
-  html {
+  html:not([cds-text]) {
     @include css-var(color, clr-global-font-color, $clr-global-font-color, $clr-use-custom-properties);
     @include css-var(font-family, clr-font, $clr-font, $clr-use-custom-properties);
     font-size: $clr-basefont-size;


### PR DESCRIPTION
• prevent clr-ui styles from being applied to text nodes with [cds-text] on them
• addresses major point of collision between car-ui and clr-core styles
• verified works as expected visually in dev app
• did not try to guard clr-ui component styles because those are already encapsulated within clr-ui classnames (.clr-*)

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
