### PR TITLE
fix: make the eslint rule for icons work with multiple root elements

### DIFF
--- a/packages/eslint-plugin-clarity-adoption/README.md
+++ b/packages/eslint-plugin-clarity-adoption/README.md
@@ -2,7 +2,15 @@
 
 ## Installation
 
-To install run `npm install --save-dev @clr/eslint-plugin-clarity-adoption` and then add it to your eslint configuration like you see below. The overrides section is important to enable it to parse HTML files as well.
+```sh
+npm install --save-dev @clr/eslint-plugin-clarity-adoption @typescript-eslint/parser eslint
+```
+
+## Usage
+
+Configure in your ESLint config file like you see below. The overrides section is important to enable it to parse HTML files as well.
+
+**.eslintrc.json**
 
 ```json
 {
@@ -14,16 +22,19 @@ To install run `npm install --save-dev @clr/eslint-plugin-clarity-adoption` and 
   "plugins": ["@clr/clarity-adoption"],
   "rules": {
     "@clr/clarity-adoption/no-clr-button": "warn",
-    "@clr/clarity-adoption/no-clr-alert": "warn"
+    "@clr/clarity-adoption/no-clr-alert": "warn",
+    "@clr/clarity-adoption/no-clr-icon": "warn"
   },
   "overrides": [
     {
       "files": ["*.html"],
-      "parser": "eslint-html-parser"
+      "parser": "@clr/eslint-plugin-clarity-adoption/html-parser"
     }
   ]
 }
 ```
+
+**Note:** If you don't have ESLint config file, create a new file named **.eslintrc.json** in the root of your project and copy the content above.
 
 Finally, you'll need to run eslint with the `--ext` flag to enable HTML scanning like `npx eslint --ext=ts,html src/`.
 
@@ -36,9 +47,10 @@ yarn
 yarn run watch
 ```
 
-2. Open another terminal window/tab and execute `yarn link`:
+2. Open another terminal window/tab, navigate to the `dist` directory and execute `yarn link`:
 
 ```
+cd ../../dist/eslint-plugin-clarity-adoption
 yarn link
 ```
 
@@ -70,12 +82,13 @@ yarn add -D @typescript-eslint/parser eslint
   "plugins": ["@clr/clarity-adoption"],
   "rules": {
     "@clr/clarity-adoption/no-clr-button": "warn",
-    "@clr/clarity-adoption/no-clr-alert": "warn"
+    "@clr/clarity-adoption/no-clr-alert": "warn",
+    "@clr/clarity-adoption/no-clr-icon": "warn"
   },
   "overrides": [
     {
       "files": ["*.html"],
-      "parser": "@clr/eslint-plugin-clarity-adoption/dist/src/html-parser"
+      "parser": "@clr/eslint-plugin-clarity-adoption/html-parser"
     }
   ]
 }
@@ -100,13 +113,13 @@ Currently, the plugin contains a single rule - `no-clr-button`. This rule report
 
 For parsing the TS files in the project, the plugin uses [`@typescript-eslint/plugin`](https://www.npmjs.com/package/@typescript-eslint/eslint-plugin). Then, it parses the HTML within the component template with [`node-html-parser`](https://www.npmjs.com/package/node-html-parser). Using the AST tree provided from node-html-parser it detects the usage of `<button class="btn btn-primary">`.
 
-For parsing the HTML files, the plugin uses [eslint-html-parser](https://www.npmjs.com/package/eslint-html-parser).
-
-## Known issues
-
-The HTML parser that we use - [eslint-html-parser](https://www.npmjs.com/package/eslint-html-parser), cannot handle more than one root element in the HTML file. It doesn't report the rest of the tree. In the example below, only the `div` element will be traversed.
+For parsing the HTML files, the plugin uses an internalized version of [eslint-html-parser](https://www.npmjs.com/package/eslint-html-parser). The original package is patched to work with HTML files containing more than one root element, such as:
 
 ```html
-<div>First</div>
-<button class="btn btn-primary">Second</button>
+<div>
+  ...
+</div>
+<div>
+  ...
+</div>
 ```

--- a/packages/eslint-plugin-clarity-adoption/docs/rules/no-clr-icon.md
+++ b/packages/eslint-plugin-clarity-adoption/docs/rules/no-clr-icon.md
@@ -1,0 +1,21 @@
+# Disallows usage of Clarity Angular icons (no-clr-icon)
+
+The use of Clarity Angular icons is discouraged. Use Clarity Core icons instead.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```html
+<clr-icon></clr-icon>
+<clr-icon dir="left"></clr-icon>
+<clr-icon dir="left" class="is-inverse my-class is-solid has-badge--info"></clr-icon>
+```
+
+Examples of **correct** code for this rule:
+
+```html
+<cds-icon></cds-icon>
+<cds-icon direction="left"></cds-icon>
+<cds-icon direction="left" class="my-class" inverse solid badge="info"></cds-icon>
+```

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-icon/index.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-icon/index.ts
@@ -143,11 +143,11 @@ export default createESLintRule({
         const nodeStart = range[0];
         const openingTag = '<clr-icon';
         const openingTagStart = value.indexOf(openingTag) + nodeStart;
-        const openingTagEnd = openingTagStart + openingTag.length + nodeStart;
+        const openingTagEnd = openingTagStart + openingTag.length;
 
         const closingTag = '</clr-icon>';
         const closingTagStart = value.indexOf(closingTag) + nodeStart;
-        const closingTagEnd = closingTagStart + closingTag.length + nodeStart;
+        const closingTagEnd = closingTagStart + closingTag.length;
 
         context.report({
           node: node as any,

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-icon/no-clr-icon.spec.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-icon/no-clr-icon.spec.ts
@@ -1,6 +1,6 @@
 import { LineAndColumnData } from '@typescript-eslint/types/dist/ts-estree';
-import rule from '../src/rules/no-clr-icon';
-import { RuleTester } from './test-helper';
+import rule from '.';
+import { RuleTester } from '../../test-helper.spec';
 
 const htmlRuleTester = new RuleTester({
   parserOptions: {
@@ -364,6 +364,22 @@ htmlRuleTester.run('no-clr-alert', rule, {
       [{ line: 1, column: 1 }],
       [iconFailureMessageId],
       `<cds-icon shape="angle" direction="up" class="my-class" inverse solid badge="info"></cds-icon>`
+    ),
+
+    /**
+     * Multiple root elements
+     */
+    getInvalidTest(
+      `
+      <div></div>
+      <clr-icon shape="caret up" class="is-inverse my-class is-solid has-badge--info"></clr-icon>
+      `,
+      [{ line: 3, column: 7 }],
+      [iconFailureMessageId],
+      `
+      <div></div>
+      <cds-icon shape="angle" direction="up" class="my-class" inverse solid badge="info"></cds-icon>
+      `
     ),
   ],
   valid: [],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently, the ESLint rule for detecting `clr-icons` doesn't work when there are more than one root elements in the HTML file:
```
<div></div>
<clr-icon></clr-icon>
```

That's because the location of the opening (`<clr-icon`) and closing (`</clr-icon>`) tags is not calculated correctly. As a result, the locations of fixer objects that replace `<clr-icon` with `<cds-icon` and `</clr-icon>` with `</cds-icon>` overlap and the ESLint command exits with an error:

```
 Fix objects must not be overlapped in a report.
```

## What is the new behavior?

I've fixed the calculation of the locations. I've also added a unit test that covers that case.

**Note:** This PR also updated the README to acknowledge the latest changes in the repo and adds documentation for the `clr-icons` rule.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No