### PR TITLE
fix: reorder link styles so :hover will have effect even on visited links

### DIFF
--- a/packages/angular/projects/clr-angular/src/utils/_reboot.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/utils/_reboot.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -416,6 +416,11 @@
     text-decoration: none;
   }
 
+  a:visited {
+    @include css-var(color, clr-link-visited-color, $clr-link-visited-color, $clr-use-custom-properties);
+    text-decoration: none;
+  }
+
   a:hover {
     @include css-var(color, clr-link-hover-color, $clr-link-hover-color, $clr-use-custom-properties);
     text-decoration: underline;
@@ -424,11 +429,5 @@
   a:active {
     @include css-var(color, clr-link-active-color, $clr-link-active-color, $clr-use-custom-properties);
     text-decoration: underline;
-  }
-
-  a:visited {
-    //TODO: Not in the color palette. Will be added soon.
-    @include css-var(color, clr-link-visited-color, $clr-link-visited-color, $clr-use-custom-properties);
-    text-decoration: none;
   }
 }


### PR DESCRIPTION
Change the order of styles for `a` tags - so the `:hover` styles will have an effect on `<a>` tags even when they are visited. 

Need to be backported for v4, v3
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5432

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Closes #5432 