### PR TITLE
fix: template type casting for combobox and datagrid

### DIFF
--- a/packages/angular/golden/clr-angular.d.ts
+++ b/packages/angular/golden/clr-angular.d.ts
@@ -308,6 +308,7 @@ export declare class ClrCombobox<T> extends WrappedFormControl<ClrComboboxContai
     invalid: boolean;
     set multiSelect(value: boolean | string);
     get multiSelect(): boolean | string;
+    get multiSelectModel(): T[];
     get openState(): boolean;
     optionSelected: ClrOptionSelected<T>;
     optionSelectionService: OptionSelectionService<T>;
@@ -537,8 +538,8 @@ export declare class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<
     customFilter: boolean;
     get field(): string;
     set field(field: string);
-    get filterValue(): string | [number, number];
-    set filterValue(newValue: string | [number, number]);
+    get filterValue(): string | [number, number] | any;
+    set filterValue(newValue: string | [number, number] | any);
     filterValueChange: EventEmitter<any>;
     set projectedFilter(custom: any);
     showSeparator: boolean;

--- a/packages/angular/golden/clr-angular.d.ts
+++ b/packages/angular/golden/clr-angular.d.ts
@@ -538,8 +538,8 @@ export declare class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<
     customFilter: boolean;
     get field(): string;
     set field(field: string);
-    get filterValue(): string | [number, number] | any;
-    set filterValue(newValue: string | [number, number] | any);
+    get filterValue(): any;
+    set filterValue(newValue: any);
     filterValueChange: EventEmitter<any>;
     set projectedFilter(custom: any);
     showSeparator: boolean;

--- a/packages/angular/projects/clr-angular/src/data/datagrid/built-in/filters/datagrid-numeric-filter.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/built-in/filters/datagrid-numeric-filter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -119,7 +119,7 @@ export class DatagridNumericFilter<T = any> extends DatagridFilterRegistrar<T, D
 
   @Input('clrFilterValue')
   public set value(values: [number, number]) {
-    if (this.filter) {
+    if (this.filter && Array.isArray(values)) {
       if (values && (values[0] !== this.filter.low || values[1] !== this.filter.high)) {
         if (typeof values[0] === 'number') {
           this.filter.low = values[0];

--- a/packages/angular/projects/clr-angular/src/data/datagrid/built-in/filters/datagrid-string-filter.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/built-in/filters/datagrid-string-filter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -106,7 +106,7 @@ export class DatagridStringFilter<T = any> extends DatagridFilterRegistrar<T, Da
   }
   @Input('clrFilterValue')
   public set value(value: string) {
-    if (this.filter) {
+    if (this.filter && typeof value === 'string') {
       if (!value) {
         value = '';
       }

--- a/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-column.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-column.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -403,7 +403,7 @@ export class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<T, ClrDa
 
   // This property holds filter value temporarily while this.filter property is not yet registered
   // When this.filter is registered, this property value would be used update this.filter.value
-  private initFilterValue: string | [number, number];
+  private initFilterValue: string | [number, number] | any;
 
   public get filterValue() {
     if (this.filter instanceof DatagridStringFilterImpl || this.filter instanceof DatagridNumericFilterImpl) {
@@ -412,7 +412,13 @@ export class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<T, ClrDa
     return null;
   }
 
-  public set filterValue(newValue: string | [number, number]) {
+  /**
+   * @NOTE type `any` here is to let us pass templateStrictMode, because in our code we try to handle
+   * two types of filters String and Number with the same variable but both of them work with different
+   * format we got an error for casting. We could not cast anything inside the template so to not mess the
+   * casting, the last type is set to `any`
+   */
+  public set filterValue(newValue: string | [number, number] | any) {
     if (this.filter instanceof DatagridStringFilterImpl || this.filter instanceof DatagridNumericFilterImpl) {
       this.updateFilterValue = newValue;
       this.filterValueChange.emit(this.filter.value);

--- a/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-column.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-column.ts
@@ -403,7 +403,8 @@ export class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<T, ClrDa
 
   // This property holds filter value temporarily while this.filter property is not yet registered
   // When this.filter is registered, this property value would be used update this.filter.value
-  private initFilterValue: string | [number, number] | any;
+  //
+  private initFilterValue: string | [number, number];
 
   public get filterValue() {
     if (this.filter instanceof DatagridStringFilterImpl || this.filter instanceof DatagridNumericFilterImpl) {
@@ -417,8 +418,10 @@ export class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<T, ClrDa
    * two types of filters String and Number with the same variable but both of them work with different
    * format we got an error for casting. We could not cast anything inside the template so to not mess the
    * casting, the last type is set to `any`
+   *
+   * Orignial types: string | [number, number]
    */
-  public set filterValue(newValue: string | [number, number] | any) {
+  public set filterValue(newValue: any) {
     if (this.filter instanceof DatagridStringFilterImpl || this.filter instanceof DatagridNumericFilterImpl) {
       this.updateFilterValue = newValue;
       this.filterValueChange.emit(this.filter.value);

--- a/packages/angular/projects/clr-angular/src/data/datagrid/utils/datagrid-filter-registrar.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/utils/datagrid-filter-registrar.ts
@@ -14,7 +14,7 @@ export abstract class DatagridFilterRegistrar<T, F extends ClrDatagridFilterInte
   /**
    * @NOTEe Type `any` is set here to be able to pass templateStrictMode
    */
-  public registered: RegisteredFilter<T, F> | any;
+  public registered: any;
 
   public get filter(): F {
     return this.registered && this.registered.filter;

--- a/packages/angular/projects/clr-angular/src/data/datagrid/utils/datagrid-filter-registrar.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/utils/datagrid-filter-registrar.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -11,7 +11,10 @@ import { FiltersProvider, RegisteredFilter } from '../providers/filters';
 export abstract class DatagridFilterRegistrar<T, F extends ClrDatagridFilterInterface<T>> implements OnDestroy {
   constructor(private filters: FiltersProvider<T>) {}
 
-  public registered: RegisteredFilter<T, F>;
+  /**
+   * @NOTEe Type `any` is set here to be able to pass templateStrictMode
+   */
+  public registered: RegisteredFilter<T, F> | any;
 
   public get filter(): F {
     return this.registered && this.registered.filter;

--- a/packages/angular/projects/clr-angular/src/forms/combobox/combobox.html
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/combobox.html
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+* Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 * This software is released under MIT license.
 * The full license information can be found in LICENSE in the root directory of this project.
 -->
@@ -22,11 +22,7 @@
     [attr.aria-label]="getSelectionAriaLabel()"
     [attr.aria-disabled]="control?.disabled? true: null"
   >
-    <span
-      *ngFor="let item of optionSelectionService.selectionModel.model; let i = index"
-      class="label label-combobox-pill"
-      role="row"
-    >
+    <span *ngFor="let item of multiSelectModel; let i = index" class="label label-combobox-pill" role="row">
       <span role="gridcell">
         <span class="clr-combobox-pill-content" clrKeyFocusItem>
           <ng-container

--- a/packages/angular/projects/clr-angular/src/forms/combobox/combobox.ts
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/combobox.ts
@@ -148,6 +148,13 @@ export class ClrCombobox<T> extends WrappedFormControl<ClrComboboxContainer>
     return this._searchText;
   }
 
+  get multiSelectModel(): T[] {
+    if (!this.multiSelect) {
+      throw Error('multiSelectModel is not available in single selection context');
+    }
+    return (this.optionSelectionService.selectionModel as MultiSelectComboboxModel<T>).model;
+  }
+
   public smartPosition: ClrPopoverPosition = {
     axis: ClrAxis.VERTICAL,
     side: ClrSide.AFTER,

--- a/packages/angular/projects/clr-angular/src/utils/focus/key-focus/roving-tabindex.ts
+++ b/packages/angular/projects/clr-angular/src/utils/focus/key-focus/roving-tabindex.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -21,11 +21,11 @@ export class ClrRovingTabindex extends ClrKeyFocus {
 
   // Proxy the input, as the selector name from parent class will still be "clrKeyFocus".
   @Input('clrRovingTabindex')
-  set rovingIndexItems(elements: Array<FocusableItem>) {
-    this.focusableItems = elements;
+  set rovingIndexItems(elements: Array<FocusableItem> | string) {
+    this.focusableItems = elements as Array<FocusableItem>;
   }
 
-  get rovingIndexItems(): Array<FocusableItem> {
+  get rovingIndexItems(): Array<FocusableItem> | string {
     return this.focusableItems;
   }
 


### PR DESCRIPTION
Fix error when running `yarn run start` with strict mode for templates

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
