### PR TITLE
fix(website): timeline demos

### DIFF
--- a/apps/website/.vuepress/code/demos/timeline/horizontal-ng.html
+++ b/apps/website/.vuepress/code/demos/timeline/horizontal-ng.html
@@ -1,7 +1,7 @@
 <ul class="clr-timeline clr-timeline-horizontal">
   <li class="clr-timeline-step disabled">
     <div class="clr-timeline-step-header">11:59 am</div>
-    <clr-icon shape="circle" aria-label="Not started"></clr-icon>
+    <cds-icon shape="circle" aria-label="Not started"></cds-icon>
     <div class="clr-timeline-step-body">
       <span class="clr-timeline-step-title">Add KMS</span>
       <span class="clr-timeline-step-description">Root CA certificate requested.</span>
@@ -9,7 +9,7 @@
   </li>
   <li class="clr-timeline-step">
     <div class="clr-timeline-step-header">11:59 am</div>
-    <clr-icon shape="dot-circle" aria-current="true" aria-label="Current"></clr-icon>
+    <cds-icon shape="dot-circle" aria-current="true" aria-label="Current"></cds-icon>
     <div class="clr-timeline-step-body">
       <span class="clr-timeline-step-title">Add KMS</span>
       <span class="clr-timeline-step-description">
@@ -31,7 +31,7 @@
   </li>
   <li class="clr-timeline-step">
     <div class="clr-timeline-step-header">11:59 am</div>
-    <clr-icon shape="success-standard" aria-label="Completed"></clr-icon>
+    <cds-icon shape="success-standard" aria-label="Completed"></cds-icon>
     <div class="clr-timeline-step-body">
       <span class="clr-timeline-step-title">Make KMS trust vCenter</span>
       <span class="clr-timeline-step-description"
@@ -42,7 +42,7 @@
   </li>
   <li class="clr-timeline-step">
     <div class="clr-timeline-step-header">11:59 am</div>
-    <clr-icon shape="error-standard" aria-label="Error"></clr-icon>
+    <cds-icon shape="error-standard" aria-label="Error"></cds-icon>
     <div class="clr-timeline-step-body">
       <span class="clr-timeline-step-title">Connected</span>
       <span class="clr-timeline-step-description">No. It's not connected.</span>

--- a/apps/website/.vuepress/code/demos/timeline/horizontal.html
+++ b/apps/website/.vuepress/code/demos/timeline/horizontal.html
@@ -1,7 +1,7 @@
 <ul class="clr-timeline clr-timeline-horizontal">
   <li class="clr-timeline-step disabled">
     <div class="clr-timeline-step-header">11:59 am</div>
-    <clr-icon shape="circle" aria-label="Not started"></clr-icon>
+    <cds-icon shape="circle" aria-label="Not started"></cds-icon>
     <div class="clr-timeline-step-body">
       <span class="clr-timeline-step-title">Add KMS</span>
       <span class="clr-timeline-step-description">Root CA certificate requested.</span>
@@ -9,7 +9,7 @@
   </li>
   <li class="clr-timeline-step">
     <div class="clr-timeline-step-header">11:59 am</div>
-    <clr-icon shape="dot-circle" aria-current="true" aria-label="Current"></clr-icon>
+    <cds-icon shape="dot-circle" aria-current="true" aria-label="Current"></cds-icon>
     <div class="clr-timeline-step-body">
       <span class="clr-timeline-step-title">Add KMS</span>
       <span class="clr-timeline-step-description">
@@ -32,7 +32,7 @@
   </li>
   <li class="clr-timeline-step">
     <div class="clr-timeline-step-header">11:59 am</div>
-    <clr-icon shape="success-standard" aria-label="Completed"></clr-icon>
+    <cds-icon shape="success-standard" aria-label="Completed"></cds-icon>
     <div class="clr-timeline-step-body">
       <span class="clr-timeline-step-title">Make KMS trust vCenter</span>
       <span class="clr-timeline-step-description"
@@ -43,7 +43,7 @@
   </li>
   <li class="clr-timeline-step">
     <div class="clr-timeline-step-header">11:59 am</div>
-    <clr-icon shape="error-standard" aria-label="Error"></clr-icon>
+    <cds-icon shape="error-standard" aria-label="Error"></cds-icon>
     <div class="clr-timeline-step-body">
       <span class="clr-timeline-step-title">Connected</span>
       <span class="clr-timeline-step-description">No. It's not connected.</span>

--- a/apps/website/.vuepress/code/demos/timeline/vertical-ng.html
+++ b/apps/website/.vuepress/code/demos/timeline/vertical-ng.html
@@ -1,7 +1,7 @@
 <ul class="clr-timeline clr-timeline-vertical">
   <li class="clr-timeline-step disabled">
     <div class="clr-timeline-step-header">11:59 am</div>
-    <clr-icon shape="circle" aria-label="Not started"></clr-icon>
+    <cds-icon shape="circle" aria-label="Not started"></cds-icon>
     <div class="clr-timeline-step-body">
       <span class="clr-timeline-step-title">Add KMS</span>
       <span class="clr-timeline-step-description">Root CA certificate requested.</span>
@@ -9,7 +9,7 @@
   </li>
   <li class="clr-timeline-step">
     <div class="clr-timeline-step-header">11:59 am</div>
-    <clr-icon shape="dot-circle" aria-current="true" aria-label="Current"></clr-icon>
+    <cds-icon shape="dot-circle" aria-current="true" aria-label="Current"></cds-icon>
     <div class="clr-timeline-step-body">
       <span class="clr-timeline-step-title">Add KMS</span>
       <span class="clr-timeline-step-description">
@@ -31,7 +31,7 @@
   </li>
   <li class="clr-timeline-step">
     <div class="clr-timeline-step-header">11:59 am</div>
-    <clr-icon shape="success-standard" aria-label="Completed"></clr-icon>
+    <cds-icon shape="success-standard" aria-label="Completed"></cds-icon>
     <div class="clr-timeline-step-body">
       <span class="clr-timeline-step-title">Make KMS trust vCenter</span>
       <span class="clr-timeline-step-description"
@@ -42,7 +42,7 @@
   </li>
   <li class="clr-timeline-step">
     <div class="clr-timeline-step-header">11:59 am</div>
-    <clr-icon shape="error-standard" aria-label="Error"></clr-icon>
+    <cds-icon shape="error-standard" aria-label="Error"></cds-icon>
     <div class="clr-timeline-step-body">
       <span class="clr-timeline-step-title">Connected</span>
       <span class="clr-timeline-step-description">No. It's not connected.</span>

--- a/apps/website/.vuepress/code/demos/timeline/vertical.html
+++ b/apps/website/.vuepress/code/demos/timeline/vertical.html
@@ -1,7 +1,7 @@
 <ul class="clr-timeline clr-timeline-vertical">
   <li class="clr-timeline-step disabled">
     <div class="clr-timeline-step-header">11:59 am</div>
-    <clr-icon shape="circle" aria-label="Not started"></clr-icon>
+    <cds-icon shape="circle" aria-label="Not started"></cds-icon>
     <div class="clr-timeline-step-body">
       <span class="clr-timeline-step-title">Add KMS</span>
       <span class="clr-timeline-step-description">Root CA certificate requested.</span>
@@ -9,7 +9,7 @@
   </li>
   <li class="clr-timeline-step">
     <div class="clr-timeline-step-header">11:59 am</div>
-    <clr-icon shape="dot-circle" aria-current="true" aria-label="Current"></clr-icon>
+    <cds-icon shape="dot-circle" aria-current="true" aria-label="Current"></cds-icon>
     <div class="clr-timeline-step-body">
       <span class="clr-timeline-step-title">Add KMS</span>
       <span class="clr-timeline-step-description">
@@ -32,7 +32,7 @@
   </li>
   <li class="clr-timeline-step">
     <div class="clr-timeline-step-header">11:59 am</div>
-    <clr-icon shape="success-standard" aria-label="Completed"></clr-icon>
+    <cds-icon shape="success-standard" aria-label="Completed"></cds-icon>
     <div class="clr-timeline-step-body">
       <span class="clr-timeline-step-title">Make KMS trust vCenter</span>
       <span class="clr-timeline-step-description"
@@ -43,7 +43,7 @@
   </li>
   <li class="clr-timeline-step">
     <div class="clr-timeline-step-header">11:59 am</div>
-    <clr-icon shape="error-standard" aria-label="Error"></clr-icon>
+    <cds-icon shape="error-standard" aria-label="Error"></cds-icon>
     <div class="clr-timeline-step-body">
       <span class="clr-timeline-step-title">Connected</span>
       <span class="clr-timeline-step-description">No. It's not connected.</span>


### PR DESCRIPTION
Closes #5534

Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

## PR Type

What kind of change does this PR introduce?

- [x] clarity.design website / infrastructure changes

## What is the current behavior?

Issue Number: #5534

## What is the new behavior?

The timeline icons on the website are fixed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The reason was that the timeline on the website is presented as HTML and CSS and the `clr-icon`s were used instead of `cds-icon`s.

We can see in the dev app that the Angular component works as expected 

![image](https://user-images.githubusercontent.com/15037947/106273245-0156f280-623b-11eb-9728-eafb0fa499ba.png)


