### PR TITLE
fix(icons): backwards compatibility for the static components in v5

### DIFF
--- a/packages/angular/projects/clr-angular/src/accordion/_accordion.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/accordion/_accordion.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -310,7 +310,8 @@
     .clr-accordion-status {
       width: $clr_baselineRem_0_8;
 
-      cds-icon {
+      cds-icon,
+      clr-icon {
         @include equilateral($clr_baselineRem_0_583);
       }
     }

--- a/packages/angular/projects/clr-angular/src/button/_buttons.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/button/_buttons.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -87,7 +87,8 @@
   @include button-css-var($button-type, background-color, bg-color, $clr-use-custom-properties);
   @include button-css-var($button-type, color, color, $clr-use-custom-properties);
 
-  cds-icon {
+  cds-icon,
+  clr-icon {
     @include button-css-var($button-type, color, color, $clr-use-custom-properties);
   }
 
@@ -261,7 +262,8 @@
   //Clarity Buttons
   .btn-group > .btn,
   .btn {
-    cds-icon {
+    cds-icon,
+    clr-icon {
       transform: translate3d(0, -1 * $clr_baselineRem_2px, 0);
     }
   }

--- a/packages/angular/projects/clr-angular/src/button/button-group/_button-group.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/button/button-group/_button-group.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -148,7 +148,8 @@
     }
 
     .dropdown-menu {
-      cds-icon {
+      cds-icon,
+      clr-icon {
         display: none;
       }
 

--- a/packages/angular/projects/clr-angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/_datagrid.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -234,7 +234,8 @@
           }
         }
 
-        cds-icon {
+        cds-icon,
+        clr-icon {
           vertical-align: middle;
           transform: translate3d(0px, -1 * $clr_baselineRem_1px, 0);
         }
@@ -357,7 +358,8 @@
           }
         }
 
-        cds-icon {
+        cds-icon,
+        clr-icon {
           vertical-align: middle;
           transform: translate3d(0px, -1 * $clr_baselineRem_1px, 0);
         }
@@ -477,7 +479,8 @@
           }
         }
 
-        cds-icon {
+        cds-icon,
+        clr-icon {
           vertical-align: middle;
           transform: translate3d(0px, -1 * $clr_baselineRem_1px, 0);
         }
@@ -691,20 +694,31 @@
         margin-left: $clr_baselineRem_0_25;
         background-repeat: no-repeat;
         background-size: contain;
-        cds-icon {
+
+        cds-icon,
+        clr-icon {
           @include css-var(color, clr-color-neutral-500, $clr-color-neutral-500, $clr-use-custom-properties);
         }
 
-        &:hover cds-icon {
-          @include css-var(color, clr-color-action-600, $clr-color-action-600, $clr-use-custom-properties);
+        &:hover {
+          cds-icon,
+          clr-icon {
+            @include css-var(color, clr-color-action-600, $clr-color-action-600, $clr-use-custom-properties);
+          }
         }
 
-        &.datagrid-filter-open cds-icon {
-          @include css-var(color, clr-color-action-600, $clr-color-action-600, $clr-use-custom-properties);
+        &.datagrid-filter-open {
+          cds-icon,
+          clr-icon {
+            @include css-var(color, clr-color-action-600, $clr-color-action-600, $clr-use-custom-properties);
+          }
         }
 
-        &.datagrid-filtered cds-icon {
-          @include css-var(color, clr-color-action-600, $clr-color-action-600, $clr-use-custom-properties);
+        &.datagrid-filtered {
+          cds-icon,
+          clr-icon {
+            @include css-var(color, clr-color-action-600, $clr-color-action-600, $clr-use-custom-properties);
+          }
         }
       }
 
@@ -969,13 +983,22 @@
 
       .datagrid-action-toggle {
         @include clr-no-styles-button();
-        cds-icon {
+        cds-icon,
+        clr-icon {
           @include css-var(color, clr-datagrid-icon-color, $clr-datagrid-icon-color, $clr-use-custom-properties);
         }
 
-        &:active cds-icon {
-          // Fixed active state on this button for Safari.
-          @include css-var(color, clr-datagrid-action-toggle, $clr-datagrid-action-toggle, $clr-use-custom-properties);
+        &:active {
+          cds-icon,
+          clr-icon {
+            // Fixed active state on this button for Safari.
+            @include css-var(
+              color,
+              clr-datagrid-action-toggle,
+              $clr-datagrid-action-toggle,
+              $clr-use-custom-properties
+            );
+          }
         }
       }
 
@@ -1151,8 +1174,11 @@
       flex: 0 0 auto;
 
       &.active {
-        .column-toggle--action cds-icon {
-          @include css-var(color, clr-color-action-600, $clr-color-action-600, $clr-use-custom-properties);
+        .column-toggle--action {
+          cds-icon,
+          clr-icon {
+            @include css-var(color, clr-color-action-600, $clr-color-action-600, $clr-use-custom-properties);
+          }
         }
       }
       .column-toggle--action {
@@ -1160,12 +1186,16 @@
         min-width: $clr_baselineRem_0_75;
         padding-left: 0;
         padding-right: 0;
-        cds-icon {
+        cds-icon,
+        clr-icon {
           @include css-var(color, clr-color-neutral-500, $clr-color-neutral-500, $clr-use-custom-properties);
         }
 
-        &:hover cds-icon {
-          @include css-var(color, clr-color-action-600, $clr-color-action-600, $clr-use-custom-properties);
+        &:hover {
+          cds-icon,
+          clr-icon {
+            @include css-var(color, clr-color-action-600, $clr-color-action-600, $clr-use-custom-properties);
+          }
         }
       }
 
@@ -1368,7 +1398,8 @@
       }
     }
     .datagrid-cell {
-      cds-icon {
+      cds-icon,
+      clr-icon {
         margin-top: (-1 * $clr_baselineRem_0_125) - $clr_baselineRem_1px;
         margin-bottom: -1 * $clr_baselineRem_0_125;
         transform: translateY(-1 * $clr_baselineRem_1px);
@@ -1400,7 +1431,8 @@
       }
     }
     .datagrid-signpost-trigger .signpost .signpost-trigger {
-      cds-icon:not([shape='info-circle'], [shape='exclamation-triangle'], [shape='exclamation-circle'], [shape='check-circle'], [shape='info'], [shape='error']) {
+      cds-icon:not([shape='info-circle'], [shape='exclamation-triangle'], [shape='exclamation-circle'], [shape='check-circle'], [shape='info'], [shape='error']),
+      clr-icon:not([shape='info-circle'], [shape='exclamation-triangle'], [shape='exclamation-circle'], [shape='check-circle'], [shape='info'], [shape='error']) {
         @include equilateral($clr_baselineRem_0_875);
       }
     }
@@ -1994,7 +2026,8 @@
         }
       }
 
-      cds-icon {
+      cds-icon,
+      clr-icon {
         vertical-align: middle;
         transform: translate3d(0px, -1px, 0);
       }

--- a/packages/angular/projects/clr-angular/src/data/tree-view/_tree-view.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/data/tree-view/_tree-view.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -45,7 +45,8 @@
     );
     line-height: $clr-tree-node-touch-target;
 
-    cds-icon {
+    cds-icon,
+    clr-icon {
       @include equilateral($clr-tree-caret-size);
       margin-right: $clr-tree-node-content-icon-margin-right;
       vertical-align: middle;

--- a/packages/angular/projects/clr-angular/src/emphasis/alert/_alert.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/emphasis/alert/_alert.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -98,7 +98,8 @@
       $clr-use-custom-properties
     );
 
-    cds-icon {
+    cds-icon,
+    clr-icon {
       @include css-var(fill, $myCloseIconCssVar, $myCloseIconSassVar, $clr-use-custom-properties);
     }
 
@@ -267,7 +268,8 @@
       order: 100;
       padding-right: $closeBtnNudge;
 
-      cds-icon {
+      cds-icon,
+      clr-icon {
         $alert-close-icon-dims: $clr_baselineRem_1 - $clr-alert-borderwidth;
         margin-top: -1 * $clr_baselineRem_0_125;
         @include equilateral($alert-close-icon-dims);
@@ -340,7 +342,8 @@
       height: $clr_baselineRem_1_5;
       overflow: hidden;
 
-      cds-icon {
+      cds-icon,
+      clr-icon {
         margin-top: -1 * $clr_baselineRem_5px;
       }
     }
@@ -396,7 +399,8 @@
       height: $clr_baselineRem_1;
       line-height: $clr_baselineRem_1;
 
-      cds-icon {
+      cds-icon,
+      clr-icon {
         $smallAlertCloseIconDims: $clr_baselineRem_0_83;
         margin-top: -1 * ($alertSmallNudge + $clr_baselineRem_1px);
         margin-right: -1 * $clr_baselineRem_1px;
@@ -512,7 +516,8 @@
     @include css-var(color, clr-app-alert-pager-text-color, $clr-color-neutral-0, $clr-use-custom-properties);
     cursor: pointer;
 
-    cds-icon {
+    cds-icon,
+    clr-icon {
       @include css-var(color, clr-app-alert-pager-text-color, $clr-color-neutral-0, $clr-use-custom-properties);
     }
   }

--- a/packages/angular/projects/clr-angular/src/forms/combobox/_combobox.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/_combobox.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -138,7 +138,8 @@
         padding: 0 $clr_baselineRem_8px 0 $clr_baselineRem_4px;
       }
 
-      cds-icon[shape='window-close'] {
+      cds-icon[shape='window-close'],
+      clr-icon[shape='window-close'] {
         @include css-var(
           color,
           clr-combobox-pill-font-color,
@@ -175,7 +176,8 @@
     cursor: pointer;
     outline: none;
 
-    cds-icon[shape='angle'] {
+    cds-icon[shape='angle'],
+    clr-icon[shape='angle'] {
       @include css-var(color, clr-combobox-pill-font-color, $clr-combobox-pill-font-color, $clr-use-custom-properties);
     }
   }

--- a/packages/angular/projects/clr-angular/src/forms/datepicker/_datepicker.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/forms/datepicker/_datepicker.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -249,7 +249,8 @@
   .switcher {
     @include css-var(color, clr-calendar-btn-color, $clr-calendar-btn-color, $clr-use-custom-properties);
 
-    cds-icon {
+    cds-icon,
+    clr-icon {
       @include equilateral($clr_baselineRem_0_75);
     }
   }

--- a/packages/angular/projects/clr-angular/src/forms/styles/_input-group.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/forms/styles/_input-group.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -48,7 +48,8 @@
       @include css-var(color, clr-forms-focused-color, $clr-forms-focused-color, $clr-use-custom-properties);
       padding: 0 $clr-forms-baseline * 1.5;
 
-      cds-icon {
+      cds-icon,
+      clr-icon {
         @include equilateral($clr_baselineRem_0_75);
         transform: translate(-1 * $clr_baselineRem_1px, -1 * $clr_baselineRem_1px);
       }

--- a/packages/angular/projects/clr-angular/src/layout/nav/_header.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/layout/nav/_header.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -79,7 +79,8 @@
     }
 
     .clr-icon,
-    cds-icon {
+    cds-icon,
+    clr-icon {
       flex-grow: 0;
       flex-shrink: 0;
       @include equilateral($clr-logo-width);
@@ -118,7 +119,8 @@
       font-weight: 500;
     }
 
-    cds-icon {
+    cds-icon,
+    clr-icon {
       @include css-var(color, clr-header-font-color, $clr-header-font-color, $clr-use-custom-properties);
     }
 
@@ -139,7 +141,8 @@
         font-size: $clr-nav-icon-size;
       }
 
-      cds-icon {
+      cds-icon,
+      clr-icon {
         position: absolute;
         top: 50%;
         left: 50%;
@@ -148,7 +151,8 @@
       }
 
       &.nav-icon-text {
-        cds-icon {
+        cds-icon,
+        clr-icon {
           position: relative;
           top: auto;
           left: auto;
@@ -238,24 +242,31 @@
         @include header-nav-appearance();
       }
 
-      .dropdown-toggle.nav-icon cds-icon:not([shape^='angle']) {
-        position: absolute;
-        top: 50%;
-        transform: translateY(-50%);
-        // Dropdown icons are 2px smaller
-        @include equilateral($clr_baselineRem_0_916);
-        right: $clr_baselineRem_1;
+      .dropdown-toggle.nav-icon {
+        cds-icon:not([shape^='angle']),
+        clr-icon:not([shape^='angle']) {
+          position: absolute;
+          top: 50%;
+          transform: translateY(-50%);
+          // Dropdown icons are 2px smaller
+          @include equilateral($clr_baselineRem_0_916);
+          right: $clr_baselineRem_1;
+        }
       }
 
-      .dropdown-toggle.nav-icon cds-icon[shape^='angle'] {
-        right: $clr-header-action-caret-icon-right-position;
+      .dropdown-toggle.nav-icon {
+        cds-icon[shape^='angle'],
+        clr-icon[shape^='angle'] {
+          right: $clr-header-action-caret-icon-right-position;
+        }
       }
 
       $dropdown-nav-text-dist: $clr_baselineRem_1_5;
       .dropdown-toggle.nav-text {
         padding: 0 $dropdown-nav-text-dist 0 $clr-header-nav-text-horizontal-padding;
 
-        cds-icon[shape^='angle'] {
+        cds-icon[shape^='angle'],
+        clr-icon[shape^='angle'] {
           right: $clr-header-nav-text-horizontal-padding;
         }
       }

--- a/packages/angular/projects/clr-angular/src/layout/nav/_responsive-nav.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/layout/nav/_responsive-nav.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -325,7 +325,8 @@
           //TODO: deprecate .clr-icon, .logo
           .clr-icon,
           .logo,
-          cds-icon {
+          cds-icon,
+          clr-icon {
             display: none;
           }
         }
@@ -423,11 +424,13 @@
             //deprecate .clr-icon, .logo
             .clr-icon,
             .logo,
-            cds-icon {
+            cds-icon,
+            clr-icon {
               display: inline-block;
             }
 
             cds-icon[shape='vm-bug'],
+            clr-icon[shape='vm-bug'],
             .clr-vmw-logo {
               background-color: $clr-color-neutral-600;
               border-radius: $clr-global-borderradius;

--- a/packages/angular/projects/clr-angular/src/layout/vertical-nav/_vertical-nav.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/layout/vertical-nav/_vertical-nav.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -157,7 +157,8 @@
       padding: 0;
 
       //Others
-      cds-icon[shape='angle-double'] {
+      cds-icon[shape='angle-double'],
+      clr-icon[shape='angle-double'] {
         @include css-var(
           color,
           clr-vertical-nav-toggle-icon-color,

--- a/packages/angular/projects/clr-angular/src/modal/_modal.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/modal/_modal.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -104,7 +104,8 @@
       font-size: $clr_baselineRem_1_0833;
       line-height: $clr_baselineRem_1;
 
-      cds-icon {
+      cds-icon,
+      clr-icon {
         @include css-var(fill, clr-modal-close-color, $clr-modal-close-color, $clr-use-custom-properties);
 
         // per measurement, this results in an icon that is 16x16...

--- a/packages/angular/projects/clr-angular/src/popover/dropdown/_dropdown.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/popover/dropdown/_dropdown.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -28,7 +28,8 @@
         margin: 0;
       }
 
-      cds-icon[shape^='angle'] {
+      cds-icon[shape^='angle'],
+      clr-icon[shape^='angle'] {
         position: absolute;
         top: 50%;
         transform: translateY(-50%);
@@ -40,7 +41,8 @@
         padding-right: $clr-btn-horizontal-padding + $clr-dropdown-caret-icon-dimension +
           $clr-dropdown-caret-left-margin;
 
-        cds-icon[shape^='angle'] {
+        cds-icon[shape^='angle'],
+        clr-icon[shape^='angle'] {
           right: $clr-btn-horizontal-padding;
         }
       }
@@ -53,7 +55,8 @@
           $clr-dropdown-active-text-color,
           $clr-use-custom-properties
         );
-        cds-icon[shape^='angle'] {
+        cds-icon[shape^='angle'],
+        clr-icon[shape^='angle'] {
           right: 0;
         }
       }

--- a/packages/angular/projects/clr-angular/src/popover/signpost/_signposts.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/popover/signpost/_signposts.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -18,7 +18,8 @@
       padding: 0;
       @include css-var(color, clr-signpost-action-color, $clr-signpost-action-color, $clr-use-custom-properties);
 
-      cds-icon {
+      cds-icon,
+      clr-icon {
         @include equilateral($clr_baselineRem_1);
       }
 
@@ -33,8 +34,11 @@
       }
     }
 
-    .signpost-content-header button cds-icon {
-      @include equilateral($clr_baselineRem_0_667);
+    .signpost-content-header button {
+      cds-icon,
+      clr-icon {
+        @include equilateral($clr_baselineRem_0_667);
+      }
     }
   }
 

--- a/packages/angular/projects/clr-angular/src/popover/tooltip/_tooltips.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/popover/tooltip/_tooltips.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -215,8 +215,10 @@
       margin-right: 0;
     }
 
-    cds-icon > svg {
-      pointer-events: none;
+    & {
+      > svg {
+        pointer-events: none;
+      }
     }
   }
 

--- a/packages/angular/projects/clr-angular/src/timeline/_timeline.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/timeline/_timeline.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -17,11 +17,13 @@
     min-width: $clr-timeline-step-min-width;
     margin-left: $clr-timeline-gutter-width;
 
-    cds-icon {
+    cds-icon,
+    clr-icon {
       @include min-equilateral($clr-timeline-icon-size);
     }
 
-    cds-icon[shape='circle'] {
+    cds-icon[shape='circle'],
+    clr-icon[shape='circle'] {
       @include css-var(
         color,
         clr-timeline-incomplete-step-color,
@@ -30,7 +32,8 @@
       );
     }
 
-    cds-icon[shape='dot-circle'] {
+    cds-icon[shape='dot-circle'],
+    clr-icon[shape='dot-circle'] {
       @include css-var(
         color,
         clr-timeline-current-step-color,
@@ -39,7 +42,8 @@
       );
     }
 
-    cds-icon[shape='success-standard'] {
+    cds-icon[shape='success-standard'],
+    clr-icon[shape='success-standard'] {
       @include css-var(
         color,
         clr-timeline-success-step-color,
@@ -48,7 +52,8 @@
       );
     }
 
-    cds-icon[shape='error-standard'] {
+    cds-icon[shape='error-standard'],
+    clr-icon[shape='error-standard'] {
       @include css-var(
         color,
         clr-timeline-error-step-color,

--- a/packages/angular/projects/clr-angular/src/utils/_close.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/utils/_close.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -22,7 +22,8 @@
     line-height: inherit;
     @include css-var(color, unquote('clr-close-color--normal'), $clr-close-color--normal, $clr-use-custom-properties);
 
-    cds-icon {
+    cds-icon,
+    clr-icon {
       @include css-var(fill, unquote('clr-close-color--normal'), $clr-close-color--normal, $clr-use-custom-properties);
     }
 
@@ -32,7 +33,8 @@
       opacity: 1;
       @include css-var(color, unquote('clr-close-color--hover'), $clr-close-color--hover, $clr-use-custom-properties);
 
-      cds-icon {
+      cds-icon,
+      clr-icon {
         @include css-var(fill, unquote('clr-close-color--hover'), $clr-close-color--hover, $clr-use-custom-properties);
       }
     }

--- a/packages/angular/projects/clr-angular/src/utils/_theme.dark.icons.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/utils/_theme.dark.icons.clarity.scss
@@ -1,6 +1,37 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
+
+/**
+ * TODO: Remove after v7 is released
+ *
+ * This one is left for backwards compatibility
+ */
+clr-icon {
+  &.is-green,
+  &.is-success {
+    fill: $clr-icon-color-success;
+  }
+  &.is-red,
+  &.is-danger,
+  &.is-error {
+    fill: $clr-icon-color-error;
+  }
+  &.is-warning {
+    fill: $clr-icon-color-warning;
+  }
+  &.is-blue,
+  &.is-info {
+    fill: $clr-icon-color-info;
+  }
+  &.is-white,
+  &.is-inverse {
+    fill: $clr-icon-color-inverse;
+  }
+  &.is-highlight {
+    fill: $clr-icon-color-highlight;
+  }
+}
 
 cds-icon {
   &[status='success'] {

--- a/packages/angular/projects/clr-angular/src/wizard/_wizard.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/wizard/_wizard.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -143,7 +143,8 @@
         );
       }
 
-      cds-icon {
+      cds-icon,
+      clr-icon {
         @include equilateral($clr-wizard-default-space - $clr_baselineRem_2px);
       }
     }


### PR DESCRIPTION
In order to keep the icons backward compatibility in v5, we need to get back the styles that affect the deprecated icons so people have time to switch to Clarity Core Icons. 

This fix only affects people that are using the static versions of the components we have. 

We saw such behavior in the timeline component in our website that we had to fix by switching to `cds-icon` in #5539

Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Static implementations will receive strange icon behavior because of missing CSS.

## What is the new behavior?

Static implementations will look as they should be in versions 4, 3, and 2.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
