### PR TITLE
fix: input groups and button content

### DIFF
--- a/apps/website/core-components/button/README.md
+++ b/apps/website/core-components/button/README.md
@@ -67,7 +67,7 @@ While buttons and links can both be given similar visual treatments, it is impor
     <cds-button>button</cds-button>
 </div>
 </DocInset>
-<p cds-text="body" cds-layout="p-t:lg p-b:md">Use  buttons when a user is expected to <span cds-text="semibold">take an action</span>.</p>
+<p cds-text="body" cds-layout="p-t:lg p-b:md">Use the <span cds-text="code">cds-button</span> element on its own when a user is expected to <span cds-text="semibold">take an action</span>.</p>
 </div>
 <div class="clr-col-sm-12 clr-col-lg-6">
 <DocInset height="72">
@@ -75,7 +75,7 @@ While buttons and links can both be given similar visual treatments, it is impor
     <a href="javascript:void(0)"><cds-button>link</cds-button></a>
 </div>
 </DocInset>
-<p cds-text="body" cds-layout="p-t:lg p-b:md">Use a link when a user is expected to be <span cds-text="semibold">taken to a different page.</span>.</p>
+<p cds-text="body" cds-layout="p-t:lg p-b:md">Wrap a <span cds-text="code">cds-button</span> inside an anchor element and use a link when a user is expected to be <span cds-text="semibold">taken to a different page.</span>.</p>
 </div>
 </div>
 

--- a/apps/website/core-components/input-group/README.md
+++ b/apps/website/core-components/input-group/README.md
@@ -35,8 +35,6 @@ An input group can behave in all the ways a standard single input will. It may b
 
 :::
 
-</div>
-
 ::: component-section-level-one-title
 
 ## States
@@ -73,10 +71,6 @@ Use when interactive and ready for input.
 
 :::
 
-</div>
-
-<div class="component-section-horizontal">
-
 ::: component-section-level-two
 
 ### Active
@@ -96,10 +90,6 @@ Use when selected by a user with an input method, such as mouse or keyboard.
 </div>
 
 :::
-
-</div>
-
-<div class="component-section-horizontal">
 
 ::: component-section-level-two
 


### PR DESCRIPTION
closes #5532
closes #5529

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

This is a patch with two fixes to buttons and input-groups content. 

Issue Number: #5532 and #5529

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
