### PR TITLE
fix: core input control spacing

### DIFF
--- a/packages/core/src/forms/control/control.element.spec.ts
+++ b/packages/core/src/forms/control/control.element.spec.ts
@@ -166,6 +166,11 @@ describe('cds-control', () => {
     await componentIsStable(control);
     expect(control.shadowRoot.querySelector('.rtl')).toBeTruthy();
   });
+
+  it('should not set input inline padding style if no control actions are used', async () => {
+    await componentIsStable(control);
+    expect(control.inputControl.hasAttribute('style')).toBe(false);
+  });
 });
 
 describe('cds-control validation', () => {

--- a/packages/core/src/forms/control/control.element.ts
+++ b/packages/core/src/forms/control/control.element.ts
@@ -201,6 +201,14 @@ export class CdsControl extends LitElement {
     return html``;
   }
 
+  private get hasControlActions() {
+    return (
+      this.controlActions.length ||
+      this.prefixDefaultTemplate.getHTML().length ||
+      this.suffixDefaultTemplate.getHTML().length
+    );
+  }
+
   private get primaryLabelTemplate() {
     return html`
       ${!this.hiddenLabel
@@ -264,6 +272,7 @@ export class CdsControl extends LitElement {
     this.setActionOffsetPadding();
     this.setupResponsive();
     this.setupDescribedByUpdates();
+    this.setupHiddenLabel();
   }
 
   updated(props: Map<string, any>) {
@@ -299,7 +308,7 @@ export class CdsControl extends LitElement {
 
   private async setActionOffsetPadding() {
     await childrenUpdateComplete(this.controlActions);
-    if (this.supportsPrefixSuffixActions) {
+    if (this.supportsPrefixSuffixActions && this.hasControlActions) {
       const start = pxToRem(this.prefixAction.getBoundingClientRect().width + 6);
       const end = pxToRem(this.suffixAction.getBoundingClientRect().width + 6);
       this.inputControl.style.setProperty('padding-left', this.isRTL ? end : start, 'important');
@@ -318,6 +327,12 @@ export class CdsControl extends LitElement {
         this.layoutChange.emit(this.layout, { bubbles: true })
       );
       this.observers.push(observer);
+    }
+  }
+
+  private setupHiddenLabel() {
+    if (this.label.getAttribute('cds-layout')?.includes('display:screen-reader-only')) {
+      this.hiddenLabel = true;
     }
   }
 }

--- a/packages/core/src/search/search.stories.mdx
+++ b/packages/core/src/search/search.stories.mdx
@@ -48,6 +48,12 @@ import '@cds/core/search/register.js';
   <Story id="stories-search--compact" />
 </Preview>
 
+## Inline
+
+<Preview>
+  <Story id="stories-search--search-inline" />
+</Preview>
+
 ## Datalist
 
 <Preview>

--- a/packages/core/src/search/search.stories.ts
+++ b/packages/core/src/search/search.stories.ts
@@ -135,6 +135,15 @@ export function compact() {
   `;
 }
 
+export function searchInline() {
+  return html`
+    <cds-search>
+      <label cds-layout="display:screen-reader-only">search</label>
+      <input type="search" placeholder="search" />
+    </cds-search>
+  `;
+}
+
 /** @website */
 export function datalist() {
   return html`


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
There is excess alignment spacing in the cds-control in certain situations.
- If a control action is not provided inline padding is still applied making theming difficult
- If a label is hidden visually for inline inputs the CSS gap creates unnecessary white space
- 
Issue Number:
https://github.com/vmware/clarity/issues/5560

## What is the new behavior?
- remove excess padding when no control action provided
- remove excess space when label is hidden visually

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
