### PR TITLE
fix: core accordion register icon element

### DIFF
--- a/packages/core/src/accordion/register.ts
+++ b/packages/core/src/accordion/register.ts
@@ -10,6 +10,7 @@ import { CdsAccordionContent } from './accordion-content.element.js';
 import { CdsAccordionHeader } from './accordion-header.element.js';
 import { ClarityIcons } from '@cds/core/icon/icon.service.js';
 import { angleIcon } from '@cds/core/icon/shapes/angle.js';
+import '@cds/core/icon/register.js';
 
 registerElementSafely('cds-accordion', CdsAccordion);
 registerElementSafely('cds-accordion-panel', CdsAccordionPanel);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?
Adds missing icon element registry for accordion. If the accordion is loaded independently the icon element would be missing.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No