### PR TITLE
fix: swap old @clr/ui radios for cds-radio controls

### DIFF
--- a/apps/website/.vuepress/theme/global-components/ClrColorListSet.vue
+++ b/apps/website/.vuepress/theme/global-components/ClrColorListSet.vue
@@ -1,24 +1,22 @@
 <template>
   <div>
-    <div class="clr-form-control">
-      <label class="clr-control-label">Preview colors in: </label>
-      <div class="clr-control-container clr-control-inline">
-        <div class="clr-radio-wrapper">
-          <input type="radio" :id="'hsl-radio-' + listSetId" value="hsl" class="clr-radio" v-model="picked" />
-          <label :for="'hsl-radio-' + listSetId" class="clr-control-label">HSL</label>
-        </div>
-        <div class="clr-radio-wrapper">
-          <input type="radio" :id="'hex-radio-' + listSetId" value="hex" class="clr-radio" v-model="picked" />
-          <label :for="'hex-radio-' + listSetId" class="clr-control-label">HEX</label>
-        </div>
-      </div>
-    </div>
-    <div v-bind:class="{ 'in-dark-mode': colorListInMode === 'dark' }">
-      <div class="clr-row">
-        <ClrColorList v-for="colorListData in colorListSet" :colorCode="picked" :colorData="colorListData">
-          <h5 class="color-list-title">{{ colorListData.name }}</h5>
-        </ClrColorList>
-      </div>
+    <cds-radio-group layout="horizontal-inline" cds-layout="m-t:md">
+      <label>Preview colors in:</label>
+      <cds-radio>
+        <label>HSL</label>
+        <input type="radio" value="hsl" v-model="picked" />
+      </cds-radio>
+
+      <cds-radio>
+        <label>HEX</label>
+        <input type="radio" value="hex" class="clr-radio" v-model="picked" />
+      </cds-radio>
+    </cds-radio-group>
+
+    <div v-bind:class="{ 'in-dark-mode': colorListInMode === 'dark' }" cds-layout="horizontal">
+      <ClrColorList v-for="colorListData in colorListSet" :colorCode="picked" :colorData="colorListData">
+        <h5 class="color-list-title">{{ colorListData.name }}</h5>
+      </ClrColorList>
     </div>
   </div>
 </template>

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -8,8 +8,7 @@
   "private": true,
   "scripts": {
     "prestart": "ts-node --project build/tsconfig.parse.json build/parse/website-demos.ts",
-    "start": "vuepress dev",
-    "start:dev": "vuepress dev --no-cache --open",
+    "start": "vuepress dev --no-cache --open",
     "prebuild": "ts-node --project build/tsconfig.parse.json build/parse/website-demos.ts",
     "build": "vuepress build",
     "lint": "markdownlint '**/*.md' --ignore 'node_modules'"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3319,7 +3319,7 @@
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
 "@cds/angular@./dist/angular":
-  version "5.0.0-next.0"
+  version "5.0.0"
   dependencies:
     tslib "^2.0.0"
 
@@ -3329,7 +3329,7 @@
   integrity sha512-S9K+Q39BGOghyLHmR0Wdcmu1i1noSUk8HcvMj+3IaohZw02WFd99aPTQDHJeseXrXZP3CNovaSlePI0R11NcFg==
 
 "@cds/core@./dist/core":
-  version "5.0.0-rc.0"
+  version "5.0.0"
   dependencies:
     "@types/resize-observer-browser" "^0.1.3"
     lit-element "^2.3.1"
@@ -3341,7 +3341,7 @@
     normalize.css "^8.0.1"
 
 "@cds/react@./dist/react":
-  version "5.0.0-rc.0"
+  version "5.0.0"
   dependencies:
     react "^16.13.1"
     react-dom "^16.13.1"
@@ -3350,10 +3350,10 @@
     normalize.css "^8.0.1"
 
 "@clr/icons@./dist/clr-icons":
-  version "5.0.0-rc.0"
+  version "5.0.0"
 
 "@clr/ui@./dist/clr-ui":
-  version "5.0.0-rc.0"
+  version "5.0.0"
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
@@ -12686,7 +12686,7 @@ condense-whitespace@^1.0.0:
   resolved "https://registry.yarnpkg.com/condense-whitespace/-/condense-whitespace-1.0.0.tgz#8376d98ef028e6cb2cd2468e28ce42c5c65ab1a9"
   integrity sha1-g3bZjvAo5sss0kaOKM5CxcZasak=
 
-config-chain@^1.1.11:
+config-chain@^1.1.11, config-chain@^1.1.12:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.12.tgz#0fde8d091200eb5e808caf25fe618c02f48e4efa"
   integrity sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==
@@ -14993,6 +14993,16 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+editorconfig@^0.15.3:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-0.15.3.tgz#bef84c4e75fb8dcb0ce5cee8efd51c15999befc5"
+  integrity sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==
+  dependencies:
+    commander "^2.19.0"
+    lru-cache "^4.1.5"
+    semver "^5.6.0"
+    sigmund "^1.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -21582,6 +21592,17 @@ js-base64@^2.1.8:
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.2.tgz#313b6274dda718f714d00b3330bbae6e38e90209"
   integrity sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ==
 
+js-beautify@^1.13.4:
+  version "1.13.5"
+  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.13.5.tgz#a08a97890cae55daf1d758d3f6577bd4a64d7014"
+  integrity sha512-MsXlH6Z/BiRYSkSRW3clNDqDjSpiSNOiG8xYVUBXt4k0LnGvDhlTGOlHX1VFtAdoLmtwjxMG5qiWKy/g+Ipv5w==
+  dependencies:
+    config-chain "^1.1.12"
+    editorconfig "^0.15.3"
+    glob "^7.1.3"
+    mkdirp "^1.0.4"
+    nopt "^5.0.0"
+
 js-levenshtein@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
@@ -23388,7 +23409,7 @@ lowlight@~1.9.0:
     fault "^1.0.2"
     highlight.js "~9.12.0"
 
-lru-cache@4.1.x, lru-cache@^4.0.1, lru-cache@^4.1.2:
+lru-cache@4.1.x, lru-cache@^4.0.1, lru-cache@^4.1.2, lru-cache@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
   integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
@@ -25044,6 +25065,13 @@ nopt@^4.0.1:
   dependencies:
     abbrev "1"
     osenv "^0.1.4"
+
+nopt@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-5.0.0.tgz#530942bb58a512fccafe53fe210f13a25355dc88"
+  integrity sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==
+  dependencies:
+    abbrev "1"
 
 nopter@~0.3.0:
   version "0.3.0"
@@ -30503,6 +30531,11 @@ side-channel@^1.0.2:
   dependencies:
     es-abstract "^1.17.0-next.1"
     object-inspect "^1.7.0"
+
+sigmund@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
+  integrity sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=
 
 signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Type

What kind of change does this PR introduce?
Fixes radio buttons on color documentation.

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Direct navigation to `/foundation/color/` cannot use a mouse to click on the hsl <--> hex radio buttons. 
The issue seems to be an effect of the build process. This functionality was written early on and used the `@clr/ui` styles for display. 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

On the foundation color page, the radio buttons work. 

Issue Number: #5507

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

