### PR TITLE
fix: core package exports

### DIFF
--- a/packages/core/.storybook/main.js
+++ b/packages/core/.storybook/main.js
@@ -32,6 +32,7 @@ module.exports = {
 
     config.resolve.extensions.push('.ts');
     config.resolve.plugins = [new TsConfigPathsPlugin({ configFile: '.storybook/tsconfig.storybook.json' })];
+    config.resolve.alias['@cds/core'] = path.resolve(__dirname, '../dist/core');
 
     // https://github.com/storybookjs/storybook/blob/next/app/web-components/README.md
     const webComponentsRule = config.module.rules.find(

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,10 +38,14 @@
   ],
   "description": "Clarity Design System Web Components",
   "homepage": "https://clarity.design",
-  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/vmware/clarity.git"
+  },
+  "author": "clarity",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/vmware/clarity/issues"
   },
   "dependencies": {
     "@types/resize-observer-browser": "^0.1.3",
@@ -115,10 +119,5 @@
     "wc-sass-render": "1.2.3",
     "web-component-analyzer": "1.1.6",
     "webpack-cli": "3.3.11"
-  },
-  "author": "clarity",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/vmware/clarity/issues"
   }
 }

--- a/packages/core/src/accordion/package.json
+++ b/packages/core/src/accordion/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@cds/core/accordion",
-  "sideEffects": [
-    "./register.js"
-  ]
-}

--- a/packages/core/src/alert/package.json
+++ b/packages/core/src/alert/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@cds/core/alert",
-  "sideEffects": [
-    "./register.js"
-  ]
-}

--- a/packages/core/src/badge/package.json
+++ b/packages/core/src/badge/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@cds/core/badge",
-  "sideEffects": [
-    "./register.js"
-  ]
-}

--- a/packages/core/src/button/package.json
+++ b/packages/core/src/button/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@cds/core/button",
-  "sideEffects": [
-    "./register.js"
-  ]
-}

--- a/packages/core/src/checkbox/package.json
+++ b/packages/core/src/checkbox/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@cds/core/checkbox",
-  "sideEffects": [
-    "./register.js"
-  ]
-}

--- a/packages/core/src/datalist/package.json
+++ b/packages/core/src/datalist/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@cds/core/datalist",
-  "sideEffects": [
-    "./register.js"
-  ]
-}

--- a/packages/core/src/date/package.json
+++ b/packages/core/src/date/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@cds/core/date",
-  "sideEffects": [
-    "./register.js"
-  ]
-}

--- a/packages/core/src/divider/package.json
+++ b/packages/core/src/divider/package.json
@@ -1,6 +1,0 @@
-{
-    "name": "@cds/core/divider",
-    "sideEffects": [
-      "./register.js"
-    ]
-  }

--- a/packages/core/src/file/package.json
+++ b/packages/core/src/file/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@cds/core/file",
-  "sideEffects": [
-    "./register.js"
-  ]
-}

--- a/packages/core/src/forms/package.json
+++ b/packages/core/src/forms/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@cds/core/forms",
-  "sideEffects": [
-    "./register.js"
-  ]
-}

--- a/packages/core/src/icon/package.json
+++ b/packages/core/src/icon/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@cds/core/icon",
-  "sideEffects": [
-    "./register.js"
-  ]
-}

--- a/packages/core/src/input/package.json
+++ b/packages/core/src/input/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@cds/core/input",
-  "sideEffects": [
-    "./register.js"
-  ]
-}

--- a/packages/core/src/internal-components/close-button/package.json
+++ b/packages/core/src/internal-components/close-button/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@cds/core/internal-components/close-button",
-  "sideEffects": [
-    "./register.js"
-  ]
-}

--- a/packages/core/src/internal-components/overlay/package.json
+++ b/packages/core/src/internal-components/overlay/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@cds/core/internal-components/overlay",
-  "sideEffects": [
-    "./register.js"
-  ]
-}

--- a/packages/core/src/internal/package.json
+++ b/packages/core/src/internal/package.json
@@ -1,4 +1,0 @@
-{
-  "sideEffects": false,
-  "name": "@cds/core/internal"
-}

--- a/packages/core/src/modal/package.json
+++ b/packages/core/src/modal/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@cds/core/modal",
-  "sideEffects": [
-    "./register.js"
-  ]
-}

--- a/packages/core/src/password/package.json
+++ b/packages/core/src/password/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@cds/core/password",
-  "sideEffects": [
-    "./register.js"
-  ]
-}

--- a/packages/core/src/progress-circle/package.json
+++ b/packages/core/src/progress-circle/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@cds/core/progress-circle",
-  "sideEffects": [
-    "./register.js"
-  ]
-}

--- a/packages/core/src/radio/package.json
+++ b/packages/core/src/radio/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@cds/core/radio",
-  "sideEffects": [
-    "./register.js"
-  ]
-}

--- a/packages/core/src/range/package.json
+++ b/packages/core/src/range/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@cds/core/range",
-  "sideEffects": [
-    "./register.js"
-  ]
-}

--- a/packages/core/src/search/package.json
+++ b/packages/core/src/search/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@cds/core/search",
-  "sideEffects": [
-    "./register.js"
-  ]
-}

--- a/packages/core/src/select/package.json
+++ b/packages/core/src/select/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@cds/core/select",
-  "sideEffects": [
-    "./register.js"
-  ]
-}

--- a/packages/core/src/tag/package.json
+++ b/packages/core/src/tag/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@cds/core/tag",
-  "sideEffects": [
-    "./register.js"
-  ]
-}

--- a/packages/core/src/test-dropdown/package.json
+++ b/packages/core/src/test-dropdown/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@cds/core/test-dropdown",
-  "sideEffects": [
-    "./register.js"
-  ]
-}

--- a/packages/core/src/textarea/package.json
+++ b/packages/core/src/textarea/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@cds/core/textarea",
-  "sideEffects": [
-    "./register.js"
-  ]
-}

--- a/packages/core/src/time/package.json
+++ b/packages/core/src/time/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@cds/core/time",
-  "sideEffects": [
-    "./register.js"
-  ]
-}

--- a/packages/core/src/toggle/package.json
+++ b/packages/core/src/toggle/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@cds/core/toggle",
-  "sideEffects": [
-    "./register.js"
-  ]
-}

--- a/packages/core/tsconfig.project.json
+++ b/packages/core/tsconfig.project.json
@@ -6,6 +6,7 @@
   },
   "include": ["./"],
   "references": [
+    { "path": "./src/accordion/entrypoint.tsconfig.json" },
     { "path": "./src/alert/entrypoint.tsconfig.json" },
     { "path": "./src/badge/entrypoint.tsconfig.json" },
     { "path": "./src/button/entrypoint.tsconfig.json" },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:



## What is the new behavior?
This fixes an issue with applications using build tools that understand the new [node exports/entrypoint feature](https://nodejs.org/api/packages.html#packages_package_entry_points). The node entrypoint feature allows a pacakge to define what imports are allowed from the package. However our package file was missing a entrypoint mapping to `register.js` causing some build tools to not resolve to the register files for our components. This was happening in certain cases with cds/react and plain js imports.

This PR adds the missing entry as well as simplifies our entrypoint definitions. With the new standard in node we can use a single package.json to define all entrypoints and side effects rather than nested package.json files. Once TypeScript adds support we will be able to simplify even more and remove mappings such as this https://github.com/vmware/clarity/blob/next/packages/core/tsconfig.project.json 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
