### PR TITLE
fix: tag a11y (remove inner badge role button + aria-label for inner badge)

### DIFF
--- a/packages/core/src/tag/tag.element.spec.ts
+++ b/packages/core/src/tag/tag.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -81,28 +81,5 @@ describe('tag element', () => {
     component.closable = true;
     await componentIsStable(component);
     expect(!!component.readonly).toBe(false);
-  });
-
-  it('should warn if closable but there is no aria-label', async () => {
-    await createTestElement(html`
-      <cds-tag class="${readonlyClassname}" readonly>Readonly Tag</cds-tag>
-      <cds-tag class="${closableClassname}" closable>Closable Tag</cds-tag>
-    `);
-    expect(console.warn).toHaveBeenCalledTimes(1);
-  });
-
-  it('should warn if clickable but there is no aria-label', async () => {
-    await createTestElement(html`
-      <cds-tag class="${readonlyClassname}" readonly>Readonly Tag</cds-tag>
-      <cds-tag class="${closableClassname}">Clickable Tag</cds-tag>
-    `);
-    expect(console.warn).toHaveBeenCalledTimes(1);
-  });
-
-  it('should NOT warn if aria-labels are present', async () => {
-    const component = getTagComponentFromElement(testElement, 'closable');
-    await componentIsStable(component);
-
-    expect(console.warn).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/tag/tag.element.ts
+++ b/packages/core/src/tag/tag.element.ts
@@ -1,17 +1,10 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import {
-  assignSlotNames,
-  baseStyles,
-  CdsBaseButton,
-  property,
-  StatusTypes,
-  syncDefinedProps,
-} from '@cds/core/internal';
+import { assignSlotNames, baseStyles, CdsBaseButton, property, StatusTypes, syncProps } from '@cds/core/internal';
 import { html } from 'lit-element';
 import { styles } from './tag.element.css.js';
 
@@ -76,11 +69,9 @@ export class CdsTag extends CdsBaseButton {
       this.readonly = false;
     }
 
-    if (!this.readonly && !this.getAttribute('aria-label')) {
-      console.warn('Clickable and closable tags need aria-labels.');
+    if (this.badge) {
+      syncProps(this.badge, this, { status: props.has('status'), color: props.has('color') });
     }
-
-    syncDefinedProps(props, this, [this.badge]);
   }
 
   render() {

--- a/packages/core/src/tag/tag.stories.ts
+++ b/packages/core/src/tag/tag.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -35,7 +35,9 @@ export default {
 export function API(args: any) {
   return html`
     <cds-tag ...="${spreadProps(getElementStorybookArgs(args))}" @click=${action('click')}>
-      ${args.default}${args.badgeValue !== 0 ? html`<cds-badge>${args.badgeValue}</cds-badge>` : ''}
+      ${args.default}${args.badgeValue !== 0
+        ? html`<cds-badge aria-label="notification ${args.badgeValue}">${args.badgeValue}</cds-badge>`
+        : ''}
     </cds-tag>
   `;
 }
@@ -70,11 +72,17 @@ export function color() {
 export function badgesStatus() {
   return html`
     <div cds-layout="vertical gap:sm">
-      <cds-tag readonly status="info">Info <cds-badge status="info">1</cds-badge></cds-tag>
-      <cds-tag readonly status="success">Success <cds-badge status="success">2</cds-badge></cds-tag>
-      <cds-tag readonly status="warning">Warning <cds-badge status="warning">3</cds-badge> </cds-tag>
-      <cds-tag readonly status="danger">Danger <cds-badge status="danger">12</cds-badge></cds-tag>
-      <cds-tag disabled status="info">Disabled <cds-badge>12</cds-badge></cds-tag>
+      <cds-tag readonly status="info">Info <cds-badge aria-label="notification 1" status="info">1</cds-badge></cds-tag>
+      <cds-tag readonly status="success"
+        >Success <cds-badge aria-label="notification 2" status="success">2</cds-badge></cds-tag
+      >
+      <cds-tag readonly status="warning"
+        >Warning <cds-badge aria-label="notification 3" status="warning">3</cds-badge>
+      </cds-tag>
+      <cds-tag readonly status="danger"
+        >Danger <cds-badge aria-label="notification 12" status="danger">12</cds-badge></cds-tag
+      >
+      <cds-tag disabled status="info">Disabled <cds-badge aria-label="notification 12">12</cds-badge></cds-tag>
     </div>
   `;
 }
@@ -83,11 +91,11 @@ export function badgesStatus() {
 export function badgesColor() {
   return html`
     <cds-tag readonly>No Badge</cds-tag>
-    <cds-tag readonly color="gray">Default <cds-badge>1</cds-badge></cds-tag>
-    <cds-tag readonly color="purple">Purple <cds-badge>2</cds-badge></cds-tag>
-    <cds-tag readonly color="blue">Blue <cds-badge>3</cds-badge></cds-tag>
-    <cds-tag readonly color="orange">Orange <cds-badge>12</cds-badge></cds-tag>
-    <cds-tag readonly color="light-blue">Light Blue <cds-badge>15</cds-badge></cds-tag>
+    <cds-tag readonly color="gray">Default <cds-badge aria-label="notification 1">1</cds-badge></cds-tag>
+    <cds-tag readonly color="purple">Purple <cds-badge aria-label="notification 2">2</cds-badge></cds-tag>
+    <cds-tag readonly color="blue">Blue <cds-badge aria-label="notification 3">3</cds-badge></cds-tag>
+    <cds-tag readonly color="orange">Orange <cds-badge aria-label="notification 12">12</cds-badge></cds-tag>
+    <cds-tag readonly color="light-blue">Light Blue <cds-badge aria-label="notification 15">15</cds-badge></cds-tag>
   `;
 }
 
@@ -96,120 +104,92 @@ export function clickable() {
   return html`
     <div cds-layout="vertical gap:md">
       <div cds-layout="horizontal gap:sm">
-        <cds-tag aria-label="Clickable example of a default tag" closable>Closable</cds-tag>
-        <cds-tag aria-label="Disabled example of a default tag" status="info" disabled>Disabled</cds-tag>
-        <cds-tag aria-label="Clickable example of a default tag">Default</cds-tag>
-        <cds-tag aria-label="Clickable example of a tag with the info status" status="info">Info</cds-tag>
-        <cds-tag aria-label="Clickable example of a tag with the success status" status="success">Success</cds-tag>
-        <cds-tag aria-label="Clickable example of a tag with the warning status" status="warning">Warning</cds-tag>
-        <cds-tag aria-label="Clickable example of a tag with the danger status" status="danger">Danger</cds-tag>
+        <cds-tag closable>Closable</cds-tag>
+        <cds-tag status="info" disabled>Disabled</cds-tag>
+        <cds-tag>Default</cds-tag>
+        <cds-tag status="info">Info</cds-tag>
+        <cds-tag status="success">Success</cds-tag>
+        <cds-tag status="warning">Warning</cds-tag>
+        <cds-tag status="danger">Danger</cds-tag>
       </div>
       <div cds-layout="horizontal gap:sm">
-        <cds-tag aria-label="Disabled example of a default tag" status="info" disabled
-          >Disabled <cds-badge>0</cds-badge></cds-tag
+        <cds-tag status="info" disabled>Disabled <cds-badge aria-label="notification 0">0</cds-badge></cds-tag>
+        <cds-tag>Default <cds-badge aria-label="notification 0">0</cds-badge></cds-tag>
+        <cds-tag status="info">Info <cds-badge aria-label="notification 1" status="info">1</cds-badge></cds-tag>
+        <cds-tag status="success"
+          >Success <cds-badge aria-label="notification 2" status="success">2</cds-badge></cds-tag
         >
-        <cds-tag aria-label="Clickable example of a default tag">Default <cds-badge>0</cds-badge></cds-tag>
-        <cds-tag aria-label="Clickable example of a tag with the info status" status="info"
-          >Info <cds-badge status="info">1</cds-badge></cds-tag
+        <cds-tag status="warning"
+          >Warning <cds-badge aria-label="notification 3" status="warning">3</cds-badge></cds-tag
         >
-        <cds-tag aria-label="Clickable example of a tag with the success status" status="success"
-          >Success <cds-badge status="success">2</cds-badge></cds-tag
-        >
-        <cds-tag aria-label="Clickable example of a tag with the warning status" status="warning"
-          >Warning <cds-badge status="warning">3</cds-badge></cds-tag
-        >
-        <cds-tag aria-label="Clickable example of a tag with the danger status" status="danger"
-          >Danger <cds-badge status="danger">12</cds-badge></cds-tag
-        >
+        <cds-tag status="danger">Danger <cds-badge aria-label="notification 12" status="danger">12</cds-badge></cds-tag>
       </div>
       <div cds-layout="horizontal gap:sm">
-        <cds-tag aria-label="Disabled example of a default tag" status="info" disabled
-          ><cds-icon shape="info-standard"></cds-icon>Disabled</cds-tag
-        >
-        <cds-tag aria-label="Clickable example of a default tag"
-          ><cds-icon shape="info-standard"></cds-icon>Default</cds-tag
-        >
-        <cds-tag aria-label="Clickable example of a tag with the info status" status="info"
-          ><cds-icon shape="info-standard"></cds-icon>Info</cds-tag
-        >
-        <cds-tag aria-label="Clickable example of a tag with the success status" status="success"
-          ><cds-icon shape="info-standard"></cds-icon>Success</cds-tag
-        >
-        <cds-tag aria-label="Clickable example of a tag with the warning status" status="warning"
-          ><cds-icon shape="info-standard"></cds-icon>Warning</cds-tag
-        >
-        <cds-tag aria-label="Clickable example of a tag with the danger status" status="danger"
-          ><cds-icon shape="info-standard"></cds-icon>Danger</cds-tag
-        >
+        <cds-tag status="info" disabled><cds-icon shape="info-standard"></cds-icon>Disabled</cds-tag>
+        <cds-tag><cds-icon shape="info-standard"></cds-icon>Default</cds-tag>
+        <cds-tag status="info"><cds-icon shape="info-standard"></cds-icon>Info</cds-tag>
+        <cds-tag status="success"><cds-icon shape="info-standard"></cds-icon>Success</cds-tag>
+        <cds-tag status="warning"><cds-icon shape="info-standard"></cds-icon>Warning</cds-tag>
+        <cds-tag status="danger"><cds-icon shape="info-standard"></cds-icon>Danger</cds-tag>
       </div>
       <div cds-layout="horizontal gap:sm">
-        <cds-tag aria-label="Disabled example of a default tag" status="info" disabled
-          ><cds-icon shape="info-standard"></cds-icon>Disabled <cds-badge>0</cds-badge></cds-tag
+        <cds-tag status="info" disabled
+          ><cds-icon shape="info-standard"></cds-icon>Disabled
+          <cds-badge aria-label="notification 0">0</cds-badge></cds-tag
         >
-        <cds-tag aria-label="Clickable example of a default tag"
-          ><cds-icon shape="info-standard"></cds-icon>Default <cds-badge>0</cds-badge></cds-tag
+        <cds-tag
+          ><cds-icon shape="info-standard"></cds-icon>Default
+          <cds-badge aria-label="notification 0">0</cds-badge></cds-tag
         >
-        <cds-tag aria-label="Clickable example of a tag with the info status" status="info"
-          ><cds-icon shape="info-standard"></cds-icon>Info <cds-badge status="info">1</cds-badge></cds-tag
+        <cds-tag status="info"
+          ><cds-icon shape="info-standard"></cds-icon>Info
+          <cds-badge aria-label="notification 1" status="info">1</cds-badge></cds-tag
         >
-        <cds-tag aria-label="Clickable example of a tag with the success status" status="success"
-          ><cds-icon shape="info-standard"></cds-icon>Success <cds-badge status="success">2</cds-badge></cds-tag
+        <cds-tag status="success"
+          ><cds-icon shape="info-standard"></cds-icon>Success
+          <cds-badge aria-label="notification 2" status="success">2</cds-badge></cds-tag
         >
-        <cds-tag aria-label="Clickable example of a tag with the warning status" status="warning"
-          ><cds-icon shape="info-standard"></cds-icon>Warning <cds-badge status="warning">3</cds-badge></cds-tag
+        <cds-tag status="warning"
+          ><cds-icon shape="info-standard"></cds-icon>Warning
+          <cds-badge aria-label="notification 3" status="warning">3</cds-badge></cds-tag
         >
-        <cds-tag aria-label="Clickable example of a tag with the danger status" status="danger"
-          ><cds-icon shape="info-standard"></cds-icon>Danger <cds-badge status="danger">12</cds-badge></cds-tag
+        <cds-tag status="danger"
+          ><cds-icon shape="info-standard"></cds-icon>Danger
+          <cds-badge aria-label="notification 12" status="danger">12</cds-badge></cds-tag
         >
       </div>
       <br />
       <div cds-layout="horizontal gap:sm">
-        <cds-tag aria-label="Clickable example of a purple tag" color="purple">Purple</cds-tag>
-        <cds-tag aria-label="Clickable example of a blue tag" color="blue">Blue</cds-tag>
-        <cds-tag aria-label="Clickable example of an orange tag" color="orange">Orange</cds-tag>
-        <cds-tag aria-label="Clickable example of a light blue tag" color="light-blue">Light Blue</cds-tag>
+        <cds-tag color="purple">Purple</cds-tag>
+        <cds-tag color="blue">Blue</cds-tag>
+        <cds-tag color="orange">Orange</cds-tag>
+        <cds-tag color="light-blue">Light Blue</cds-tag>
       </div>
       <div cds-layout="horizontal gap:sm">
-        <cds-tag aria-label="Clickable example of a purple tag with a badge" color="purple"
-          >Purple <cds-badge>B</cds-badge></cds-tag
-        >
-        <cds-tag aria-label="Clickable example of a blue tag with a badge" color="blue"
-          >Blue <cds-badge>C</cds-badge></cds-tag
-        >
-        <cds-tag aria-label="Clickable example of an orange tag with a badge" color="orange"
-          >Orange <cds-badge>D</cds-badge></cds-tag
-        >
-        <cds-tag aria-label="Clickable example of a light-blue tag with a badge" color="light-blue"
-          >Light Blue <cds-badge>E</cds-badge></cds-tag
-        >
+        <cds-tag color="purple">Purple <cds-badge aria-label="notification B">B</cds-badge></cds-tag>
+        <cds-tag color="blue">Blue <cds-badge aria-label="notification C">C</cds-badge></cds-tag>
+        <cds-tag color="orange">Orange <cds-badge aria-label="notification D">D</cds-badge></cds-tag>
+        <cds-tag color="light-blue">Light Blue <cds-badge aria-label="notification E">E</cds-badge></cds-tag>
       </div>
       <div cds-layout="horizontal gap:sm">
-        <cds-tag aria-label="Clickable example of a purple tag with an icon" color="purple"
-          ><cds-icon shape="info-standard"></cds-icon>Purple</cds-tag
-        >
-        <cds-tag aria-label="Clickable example of a blue tag with an icon" color="blue"
-          ><cds-icon shape="info-standard"></cds-icon>Blue</cds-tag
-        >
-        <cds-tag aria-label="Clickable example of an orange tag with an icon" color="orange"
-          ><cds-icon shape="info-standard"></cds-icon>Orange</cds-tag
-        >
-        <cds-tag aria-label="Clickable example of a light-blue tag with an icon" color="light-blue"
-          ><cds-icon shape="info-standard"></cds-icon>Light Blue</cds-tag
-        >
+        <cds-tag color="purple"><cds-icon shape="info-standard"></cds-icon>Purple</cds-tag>
+        <cds-tag color="blue"><cds-icon shape="info-standard"></cds-icon>Blue</cds-tag>
+        <cds-tag color="orange"><cds-icon shape="info-standard"></cds-icon>Orange</cds-tag>
+        <cds-tag color="light-blue"><cds-icon shape="info-standard"></cds-icon>Light Blue</cds-tag>
       </div>
       <div cds-layout="horizontal gap:sm">
-        <cds-tag aria-label="Clickable example of a purple tag with an icon and badge" color="purple"
-          ><cds-icon shape="info-standard"></cds-icon>Purple <cds-badge>1</cds-badge></cds-tag
-        >
-        <cds-tag aria-label="Clickable example of a blue tag with an icon and badge" color="blue"
-          ><cds-icon shape="info-standard"></cds-icon>Blue <cds-badge>1</cds-badge></cds-tag
-        >
-        <cds-tag aria-label="Clickable example of an orange tag with an icon and badge" color="orange"
-          ><cds-icon shape="info-standard"></cds-icon>Orange <cds-badge>1</cds-badge></cds-tag
-        >
-        <cds-tag aria-label="Clickable example of a light-blue tag with icon and a badge" color="light-blue"
-          ><cds-icon shape="info-standard"></cds-icon>Light Blue <cds-badge>1</cds-badge></cds-tag
-        >
+        <cds-tag color="purple">
+          <cds-icon shape="info-standard"></cds-icon>Purple <cds-badge aria-label="notification 1">1</cds-badge>
+        </cds-tag>
+        <cds-tag color="blue">
+          <cds-icon shape="info-standard"></cds-icon>Blue <cds-badge aria-label="notification 1">1</cds-badge>
+        </cds-tag>
+        <cds-tag color="orange">
+          <cds-icon shape="info-standard"></cds-icon>Orange <cds-badge aria-label="notification 1">1</cds-badge>
+        </cds-tag>
+        <cds-tag color="light-blue">
+          <cds-icon shape="info-standard"></cds-icon>Light Blue <cds-badge aria-label="notification 1">1</cds-badge>
+        </cds-tag>
       </div>
     </div>
   `;
@@ -219,21 +199,22 @@ export function clickable() {
 export function links() {
   return html`
     <div cds-layout="horizontal gap:sm p-b:lg">
-      <a href="javascript:void(0)" aria-label="Link">
+      <a href="javascript:void(0)">
         <cds-tag status="info">link</cds-tag>
       </a>
 
-      <a href="javascript:void(0)" aria-label="Link, 1 item">
-        <cds-tag status="success">link <cds-badge status="info">1</cds-badge></cds-tag>
+      <a href="javascript:void(0)">
+        <cds-tag status="success">link <cds-badge aria-label="notification 1" status="info">1</cds-badge></cds-tag>
       </a>
 
-      <a href="javascript:void(0)" aria-label="User image, link, 1 item">
+      <a href="javascript:void(0)">
         <cds-tag status="warning"
-          ><cds-icon shape="user"></cds-icon> link <cds-badge status="info">1</cds-badge></cds-tag
+          ><cds-icon shape="user"></cds-icon> link
+          <cds-badge aria-label="notification 1" status="info">1</cds-badge></cds-tag
         >
       </a>
 
-      <a href="javascript:void(0)" aria-label="Link">
+      <a href="javascript:void(0)">
         <cds-tag status="danger">link</cds-tag>
       </a>
     </div>
@@ -249,22 +230,16 @@ export function links() {
 export function closable() {
   return html`
     <div>
-      <cds-tag aria-label="default" color="gray" closable>Default</cds-tag>
-      <cds-tag aria-label="purple" color="purple" closable>Purple</cds-tag>
-      <cds-tag aria-label="blue" color="blue" closable>Blue</cds-tag>
-      <cds-tag aria-label="orange" color="orange" closable>Orange</cds-tag>
-      <cds-tag aria-label="light blue" color="light-blue" closable>Light Blue</cds-tag>
+      <cds-tag color="gray" closable>Default</cds-tag>
+      <cds-tag color="purple" closable>Purple</cds-tag>
+      <cds-tag color="blue" closable>Blue</cds-tag>
+      <cds-tag color="orange" closable>Orange</cds-tag>
+      <cds-tag color="light-blue" closable>Light Blue</cds-tag>
     </div>
     <div>
-      <cds-tag aria-label="user image, default, close image" color="gray" closable
-        ><cds-icon shape="user"></cds-icon>Default</cds-tag
-      >
-      <cds-tag aria-label="user image, blue, close image" color="blue" closable
-        ><cds-icon shape="user"></cds-icon>Blue</cds-tag
-      >
-      <cds-tag aria-label="user image, orange, close image" color="orange" closable
-        ><cds-icon shape="user"></cds-icon>Orange</cds-tag
-      >
+      <cds-tag color="gray" closable><cds-icon shape="user"></cds-icon>Default</cds-tag>
+      <cds-tag color="blue" closable><cds-icon shape="user"></cds-icon>Blue</cds-tag>
+      <cds-tag color="orange" closable><cds-icon shape="user"></cds-icon>Orange</cds-tag>
     </div>
   `;
 }
@@ -276,44 +251,61 @@ export function tagsAndIcons() {
   return html`
     <div cds-layout="vertical gap:sm">
       <div cds-layout="horizontal gap:xs">
-        <cds-tag readonly aria-label="no icon">No Icon</cds-tag>
-        <cds-tag readonly aria-label="user image, no badge"><cds-icon shape="user"></cds-icon>No Badge</cds-tag>
-        <cds-tag readonly color="gray" aria-label="user image, default, 1 item"
-          ><cds-icon shape="user" ?solid=${solidIcon}></cds-icon>Default <cds-badge>1</cds-badge></cds-tag
+        <cds-tag readonly>No Icon</cds-tag>
+        <cds-tag readonly><cds-icon shape="user"></cds-icon>No Badge</cds-tag>
+        <cds-tag readonly color="gray"
+          ><cds-icon shape="user" ?solid=${solidIcon}></cds-icon>Default
+          <cds-badge aria-label="notification 1">1</cds-badge></cds-tag
         >
-        <cds-tag readonly color="purple" aria-label="user image, purple, 2 items"
-          ><cds-icon shape="user" ?solid=${solidIcon}></cds-icon>Purple <cds-badge>2</cds-badge></cds-tag
+        <cds-tag readonly color="purple"
+          ><cds-icon shape="user" ?solid=${solidIcon}></cds-icon>Purple
+          <cds-badge aria-label="notification 2">2</cds-badge></cds-tag
         >
-        <cds-tag readonly color="blue" aria-label="user image, blue, 3 items"
-          ><cds-icon shape="user" ?solid=${solidIcon}></cds-icon>Blue <cds-badge>3</cds-badge></cds-tag
+        <cds-tag readonly color="blue"
+          ><cds-icon shape="user" ?solid=${solidIcon}></cds-icon>Blue
+          <cds-badge aria-label="notification 3">3</cds-badge></cds-tag
         >
-        <cds-tag readonly color="orange" aria-label="user image, orange, 12 items"
-          ><cds-icon shape="user" ?solid=${solidIcon}></cds-icon>Orange <cds-badge>12</cds-badge></cds-tag
+        <cds-tag readonly color="orange"
+          ><cds-icon shape="user" ?solid=${solidIcon}></cds-icon>Orange
+          <cds-badge aria-label="notification 12">12</cds-badge></cds-tag
         >
-        <cds-tag readonly color="light-blue" aria-label="user image, light blue, 15 items"
-          ><cds-icon shape="user" ?solid=${solidIcon}></cds-icon>Light Blue <cds-badge>15</cds-badge></cds-tag
+        <cds-tag readonly color="light-blue"
+          ><cds-icon shape="user" ?solid=${solidIcon}></cds-icon>Light Blue
+          <cds-badge aria-label="notification 15">15</cds-badge></cds-tag
         >
       </div>
       <div cds-layout="horizontal gap:xs">
-        <cds-tag readonly status="info" aria-label="no icon">No Icon</cds-tag>
-        <cds-tag readonly status="info" aria-label="info image, no badge"
+        <cds-tag readonly status="info">No Icon</cds-tag>
+        <cds-tag readonly status="info"
           ><cds-icon shape="info-standard" ?solid=${solidIcon}></cds-icon>No Badge</cds-tag
         >
-        <cds-tag readonly status="info" aria-label="info image, info, 1 item"
-          ><cds-icon shape="info-standard" ?solid=${solidIcon}></cds-icon>Info
-          <cds-badge status="info">1</cds-badge></cds-tag
+        <cds-tag readonly status="info"
+          ><cds-icon shape="info-standard" ?solid=${solidIcon}></cds-icon>Info<cds-badge
+            aria-label="notification 1"
+            status="info"
+            >1</cds-badge
+          ></cds-tag
         >
-        <cds-tag readonly status="success" aria-label="info image, success, 2 items"
-          ><cds-icon shape="info-standard" ?solid=${solidIcon}></cds-icon>Success
-          <cds-badge status="success">2</cds-badge></cds-tag
+        <cds-tag readonly status="success"
+          ><cds-icon shape="info-standard" ?solid=${solidIcon}></cds-icon>Success<cds-badge
+            aria-label="notification 2"
+            status="success"
+            >2</cds-badge
+          ></cds-tag
         >
-        <cds-tag readonly status="warning" aria-label="info image, warning, 3 items"
-          ><cds-icon shape="info-standard" ?solid=${solidIcon}></cds-icon>Warning
-          <cds-badge status="warning">3</cds-badge>
-        </cds-tag>
-        <cds-tag readonly status="danger" aria-label="info image, danger, 12 items"
-          ><cds-icon shape="info-standard" ?solid=${solidIcon}></cds-icon>Danger
-          <cds-badge status="danger">12</cds-badge></cds-tag
+        <cds-tag readonly status="warning"
+          ><cds-icon shape="info-standard" ?solid=${solidIcon}></cds-icon>Warning<cds-badge
+            aria-label="notification 3"
+            status="warning"
+            >3</cds-badge
+          ></cds-tag
+        >
+        <cds-tag readonly status="danger"
+          ><cds-icon shape="info-standard" ?solid=${solidIcon}></cds-icon>Danger<cds-badge
+            aria-label="notification 12"
+            status="danger"
+            >12</cds-badge
+          ></cds-tag
         >
       </div>
     </div>
@@ -325,19 +317,29 @@ export function darkTheme() {
   return html`
     <div cds-layout="horizontal gap:sm" cds-theme="dark">
       <cds-tag status="info"
-        ><cds-icon shape="info-standard"></cds-icon>Info <cds-badge status="info">10</cds-badge></cds-tag
+        ><cds-icon shape="info-standard"></cds-icon>Info
+        <cds-badge aria-label="notification 10" status="info">10</cds-badge></cds-tag
       >
       <cds-tag status="success"
-        ><cds-icon shape="info-standard"></cds-icon>Success <cds-badge status="success">20</cds-badge></cds-tag
+        ><cds-icon shape="info-standard"></cds-icon>Success
+        <cds-badge aria-label="notification 20" status="success">20</cds-badge></cds-tag
       >
       <cds-tag status="warning"
-        ><cds-icon shape="info-standard"></cds-icon>Warning <cds-badge status="warning">30</cds-badge></cds-tag
+        ><cds-icon shape="info-standard"></cds-icon>Warning
+        <cds-badge aria-label="notification 30" status="warning">30</cds-badge></cds-tag
       >
       <cds-tag status="danger"
-        ><cds-icon shape="info-standard"></cds-icon>Danger <cds-badge status="danger">40</cds-badge></cds-tag
+        ><cds-icon shape="info-standard"></cds-icon>Danger
+        <cds-badge aria-label="notification 40" status="danger">40</cds-badge></cds-tag
       >
-      <cds-tag><cds-icon shape="info-standard"></cds-icon>Default <cds-badge>50</cds-badge></cds-tag>
-      <cds-tag disabled><cds-icon shape="info-standard"></cds-icon>Disabled <cds-badge>60</cds-badge></cds-tag>
+      <cds-tag
+        ><cds-icon shape="info-standard"></cds-icon>Default
+        <cds-badge aria-label="notification 50">50</cds-badge></cds-tag
+      >
+      <cds-tag disabled
+        ><cds-icon shape="info-standard"></cds-icon>Disabled
+        <cds-badge aria-label="notification 60">60</cds-badge></cds-tag
+      >
       <cds-tag closable><cds-icon shape="info-standard"></cds-icon>Closable</cds-tag>
     </div>
   `;


### PR DESCRIPTION
This PR fixes two issues regarding tag a11y:
- Our code to sync props was incorrectly letting the badge inside clickable tag inherit the base button behavior, resulting in assigning role of button. This has been fixed.
- The preference for best experience for SR is to let the content of the tag be read directly. So we are removing the `aria-label` attached to the tag in our example codes in storybook. However, a second wish list item was to have some kind of separation indicator between the content of the tag and content inside the badge inside the tag when SR is reading the content. We experimented with a couple of different options but settled on setting an explicit `aria-label` in the inner badge with some text to add separation between reading the content inside the tag and inside the badge inside the tag (e.g. `notification` in our examples but can be any other reasonable text). Since the `aria-label` overrides whatever content is inside the badge now, that part needs to be added to the `aria-label` as well. So in our examples you will see labels like `notification 10`.

Signed-off-by: Jeeyun Lim <jeeyun.lim@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
