### PR TITLE
fix: core form style hooks, private host styles

### DIFF
--- a/packages/core/src/alert/alert-actions.element.scss
+++ b/packages/core/src/alert/alert-actions.element.scss
@@ -10,12 +10,12 @@
   // TODO: add style override for dropdown component inside alert-actions after cds-dropdown is implemented
 }
 
-:host([type='light']) {
+:host([_type='light']) {
   display: none !important;
 }
 
-:host([type='light']),
-:host([type='default']) {
+:host([_type='light']),
+:host([_type='default']) {
   ::slotted(cds-button) {
     --color: var(--action-text-color);
     --border-color: var(--action-text-color);
@@ -46,11 +46,11 @@
   }
 }
 
-:host([type='default']) {
+:host([_type='default']) {
   --action-size: calc(#{$cds-global-space-9} - #{$cds-global-space-3});
 }
 
-:host([type='banner']) {
+:host([_type='banner']) {
   --action-size: #{$cds-global-space-9};
 
   ::slotted(cds-button) {
@@ -59,18 +59,18 @@
   }
 }
 
-:host([type='default']),
-:host([type='banner']) {
+:host([_type='default']),
+:host([_type='banner']) {
   &::slotted(a) {
     color: var(--action-text-color);
   }
 }
 
-:host([type='default']) .private-host {
+:host([_type='default']) .private-host {
   height: calc(var(--action-size) + #{$cds-global-space-2});
 }
 
-:host([type='default']) ::slotted(cds-button) {
+:host([_type='default']) ::slotted(cds-button) {
   --font-size: var(--action-font-size);
   --letter-spacing: normal;
   --height: var(--action-size);

--- a/packages/core/src/alert/alert.element.scss
+++ b/packages/core/src/alert/alert.element.scss
@@ -20,23 +20,23 @@ $lightweight-alert-line-height: $cds-global-typography-body-line-height;
   color: var(--color);
 }
 
-:host([type='default']) .alert-spinner,
-:host([type='banner']) .alert-spinner {
+:host([_type='default']) .alert-spinner,
+:host([_type='banner']) .alert-spinner {
   --fill-color: var(--icon-color);
 }
 
-:host([type='default']) {
+:host([_type='default']) {
   --font-size: #{$cds-global-typography-font-size-3};
 }
 
-:host([type='default']) ::slotted(cds-alert-actions),
-:host([type='banner']) ::slotted(cds-alert-actions) {
+:host([_type='default']) ::slotted(cds-alert-actions),
+:host([_type='banner']) ::slotted(cds-alert-actions) {
   --action-size: calc(var(--min-height) - #{$cds-global-space-4});
   white-space: nowrap;
   display: block;
 }
 
-:host([type='banner']) {
+:host([_type='banner']) {
   --icon-size: #{$cds-global-space-9};
 }
 
@@ -81,51 +81,51 @@ cds-internal-close-button {
   display: none;
 }
 
-:host([type='default']) cds-internal-close-button {
+:host([_type='default']) cds-internal-close-button {
   height: #{$cds-global-space-8};
 }
 
-:host([type='default']) .alert-content-wrapper {
+:host([_type='default']) .alert-content-wrapper {
   align-items: self-start;
 }
 
-:host([type='light'][status='info']) {
+:host([_type='light'][status='info']) {
   --icon-color: #{$cds-alias-status-info};
 }
 
-:host([type='light'][status='success']) {
+:host([_type='light'][status='success']) {
   --icon-color: #{$cds-alias-status-success};
 }
 
-:host([type='light'][status='warning']) {
+:host([_type='light'][status='warning']) {
   --icon-color: #{$cds-alias-status-warning-shade};
 }
 
-:host([type='light'][status='danger']) {
+:host([_type='light'][status='danger']) {
   --icon-color: #{$cds-alias-status-danger};
 }
 
-:host([status='loading'][type='default']) .alert-spinner {
+:host([status='loading'][_type='default']) .alert-spinner {
   --ring-color: var(--icon-color);
 }
 
-:host([size='sm']:not([type='banner'])) {
+:host([size='sm']:not([_type='banner'])) {
   --font-size: #{$cds-global-typography-font-size-2};
   --letter-spacing: normal;
 }
 
 // banner styles
-:host([type='banner']) .alert-content-wrapper {
+:host([_type='banner']) .alert-content-wrapper {
   transform: none;
   min-height: #{$cds-global-space-10};
 }
 
-:host([type='banner']) {
+:host([_type='banner']) {
   --color: #{$cds-global-typography-color-100};
 }
 
-:host([type='default'][status='warning']),
-:host([type='banner'][status='warning']) {
+:host([_type='default'][status='warning']),
+:host([_type='banner'][status='warning']) {
   --color: #{$cds-global-color-gray-1000};
 
   cds-alert-actions {
@@ -134,19 +134,19 @@ cds-internal-close-button {
   }
 }
 
-:host([type='banner']) .spinner {
+:host([_type='banner']) .spinner {
   @include min-equilateral(calc(#{$cds-global-space-8} + #{$cds-global-space-2}));
   margin-top: #{$cds-global-space-2};
 }
 
-:host([type='banner']) cds-internal-close-button {
+:host([_type='banner']) cds-internal-close-button {
   height: $cds-global-space-9;
   margin-top: $cds-global-space-3;
 }
 
 @supports (-moz-appearance: none) and (text-emphasis: none) {
   // nudge for alert text content firefox
-  :host(:not([type='banner']):not([size='sm'])) .alert-content {
+  :host(:not([_type='banner']):not([size='sm'])) .alert-content {
     transform: translateY(calc(-1 * #{$cds-global-space-2}));
   }
 }

--- a/packages/core/src/alert/alert.element.spec.ts
+++ b/packages/core/src/alert/alert.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -202,7 +202,7 @@ describe('Alert element – ', () => {
       await componentIsStable(component);
       const slots = getComponentSlotContent(component);
       expect(slots.actions.trim()).toBe(
-        `<cds-alert-actions slot="actions" type="default"><!---->${placeholderActionsText}<!----></cds-alert-actions>`
+        `<cds-alert-actions slot="actions" _type="default"><!---->${placeholderActionsText}<!----></cds-alert-actions>`
       );
     });
   });

--- a/packages/core/src/button/button.element.spec.ts
+++ b/packages/core/src/button/button.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -308,9 +308,9 @@ describe('button keyboard interaction: ', () => {
   it('should add active attr on click', async done => {
     const element = await createTestElement(html`<cds-button>Text slot</cds-button>`);
     const component = element.querySelector('cds-button');
-    expect(component.hasAttribute('active')).toBe(false);
+    expect(component.hasAttribute('_active')).toBe(false);
 
-    listenForAttributeChange(component, 'active', () => {
+    listenForAttributeChange(component, '_active', () => {
       expect(true).toBe(true, 'active attr was added on click');
       done();
     });

--- a/packages/core/src/checkbox/checkbox.element.scss
+++ b/packages/core/src/checkbox/checkbox.element.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -48,33 +48,33 @@
   transform: translateY($cds-global-space-3-static) rotate(-45deg);
 }
 
-:host([indeterminate]) {
+:host([_indeterminate]) {
   --color: #{$cds-alias-status-neutral};
 }
 
-:host([indeterminate]) .input::after {
+:host([_indeterminate]) .input:after {
   border-left: none;
   border-bottom-color: var(--color);
   display: inline-block;
   transform: translateY(0.15rem);
 }
 
-:host([checked]) {
+:host([_checked]) {
   --color: #{$cds-alias-status-info};
   --background: var(--color);
   --border: #{$cds-alias-object-border-width-100} solid #{$cds-alias-status-info};
 
-  .input::after {
+  .input:after {
     display: inline-block;
   }
 }
 
-:host([status='error']:not([checked])) {
+:host([status='error']:not([_checked])) {
   --color: #{$cds-alias-status-danger};
   --border: #{$cds-alias-object-border-width-100} solid #{$cds-alias-status-danger};
 }
 
-:host([disabled]) {
+:host([_disabled]) {
   --color: #{$cds-alias-status-disabled-tint};
   --border: #{$cds-alias-object-border-width-100} solid #{$cds-alias-status-disabled-tint};
 

--- a/packages/core/src/checkbox/checkbox.element.spec.ts
+++ b/packages/core/src/checkbox/checkbox.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -36,22 +36,22 @@ describe('cds-checkbox', () => {
 
   it('should update the indeterminate attr for host', async () => {
     await componentIsStable(component);
-    expect(component.hasAttribute('indeterminate')).toBe(false);
+    expect(component.hasAttribute('_indeterminate')).toBe(false);
 
     component.inputControl.setAttribute('indeterminate', '');
     await componentIsStable(component);
-    expect(component.hasAttribute('indeterminate')).toBe(true);
+    expect(component.hasAttribute('_indeterminate')).toBe(true);
   });
 
   it('should remove indeterminate state when checked', async () => {
-    component.inputControl.setAttribute('indeterminate', '');
+    component.inputControl.indeterminate = true;
     await componentIsStable(component);
-    expect(component.hasAttribute('checked')).toBe(false);
-    expect(component.hasAttribute('indeterminate')).toBe(true);
+    expect(component.hasAttribute('_checked')).toBe(false);
+    expect(component.hasAttribute('_indeterminate')).toBe(true);
 
-    component.inputControl.click();
+    component.inputControl.checked = true;
     await componentIsStable(component);
-    expect(component.hasAttribute('checked')).toBe(true);
-    expect(component.hasAttribute('indeterminate')).toBe(false);
+    expect(component.hasAttribute('_checked')).toBe(true);
+    expect(component.hasAttribute('_indeterminate')).toBe(false);
   });
 });

--- a/packages/core/src/checkbox/checkbox.element.ts
+++ b/packages/core/src/checkbox/checkbox.element.ts
@@ -1,10 +1,9 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { internalProperty, listenForAttributeChange } from '@cds/core/internal';
 import { CdsInternalControlInline } from '@cds/core/forms';
 import { styles } from './checkbox.element.css.js';
 
@@ -31,30 +30,7 @@ import { styles } from './checkbox.element.css.js';
  * @cssprop --border-radius
  */
 export class CdsCheckbox extends CdsInternalControlInline {
-  @internalProperty({ type: Boolean, reflect: true }) protected checked = false;
-
-  @internalProperty({ type: Boolean, reflect: true }) protected indeterminate = false;
-
   static get styles() {
     return [...super.styles, styles];
-  }
-
-  firstUpdated(props: Map<string, any>) {
-    super.firstUpdated(props);
-    this.listenForIndeterminateState();
-    this.checked = this.inputControl.checked;
-    this.inputControl.addEventListener('change', () => {
-      this.checked = this.inputControl.checked;
-      this.indeterminate = false;
-    });
-  }
-
-  private listenForIndeterminateState() {
-    this.indeterminate = this.inputControl.indeterminate || this.inputControl.hasAttribute('indeterminate');
-    this.inputControl.indeterminate = this.indeterminate;
-
-    this.observers.push(
-      listenForAttributeChange(this.inputControl, 'indeterminate', val => (this.indeterminate = val !== null))
-    );
   }
 }

--- a/packages/core/src/checkbox/checkbox.stories.ts
+++ b/packages/core/src/checkbox/checkbox.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -27,7 +27,7 @@ export function API(args: any) {
     <cds-checkbox ...="${spreadProps(getElementStorybookArgs(args))}">
       <label>checked</label>
       <input type="checkbox" checked />
-      <cds-control-message .status=${args.status}>message message</cds-control-message>
+      <cds-control-message .status=${args.status}>message text</cds-control-message>
     </cds-checkbox>
   `;
 }
@@ -38,7 +38,7 @@ export function checkbox() {
     <cds-checkbox>
       <label>checkbox</label>
       <input type="checkbox" checked />
-      <cds-control-message>message message</cds-control-message>
+      <cds-control-message>message text</cds-control-message>
     </cds-checkbox>
   `;
 }

--- a/packages/core/src/forms/control-action/control-action.element.scss
+++ b/packages/core/src/forms/control-action/control-action.element.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -41,6 +41,6 @@
   --color: #{$cds-alias-object-interaction-color-active};
 }
 
-:host([disabled]) ::slotted(cds-icon) {
+:host([_disabled]) ::slotted(cds-icon) {
   --color: #{$cds-alias-object-interaction-color-disabled};
 }

--- a/packages/core/src/forms/control-group/control-group.element.spec.ts
+++ b/packages/core/src/forms/control-group/control-group.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -108,7 +108,7 @@ describe('cds-internal-control-group', () => {
   it('should set the disabled style on all messages if group is disabled', async () => {
     controlGroup.disabled = true;
     await componentIsStable(controlGroup);
-    expect(message.getAttribute('disabled')).toBe('');
+    expect(message.getAttribute('_disabled')).toBe('');
   });
 
   it('should determine if layout is stable', async () => {

--- a/packages/core/src/forms/control-group/control-group.element.ts
+++ b/packages/core/src/forms/control-group/control-group.element.ts
@@ -97,7 +97,7 @@ export class CdsInternalControlGroup extends LitElement {
   })
   protected label: HTMLLabelElement;
 
-  @querySlotAll('cds-control, [cds-control], [cds-inline-control]', { assign: 'controls' })
+  @querySlotAll('cds-control, [cds-control]', { assign: 'controls' })
   protected controls: NodeListOf<CdsControl | CdsInternalControlInline>;
 
   @querySlotAll('cds-control-message') protected messages: NodeListOf<CdsControlMessage>;

--- a/packages/core/src/forms/control-inline/control-inline.element.spec.ts
+++ b/packages/core/src/forms/control-inline/control-inline.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -31,7 +31,7 @@ describe('cds-internal-control-inline', () => {
   });
 
   it('should set identifier attribute', () => {
-    expect(control.getAttribute('cds-control-inline')).toBe('');
+    expect(control.getAttribute('cds-control')).toBe('');
   });
 
   it('should allow inline label to be place left or right of the control', async () => {

--- a/packages/core/src/forms/control-message/control-message.element.scss
+++ b/packages/core/src/forms/control-message/control-message.element.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -27,7 +27,7 @@
   --color: #{$cds-alias-status-success};
 }
 
-:host([disabled]) {
+:host([_disabled]) {
   --color: #{$cds-alias-status-disabled};
 }
 

--- a/packages/core/src/forms/control/control.element.scss
+++ b/packages/core/src/forms/control/control.element.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -13,7 +13,7 @@
   line-height: 0;
 }
 
-:host([disabled]) .input {
+:host([_disabled]) .input {
   cursor: not-allowed;
 }
 

--- a/packages/core/src/forms/control/control.element.spec.ts
+++ b/packages/core/src/forms/control/control.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -73,6 +73,23 @@ describe('cds-control', () => {
     expect(getStatusIcon().status).toBe('success');
   });
 
+  it('should apply disabled styles when native input is disabled', async () => {
+    await componentIsStable(control);
+    expect(input.hasAttribute('disabled')).toBe(false);
+
+    input.setAttribute('disabled', '');
+    await componentIsStable(control);
+    expect(control.hasAttribute('_disabled')).toBe(true);
+
+    input.removeAttribute('disabled');
+    await componentIsStable(control);
+    expect(control.hasAttribute('_disabled')).toBe(false);
+
+    input.disabled = true;
+    await componentIsStable(control);
+    expect(control.hasAttribute('_disabled')).toBe(true);
+  });
+
   it('should allow control of the input width', async () => {
     control.style.width = '500px';
 
@@ -108,19 +125,18 @@ describe('cds-control', () => {
   it('should apply focus style attribute when native element is focused', async () => {
     input.dispatchEvent(new Event('focusin'));
     await componentIsStable(control);
-    expect(control.getAttribute('focused')).toBe('');
+    expect(control.getAttribute('_focused')).toBe('');
 
     input.dispatchEvent(new Event('focusout'));
     await componentIsStable(control);
-    expect(control.getAttribute('focused')).toBe(null);
+    expect(control.getAttribute('_focused')).toBe(null);
   });
 
   it('should apply disabled style attribute when native input is disabled', done => {
     expect(control.getAttribute('disabled')).toBe(null);
-    input.setAttribute('disabled', '');
 
-    listenForAttributeChange(control, 'disabled', () => {
-      expect(control.getAttribute('disabled')).toBe('');
+    listenForAttributeChange(control, '_disabled', () => {
+      expect(control.getAttribute('_disabled')).toBe('');
       done();
     });
 

--- a/packages/core/src/forms/control/control.element.ts
+++ b/packages/core/src/forms/control/control.element.ts
@@ -11,7 +11,6 @@ import {
   querySlot,
   querySlotAll,
   id,
-  listenForAttributeChange,
   childrenUpdateComplete,
   getElementLanguageDirection,
   event,
@@ -21,6 +20,7 @@ import {
   internalProperty,
   syncProps,
   pxToRem,
+  getElementUpdates,
 } from '@cds/core/internal';
 import { ClarityIcons } from '@cds/core/icon/icon.service.js';
 import { exclamationCircleIcon } from '@cds/core/icon/shapes/exclamation-circle.js';
@@ -268,7 +268,6 @@ export class CdsControl extends LitElement {
 
   updated(props: Map<string, any>) {
     super.updated(props);
-    syncProps(this.inputControl, this, { disabled: props.has('disabled') });
     this.messages.forEach(message => syncProps(message, this, { disabled: props.has('disabled') }));
   }
 
@@ -287,9 +286,8 @@ export class CdsControl extends LitElement {
   private setupHostAttributes() {
     this.inputControl.addEventListener('focusin', () => (this.focused = true));
     this.inputControl.addEventListener('focusout', () => (this.focused = false));
-    this.disabled = this.inputControl.disabled;
     this.observers.push(
-      listenForAttributeChange(this.inputControl, 'disabled', () => (this.disabled = this.inputControl.disabled))
+      getElementUpdates(this.inputControl, 'disabled', (value: any) => (this.disabled = value === '' ? true : value))
     );
   }
 

--- a/packages/core/src/forms/index.ts
+++ b/packages/core/src/forms/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/packages/core/src/icon/icon.element.ts
+++ b/packages/core/src/icon/icon.element.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -147,7 +147,7 @@ export class CdsIcon extends LitElement {
    * @private
    * given a pixel value offset any surrounding whitespace within the svg
    */
-  @internalProperty({ type: Number, reflect: true })
+  @internalProperty({ type: Number })
   innerOffset: number; // Performance optimization: default to undefined so attr is not initially rendered
 
   @query('svg') private svg: SVGElement;

--- a/packages/core/src/input/input.element.scss
+++ b/packages/core/src/input/input.element.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -86,7 +86,7 @@
   }
 }
 
-:host([focused]) {
+:host([_focused]) {
   --background-size: 100% 100%;
   --border-color: #{$cds-alias-status-info};
 }
@@ -98,7 +98,7 @@
 }
 
 :host([status='error']),
-:host([status='error'][focused]) {
+:host([status='error'][_focused]) {
   --border-color: #{$cds-alias-status-danger};
 }
 
@@ -106,6 +106,6 @@
   --border-color: #{$cds-alias-status-success};
 }
 
-:host([disabled]) {
+:host([_disabled]) {
   --border-color: #{$cds-alias-status-disabled};
 }

--- a/packages/core/src/internal-components/overlay/overlay.element.scss
+++ b/packages/core/src/internal-components/overlay/overlay.element.scss
@@ -34,7 +34,7 @@
   background: var(--layered-backdrop-background, var(--backdrop-background));
 }
 
-:host([__demo-mode]) {
+:host([_demo-mode]) {
   position: absolute;
 
   .overlay-backdrop {

--- a/packages/core/src/internal-components/overlay/overlay.stories.ts
+++ b/packages/core/src/internal-components/overlay/overlay.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -65,7 +65,7 @@ export const basic = () => {
       }
     </style>
     <cds-demo popover>
-      <cds-internal-overlay __demo-mode>
+      <cds-internal-overlay _demo-mode>
         <div cds-layout="vertical gap:lg p:lg align:stretch" class="my-overlay">
           <h3 cds-text="section">An overlay demo</h3>
           <p cds-text="body">I am an overlay.</p>
@@ -260,7 +260,7 @@ export const custom = () => {
     </style>
 
     <cds-demo popover>
-      <cds-internal-overlay __demo-mode id="${purpleOverlayId}" class="purple-overlay">
+      <cds-internal-overlay _demo-mode id="${purpleOverlayId}" class="purple-overlay">
         <div cds-layout="vertical gap:lg p:lg align:stretch" class="my-multi-overlay" style="width: 480px">
           <h1 cds-text="section">I am a purple overlay</h1>
           <p cds-text="body">Hello, I am an overlay with a purple backdrop.</p>
@@ -276,7 +276,7 @@ export const custom = () => {
           </div>
         </div>
       </cds-internal-overlay>
-      <cds-internal-overlay __demo-mode hidden id="${whiteOverlayId}" class="white-overlay">
+      <cds-internal-overlay _demo-mode hidden id="${whiteOverlayId}" class="white-overlay">
         <div cds-layout="vertical gap:lg p:lg align:stretch" class="my-multi-overlay">
           <h1 cds-text="section">I am whitish</h1>
           <p cds-text="body">Hello, I am an overlay with a mostly opaque white backdrop!</p>
@@ -301,7 +301,7 @@ export const custom = () => {
           </div>
         </div>
       </cds-internal-overlay>
-      <cds-internal-overlay __demo-mode hidden id="${orangeOverlayId}" class="orange-overlay">
+      <cds-internal-overlay _demo-mode hidden id="${orangeOverlayId}" class="orange-overlay">
         <div cds-layout="vertical gap:lg p:lg align:stretch" class="my-multi-overlay">
           <h1 cds-text="section" id="custom-demo-3-title">I am orange</h1>
           <p cds-text="body">Hello, I am an overlay with an opaque orange backdrop!</p>

--- a/packages/core/src/internal/base/base.element.scss
+++ b/packages/core/src/internal/base/base.element.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -33,7 +33,7 @@ slot {
 }
 
 :host([role='button']),
-:host([is-anchor]) {
+:host([_is-anchor]) {
   cursor: pointer !important;
 
   ::slotted(*) {
@@ -56,15 +56,15 @@ slot {
 
 // normalize focus styles
 :host([tabindex='0']:focus),
-:host([focused][contains-anchor]),
-:host([focused]) .input {
+:host([_focused][contains-anchor]),
+:host([_focused]) .input {
   outline: Highlight solid $cds-global-space-2;
   outline-offset: $cds-global-space-1;
 }
 
 @media (-webkit-min-device-pixel-ratio: 0) {
   :host([tabindex='0']:focus),
-  :host([focused]) .input {
+  :host([_focused]) .input {
     outline-color: -webkit-focus-ring-color;
   }
 }

--- a/packages/core/src/internal/base/button.base.ts
+++ b/packages/core/src/internal/base/button.base.ts
@@ -11,7 +11,6 @@ import { property, internalProperty } from '../decorators/property.js';
 import { querySlot } from '../decorators/query-slot.js';
 import { onAnyKey } from '../utils/keycodes.js';
 import { stopEvent } from './../utils/events.js';
-import { browserFeatures } from '../utils/supports.js';
 
 // @dynamic
 export class CdsBaseButton extends LitElement {
@@ -36,10 +35,7 @@ export class CdsBaseButton extends LitElement {
 
   @internalProperty({ type: Boolean, reflect: true }) protected active = false;
 
-  @internalProperty({ type: String, reflect: true }) protected role: string | null = 'button';
-
-  @internalProperty({ type: Boolean, reflect: true }) protected hasFlexGapSupport: boolean =
-    browserFeatures.supports.flexGap;
+  @internalProperty({ type: String, reflect: true, attribute: 'role' }) protected role: string | null = 'button';
 
   @internalProperty({ type: Boolean, reflect: true }) protected isAnchor = false;
 
@@ -70,7 +66,7 @@ export class CdsBaseButton extends LitElement {
    * Browsers do not apply the CSS psuedo-selector :active in those instances. So we need this
    * for our :active styles to show.
    *
-   * Make sure to update a component's CSS to account for the presence of the [active] attribute
+   * Make sure to update a component's CSS to account for the presence of the [_active] attribute
    * in all instance where :active is defined.
    *
    * @private

--- a/packages/core/src/internal/base/focus-trap.base.spec.ts
+++ b/packages/core/src/internal/base/focus-trap.base.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -88,7 +88,7 @@ describe('focus trap element', () => {
 
     beforeEach(async () => {
       testElement = await createTestElement(html`
-        <cds-base-focus-trap __demo-mode>
+        <cds-base-focus-trap _demo-mode>
           <cds-button>
             <span>${placeholderText}</span>
           </cds-button>

--- a/packages/core/src/internal/base/focus-trap.base.ts
+++ b/packages/core/src/internal/base/focus-trap.base.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -23,7 +23,7 @@ export class CdsBaseFocusTrap extends LitElement {
   @property({ type: Boolean }) hidden = false;
 
   @internalProperty({ type: Boolean, reflect: true })
-  protected __demoMode = false;
+  protected demoMode = false;
 
   @property({ type: String }) focusTrapId: string;
 
@@ -58,7 +58,7 @@ export class CdsBaseFocusTrap extends LitElement {
   }
 
   private toggleFocusTrap() {
-    if (!this.__demoMode && !this.hasAttribute('hidden')) {
+    if (!this.demoMode && !this.hasAttribute('hidden')) {
       this.focusTrap.enableFocusTrap();
     } else {
       this.focusTrap.removeFocusTrap();

--- a/packages/core/src/internal/decorators/property.ts
+++ b/packages/core/src/internal/decorators/property.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -151,6 +151,12 @@ export function internalProperty(options?: PropertyConfig) {
 
     if (defaultOptions) {
       defaultOptions.reflect = options?.reflect ? options.reflect : false; // prevent attr reflection by default
+
+      if (defaultOptions.reflect && !options?.attribute) {
+        // mark as internal attr if reflect and no provided attr
+        // see description for more detail https://github.com/vmware/clarity/pull/5431
+        defaultOptions.attribute = `_${camelCaseToKebabCase(name)}`;
+      }
     }
 
     return prop(defaultOptions)(protoOrDescriptor, name);

--- a/packages/core/src/internal/index.ts
+++ b/packages/core/src/internal/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -37,6 +37,7 @@ export * from './utils/responsive.js';
 export * from './utils/size.js';
 export * from './utils/string.js';
 export * from './utils/supports.js';
+export * from './utils/events.js';
 export * from './utils/event-subject.js';
 export * from './interfaces/index.js';
 export { styles as baseStyles } from './base/base.element.css.js';

--- a/packages/core/src/internal/utils/events.ts
+++ b/packages/core/src/internal/utils/events.ts
@@ -1,10 +1,29 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
+
+import { listenForAttributeChange } from './dom.js';
 
 export function stopEvent(event: Event) {
   event.preventDefault();
   event.stopPropagation();
 }
+
+export const getElementUpdates = (element: HTMLElement, propertyKey: string, callback: (value: any) => void) => {
+  callback(
+    (element as any)[propertyKey] !== undefined ? (element as any)[propertyKey] : element.getAttribute(propertyKey)
+  );
+
+  const updatedProp = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, propertyKey) as any;
+  Object.defineProperty(element, propertyKey, {
+    get: updatedProp.get,
+    set: val => {
+      callback(val);
+      updatedProp.set.call(element, val);
+    },
+  });
+
+  return listenForAttributeChange(element, propertyKey, val => callback(val));
+};

--- a/packages/core/src/modal/modal.element.scss
+++ b/packages/core/src/modal/modal.element.scss
@@ -22,7 +22,7 @@
   --width: calc(16 * #{$cds-global-space-13});
 }
 
-:host([__demo-mode]) {
+:host([_demo-mode]) {
   position: absolute;
 }
 

--- a/packages/core/src/modal/modal.stories.ts
+++ b/packages/core/src/modal/modal.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -59,7 +59,7 @@ export function API(args: any) {
 export function small() {
   return html`
     <cds-demo popover>
-      <cds-modal __demo-mode size="sm">
+      <cds-modal _demo-mode size="sm">
         <cds-modal-header>
           <h3 cds-text="title">Small Modal</h3>
         </cds-modal-header>
@@ -79,7 +79,7 @@ export function small() {
 export function defaultSize() {
   return html`
     <cds-demo popover>
-      <cds-modal __demo-mode>
+      <cds-modal _demo-mode>
         <cds-modal-header>
           <h3 cds-text="title">Modal Example</h3>
         </cds-modal-header>
@@ -99,7 +99,7 @@ export function defaultSize() {
 export function large() {
   return html`
     <cds-demo popover>
-      <cds-modal __demo-mode size="lg">
+      <cds-modal _demo-mode size="lg">
         <cds-modal-header>
           <h3 cds-text="title">Large Modal Example</h3>
         </cds-modal-header>
@@ -119,7 +119,7 @@ export function large() {
 export function extraLarge() {
   return html`
     <cds-demo popover>
-      <cds-modal __demo-mode size="xl">
+      <cds-modal _demo-mode size="xl">
         <cds-modal-header>
           <h3 cds-text="title">Extra Large Modal Example</h3>
         </cds-modal-header>
@@ -139,7 +139,7 @@ export function extraLarge() {
 export function darkTheme() {
   return html`
     <cds-demo popover cds-theme="dark">
-      <cds-modal __demo-mode>
+      <cds-modal _demo-mode>
         <cds-modal-header>
           <h3 cds-text="title">My Modal</h3>
         </cds-modal-header>
@@ -176,7 +176,7 @@ export function customStyles() {
     </style>
 
     <cds-demo popover>
-      <cds-modal __demo-mode class="modal-branding" size="lg">
+      <cds-modal _demo-mode class="modal-branding" size="lg">
         <cds-modal-header>
           <h3 cds-text="title">Customizing Modal Styles</h3>
         </cds-modal-header>

--- a/packages/core/src/radio/radio-group.element.ts
+++ b/packages/core/src/radio/radio-group.element.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -54,9 +54,11 @@ export class CdsRadioGroup extends CdsInternalControlGroup {
 
   private syncRadioControls() {
     this.controls.forEach(c =>
-      c.inputControl.addEventListener('click', (e: any) => {
-        Array.from(this.controls).forEach(c => c.inputControl.removeAttribute('checked'));
-        e.target.setAttribute('checked', '');
+      c.addEventListener('checkedChange', (e: any) => {
+        if (e.detail) {
+          Array.from(this.controls).forEach(c => (c.inputControl.checked = false));
+          e.target.inputControl.checked = true;
+        }
       })
     );
   }

--- a/packages/core/src/radio/radio.element.scss
+++ b/packages/core/src/radio/radio.element.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -37,12 +37,12 @@
   --border: #{$cds-alias-object-border-width-100} solid #{$cds-alias-status-danger};
 }
 
-:host([checked]) {
+:host([_checked]) {
   --fill-box-shadow: inset 0 0 0 #{$cds-global-space-4} #{$cds-alias-status-info};
   --border: 0 !important;
 }
 
-:host([checked][disabled]) {
+:host([_disabled][_checked]) {
   --fill-box-shadow: inset 0 0 0 #{$cds-global-space-4} #{$cds-alias-status-disabled-tint};
   --border: 0 !important;
 }

--- a/packages/core/src/radio/radio.element.spec.ts
+++ b/packages/core/src/radio/radio.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -53,13 +53,13 @@ describe('cds-radio', () => {
   it('should mark checked radio with a checked attribute based on input checked state', async () => {
     await componentIsStable(component);
 
-    expect(component.hasAttribute('checked')).toBe(false);
-    expect(componentTwo.hasAttribute('checked')).toBe(true);
+    expect(component.hasAttribute('_checked')).toBe(false);
+    expect(componentTwo.hasAttribute('_checked')).toBe(true);
     await componentIsStable(component);
     component.inputControl.click();
     await componentIsStable(component);
 
-    expect(component.hasAttribute('checked')).toBe(true);
-    expect(componentTwo.hasAttribute('checked')).toBe(false);
+    expect(component.hasAttribute('_checked')).toBe(true);
+    expect(componentTwo.hasAttribute('_checked')).toBe(false);
   });
 });

--- a/packages/core/src/radio/radio.element.ts
+++ b/packages/core/src/radio/radio.element.ts
@@ -1,10 +1,9 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { internalProperty, listenForAttributeChange } from '@cds/core/internal';
 import { CdsInternalControlInline } from '@cds/core/forms';
 import { styles } from './radio.element.css.js';
 
@@ -30,16 +29,7 @@ import { styles } from './radio.element.css.js';
  * @cssprop --fill-box-shadow
  */
 export class CdsRadio extends CdsInternalControlInline {
-  @internalProperty({ type: Boolean, reflect: true }) protected checked = false;
-
   static get styles() {
     return [...super.styles, styles];
-  }
-
-  firstUpdated(props: Map<string, any>) {
-    super.firstUpdated(props);
-    this.checked = this.inputControl.hasAttribute('checked') || this.inputControl.checked;
-    this.checked ? this.inputControl.setAttribute('checked', '') : this.inputControl.removeAttribute('checked');
-    this.observers.push(listenForAttributeChange(this.inputControl, 'checked', val => (this.checked = val !== null)));
   }
 }

--- a/packages/core/src/range/range.element.scss
+++ b/packages/core/src/range/range.element.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -43,7 +43,7 @@
   z-index: 999;
 }
 
-:host([disabled]) {
+:host([_disabled]) {
   --track-background: #{$cds-alias-status-disabled-shade};
   --track-fill-background: #{$cds-alias-status-disabled};
   --thumb-background: #{$cds-alias-status-disabled};

--- a/packages/core/src/select/select.element.scss
+++ b/packages/core/src/select/select.element.scss
@@ -1,11 +1,16 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
 @import './../styles/tokens/generated/index';
 
-:host([multiple]) {
+:host([_multiple]) {
   --border: #{$cds-alias-object-border-width-100} solid #{$cds-alias-object-border-color} !important;
+  --border-bottom: 0;
+
+  cds-control-action {
+    display: none;
+  }
 }
 
 ::slotted([slot='input']) {
@@ -18,12 +23,4 @@
   border: var(--border);
   padding: 0 !important;
   font-size: $cds-global-typography-font-size-3 !important;
-}
-
-:host([multiple]) .input-container {
-  --border-bottom: 0;
-}
-
-:host([multiple]) cds-control-action {
-  display: none;
 }

--- a/packages/core/src/select/select.element.spec.ts
+++ b/packages/core/src/select/select.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -40,10 +40,10 @@ describe('cds-select', () => {
 
   it('should sync host multiple attr', async () => {
     await componentIsStable(component);
-    expect(component.hasAttribute('multiple')).toBe(false);
+    expect(component.hasAttribute('_multiple')).toBe(false);
 
     component.inputControl.setAttribute('multiple', '');
     await componentIsStable(component);
-    expect(component.hasAttribute('multiple')).toBe(true);
+    expect(component.hasAttribute('_multiple')).toBe(true);
   });
 });

--- a/packages/core/src/styles/module.reset.scss
+++ b/packages/core/src/styles/module.reset.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -35,7 +35,7 @@ html {
   color: $cds-global-typography-color-200;
 }
 
-[cds-control][disabled] {
+[cds-control][_disabled] {
   --cds-global-typography-color-200: #{$cds-alias-status-disabled};
 }
 

--- a/packages/core/src/tag/tag.element.scss
+++ b/packages/core/src/tag/tag.element.scss
@@ -39,7 +39,7 @@ cds-icon[shape='times'] {
 }
 
 :host(:not([readonly])) {
-  &:host([active]),
+  &:host([_active]),
   &:host(:hover),
   &:host(:focus),
   &:host(:active) {
@@ -58,7 +58,7 @@ cds-icon[shape='times'] {
     }
   }
 
-  &:host([active]),
+  &:host([_active]),
   &:host(:active) {
     .private-host {
       box-shadow: 0 #{$cds-global-space-1} 0 0 var(--border-color) inset;

--- a/packages/core/src/textarea/textarea.element.scss
+++ b/packages/core/src/textarea/textarea.element.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -35,6 +35,6 @@
   --border: #{$cds-alias-object-border-width-100} solid #{$cds-alias-status-success};
 }
 
-:host([disabled]) {
+:host([_disabled]) {
   --border: #{$cds-alias-object-border-width-100} solid #{$cds-alias-status-disabled};
 }

--- a/packages/core/src/toggle/toggle.element.scss
+++ b/packages/core/src/toggle/toggle.element.scss
@@ -1,11 +1,11 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
 @import './../styles/tokens/generated/index';
 
 :host {
-  --background: #{$cds-alias-status-neutral-tint};
+  --background: #{$cds-alias-status-neutral};
   --border: #{$cds-alias-object-border-width-200} solid var(--background);
   --border-radius: #{$cds-alias-object-border-radius-200};
   --height: #{$cds-global-space-8};
@@ -45,15 +45,16 @@
   transition-property: transform;
 }
 
-:host([checked]) {
+:host([_checked]) {
   --background: #{$cds-alias-status-success};
+  --border: #{$cds-alias-object-border-width-200} solid var(--background);
+
+  .input:after {
+    transform: translate(calc(#{$cds-global-space-7} - #{$cds-global-space-1}), 0);
+  }
 }
 
-:host([checked]) .input:after {
-  transform: translate(calc(#{$cds-global-space-7} - #{$cds-global-space-1}), 0);
-}
-
-:host([disabled]) .input {
+:host([_disabled]) .input {
   opacity: 0.6;
   cursor: not-allowed;
 }

--- a/packages/core/src/toggle/toggle.element.spec.ts
+++ b/packages/core/src/toggle/toggle.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -35,10 +35,10 @@ describe('cds-toggle', () => {
 
   it('should sync host checked attr', async () => {
     await componentIsStable(component);
-    expect(component.hasAttribute('checked')).toBe(false);
+    expect(component.hasAttribute('_checked')).toBe(false);
 
     component.inputControl.click();
     await componentIsStable(component);
-    expect(component.hasAttribute('checked')).toBe(true);
+    expect(component.hasAttribute('_checked')).toBe(true);
   });
 });

--- a/packages/core/src/toggle/toggle.element.ts
+++ b/packages/core/src/toggle/toggle.element.ts
@@ -1,10 +1,9 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { internalProperty } from '@cds/core/internal';
 import { CdsInternalControlInline } from '@cds/core/forms';
 import { styles } from './toggle.element.css.js';
 
@@ -35,15 +34,7 @@ import { styles } from './toggle.element.css.js';
  * @cssprop --anchor-height
  */
 export class CdsToggle extends CdsInternalControlInline {
-  @internalProperty({ type: Boolean, reflect: true }) protected checked = false;
-
   static get styles() {
     return [...super.styles, styles];
-  }
-
-  firstUpdated(props: Map<string, any>) {
-    super.firstUpdated(props);
-    this.checked = this.inputControl.checked;
-    this.inputControl.addEventListener('change', () => (this.checked = this.inputControl.checked));
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## Fix Part 1

For some Core form components such as checkbox, toggle and radio we need to know when the state of the native input changes. We must know when these components are changed so we can update the CSS to reflect those changes.

In clr-ui for custom checkboxes we would use a combination of `:checked` and `::before`/`::after` to create the custom checkbox look. However in Core with shadow dom [Safari does not properly support these selectors for slotted elements](https://bugs.webkit.org/show_bug.cgi?id=178237).
To fix this we have a div in the component template that is styled base on if the component is in one of the possible states the native input can be in.

The current version would listen to the `change` event of the native input and update our CSS base on that update. However I missed the use case of a developer programmatically updating a native input. Example:

```typescript
const checkbox = document.querySelector('cds-checkbox input');
checkbox.checked = true; // checkbox would not show the checked styles
``` 

Our component would not see that `checked` was set only `change` events. This caused the bug reported in https://github.com/vmware/clarity/issues/5397. You can find a plain JS example of the bug here https://stackblitz.com/edit/typescript-nbrgi7 as well as in React here https://stackblitz.com/edit/react-ts-yaoseg 

The fix for this bug is to override the setter on the native input as well as listen for attr changes on the native element.
This way if the checkbox is updated by the user, or its checked property and attr is set our component will update.
This PR adds a util function called `getElementUpdates()` which given an element and property name will notify when the property or its corresponding attribute has changed.

## Fix Part 2

The second part of this PR is to help some of the confusion in https://github.com/vmware/clarity/issues/5397. When we style our components/theme based on component state we often use host attr selectors.

```html
<cds-button status="success">...</cds-button>
```
```css
:host([status='success']) {
  --color: green;
}
```

This works well, however, at times we need to use host attrs to set internal styles. Sometimes these internal style hooks can cause confusion with the public API. Example form components should be disabled by setting the `disabled` attr or property on the native input not `<cds-input>`.

```html
<cds-input>
  <label>disabled input</label>
  <input type="text" disabled />
</cds-input>
```

Our component will add a `disabled` attr to `cds-input` so internally we can easily update the css custom properties based on the native input state.

```html
<cds-input disabled> <!-- added/removed based on native input -->
  <label>disabled input</label>
  <input type="text" disabled />
</cds-input>
```

This is a point of confusion for our APIs as when debugging. It creates similarly named attrs in the DOM and uncertainty of what should be updated.

We could remove host attrs for internal styles but this often breaks or complicates the CSS custom property themes. Example given this css in a component the `.active` class creates a new instance of `--color` in different scope.

```css
  :host {
    --color: blue;
  }

  p {
    color: var(--color);
  }

  .active {
    --color: red;
  }
```

If a user attempts to override `--color` and `.active` is applied they will no longer be able to customize `--color` because it refers to the element with the active class and not the `--color` defined on the host. Other web component libraries have this same issue. Ionic solves it by keeping the style hooks on host to avoid this. See this example for more detail https://stackblitz.com/edit/lit-element-example-gf19vu 

So to allow internal host attrs for internal styles without breaking the theme API this PR follows something similar to Ionic by keeping the style hooks on the host element but prefixing or marking them as internal. Now `@internalProperty()` will prefix host attributes with an `_` if `reflect: true` is set and no custom attr name is provided.

```typescript
@internalProperty({ type: Boolean; reflect: true }) type = 'banner';
```
```
<my-element _type="banner"></my-element>
```

So now in our example of `cds-input` when the native text input disabled is set the output HTML will look like the following:

```html
<cds-input __disabled>
  <label>disabled input</label>
  <input type="text" disabled />
</cds-input>
```

While still not the most ideal this hopefully is a step in the right direction and does seem to align with some of the other web component library patterns. (See ionic toggle component for a good example) This is an internal change so no breaking changes and could be iterated on without worry of future breaking changes.

closes #5397 
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
