### PR TITLE
fix: combobox options exception on null values

### DIFF
--- a/packages/angular/projects/clr-angular/src/forms/combobox/option-items.directive.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/option-items.directive.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -197,6 +197,13 @@ export default function (): void {
         const optionService: OptionSelectionService<any> = TestBed.get(OptionSelectionService);
         expect(this.clarityDirective._filterField).toEqual('a');
         expect(optionService.displayField).toEqual('a');
+      });
+
+      it('handles null values', function () {
+        expect(() => {
+          this.testComponent.numbers = [{ a: null }, ...this.testComponent.numbers];
+          this.fixture.detectChanges();
+        }).not.toThrow();
       });
     });
   });

--- a/packages/angular/projects/clr-angular/src/forms/combobox/option-items.directive.ts
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/option-items.directive.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -72,9 +72,7 @@ export class ClrOptionItems<T> implements DoCheck, OnDestroy {
     if (this._filterField) {
       this.filteredItems = this._rawItems.filter(item => {
         const objValue = (item as any)[this._filterField];
-        return objValue !== undefined
-          ? objValue.toString().toLowerCase().indexOf(this.filter.toLowerCase().toString()) > -1
-          : false;
+        return objValue ? objValue.toString().toLowerCase().indexOf(this.filter.toLowerCase().toString()) > -1 : false;
       });
     } else {
       // Filter by all item object values
@@ -83,7 +81,7 @@ export class ClrOptionItems<T> implements DoCheck, OnDestroy {
           return item.toString().toLowerCase().indexOf(this.filter.toString().toLowerCase()) > -1;
         }
         const objValues = Object.values(item).filter(value => {
-          return value.toString().toLowerCase().indexOf(this.filter.toString().toLowerCase()) > -1;
+          return value ? value.toString().toLowerCase().indexOf(this.filter.toString().toLowerCase()) > -1 : false;
         });
         return objValues.length > 0;
       });


### PR DESCRIPTION
closes #5458
Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Exception and broken component if any value in the object data is null

Issue Number: #5458

## What is the new behavior?

Handles null values by excluding them from filtering logic.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
