### PR TITLE
fix: correct links

### DIFF
--- a/apps/website/.vuepress/theme/components/Home.vue
+++ b/apps/website/.vuepress/theme/components/Home.vue
@@ -68,7 +68,7 @@
             the people we build it for, and the community that makes us who we are.
           </p>
         </div>
-        <router-link to="/get-started" cds-layout="m-t:lg">
+        <router-link to="/get-started/" cds-layout="m-t:lg">
           <cds-button>
             Get Started using Clarity
           </cds-button>
@@ -149,7 +149,7 @@
             Vue. Our latest web components provide support for them all. Clarity provides code examples and detailed API
             documentation that guide you as you build your next application.
           </p>
-          <router-link to="angular-components/get-started/" cds-layout="m-t:lg" cds-text="subsection expanded"
+          <router-link to="/get-started/" cds-layout="m-t:lg" cds-text="subsection expanded"
             >Get started with Angular</router-link
           >
           <a target="_blank" href="/storybook/core" cds-layout="m-t:md">Get started with web components</a>
@@ -232,7 +232,7 @@
           priorities. We are proud of what we have running under the hood. Check out our Github and take a look at our
           priority list, our code, our documentation, and join our community.
         </p>
-        <router-link to="/get-started">
+        <router-link to="/get-started/">
           <cds-button cds-layout="m-t:lg" action="outline">
             Join the community
           </cds-button>
@@ -269,7 +269,7 @@
               Get started developing
             </cds-button>
           </router-link>
-          <router-link to="/get-started/design">
+          <router-link to="/get-started/design/">
             <cds-button action="outline">
               Get started designing
             </cds-button>

--- a/apps/website/foundation/icons/README.md
+++ b/apps/website/foundation/icons/README.md
@@ -13,7 +13,7 @@ The Clarity Icons presents pixel-perfect, scalable SVG-based icons. The icon sys
 
 ## Usage
 
-Follow the instructions in the web components getting [started page](../get-started) to install the @cds/core package.
+Follow the instructions in the web components getting [started page](/get-started/developing/) to install the @cds/core package.
 
 ### Import
 

--- a/apps/website/get-started/README.md
+++ b/apps/website/get-started/README.md
@@ -9,12 +9,12 @@ If you are new to Clarity, we suggest using Clarity's web component implemenatio
 ## How to get started
 
 - [Getting started with Clarity for designers](./design.md)
-- [Getting started with Clarity Core using our Web Components](../angular-components/get-started.md)
-- [Getting started with Clarity Angular using our Angular Components](../core-components/get-started.md)
+- [Getting started with Clarity Core using our Web Components](/get-started/developing/)
+- [Getting started with Clarity Angular using our Angular Components](/get-started/developing/angular/)
 
 ## Contributing to Clarity
 
-The Clarity team welcomes contributions from the community. See our [contribution guidelines](https://github.com/vmware/clarity//blob/master/CONTRIBUTING.md) on GitHub.
+The Clarity team welcomes contributions from the community. See our [contribution guidelines](https://github.com/vmware/clarity/blob/master/CONTRIBUTING.md) on GitHub.
 
 ## Clarity Blog
 

--- a/apps/website/get-started/design.md
+++ b/apps/website/get-started/design.md
@@ -49,7 +49,7 @@ We provide a convenient zip of all icon files. This download includes all svg fi
 Clarity uses the popular design tool [Figma](https://www.figma.com/) when designing and documenting components and foundations. Bookmark these resources to re-use Clarity assets in your design process.
 
 <div  cds-layout="m-t:md">
-<a class="btn btn-primary asset-download-btn" target="_blank" href="https://www.figma.com/files/667807410136546364/project/337681/Libraries"><cds-icon shape="download"></cds-icon> Clarity Figma Libraries</a>
+<a class="btn btn-primary asset-download-btn" target="_blank" href="https://www.figma.com/@vmware"><cds-icon shape="download"></cds-icon> Clarity Figma Libraries</a>
 </div>
 
 </div>

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "website",
-  "version": "5.0.0-next.0",
+  "version": "5.0.0",
   "description": "Clarity Website",
   "main": "index.js",
   "author": "VMware Clarity Team",


### PR DESCRIPTION
- get-started links for the directy changes
- update figma link to the figma homepage for vmware design

closes #5495

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?
Fixes several broken links and updates the link to figma resources.

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Broken or out of date links. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5495

## What is the new behavior?
Correct links. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
