### PR TITLE
fix: color for status badge-warning

### DIFF
--- a/packages/angular/projects/clr-angular/src/emphasis/_properties.badges.scss
+++ b/packages/angular/projects/clr-angular/src/emphasis/_properties.badges.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -14,7 +14,7 @@
       --clr-badge-success-bg-color: var(--clr-color-success-800);
       --clr-badge-success-color: var(--clr-color-neutral-0);
       --clr-badge-warning-bg-color: var(--clr-color-warning-1000);
-      --clr-badge-warning-color: var(--clr-color-neutral-1000);
+      --clr-badge-warning-color: var(--clr-color-neutral-0);
       --clr-badge-danger-bg-color: var(--clr-color-danger-900);
       --clr-badge-danger-color: var(--clr-color-neutral-0);
 

--- a/packages/angular/projects/clr-angular/src/emphasis/_variables.badges.scss
+++ b/packages/angular/projects/clr-angular/src/emphasis/_variables.badges.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -12,7 +12,7 @@ $clr-badge-info-color: $clr-color-neutral-0 !default;
 $clr-badge-success-bg-color: $clr-color-success-800 !default;
 $clr-badge-success-color: $clr-color-neutral-0 !default;
 $clr-badge-warning-bg-color: $clr-color-warning-1000 !default;
-$clr-badge-warning-color: $clr-color-neutral-1000 !default;
+$clr-badge-warning-color: $clr-color-neutral-0 !default;
 $clr-badge-danger-bg-color: $clr-color-danger-900 !default;
 $clr-badge-danger-color: $clr-color-neutral-0 !default;
 

--- a/packages/angular/projects/clr-angular/src/utils/_overwrites.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/utils/_overwrites.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -717,7 +717,7 @@ $clr-badge-success-color: null; // $clr-color-neutral-0
 
 // Warning
 $clr-badge-warning-bg-color: null; // $clr-color-warning-300
-$clr-badge-warning-color: null; // $clr-color-neutral-1000
+$clr-badge-warning-color: null; // $clr-color-neutral-0
 
 // Danger
 $clr-badge-danger-bg-color: null; // $clr-color-danger-800


### PR DESCRIPTION
After updating to Core colors, our warning background is too dark, but we left font color black. Need to update it to white.

closes #5259
Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Black color over dark background in badge warning

Issue Number: #5259

## What is the new behavior?

White color over dark background with good color contrast

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
