### PR TITLE
fix: core layout css gap shim

### DIFF
--- a/packages/core/src/forms/control-group/control-group.element.ts
+++ b/packages/core/src/forms/control-group/control-group.element.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -16,7 +16,6 @@ import {
   syncDefinedProps,
   describeElementByElements,
   updateComponentLayout,
-  supportsResizeObserver,
   setAttributes,
   syncProps,
 } from '@cds/core/internal';
@@ -229,7 +228,7 @@ export class CdsInternalControlGroup extends LitElement {
   }
 
   private setupResponsive() {
-    if (supportsResizeObserver() && this.responsive) {
+    if (this.responsive) {
       const layoutConfig = { layouts: formLayouts, initialLayout: this.layout };
       const observer = updateComponentLayout(this, layoutConfig, () =>
         this.layoutChange.emit(this.layout, { bubbles: true })

--- a/packages/core/src/forms/control/control.element.ts
+++ b/packages/core/src/forms/control/control.element.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -18,7 +18,6 @@ import {
   EventEmitter,
   describeElementByElements,
   updateComponentLayout,
-  supportsResizeObserver,
   internalProperty,
   syncProps,
   pxToRem,
@@ -315,7 +314,7 @@ export class CdsControl extends LitElement {
   }
 
   private setupResponsive() {
-    if (supportsResizeObserver() && this.responsive && !this.hiddenLabel && this.controlLabel) {
+    if (this.responsive && !this.hiddenLabel && this.controlLabel) {
       const layoutConfig = { layouts: formLayouts, initialLayout: this.layout };
       const observer = updateComponentLayout(this, layoutConfig, () =>
         this.layoutChange.emit(this.layout, { bubbles: true })

--- a/packages/core/src/internal/base/button.base.ts
+++ b/packages/core/src/internal/base/button.base.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -11,7 +11,7 @@ import { property, internalProperty } from '../decorators/property.js';
 import { querySlot } from '../decorators/query-slot.js';
 import { onAnyKey } from '../utils/keycodes.js';
 import { stopEvent } from './../utils/events.js';
-import { supportsFlexGap } from '../utils/supports.js';
+import { browserFeatures } from '../utils/supports.js';
 
 // @dynamic
 export class CdsBaseButton extends LitElement {
@@ -38,7 +38,8 @@ export class CdsBaseButton extends LitElement {
 
   @internalProperty({ type: String, reflect: true }) protected role: string | null = 'button';
 
-  @internalProperty({ type: Boolean, reflect: true }) protected hasFlexGapSupport: boolean = supportsFlexGap();
+  @internalProperty({ type: Boolean, reflect: true }) protected hasFlexGapSupport: boolean =
+    browserFeatures.supports.flexGap;
 
   @internalProperty({ type: Boolean, reflect: true }) protected isAnchor = false;
 

--- a/packages/core/src/internal/utils/global.ts
+++ b/packages/core/src/internal/utils/global.ts
@@ -1,16 +1,18 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { isBrowser } from './exists.js';
 import { getAngularVersion, getReactVersion, getVueVersion, getAngularJSVersion } from './framework.js';
+import { FeatureSupportMatrix, browserFeatures } from './supports.js';
 
 export interface CDSGlobal {
   _version: string[];
   _loadedElements: string[];
   _react: { version: string }; // set by @cds/react
+  _supports: FeatureSupportMatrix;
   getVersion: () => CDSLog;
   logVersion: () => void;
   environment: {
@@ -23,6 +25,7 @@ export interface CDSLog {
   versions: string[];
   loadedElements: string[];
   userAgent: string;
+  supports: {};
   angularVersion?: string | undefined;
   angularJSVersion?: string | undefined;
   reactVersion?: string | undefined;
@@ -38,11 +41,19 @@ declare global {
   }
 }
 
+export function setupCDSGlobal() {
+  if (isBrowser()) {
+    initializeCDSGlobal();
+    setRunningVersion();
+  }
+}
+
 function getVersion() {
   const log: CDSLog = {
     versions: window.CDS._version,
     environment: window.CDS.environment,
     userAgent: navigator.userAgent,
+    supports: window.CDS._supports,
     angularVersion: getAngularVersion(false),
     angularJSVersion: getAngularJSVersion(false),
     reactVersion: getReactVersion(false),
@@ -61,6 +72,7 @@ function initializeCDSGlobal() {
     _version: [],
     _loadedElements: [],
     _react: { version: undefined },
+    _supports: browserFeatures.supports,
     environment: {
       production: false,
     },
@@ -81,12 +93,5 @@ function setRunningVersion() {
     console.warn(
       'Running more than one version of Clarity can cause unexpected issues. Please ensure only one version is loaded.'
     );
-  }
-}
-
-export function setupCDSGlobal() {
-  if (isBrowser()) {
-    initializeCDSGlobal();
-    setRunningVersion();
   }
 }

--- a/packages/core/src/internal/utils/supports.spec.ts
+++ b/packages/core/src/internal/utils/supports.spec.ts
@@ -1,16 +1,13 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { supportsFlexGap, supportsResizeObserver } from './supports.js';
-
 describe('browser support feature checks', () => {
-  it('should check if browser supports ResizeObserver', () => {
-    expect(supportsResizeObserver()).toBe(true);
-  });
-  it('should check if browser supports FlexGap', () => {
-    expect(supportsFlexGap()).toBe(true);
+  it('should check browser support value strings in cds-support attr', () => {
+    const supportValues = document.body.getAttribute('cds-supports');
+    expect(supportValues).toContain('js');
+    expect(supportValues).toContain('flex-gap');
   });
 });

--- a/packages/core/src/internal/utils/supports.ts
+++ b/packages/core/src/internal/utils/supports.ts
@@ -1,16 +1,38 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { isBrowser } from './exists.js';
+import { camelCaseToKebabCase } from './string.js';
 
-export function supportsResizeObserver() {
-  return isBrowser() && !!window.ResizeObserver;
+export interface FeatureSupportMatrix {
+  js?: boolean;
+  flexGap?: boolean;
 }
 
-export function supportsFlexGap(): boolean {
+class BrowserFeatures {
+  supports = {
+    js: true,
+    flexGap: supportsFlexGap(),
+  };
+
+  constructor() {
+    if (!document.body.hasAttribute('cds-supports') || document.body.getAttribute('cds-supports') === 'no-js') {
+      const supports = camelCaseToKebabCase(
+        Object.keys(this.supports).reduce(
+          (prev, next) => `${prev} ${(this.supports as any)[next] ? next : `no-${next}`}`,
+          ''
+        )
+      ).trim();
+      document.body.setAttribute('cds-supports', supports);
+    }
+  }
+}
+
+export const browserFeatures = new BrowserFeatures();
+
+function supportsFlexGap(): boolean {
   const flex = document.createElement('div');
   flex.style.display = 'flex';
   flex.style.flexDirection = 'column';

--- a/packages/core/src/styles/module.shims.scss
+++ b/packages/core/src/styles/module.shims.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -10,6 +10,6 @@
 @import './layout/shims/gap';
 
 // older safari
-@media not all and (min-resolution: 0.001dpcm) {
+[cds-supports~='no-flex-gap'] {
   @include generateGapShim();
 }

--- a/packages/core/test-bundles/bundlesize.json
+++ b/packages/core/test-bundles/bundlesize.json
@@ -37,7 +37,7 @@
     },
     {
       "path": "./dist/test-bundles/webpack.bundle.js",
-      "maxSize": "15.6 kB",
+      "maxSize": "15.75 kB",
       "compression": "brotli"
     }
   ]


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The CSS gap shim for safari breaks in the next major Safari release.

Issue Number: 
fixes https://github.com/vmware/clarity/issues/5420 

## What is the new behavior?
Adds a `cds-supports` attr to easily set css values for certain feature support in browsers. For the current Safari version this ensures the css gap shim is only applied if flex gap is not supported. This will ensure the shim does not run on the next Safari version which does support CSS Gap. You can see this behavior using the Safari Technical Preview. The attr is needed instead of the [CSS @support selector](https://developer.mozilla.org/en-US/docs/Web/CSS/@supports) due to Safari reporting a false positive supporting gap due to css gap in grid not flexbox.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
