### PR TITLE
fix: core safari flex shim

### DIFF
--- a/packages/core/src/internal/base/base.element.scss
+++ b/packages/core/src/internal/base/base.element.scss
@@ -6,8 +6,8 @@
 @import './../../styles/module.typography';
 @import './../../styles/layout/shims/gap';
 
-// older safari
-@media not all and (min-resolution: 0.001dpcm) {
+// Safari, if no flex gap apply shim
+:host([_nfg]) {
   @include generateGapShim();
 }
 

--- a/packages/core/src/internal/base/css-gap.base.spec.ts
+++ b/packages/core/src/internal/base/css-gap.base.spec.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { LitElement, html } from 'lit-element';
+import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test/utils';
+import { applyCSSGapShim } from './css-gap.base.js';
+import { browserFeatures } from '../utils/supports.js';
+
+class GapShim extends LitElement {}
+class GapShimSupports extends LitElement {}
+
+window.customElements.define('gap-shim-support', applyCSSGapShim(GapShimSupports));
+
+(browserFeatures as any).supports.flexGap = false; // force false flex gap support
+const shimClass = applyCSSGapShim(GapShim);
+(browserFeatures as any).supports.flexGap = true;
+window.customElements.define('gap-shim', shimClass);
+
+describe('CSS Flex Gap Shim', () => {
+  let testElement: HTMLElement;
+  let component: GapShim;
+  let componentSupports: GapShimSupports;
+
+  beforeEach(async () => {
+    testElement = await createTestElement(html`
+      <gap-shim></gap-shim>
+      <gap-shim-support></gap-shim-support>
+    `);
+    component = testElement.querySelector<GapShim>('gap-shim');
+    componentSupports = testElement.querySelector<GapShimSupports>('gap-shim-support');
+  });
+
+  afterEach(() => {
+    removeTestElement(testElement);
+  });
+
+  it('should not apply css gap shim attr if not supported', async () => {
+    await componentIsStable(componentSupports);
+    expect(componentSupports.getAttribute('_nfg')).toBe(null);
+  });
+
+  it('should apply css gap shim attr if not supported', async () => {
+    await componentIsStable(component);
+    expect(component.getAttribute('_nfg')).toBe('');
+    (browserFeatures as any).supports.flexGap = true;
+  });
+});

--- a/packages/core/src/internal/base/css-gap.base.ts
+++ b/packages/core/src/internal/base/css-gap.base.ts
@@ -1,0 +1,28 @@
+import { browserFeatures } from '../utils/supports.js';
+
+/**
+ * @internal
+ * This base class allows us to conditionally apply the css shim needed
+ * for Safari to use CSS Gap API. CSS Gap is used within our layout utilities.
+ *
+ * The shim is loaded in the `base.element.scss` and conditionally applied
+ * when the `_nfg` (no flex gap) attribute is on the component. Unfortunately
+ * there is no way to detect flex gap support with only CSS and JS is required.
+ *
+ * The Class is applied during the registration step of the custom element.
+ * This shim CSS is also applied at the global level for applications in
+ * the `module.shims.css` file.
+ *
+ * Once Safari ships Flex Gap support this can be removed. Currently Safari
+ * supports Flex Gap in the Safari Technical Preview so it should be available
+ * in the next major release.
+ */
+export function applyCSSGapShim(elementClass: any) {
+  class GapShim extends elementClass {
+    connectedCallback() {
+      super.connectedCallback();
+      this.setAttribute('_nfg', '');
+    }
+  }
+  return browserFeatures.supports.flexGap ? elementClass : GapShim;
+}

--- a/packages/core/src/internal/utils/register.ts
+++ b/packages/core/src/internal/utils/register.ts
@@ -9,6 +9,7 @@ import { elementExists, existsInWindow, isBrowser } from './exists.js';
 import { setupCDSGlobal } from './global.js';
 import { isStorybook } from './framework.js';
 import { LogService } from '../services/log.service.js';
+import { applyCSSGapShim } from '../base/css-gap.base.js';
 
 const addElementToRegistry = curryN(
   3,
@@ -16,7 +17,7 @@ const addElementToRegistry = curryN(
     if (elementExists(tagName) && !isStorybook()) {
       LogService.warn(`${tagName} has already been registered`);
     } else {
-      registry.define(tagName, elementClass);
+      registry.define(tagName, applyCSSGapShim(elementClass));
       setupCDSGlobal();
 
       if (!window.CDS._loadedElements.some(i => i === tagName)) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

We use CSS Flex Gap for many of our layout utilities. Unfortunately as of Safari version 14 this is not supported. We provide a shim of sorts that provides a fallback using margins for safari. This already is supported in our global CSS. This bug fixes an issue when the web component uses the layout utils but does not have the css gap shim provided. Because of the shadow DOM the components do not have access to the global layout utils by default.

Issue Number: N/A

## What is the new behavior?

The fix for this pr is to dynamically check if flex gap is supported then to dynamically apply the css gap shim to the component. Because this is a runtime check in the browser, every component needs to know if the css should be applied for safari. Rather than adding a base class or function call to every component, I created a small base class that is applied when the component is registered and only if the browser needs it.

This is a short term fix as Safari Technical Preview does support Flex Gap. So the next release of Safari it will be supported and the shim will be no longer needed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
