### PR TITLE
fix: @types/jsdom build errors

### DIFF
--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-alert/index.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-alert/index.ts
@@ -52,9 +52,9 @@ export default createESLintRule({
         const dom = new JSDOM(templateContent, {
           includeNodeLocations: true,
         });
-        const clrAlerts = dom.window.document.querySelectorAll(disallowedAlertsSelector);
+        const clrAlerts = dom.window.document.querySelectorAll(disallowedAlertsSelector as any);
 
-        for (const alert of clrAlerts) {
+        clrAlerts.forEach(alert => {
           const nodeLocation = dom.nodeLocation(alert) as DomElementLocation;
           const loc = calculateLocation(templateContentNode, nodeLocation);
           context.report({
@@ -62,7 +62,7 @@ export default createESLintRule({
             messageId: 'clrAlertFailure',
             loc,
           });
-        }
+        });
       },
     };
   },

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-button/index.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-button/index.ts
@@ -50,9 +50,9 @@ export default createESLintRule({
         const dom = new JSDOM(templateContent, {
           includeNodeLocations: true,
         });
-        const clrButtons = dom.window.document.querySelectorAll(disallowedButtonsSelector);
+        const clrButtons = dom.window.document.querySelectorAll(disallowedButtonsSelector as any);
 
-        for (const button of clrButtons) {
+        clrButtons.forEach(button => {
           const nodeLocation = dom.nodeLocation(button) as DomElementLocation;
           const loc = calculateLocation(templateContentNode, nodeLocation);
           context.report({
@@ -60,7 +60,7 @@ export default createESLintRule({
             messageId: 'clrButtonFailure',
             loc,
           });
-        }
+        });
       },
     };
   },

--- a/packages/eslint-plugin-clarity-adoption/tsconfig.json
+++ b/packages/eslint-plugin-clarity-adoption/tsconfig.json
@@ -7,7 +7,7 @@
     "target": "es2015",
     "outDir": "../../dist/eslint-plugin-clarity-adoption",
     "typeRoots": ["./node_modules/@types/"],
-    "lib": ["es2017"],
+    "lib": ["es2017", "dom"],
     "declaration": true,
     "forceConsistentCasingInFileNames": true,
     "noEmitOnError": true,


### PR DESCRIPTION
## PR Checklist

This PR adds `dom` to the `libs` property in the TypeScript config for the `@clr/eslint-plugin-clarity-adoption` package. It also refactors the code to work-around some differences between the `jsdom` types and the built-in `dom` types.

Before that, the `@types/jsdom` package was failing the package build with the following errors:

```js
../../../node_modules/@types/jsdom/ts3.3/index.d.ts:441:32 - error TS2304: Cannot find name 'XPathEvaluator'.

441         XPathEvaluator: typeof XPathEvaluator;
                                   ~~~~~~~~~~~~~~

../../../node_modules/@types/jsdom/ts3.4/index.d.ts:7:28 - error TS2304: Cannot find name 'ShadowRoot'.

7         ShadowRoot: typeof ShadowRoot;
                             ~~~~~~~~~~

../../../node_modules/@types/jsdom/ts3.5/index.d.ts:12:29 - error TS2304: Cannot find name 'WebAssembly'.

12         WebAssembly: typeof WebAssembly;

...
```


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

