### PR TITLE
fix: combobox no list reset on blur

### DIFF
--- a/packages/angular/projects/clr-angular/src/forms/combobox/combobox.ts
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/combobox.ts
@@ -268,7 +268,7 @@ export class ClrCombobox<T> extends WrappedFormControl<ClrComboboxContainer>
         if (this.multiSelect) {
           this.searchText = '';
         } else {
-          this.searchText = this.getDisplayNames(this.optionSelectionService.selectionModel.model)[0];
+          this.searchText = this.getDisplayNames(this.optionSelectionService.selectionModel.model)[0] || '';
         }
       })
     );


### PR DESCRIPTION
closes #5361
Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

If single selection combobox is cleared, closed, then opened again, filtered, closed, then the filter from the field is removed, but not from the list. On the next open we have a filtered list.

Issue Number: #5361

## What is the new behavior?
Filter list cleanup is working fine.
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
This fix works, because the null value for the input is invalid and is hitting a code protection block in another component.
It is hard to create a meaningful test, because this is a broken communication that's private to the class.
