### PR TITLE
fix(modal): positioning of overlay backdrop in demos in safari

### DIFF
--- a/packages/core/src/internal-components/overlay/overlay.element.scss
+++ b/packages/core/src/internal-components/overlay/overlay.element.scss
@@ -36,4 +36,10 @@
 
 :host([__demo-mode]) {
   position: absolute;
+
+  .overlay-backdrop {
+    // we need this here because safari doesn't understand what to do with
+    // position: fixed inside of a constrained demo box...
+    position: absolute;
+  }
 }


### PR DESCRIPTION
• found this while working on motion
• Safari gets confused with position: fixed inside a position: absolute
• this only applies to "demoMode" overlays/modals

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
