### PR TITLE
fix: simplifying fallback system fonts

### DIFF
--- a/packages/core/build/tokens.ts
+++ b/packages/core/build/tokens.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -339,8 +339,8 @@ const typography = {
   },
   baseFontSize: token('125%'),
   baseFontSizePx: token(20),
-  fontFamily: token("'Clarity City', 'Avenir Next', 'Helvetica Neue', Arial, sans-serif"),
-  headerFontFamily: token("'Clarity City', 'Avenir Next', 'Helvetica Neue', Arial, sans-serif"),
+  fontFamily: token("'Clarity City', 'Avenir Next', sans-serif"),
+  headerFontFamily: token("'Clarity City', 'Avenir Next', sans-serif"),
   topGapHeight: token('0.1475em'), // line-height eraser
   ascenderHeight: token('0.1703em'), // line-height eraser
   xHeight: token('0.517em'), // line-height eraser

--- a/packages/core/src/forms/control-label/control-label.element.scss
+++ b/packages/core/src/forms/control-label/control-label.element.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -10,7 +10,7 @@
 }
 
 ::slotted([slot='label']) {
-  font-family: 'Clarity City', 'Avenir Next', 'Helvetica Neue', Arial, sans-serif !important;
+  font-family: $cds-global-typography-font-family !important;
   max-width: var(--internal-label-max-width, initial) !important;
   display: inline-block !important;
   text-transform: capitalize !important;

--- a/packages/core/src/styles/typography/_legacy-typography.scss
+++ b/packages/core/src/styles/typography/_legacy-typography.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -78,8 +78,6 @@ $typography-header-font-family: var(
   --cds-global-typography-header-font-family,
   'Clarity City',
   'Avenir Next',
-  'Helvetica Neue',
-  Arial,
   sans-serif
 );
 $typography-p0-color: hsl(0, 0%, 20%);

--- a/packages/core/test-bundles/bundlesize.json
+++ b/packages/core/test-bundles/bundlesize.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "./dist/core/global.min.css",
-      "maxSize": "7.8 kB",
+      "maxSize": "8 kB",
       "compression": "brotli"
     },
     {


### PR DESCRIPTION
• removed 'Helvetica Neue' and 'Arial' from fallback font list
• both were wildly different from Clarity City and introduced issues with LHEs

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
