### PR TITLE
fix: change dev serve task to monitor @clr/ui for changes

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -7,7 +7,8 @@
     "start:dev": "ng build clr-angular --watch --prod",
     "start:storybook": "stmux -w always -e ERROR -m beep,system [ \"yarn start:dev\" : \"sleep 25 && yarn storybook\" : \"yarn --cwd ../ui run build:watch\" ]",
     "start:adoption": "ng build clarity-adoption --watch --prod",
-    "serve": "ng serve dev",
+    "serve": "npm-run-all -p serve:watch sass:watch",
+    "serve:watch": "ng serve dev",
     "serve:adoption": "ng serve clarity-adoption",
     "serve:dark": "ng serve dev -c dark",
     "storybook": "start-storybook -s .storybook/public -p 6006",
@@ -39,7 +40,8 @@
     "lint:ts": "eslint -c .eslintrc.js \"src/**/*.ts\" \"projects/**/*.ts\"",
     "lint:styles": "stylelint \"src/**/*.scss\" \"projects/**/*.scss\"",
     "lint:fix": "eslint --fix -c .eslintrc.js \"src/**/*.ts\" \"projects/**/*.ts\" && stylelint --fix \"src/**/*.scss\" \"projects/**/*.scss\"",
-    "golden:fix": "yarn run build:lib:clr && ts-api-guardian --out golden/clr-angular.d.ts --stripExportPattern '^Çlr' ./dist/clr-angular/index.d.ts"
+    "golden:fix": "yarn run build:lib:clr && ts-api-guardian --out golden/clr-angular.d.ts --stripExportPattern '^Çlr' ./dist/clr-angular/index.d.ts",
+    "sass:watch": "yarn --cwd ../ui run build:watch"
   },
   "dependencies": {
     "@angular/animations": "11.0.0",


### PR DESCRIPTION
Change the `yarn run serve` for angular dev app to monitor and trigger reload when changing `@clr/ui` - before that you had to manually trigger a rebuild of `@clr/ui` so any `sass` change will have an effect.

If you don't plan to make any style changes you could run 
```bash
yarn run serve:watch
```

This task will exclude monitoring the changes on the UI package. If you at some point require to make a small change to the styles running `yarn --cwd ../ui run build` will trigger only a single rebuild.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
