### PR TITLE
fix: core input readonly style

### DIFF
--- a/packages/core/src/forms/control/control.element.spec.ts
+++ b/packages/core/src/forms/control/control.element.spec.ts
@@ -143,6 +143,17 @@ describe('cds-control', () => {
     input.setAttribute('disabled', '');
   });
 
+  it('should apply readonly style attribute when native input is readonly', done => {
+    expect(control.getAttribute('readonly')).toBe(null);
+
+    listenForAttributeChange(control, '_readonly', () => {
+      expect(control.getAttribute('_readonly')).toBe('');
+      done();
+    });
+
+    input.setAttribute('readonly', '');
+  });
+
   it('should convert form layout types to control layout types', () => {
     (control.layout as any) = 'horizontal-inline';
     expect(control.layout).toBe('horizontal');

--- a/packages/core/src/forms/control/control.element.ts
+++ b/packages/core/src/forms/control/control.element.ts
@@ -104,6 +104,8 @@ export class CdsControl extends LitElement {
 
   @internalProperty({ type: Boolean, reflect: true }) protected disabled = false;
 
+  @internalProperty({ type: Boolean, reflect: true }) protected readonly = false;
+
   @internalProperty() protected fixedControlWidth = false;
 
   @internalProperty() protected supportsPrefixSuffixActions = true;
@@ -287,7 +289,8 @@ export class CdsControl extends LitElement {
     this.inputControl.addEventListener('focusin', () => (this.focused = true));
     this.inputControl.addEventListener('focusout', () => (this.focused = false));
     this.observers.push(
-      getElementUpdates(this.inputControl, 'disabled', (value: any) => (this.disabled = value === '' ? true : value))
+      getElementUpdates(this.inputControl, 'disabled', (value: any) => (this.disabled = value === '' ? true : value)),
+      getElementUpdates(this.inputControl, 'readonly', (value: any) => (this.readonly = value === '' ? true : value))
     );
   }
 

--- a/packages/core/src/input/input.element.scss
+++ b/packages/core/src/input/input.element.scss
@@ -91,7 +91,7 @@
   --border-color: #{$cds-alias-status-info};
 }
 
-::slotted([slot='input']:not([multiple])[readonly]) {
+:host([_readonly]) {
   --border-bottom: 0;
   --background-size: 0% 100%;
   --background: #{$cds-alias-object-opacity-0};

--- a/packages/core/src/input/input.stories.mdx
+++ b/packages/core/src/input/input.stories.mdx
@@ -69,6 +69,12 @@ The `cds-input` component supports a variety of native text based input types.
   <Story id="stories-input--dark-theme" />
 </Preview>
 
+## Readonly
+
+<Preview>
+  <Story id="stories-input--readonly" />
+</Preview>
+
 ## Input API
 
 <Props of={'cds-input'} />

--- a/packages/core/src/input/input.stories.ts
+++ b/packages/core/src/input/input.stories.ts
@@ -135,6 +135,15 @@ export function compact() {
   `;
 }
 
+export function readonly() {
+  return html`
+    <cds-input layout="vertical" control-width="shrink">
+      <label>readonly input</label>
+      <input placeholder="name" readonly />
+    </cds-input>
+  `;
+}
+
 /** @website */
 export function inputWidth() {
   return html`

--- a/packages/core/src/internal/utils/events.ts
+++ b/packages/core/src/internal/utils/events.ts
@@ -16,14 +16,17 @@ export const getElementUpdates = (element: HTMLElement, propertyKey: string, cal
     (element as any)[propertyKey] !== undefined ? (element as any)[propertyKey] : element.getAttribute(propertyKey)
   );
 
-  const updatedProp = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, propertyKey) as any;
-  Object.defineProperty(element, propertyKey, {
-    get: updatedProp.get,
-    set: val => {
-      callback(val);
-      updatedProp.set.call(element, val);
-    },
-  });
+  const updatedProp = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(element), propertyKey) as any;
+
+  if (updatedProp) {
+    Object.defineProperty(element, propertyKey, {
+      get: updatedProp.get,
+      set: val => {
+        callback(val);
+        updatedProp.set.call(element, val);
+      },
+    });
+  }
 
   return listenForAttributeChange(element, propertyKey, val => callback(val));
 };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
- cds-input readonly styles did not apply correctly

Issue Number: N/A

## What is the new behavior?

cds-input now applies correct readonly style

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
