### PR TITLE
fix: website toggle demo

### DIFF
--- a/apps/website/.vuepress/code/core-usage-demos/toggle/success.html
+++ b/apps/website/.vuepress/code/core-usage-demos/toggle/success.html
@@ -1,11 +1,11 @@
-<cds-toggle-group>
+<cds-toggle-group status="success">
   <cds-toggle>
     <label>Wi-Fi</label>
     <input type="checkbox" />
   </cds-toggle>
   <cds-toggle>
     <label>Bluetooth</label>
-    <input type="checkbox" />
+    <input type="checkbox" checked />
   </cds-toggle>
-  <cds-control-message status="error">Changes saved</cds-control-message>
+  <cds-control-message status="success">Changes saved</cds-control-message>
 </cds-toggle-group>

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "prestart": "ts-node --project build/tsconfig.parse.json build/parse/website-demos.ts",
     "start": "vuepress dev",
+    "start:dev": "vuepress dev --no-cache --open",
     "prebuild": "ts-node --project build/tsconfig.parse.json build/parse/website-demos.ts",
     "build": "vuepress build",
     "lint": "markdownlint '**/*.md' --ignore 'node_modules'"

--- a/packages/core/src/toggle/toggle.stories.ts
+++ b/packages/core/src/toggle/toggle.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -73,7 +73,7 @@ export function status() {
 
       <cds-toggle status="success">
         <label>success</label>
-        <input type="checkbox" />
+        <input type="checkbox" checked />
         <cds-control-message status="success">success text</cds-control-message>
       </cds-toggle>
     </div>


### PR DESCRIPTION
• added a `start:dev` command to package.json to make it easier to run off clean cache to test locally
• updated success status website demo and core demo to better illustrate the toggle component

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5527

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
