### PR TITLE
fix: password input aria-label

### DIFF
--- a/packages/core/src/internal/services/i18n.service.ts
+++ b/packages/core/src/internal/services/i18n.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -29,6 +29,10 @@ export interface I18nStrings {
     contentBox: string;
     contentEnd: string;
   };
+  password: {
+    showButtonAriaLabel: string;
+    hideButtonAriaLabel: string;
+  };
 }
 
 export const componentStringsDefault = {
@@ -53,6 +57,10 @@ export const componentStringsDefault = {
     contentStart: 'Beginning of Modal Content',
     contentBox: 'Scrollable Modal Body',
     contentEnd: 'End of Modal Content',
+  },
+  password: {
+    showButtonAriaLabel: 'Show password',
+    hideButtonAriaLabel: 'Hide password',
   },
 };
 

--- a/packages/core/src/password/password.element.spec.ts
+++ b/packages/core/src/password/password.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -61,5 +61,24 @@ describe('cds-password', () => {
     component.shadowRoot.querySelector('cds-control-action').click();
     await componentIsStable(component);
     expect(document.activeElement).toEqual(component.inputControl);
+  });
+
+  it('should have the correct aria-label for the show/hide button', async () => {
+    await componentIsStable(component);
+    expect(component.shadowRoot.querySelector('cds-control-action').getAttribute('aria-label')).toEqual(
+      'Show password'
+    );
+
+    component.shadowRoot.querySelector('cds-control-action').click();
+    await componentIsStable(component);
+    expect(component.shadowRoot.querySelector('cds-control-action').getAttribute('aria-label')).toEqual(
+      'Hide password'
+    );
+
+    component.shadowRoot.querySelector('cds-control-action').click();
+    await componentIsStable(component);
+    expect(component.shadowRoot.querySelector('cds-control-action').getAttribute('aria-label')).toEqual(
+      'Show password'
+    );
   });
 });

--- a/packages/core/src/password/password.element.ts
+++ b/packages/core/src/password/password.element.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -51,7 +51,7 @@ export class CdsPassword extends CdsControl {
   }
 
   private get ariaLabel() {
-    return this.showPassword ? I18nService.keys.hide : I18nService.keys.show;
+    return this.showPassword ? this.i18n.hideButtonAriaLabel : this.i18n.showButtonAriaLabel;
   }
 
   protected get suffixDefaultTemplate() {


### PR DESCRIPTION
Missed porting over the i18n strings for the aria button in password input show/hide button. Added tests to catch it.

Signed-off-by: Jeeyun Lim <jeeyun.lim@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Screenreader reads "undefined" for the show/hide button in the password input field.

Issue Number: N/A

## What is the new behavior?

Screenreader reads "Show password" or "Hide password" for the show/hide button in the password input field.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
