### PR TITLE
fix: core input control disabled style

### DIFF
--- a/packages/core/src/forms/control/control.element.scss
+++ b/packages/core/src/forms/control/control.element.scss
@@ -13,7 +13,7 @@
   line-height: 0;
 }
 
-:host([_disabled]) .input {
+:host([_disabled]) ::slotted([slot='input']) {
   cursor: not-allowed;
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The not allowed cursor is missing from disabled input controls.

Issue Number: N/A

## What is the new behavior?
The cursor now shows the correct not allowed when disabled

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
