### PR TITLE
fix(accordion): fix Safari flex gap issue overflow

### DIFF
--- a/packages/core/src/accordion/accordion-header.element.scss
+++ b/packages/core/src/accordion/accordion-header.element.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -27,6 +27,10 @@
     font-size: var(--font-size);
     font-weight: var(--font-weight);
   }
+}
+
+:host([_nfg]) {
+  overflow: hidden;
 }
 
 :host(:hover) {


### PR DESCRIPTION
Added an overflow hidden to the containing header element, which is only applied when _nfg is present.

Verified that this does not prevent content inside the accordion header from wrapping. There is no unintended cutoff.

Tested in:
✔︎ Chrome
✔︎ Safari
✔︎ Edge

Fixes: #5588

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5588 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
