### PR TITLE
fix(inline-button): use same color on hover as regular links

### DIFF
--- a/packages/core/src/button/inline-button.element.scss
+++ b/packages/core/src/button/inline-button.element.scss
@@ -53,6 +53,6 @@ slot {
 
 :host(:active),
 :host(:hover) {
-  --color: #{$cds-alias-status-info-tint};
+  --color: #{$cds-alias-status-info-shade};
   --text-decoration: underline;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

![inline-button-before](https://user-images.githubusercontent.com/113730/106486805-08bb0d80-6480-11eb-9a7e-9b6034a8c5ef.gif)

Issue Number: N/A

## What is the new behavior?

![inline-button-after](https://user-images.githubusercontent.com/113730/106486830-0eb0ee80-6480-11eb-9eb6-e221a2084004.gif)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This is now effectively the same as regular links:

![link](https://user-images.githubusercontent.com/113730/106486849-14a6cf80-6480-11eb-8f4f-a8735a4d59f0.gif)

Follow-up of https://github.com/vmware/clarity/commit/d5da735da3bd68938c3e52e9708a137f589fa054#diff-7ef4bf13da984d496779cb3e8f9830ace1d871ae35bbdda1f2c2c1e1e1d75207L191-R191