### PR TITLE
fix: adds version.json to website for version switchers

### DIFF
--- a/apps/website/.vuepress/public/versions.json
+++ b/apps/website/.vuepress/public/versions.json
@@ -1,0 +1,11 @@
+[
+  { "version": "v5", "url": "https://clarity.design" },
+  { "version": "v4", "url": "https://v4.clarity.design/documentation" },
+  { "version": "v3", "url": "https://v3.clarity.design" },
+  { "version": "v2", "url": "https://v2.clarity.design" },
+  { "version": "v1", "url": "https://v1.clarity.design" },
+  { "version": "v0.13", "url": "https://vmware.github.io/clarity/documentation/v0.13" },
+  { "version": "v0.12", "url": "https://vmware.github.io/clarity/documentation/v0.12" },
+  { "version": "v0.11", "url": "https://vmware.github.io/clarity/documentation/v0.11" },
+  { "version": "v0.10", "url": "https://vmware.github.io/clarity/documentation/v0.10" }
+]


### PR DESCRIPTION
Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?
Adds an update versions.json file to the new website. This fixes the over websites that use the `version-switcher` to navigate between different clarity versions. 

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
the version switcher is broken on all vX.clarity.design sub-domains.

## What is the new behavior?
The version switcher will work again.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
