### PR TITLE
fix: core button space and inverse style

### DIFF
--- a/packages/core/src/button/base-button.element.scss
+++ b/packages/core/src/button/base-button.element.scss
@@ -106,16 +106,13 @@
 
 :host([action='outline']:hover),
 :host([action='outline']:focus),
-:host([action='outline']:active) {
-  .private-host::after {
-    opacity: 0.1;
-  }
-}
-
+:host([action='outline']:active),
 :host([status='inverse']:hover),
 :host([status='inverse']:focus),
 :host([status='inverse']:active) {
-  --background: #{$cds-alias-status-disabled-tint};
+  .private-host::after {
+    opacity: 0.1;
+  }
 }
 
 ::slotted {
@@ -177,11 +174,12 @@
   pointer-events: none !important;
 }
 
-:host([disabled]) {
-  --background: #{$cds-alias-status-disabled-tint} !important;
-  --border-color: #{$cds-alias-status-disabled-tint} !important;
+:host([disabled]),
+:host([disabled][action='outline']) {
+  --background: #{$cds-alias-status-disabled-tint};
+  --border-color: #{$cds-alias-status-disabled-tint};
   --box-shadow-color: #{$cds-alias-object-opacity-0};
-  --color: #{$cds-alias-status-disabled} !important;
+  --color: #{$cds-alias-status-disabled};
 
   .private-host {
     cursor: not-allowed;
@@ -195,12 +193,12 @@
 }
 
 :host([disabled][action='outline']) {
-  --background: #{$cds-alias-object-opacity-0} !important;
+  --background: #{$cds-alias-object-opacity-0};
 }
 
 :host([disabled][action='flat']) {
-  --border-color: #{$cds-alias-object-opacity-0} !important;
-  --background: #{$cds-alias-object-opacity-0} !important;
+  --border-color: #{$cds-alias-object-opacity-0};
+  --background: #{$cds-alias-object-opacity-0};
 }
 
 :host([block]) {

--- a/packages/core/src/button/button.element.ts
+++ b/packages/core/src/button/button.element.ts
@@ -128,7 +128,7 @@ export class CdsButton extends CdsBaseButton {
   render() {
     const loadingState = this.loadingState;
     return html`<div class="private-host">
-      <div cds-layout="horizontal gap:md wrap:none align:center">
+      <div cds-layout="horizontal gap:sm wrap:none align:center">
         ${loadingState === ClrLoadingState.SUCCESS ? iconCheck : ''}
         ${loadingState === ClrLoadingState.ERROR ? iconError : ''}
         ${loadingState === ClrLoadingState.LOADING ? iconSpinner(this.size) : ''}

--- a/packages/core/src/button/icon-button.element.scss
+++ b/packages/core/src/button/icon-button.element.scss
@@ -15,9 +15,3 @@
 .private-host {
   min-width: 0;
 }
-
-::slotted(a) {
-  --color: inherit;
-  display: inline-block;
-  height: auto;
-}

--- a/packages/core/src/button/inline-button.element.scss
+++ b/packages/core/src/button/inline-button.element.scss
@@ -16,7 +16,6 @@
   font-size: inherit;
 }
 
-::slotted(a),
 .private-host {
   display: inline;
   color: var(--color) !important;
@@ -46,7 +45,6 @@ slot {
   margin-left: #{$cds-global-space-2};
 }
 
-:host([disabled]) ::slotted(a),
 :host([disabled]) .private-host {
   cursor: not-allowed !important;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

There are minor incorrect styles with cds-button/theme compared to the figma file.

Issue Number:
https://github.com/vmware/clarity/issues/5558 


## What is the new behavior?
- Fixes spacing between text/icon and missing background for inverse buttons
- remove !important statements that broke theme customization

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
