### PR TITLE
feat: add ESLint rules warning against the usage of @clr/angular components

### DIFF
--- a/packages/eslint-plugin-clarity-adoption/README.md
+++ b/packages/eslint-plugin-clarity-adoption/README.md
@@ -26,7 +26,18 @@ Configure in your ESLint config file like you see below. The overrides section i
     "@clr/clarity-adoption/no-clr-badge": "warn",
     "@clr/clarity-adoption/no-clr-button": "warn",
     "@clr/clarity-adoption/no-clr-checkbox": "warn",
-    "@clr/clarity-adoption/no-clr-icon": "warn"
+    "@clr/clarity-adoption/no-clr-datalist": "warn",
+    "@clr/clarity-adoption/no-clr-form": "warn",
+    "@clr/clarity-adoption/no-clr-icon": "warn",
+    "@clr/clarity-adoption/no-clr-input": "warn",
+    "@clr/clarity-adoption/no-clr-list": "warn",
+    "@clr/clarity-adoption/no-clr-modal": "warn",
+    "@clr/clarity-adoption/no-clr-password": "warn",
+    "@clr/clarity-adoption/no-clr-radio": "warn",
+    "@clr/clarity-adoption/no-clr-range": "warn",
+    "@clr/clarity-adoption/no-clr-select": "warn",
+    "@clr/clarity-adoption/no-clr-textarea": "warn",
+    "@clr/clarity-adoption/no-clr-toggle": "warn"
   },
   "overrides": [
     {
@@ -89,7 +100,18 @@ yarn add -D @typescript-eslint/parser eslint
     "@clr/clarity-adoption/no-clr-badge": "warn",
     "@clr/clarity-adoption/no-clr-button": "warn",
     "@clr/clarity-adoption/no-clr-checkbox": "warn",
-    "@clr/clarity-adoption/no-clr-icon": "warn"
+    "@clr/clarity-adoption/no-clr-datalist": "warn",
+    "@clr/clarity-adoption/no-clr-form": "warn",
+    "@clr/clarity-adoption/no-clr-icon": "warn",
+    "@clr/clarity-adoption/no-clr-input": "warn",
+    "@clr/clarity-adoption/no-clr-list": "warn",
+    "@clr/clarity-adoption/no-clr-modal": "warn",
+    "@clr/clarity-adoption/no-clr-password": "warn",
+    "@clr/clarity-adoption/no-clr-radio": "warn",
+    "@clr/clarity-adoption/no-clr-range": "warn",
+    "@clr/clarity-adoption/no-clr-select": "warn",
+    "@clr/clarity-adoption/no-clr-textarea": "warn",
+    "@clr/clarity-adoption/no-clr-toggle": "warn"
   },
   "overrides": [
     {

--- a/packages/eslint-plugin-clarity-adoption/docs/rules/no-clr-datalist.md
+++ b/packages/eslint-plugin-clarity-adoption/docs/rules/no-clr-datalist.md
@@ -1,0 +1,29 @@
+# Disallows usage of Clarity Angular datalist (no-clr-datalist)
+
+The use of Clarity Angular datalist is discouraged. Use Clarity Core datalist instead.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```html
+<clr-datalist-container>
+  <label>label</label>
+  <input clrDatalistInput [(ngModel)]="vertical" placeholder="placeholder text" />
+  <datalist>
+    <option *ngFor="let item of items" [value]="item"></option>
+  </datalist>
+</clr-datalist-container>
+```
+
+Examples of **correct** code for this rule:
+
+```html
+<cds-datalist control-width="shrink">
+  <label>datalist</label>
+  <input placeholder="placeholder text" />
+  <datalist>
+    <option *ngFor="let item of items" [value]="item"></option>
+  </datalist>
+</cds-datalist>
+```

--- a/packages/eslint-plugin-clarity-adoption/docs/rules/no-clr-form.md
+++ b/packages/eslint-plugin-clarity-adoption/docs/rules/no-clr-form.md
@@ -1,0 +1,29 @@
+# Disallows usage of Clarity Angular form (no-clr-form)
+
+The use of Clarity Angular form is discouraged. Use Clarity Core form instead.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```html
+<form clrForm>
+  <clr-input-container>
+    <label>input</label>
+    <input clrInput />
+  </clr-input-container>
+</form>
+```
+
+Examples of **correct** code for this rule:
+
+```html
+<form>
+  <cds-form-group>
+    <cds-input>
+      <label>input</label>
+      <input type="text" />
+    </cds-input>
+  </cds-form-group>
+</form>
+```

--- a/packages/eslint-plugin-clarity-adoption/docs/rules/no-clr-icon.md
+++ b/packages/eslint-plugin-clarity-adoption/docs/rules/no-clr-icon.md
@@ -1,6 +1,6 @@
-# Disallows usage of Clarity Angular icons (no-clr-icon)
+# Disallows usage of Clarity Angular icon (no-clr-icon)
 
-The use of Clarity Angular icons is discouraged. Use Clarity Core icons instead.
+The use of Clarity Angular icon is discouraged. Use Clarity Core icon instead.
 
 ## Rule Details
 

--- a/packages/eslint-plugin-clarity-adoption/docs/rules/no-clr-input.md
+++ b/packages/eslint-plugin-clarity-adoption/docs/rules/no-clr-input.md
@@ -1,0 +1,23 @@
+# Disallows usage of Clarity Angular input (no-clr-input)
+
+The use of Clarity Angular input is discouraged. Use Clarity Core input instead.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```html
+<clr-input-container>
+  <label>input</label>
+  <input clrInput />
+</clr-input-container>
+```
+
+Examples of **correct** code for this rule:
+
+```html
+<cds-input>
+  <label>input</label>
+  <input type="text" />
+</cds-input>
+```

--- a/packages/eslint-plugin-clarity-adoption/docs/rules/no-clr-list.md
+++ b/packages/eslint-plugin-clarity-adoption/docs/rules/no-clr-list.md
@@ -1,0 +1,25 @@
+# Disallows usage of Clarity Angular list (no-clr-list)
+
+The use of Clarity Angular list is discouraged. Use Clarity Core list instead.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```html
+<ul class="list">
+  <li>One</li>
+  <li>Two</li>
+  <li>Three</li>
+</ul>
+```
+
+Examples of **correct** code for this rule:
+
+```html
+<ul cds-list>
+  <li>One</li>
+  <li>Two</li>
+  <li>Three</li>
+</ul>
+```

--- a/packages/eslint-plugin-clarity-adoption/docs/rules/no-clr-modal.md
+++ b/packages/eslint-plugin-clarity-adoption/docs/rules/no-clr-modal.md
@@ -1,0 +1,37 @@
+# Disallows usage of Clarity Angular modal (no-clr-modal)
+
+The use of Clarity Angular modal is discouraged. Use Clarity Core modal instead.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```html
+<clr-modal [(clrModalOpen)]="openModal">
+  <h3 class="modal-title">I have a nice title</h3>
+  <div class="modal-body">
+    <p>But not much to say...</p>
+  </div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-outline" (click)="openModal = false">Cancel</button>
+    <button type="button" class="btn btn-primary" (click)="openModal = false">Ok</button>
+  </div>
+</clr-modal>
+```
+
+Examples of **correct** code for this rule:
+
+```html
+<cds-modal>
+  <cds-modal-header>
+    <h3 cds-text="title">I have a nice title</h3>
+  </cds-modal-header>
+  <cds-modal-content>
+    <p cds-text="body">But not much to say...</p>
+  </cds-modal-content>
+  <cds-modal-actions>
+    <cds-button action="outline">Cancel</cds-button>
+    <cds-button>Ok</cds-button>
+  </cds-modal-actions>
+</cds-modal>
+```

--- a/packages/eslint-plugin-clarity-adoption/docs/rules/no-clr-password.md
+++ b/packages/eslint-plugin-clarity-adoption/docs/rules/no-clr-password.md
@@ -1,0 +1,23 @@
+# Disallows usage of Clarity Angular password (no-clr-password)
+
+The use of Clarity Angular password is discouraged. Use Clarity Core password instead.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```html
+<clr-password-container>
+  <label>password</label>
+  <input clrPassword placeholder="Password" name="password" [(ngModel)]="exampleOne" />
+</clr-password-container>
+```
+
+Examples of **correct** code for this rule:
+
+```html
+<cds-password>
+  <label>password</label>
+  <input type="password" />
+</cds-password>
+```

--- a/packages/eslint-plugin-clarity-adoption/docs/rules/no-clr-radio.md
+++ b/packages/eslint-plugin-clarity-adoption/docs/rules/no-clr-radio.md
@@ -1,0 +1,37 @@
+# Disallows usage of Clarity Angular radio (no-clr-radio)
+
+The use of Clarity Angular radio is discouraged. Use Clarity Core radio instead.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```html
+<clr-radio-container clrInline>
+  <label>radio group</label>
+  <clr-radio-wrapper>
+    <input type="radio" clrRadio name="options" required value="option1" [(ngModel)]="options" />
+    <label>radio 1</label>
+  </clr-radio-wrapper>
+  <clr-radio-wrapper>
+    <input type="radio" clrRadio name="options" required value="option2" [(ngModel)]="options" />
+    <label>radio 2</label>
+  </clr-radio-wrapper>
+</clr-radio-container>
+```
+
+Examples of **correct** code for this rule:
+
+```html
+<cds-radio-group>
+  <label>radio group</label>
+  <cds-radio>
+    <label>radio 1</label>
+    <input type="radio" checked />
+  </cds-radio>
+  <cds-radio>
+    <label>radio 2</label>
+    <input type="radio" />
+  </cds-radio>
+</cds-radio-group>
+```

--- a/packages/eslint-plugin-clarity-adoption/docs/rules/no-clr-range.md
+++ b/packages/eslint-plugin-clarity-adoption/docs/rules/no-clr-range.md
@@ -1,0 +1,23 @@
+# Disallows usage of Clarity Angular range (no-clr-range)
+
+The use of Clarity Angular range is discouraged. Use Clarity Core range instead.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```html
+<clr-range-container>
+  <label>range</label>
+  <input type="range" clrRange min="60" max="80" />
+</clr-range-container>
+```
+
+Examples of **correct** code for this rule:
+
+```html
+<cds-range>
+  <label>range</label>
+  <input type="range" min="60" max="80" />
+</cds-range>
+```

--- a/packages/eslint-plugin-clarity-adoption/docs/rules/no-clr-select.md
+++ b/packages/eslint-plugin-clarity-adoption/docs/rules/no-clr-select.md
@@ -1,0 +1,27 @@
+# Disallows usage of Clarity Angular select (no-clr-select)
+
+The use of Clarity Angular select is discouraged. Use Clarity Core select instead.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```html
+<select clrSelect name="options" [(ngModel)]="options">
+  <option value="one">One</option>
+  <option value="two">Two</option>
+  <option value="three">Three</option>
+</select>
+```
+
+Examples of **correct** code for this rule:
+
+```html
+<cds-select control-width="shrink">
+  <select>
+    <option>One</option>
+    <option>Two</option>
+    <option>Three</option>
+  </select>
+</cds-select>
+```

--- a/packages/eslint-plugin-clarity-adoption/docs/rules/no-clr-textarea.md
+++ b/packages/eslint-plugin-clarity-adoption/docs/rules/no-clr-textarea.md
@@ -1,0 +1,23 @@
+# Disallows usage of Clarity Angular textarea (no-clr-textarea)
+
+The use of Clarity Angular textarea is discouraged. Use Clarity Core textarea instead.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```html
+<clr-textarea-container>
+  <label>textarea</label>
+  <textarea clrTextarea [(ngModel)]="description"></textarea>
+</clr-textarea-container>
+```
+
+Examples of **correct** code for this rule:
+
+```html
+<cds-textarea control-width="shrink">
+  <label>textarea</label>
+  <textarea></textarea>
+</cds-textarea>
+```

--- a/packages/eslint-plugin-clarity-adoption/docs/rules/no-clr-toggle.md
+++ b/packages/eslint-plugin-clarity-adoption/docs/rules/no-clr-toggle.md
@@ -1,0 +1,23 @@
+# Disallows usage of Clarity Angular toggle (no-clr-toggle)
+
+The use of Clarity Angular toggle is discouraged. Use Clarity Core toggle instead.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```html
+<clr-toggle-wrapper>
+  <input type="checkbox" clrToggle />
+  <label>toggle</label>
+</clr-toggle-wrapper>
+```
+
+Examples of **correct** code for this rule:
+
+```html
+<cds-toggle>
+  <label>toggle</label>
+  <input type="checkbox" checked />
+</cds-toggle>
+```

--- a/packages/eslint-plugin-clarity-adoption/package.json
+++ b/packages/eslint-plugin-clarity-adoption/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "build": "npm-run-all build:tsc build:package",
-    "build:package": "cpy package.json README.md ../../dist/eslint-plugin-clarity-adoption/;",
+    "build:package": "cpy package.json README.md ../../dist/eslint-plugin-clarity-adoption/; cpy docs/ ../../dist/eslint-plugin-clarity-adoption/docs/",
     "build:tsc": "tsc",
     "watch": "tsc -w",
     "lint": "npm run lint:src && npm run lint:test",

--- a/packages/eslint-plugin-clarity-adoption/src/index.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/index.ts
@@ -3,7 +3,18 @@ import noClrAlert from './rules/no-clr-alert';
 import noClrBadge from './rules/no-clr-badge';
 import noClrButton from './rules/no-clr-button';
 import noClrCheckbox from './rules/no-clr-checkbox';
+import noClrDatalist from './rules/no-clr-datalist';
+import noClrForm from './rules/no-clr-form';
 import noClrIcon from './rules/no-clr-icon';
+import noClrInput from './rules/no-clr-input';
+import noClrList from './rules/no-clr-list';
+import noClrModal from './rules/no-clr-modal';
+import noClrPassword from './rules/no-clr-password';
+import noClrRadio from './rules/no-clr-radio';
+import noClrRange from './rules/no-clr-range';
+import noClrSelect from './rules/no-clr-select';
+import noClrTextarea from './rules/no-clr-textarea';
+import noClrToggle from './rules/no-clr-toggle';
 
 module.exports = {
   rules: {
@@ -12,6 +23,17 @@ module.exports = {
     'no-clr-badge': noClrBadge,
     'no-clr-button': noClrButton,
     'no-clr-checkbox': noClrCheckbox,
+    'no-clr-datalist': noClrDatalist,
+    'no-clr-form': noClrForm,
     'no-clr-icon': noClrIcon,
+    'no-clr-input': noClrInput,
+    'no-clr-list': noClrList,
+    'no-clr-modal': noClrModal,
+    'no-clr-password': noClrPassword,
+    'no-clr-radio': noClrRadio,
+    'no-clr-range': noClrRange,
+    'no-clr-select': noClrSelect,
+    'no-clr-textarea': noClrTextarea,
+    'no-clr-toggle': noClrToggle,
   },
 };

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-datalist/index.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-datalist/index.ts
@@ -1,0 +1,39 @@
+import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { HTMLElement } from '../../types/index';
+import { lintDecoratorTemplate } from '../decorator-template-helper';
+
+export const createESLintRule = ESLintUtils.RuleCreator(() => ``);
+export type MessageIds = 'clrDatalistFailure';
+
+const disallowedTag = `clr-datalist-container`;
+
+export default createESLintRule({
+  name: 'no-clr-datalist',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow use of clr-datalist',
+      category: 'Best Practices',
+      recommended: 'warn',
+    },
+    fixable: 'code',
+    messages: {
+      clrDatalistFailure: 'Using clr-datalist is not allowed!',
+    },
+    schema: [{}],
+  },
+  defaultOptions: [{}],
+  create(context) {
+    return {
+      [`HTMLElement[tagName="${disallowedTag}"]`](node: HTMLElement): void {
+        context.report({
+          node: node as any,
+          messageId: 'clrDatalistFailure',
+        });
+      },
+      'ClassDeclaration > Decorator'(node: TSESTree.Decorator): void {
+        lintDecoratorTemplate(context, node, disallowedTag, 'clrDatalistFailure');
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-datalist/no-clr-datalist.spec.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-datalist/no-clr-datalist.spec.ts
@@ -1,0 +1,101 @@
+import rule from './index';
+import { getHtmlRuleTester, getInvalidTestFactory, getTsRuleTester } from '../../test-helper.spec';
+
+const tsRuleTester = getTsRuleTester();
+const htmlRuleTester = getHtmlRuleTester();
+
+const getInvalidDatalistTest = getInvalidTestFactory('clrDatalistFailure');
+
+htmlRuleTester.run('no-clr-datalist', rule, {
+  invalid: [
+    getInvalidDatalistTest({
+      code: `<clr-datalist-container>
+        <input clrDatalistInput [(ngModel)]="vertical" placeholder="No label" name="Option" />
+        <datalist>
+          <option *ngFor="let item of items" [value]="item"></option>
+        </datalist>
+      </clr-datalist-container>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidDatalistTest({
+      code: `
+        <div></div>
+        <clr-datalist-container>
+          <input clrDatalistInput [(ngModel)]="vertical" placeholder="No label" name="Option" />
+          <datalist>
+            <option *ngFor="let item of items" [value]="item"></option>
+          </datalist>
+        </clr-datalist-container>
+      `,
+      locations: [{ line: 3, column: 9 }],
+    }),
+    getInvalidDatalistTest({
+      code: `
+        <div>
+          <clr-datalist-container>
+            <input clrDatalistInput [(ngModel)]="vertical" placeholder="No label" name="Option" />
+            <datalist>
+              <option *ngFor="let item of items" [value]="item"></option>
+            </datalist>
+          </clr-datalist-container>
+        </div>
+      `,
+      locations: [{ line: 3, column: 11 }],
+    }),
+    getInvalidDatalistTest({
+      code: `
+        <div>
+          <clr-datalist-container>
+            <input clrDatalistInput [(ngModel)]="vertical" placeholder="No label" name="Option" />
+            <datalist>
+              <option *ngFor="let item of items" [value]="item"></option>
+            </datalist>
+          </clr-datalist-container>
+        </div>
+        <clr-datalist-container></clr-datalist-container>
+      `,
+      locations: [
+        { line: 3, column: 11 },
+        { line: 10, column: 9 },
+      ],
+    }),
+  ],
+  valid: [`<datalist></datalist>`, `<input clrDatalistInput>`],
+});
+
+tsRuleTester.run('no-clr-datalist', rule, {
+  invalid: [
+    getInvalidDatalistTest({
+      code: `
+      @Component({
+        template: \`
+          <clr-datalist-container>
+            <input clrDatalistInput [(ngModel)]="vertical" placeholder="No label" name="Option" />
+            <datalist>
+              <option *ngFor="let item of items" [value]="item"></option>
+            </datalist>
+          </clr-datalist-container>
+        \`
+      })
+      export class CustomDatalistComponent {}
+      `,
+      locations: [{ line: 4, column: 11 }],
+    }),
+  ],
+  valid: [
+    `
+    @Component({
+      selector: 'app-custom-datalist',
+      template: \`
+        <datalist></datalist>
+      \`
+      })
+      export class CustomDatalistComponent {
+        // Should we catch that case?
+        const myDatalist = \`
+          <clr-datalist></clr-datalist>
+        \`;
+      }
+    `,
+  ],
+});

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-form/index.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-form/index.ts
@@ -1,0 +1,50 @@
+import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { HTMLElement } from '../../types/index';
+import { lintDecoratorTemplate } from '../decorator-template-helper';
+
+export const createESLintRule = ESLintUtils.RuleCreator(() => ``);
+export type MessageIds = 'clrFormFailure';
+
+const disallowedTag = 'form';
+const disallowedAttribute = 'clrForm';
+const disallowedClass = 'clr-form';
+const disallowedFormElementSelector = `${disallowedTag}[${disallowedAttribute}],${disallowedTag}.${disallowedClass}`;
+
+export default createESLintRule({
+  name: 'no-clr-form',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow use of clr-form',
+      category: 'Best Practices',
+      recommended: 'warn',
+    },
+    fixable: 'code',
+    messages: {
+      clrFormFailure: 'Using clr-form is not allowed!',
+    },
+    schema: [{}],
+  },
+  defaultOptions: [{}],
+  create(context) {
+    return {
+      [`HTMLElement[tagName="${disallowedTag}"]`](node: HTMLElement): void {
+        const classNode = node.attributes?.find(attribute => attribute.attributeName.value === 'class');
+        const classes = classNode?.attributeValue?.value?.split(' ') || [];
+
+        const disallowedAttributeNode = node.attributes?.find(
+          attribute => attribute.attributeName.value === disallowedAttribute
+        );
+        if (classes.includes(disallowedClass) || disallowedAttributeNode) {
+          context.report({
+            node: node as any,
+            messageId: 'clrFormFailure',
+          });
+        }
+      },
+      'ClassDeclaration > Decorator'(node: TSESTree.Decorator): void {
+        lintDecoratorTemplate(context, node, disallowedFormElementSelector, 'clrFormFailure');
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-form/no-clr-form.spec.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-form/no-clr-form.spec.ts
@@ -1,0 +1,94 @@
+import rule from './index';
+import { getHtmlRuleTester, getInvalidTestFactory, getTsRuleTester } from '../../test-helper.spec';
+
+const tsRuleTester = getTsRuleTester();
+const htmlRuleTester = getHtmlRuleTester();
+
+const getInvalidFormTest = getInvalidTestFactory('clrFormFailure');
+
+htmlRuleTester.run('no-clr-form', rule, {
+  invalid: [
+    getInvalidFormTest({
+      code: `<form clrForm></form>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidFormTest({
+      code: `
+        <form clrForm>
+          <clr-input-container>
+            <label>My name</label>
+            <input clrInput placeholder="Enter text here!" name="name" [(ngModel)]="name" />
+          </clr-input-container>
+        </form>
+      `,
+      locations: [{ line: 2, column: 9 }],
+    }),
+    getInvalidFormTest({
+      code: `<form class="clr-form"></form>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+  ],
+  valid: [`<form></form>`, `<div clrForm></div>`],
+});
+
+tsRuleTester.run('no-clr-form', rule, {
+  invalid: [
+    getInvalidFormTest({
+      code: `
+      @Component({
+        template: \`
+          <form clrForm>
+            <clr-input-container>
+              <label>My name</label>
+              <input clrInput placeholder="Enter text here!" name="name" [(ngModel)]="name" />
+            </clr-input-container>
+          </form>
+        \`
+      })
+      export class CustomFormComponent {}
+      `,
+      locations: [{ line: 4, column: 11 }],
+    }),
+    getInvalidFormTest({
+      code: `
+      @Component({
+        template: \`
+          <form clrForm></form>
+        \`
+      })
+      export class CustomFormComponent {}
+      `,
+      locations: [{ line: 4, column: 11 }],
+    }),
+
+    getInvalidFormTest({
+      code: `
+      @Component({
+        template: \`
+          <form class="clr-form"></form>
+        \`
+      })
+      export class CustomFormComponent {}
+      `,
+      locations: [{ line: 4, column: 11 }],
+    }),
+  ],
+  valid: [
+    `
+    @Component({
+      template: \`
+        <form></form>
+      \`
+    })
+    export class CustomFormComponent {}
+    `,
+    `
+    @Component({
+      template: \`
+        <div clrForm></div>
+      \`
+    })
+    export class CustomFormComponent {}
+    `,
+  ],
+});

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-icon/no-clr-icon.spec.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-icon/no-clr-icon.spec.ts
@@ -287,6 +287,20 @@ htmlRuleTester.run('no-clr-icon', rule, {
       `,
       locations: [{ line: 3, column: 7 }],
     }),
+
+    /**
+     * Persisting extra attributes
+     */
+    getInvalidAlertTest({
+      code: `<clr-icon *ngIf="true"></clr-icon>`,
+      output: `<cds-icon *ngIf="true"></cds-icon>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidAlertTest({
+      code: `<clr-icon dir="left" *ngIf="true"></clr-icon>`,
+      output: `<cds-icon direction="left" *ngIf="true"></cds-icon>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
   ],
   valid: [],
 });

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-input/index.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-input/index.ts
@@ -1,0 +1,77 @@
+import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { parseDecoratorTemplate, reportNestedDisallowedElements } from '../decorator-template-helper';
+import { HTMLElement } from '../../types/index';
+
+const disallowedClass = 'clr-input';
+const disallowedDirective = 'clrInput';
+const containerTagName = 'clr-input-container';
+
+export const createESLintRule = ESLintUtils.RuleCreator(() => ``);
+const ruleFailureMessage = 'clrInputFailure';
+export type MessageIds = 'clrInputFailure';
+export default createESLintRule({
+  name: 'no-clr-input',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow use of clrInput',
+      category: 'Best Practices',
+      recommended: 'warn',
+    },
+    fixable: 'code',
+    messages: {
+      [ruleFailureMessage]: 'Using clr-input is not allowed!',
+    },
+    schema: [{}],
+  },
+  defaultOptions: [{}],
+  create(context) {
+    return {
+      // report all <clr-input-container> elements
+      [`HTMLElement[tagName="${containerTagName}"]`](node: HTMLElement): void {
+        context.report({
+          node: node as any,
+          messageId: ruleFailureMessage,
+        });
+      },
+
+      // report <input clrInput> elements that AREN'T nested in <clr-input-container> elements
+      [`:not(HTMLElement[tagName="${containerTagName}"]) > HTMLElement[tagName="input"]`](node: HTMLElement): void {
+        const classNode = node.attributes?.find(attribute => attribute.attributeName.value === 'class');
+        const classes = classNode?.attributeValue?.value?.split(' ') || [];
+
+        const disallowedDirectiveNode = node.attributes?.find(
+          attribute => attribute.attributeName.value === disallowedDirective
+        );
+
+        if (classes.includes(disallowedClass) || disallowedDirectiveNode) {
+          context.report({
+            node: node as any,
+            messageId: ruleFailureMessage,
+          });
+        }
+      },
+
+      'ClassDeclaration > Decorator'(node: TSESTree.Decorator): void {
+        const parsedTemplate = parseDecoratorTemplate(node);
+        if (!parsedTemplate) {
+          return;
+        }
+
+        const { dom, templateContentNode } = parsedTemplate;
+
+        // report all <clr-input-container> elements
+        reportNestedDisallowedElements(containerTagName, context, dom, templateContentNode, ruleFailureMessage);
+
+        // report <input clrInput> and <input class="clr-input"> elements that AREN'T nested in <clr-input-container> elements
+        reportNestedDisallowedElements(
+          `:not(${containerTagName}) > input[${disallowedDirective}],input.${disallowedClass}`,
+          context,
+          dom,
+          templateContentNode,
+          ruleFailureMessage
+        );
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-input/no-clr-input.spec.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-input/no-clr-input.spec.ts
@@ -1,0 +1,88 @@
+import rule from './index';
+import { getHtmlRuleTester, getInvalidTestFactory, getTsRuleTester } from '../../test-helper.spec';
+
+const tsRuleTester = getTsRuleTester();
+const htmlRuleTester = getHtmlRuleTester();
+
+const getInvalidInputTest = getInvalidTestFactory('clrInputFailure');
+
+htmlRuleTester.run('no-clr-input', rule, {
+  invalid: [
+    getInvalidInputTest({
+      code: `<input clrInput>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidInputTest({
+      code: `
+        <clr-input-container>
+          <input clrInput>
+        </clr-input-container>
+      `,
+      locations: [{ line: 2, column: 9 }],
+    }),
+
+    getInvalidInputTest({
+      code: `<input class="clr-input">`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+  ],
+  valid: [`<input>`, `<div clrInput></div>`],
+});
+
+tsRuleTester.run('no-clr-input', rule, {
+  invalid: [
+    getInvalidInputTest({
+      code: `
+      @Component({
+        template: \`
+          <input clrInput>
+        \`
+      })
+      export class CustomInputComponent {}
+      `,
+      locations: [{ line: 4, column: 11 }],
+    }),
+    getInvalidInputTest({
+      code: `
+      @Component({
+        template: \`
+          <clr-input-container>
+            <input clrInput>
+          </clr-input-container>
+        \`
+      })
+      export class CustomInputComponent {}
+      `,
+      locations: [{ line: 4, column: 11 }],
+    }),
+    getInvalidInputTest({
+      code: `
+      @Component({
+        template: \`
+          <input class="clr-input">
+        \`
+      })
+      export class CustomInputComponent {}
+      `,
+      locations: [{ line: 4, column: 11 }],
+    }),
+  ],
+  valid: [
+    `
+    @Component({
+      template: \`
+        <input>
+      \`
+    })
+    export class CustomInputComponent {}
+    `,
+    `
+    @Component({
+      template: \`
+        <div clrInput></div>
+      \`
+    })
+    export class CustomInputComponent {}
+    `,
+  ],
+});

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-list/index.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-list/index.ts
@@ -1,0 +1,59 @@
+import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { HTMLElement } from '../../types/index';
+import { lintDecoratorTemplate } from '../decorator-template-helper';
+
+export const createESLintRule = ESLintUtils.RuleCreator(() => ``);
+export type MessageIds = 'clrListFailure';
+
+const disallowedClasses = ['list', 'list-unstyled'];
+
+function hasDisallowedClass(classes: Array<string>): boolean {
+  return disallowedClasses.some(cls => classes.includes(cls));
+}
+const disallowedListElementSelector = disallowedClasses.map(cls => `.${cls}`).join(',');
+
+export default createESLintRule({
+  name: 'no-clr-list',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow use of clr-list',
+      category: 'Best Practices',
+      recommended: 'warn',
+    },
+    fixable: 'code',
+    messages: {
+      clrListFailure: 'Using clr-list is not allowed!',
+    },
+    schema: [{}],
+  },
+  defaultOptions: [{}],
+  create(context) {
+    return {
+      'HTMLElement[tagName="ul"]'(node: HTMLElement): void {
+        const classNode = node.attributes?.find(attribute => attribute.attributeName.value === 'class');
+        const classes = classNode?.attributeValue?.value?.split(' ') || [];
+        if (hasDisallowedClass(classes)) {
+          context.report({
+            node: node as any,
+            messageId: 'clrListFailure',
+          });
+        }
+      },
+      'HTMLElement[tagName="ol"]'(node: HTMLElement): void {
+        const classNode = node.attributes?.find(attribute => attribute.attributeName.value === 'class');
+        const classes = classNode?.attributeValue?.value?.split(' ') || [];
+        if (hasDisallowedClass(classes)) {
+          context.report({
+            node: node as any,
+            messageId: 'clrListFailure',
+          });
+        }
+      },
+
+      'ClassDeclaration > Decorator'(node: TSESTree.Decorator): void {
+        lintDecoratorTemplate(context, node, disallowedListElementSelector, 'clrListFailure');
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-list/no-clr-list.spec.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-list/no-clr-list.spec.ts
@@ -1,0 +1,178 @@
+import rule from './index';
+import { getHtmlRuleTester, getInvalidTestFactory, getTsRuleTester } from '../../test-helper.spec';
+
+const tsRuleTester = getTsRuleTester();
+const htmlRuleTester = getHtmlRuleTester();
+
+const getInvalidListTest = getInvalidTestFactory('clrListFailure');
+
+htmlRuleTester.run('no-clr-list', rule, {
+  invalid: [
+    getInvalidListTest({
+      code: `<ul class="list"></ul>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidListTest({
+      code: `<ul class="list-unstyled"></ul>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidListTest({
+      code: `<ul class="list list-unstyled"></ul>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidListTest({
+      code: `<ul class="list compact"></ul>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidListTest({
+      code: `<ul class="compact list-unstyled"></ul>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidListTest({
+      code: `<ol class="list"></ol>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidListTest({
+      code: `<ol class="list-unstyled"></ol>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidListTest({
+      code: `<ol class="list list-unstyled"></ol>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidListTest({
+      code: `<ol class="list compact"></ol>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidListTest({
+      code: `<ol class="compact list-unstyled"></ol>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+  ],
+  valid: [`<ul class="compact"></ul>`, `<div></div>`],
+});
+
+tsRuleTester.run('no-clr-list', rule, {
+  invalid: [
+    getInvalidListTest({
+      code: `
+      @Component({
+        selector: 'app-custom-list',
+        template: \`
+          <ul class="list"></ul>
+        \`
+      })
+      export class CustomListComponent {
+      }
+      `,
+      locations: [{ line: 5, column: 11 }],
+    }),
+    getInvalidListTest({
+      code: `
+      @Component({
+        selector: 'app-custom-list',
+        template: \`
+          <ul class="list-unstyled"></ul>
+        \`
+      })
+      export class CustomListComponent {
+      }
+      `,
+      locations: [{ line: 5, column: 11 }],
+    }),
+    getInvalidListTest({
+      code: `
+      @Component({
+        selector: 'app-custom-list',
+        template: \`
+          <ul class="list compact"></ul>
+        \`
+      })
+      export class CustomListComponent {
+      }
+      `,
+      locations: [{ line: 5, column: 11 }],
+    }),
+    getInvalidListTest({
+      code: `
+      @Component({
+        selector: 'app-custom-list',
+        template: \`
+          <ul class="list-unstyled compact"></ul>
+        \`
+      })
+      export class CustomListComponent {
+      }
+      `,
+      locations: [{ line: 5, column: 11 }],
+    }),
+    getInvalidListTest({
+      code: `
+      @Component({
+        selector: 'app-custom-list',
+        template: \`
+          <ol class="list"></ol>
+        \`
+      })
+      export class CustomListComponent {
+      }
+      `,
+      locations: [{ line: 5, column: 11 }],
+    }),
+    getInvalidListTest({
+      code: `
+      @Component({
+        selector: 'app-custom-list',
+        template: \`
+          <ol class="list-unstyled"></ol>
+        \`
+      })
+      export class CustomListComponent {
+      }
+      `,
+      locations: [{ line: 5, column: 11 }],
+    }),
+    getInvalidListTest({
+      code: `
+      @Component({
+        selector: 'app-custom-list',
+        template: \`
+          <ol class="list compact"></ol>
+        \`
+      })
+      export class CustomListComponent {
+      }
+      `,
+      locations: [{ line: 5, column: 11 }],
+    }),
+    getInvalidListTest({
+      code: `
+      @Component({
+        selector: 'app-custom-list',
+        template: \`
+          <ol class="list-unstyled compact"></ol>
+        \`
+      })
+      export class CustomListComponent {
+      }
+      `,
+      locations: [{ line: 5, column: 11 }],
+    }),
+  ],
+  valid: [
+    `
+    @Component({
+      selector: 'app-custom-list',
+      template: \`
+        <div></div>
+      \`
+      })
+      export class CustomListComponent {
+        // Should we catch that case?
+        const myList = \`
+          <ol class="list"></ol>
+        \`;
+      }
+    `,
+  ],
+});

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-modal/index.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-modal/index.ts
@@ -1,0 +1,51 @@
+import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { HTMLElement } from '../../types/index';
+import { lintDecoratorTemplate } from '../decorator-template-helper';
+
+export const createESLintRule = ESLintUtils.RuleCreator(() => ``);
+export type MessageIds = 'clrModalFailure';
+
+const disallowedTag = `clr-modal`;
+const disallowedClass = 'modal';
+const disallowedSelector = `${disallowedTag},div.${disallowedClass}`;
+
+export default createESLintRule({
+  name: 'no-clr-modal',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow use of clr-modal',
+      category: 'Best Practices',
+      recommended: 'warn',
+    },
+    fixable: 'code',
+    messages: {
+      clrModalFailure: 'Using clr-modal is not allowed!',
+    },
+    schema: [{}],
+  },
+  defaultOptions: [{}],
+  create(context) {
+    return {
+      [`HTMLElement[tagName="${disallowedTag}"]`](node: HTMLElement): void {
+        context.report({
+          node: node as any,
+          messageId: 'clrModalFailure',
+        });
+      },
+      [`HTMLElement[tagName="div"]`](node: HTMLElement): void {
+        const classNode = node.attributes?.find(attribute => attribute.attributeName.value === 'class');
+        const classes = classNode?.attributeValue?.value?.split(' ') || [];
+        if (classes.includes(disallowedClass)) {
+          context.report({
+            node: node as any,
+            messageId: 'clrModalFailure',
+          });
+        }
+      },
+      'ClassDeclaration > Decorator'(node: TSESTree.Decorator): void {
+        lintDecoratorTemplate(context, node, disallowedSelector, 'clrModalFailure');
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-modal/no-clr-modal.spec.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-modal/no-clr-modal.spec.ts
@@ -1,0 +1,155 @@
+import rule from './index';
+import { getHtmlRuleTester, getInvalidTestFactory, getTsRuleTester } from '../../test-helper.spec';
+
+const tsRuleTester = getTsRuleTester();
+const htmlRuleTester = getHtmlRuleTester();
+
+const getInvalidModalTest = getInvalidTestFactory('clrModalFailure');
+
+htmlRuleTester.run('no-clr-modal', rule, {
+  invalid: [
+    getInvalidModalTest({
+      code: `<div class="modal"></div>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidModalTest({
+      code: `
+        <div class="modal">
+          <div class="modal-dialog modal-sm" role="dialog" aria-hidden="true">
+            <div class="modal-content">
+              ...
+            </div>
+          </div>
+        </div>
+      `,
+      locations: [{ line: 2, column: 9 }],
+    }),
+    getInvalidModalTest({
+      code: `<clr-modal></clr-modal>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidModalTest({
+      code: `
+        <clr-modal [(clrModalOpen)]="openModal">
+          <h3 class="modal-title">I have a nice title</h3>
+          <div class="modal-body">
+            <p>But not much to say...</p>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-outline" (click)="openModal = false">Cancel</button>
+            <button type="button" class="btn btn-primary" (click)="openModal = false">Ok</button>
+          </div>
+        </clr-modal>
+      `,
+      locations: [{ line: 2, column: 9 }],
+    }),
+    getInvalidModalTest({
+      code: `
+        <div></div>
+        <clr-modal></clr-modal>
+      `,
+      locations: [{ line: 3, column: 9 }],
+    }),
+    getInvalidModalTest({
+      code: `
+        <div>
+          <clr-modal></clr-modal>
+        </div>
+      `,
+      locations: [{ line: 3, column: 11 }],
+    }),
+    getInvalidModalTest({
+      code: `
+        <div>
+          <clr-modal></clr-modal>
+        </div>
+        <clr-modal></clr-modal>
+      `,
+      locations: [
+        { line: 3, column: 11 },
+        { line: 5, column: 9 },
+      ],
+    }),
+  ],
+  valid: [],
+});
+
+tsRuleTester.run('no-clr-modal', rule, {
+  invalid: [
+    getInvalidModalTest({
+      code: `
+      @Component({
+        template: \`
+          <clr-modal [(clrModalOpen)]="openModal">
+            <h3 class="modal-title">I have a nice title</h3>
+            <div class="modal-body">
+              <p>But not much to say...</p>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-outline" (click)="openModal = false">Cancel</button>
+              <button type="button" class="btn btn-primary" (click)="openModal = false">Ok</button>
+            </div>
+          </clr-modal>
+        \`
+      })
+      export class CustomModalComponent {}
+      `,
+      locations: [{ line: 4, column: 11 }],
+    }),
+    getInvalidModalTest({
+      code: `
+      @Component({
+        template: \`
+          <div class="modal static"></div>
+        \`
+      })
+      export class CustomModalComponent {}
+      `,
+      locations: [{ line: 4, column: 11 }],
+    }),
+    getInvalidModalTest({
+      code: `
+      @Component({
+        template: \`
+          <div></div>
+          <clr-modal></clr-modal>
+        \`
+      })
+      export class CustomModalComponent {}
+      `,
+      locations: [{ line: 5, column: 11 }],
+    }),
+    getInvalidModalTest({
+      code: `
+      @Component({
+        template: \`
+          <clr-modal></clr-modal>
+          <div></div>
+          <div class="modal"></div>
+        \`
+      })
+      export class CustomModalComponent {}
+      `,
+      locations: [
+        { line: 4, column: 11 },
+        { line: 6, column: 11 },
+      ],
+    }),
+  ],
+  valid: [
+    `
+    @Component({
+      selector: 'app-custom-modal',
+      template: \`
+        <div></div>
+      \`
+      })
+      export class CustomModalComponent {
+        // Should we catch that case?
+        const myModal = \`
+          <clr-modal></clr-modal>
+        \`;
+      }
+    `,
+  ],
+});

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-password/index.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-password/index.ts
@@ -1,0 +1,73 @@
+import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { parseDecoratorTemplate, reportNestedDisallowedElements } from '../decorator-template-helper';
+import { HTMLElement } from '../../types/index';
+
+const disallowedDirective = 'clrPassword';
+const containerTagName = 'clr-password-container';
+
+export const createESLintRule = ESLintUtils.RuleCreator(() => ``);
+const ruleFailureMessage = 'clrPasswordFailure';
+export type MessageIds = 'clrPasswordFailure';
+export default createESLintRule({
+  name: 'no-clr-password',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow use of clrPassword',
+      category: 'Best Practices',
+      recommended: 'warn',
+    },
+    fixable: 'code',
+    messages: {
+      [ruleFailureMessage]: 'Using clr-password is not allowed!',
+    },
+    schema: [{}],
+  },
+  defaultOptions: [{}],
+  create(context) {
+    return {
+      // report all <clr-password-container> elements
+      [`HTMLElement[tagName="${containerTagName}"]`](node: HTMLElement): void {
+        context.report({
+          node: node as any,
+          messageId: ruleFailureMessage,
+        });
+      },
+
+      // report <input clrPassword> elements that AREN'T nested in <clr-password-container> elements
+      [`:not(HTMLElement[tagName="${containerTagName}"]) > HTMLElement[tagName="input"]`](node: HTMLElement): void {
+        const disallowedDirectiveNode = node.attributes?.find(
+          attribute => attribute.attributeName.value === disallowedDirective
+        );
+
+        if (disallowedDirectiveNode) {
+          context.report({
+            node: node as any,
+            messageId: ruleFailureMessage,
+          });
+        }
+      },
+
+      'ClassDeclaration > Decorator'(node: TSESTree.Decorator): void {
+        const parsedTemplate = parseDecoratorTemplate(node);
+        if (!parsedTemplate) {
+          return;
+        }
+
+        const { dom, templateContentNode } = parsedTemplate;
+
+        // report all <clr-password-container> elements
+        reportNestedDisallowedElements(containerTagName, context, dom, templateContentNode, ruleFailureMessage);
+
+        // report <input clrPassword> elements that AREN'T nested in <clr-password-container> elements
+        reportNestedDisallowedElements(
+          `:not(${containerTagName}) > input[${disallowedDirective}]`,
+          context,
+          dom,
+          templateContentNode,
+          ruleFailureMessage
+        );
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-password/no-clr-password.spec.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-password/no-clr-password.spec.ts
@@ -1,0 +1,72 @@
+import rule from './index';
+import { getHtmlRuleTester, getInvalidTestFactory, getTsRuleTester } from '../../test-helper.spec';
+
+const tsRuleTester = getTsRuleTester();
+const htmlRuleTester = getHtmlRuleTester();
+
+const getInvalidPasswordTest = getInvalidTestFactory('clrPasswordFailure');
+
+htmlRuleTester.run('no-clr-password', rule, {
+  invalid: [
+    getInvalidPasswordTest({
+      code: `<input clrPassword placeholder="Password" name="password" [(ngModel)]="exampleOne">`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidPasswordTest({
+      code: `
+        <clr-password-container>
+          <input clrPassword placeholder="Password" name="password" [(ngModel)]="exampleOne">
+        </clr-password-container>
+      `,
+      locations: [{ line: 2, column: 9 }],
+    }),
+  ],
+  valid: [`<input>`, `<div clrPassword></div>`, `<input clrInput>`],
+});
+
+tsRuleTester.run('no-clr-password', rule, {
+  invalid: [
+    getInvalidPasswordTest({
+      code: `
+      @Component({
+        template: \`
+          <input clrPassword placeholder="Password" name="password" [(ngModel)]="exampleOne">
+        \`
+      })
+      export class CustomPasswordComponent {}
+      `,
+      locations: [{ line: 4, column: 11 }],
+    }),
+    getInvalidPasswordTest({
+      code: `
+      @Component({
+        template: \`
+          <clr-password-container>
+            <input clrPassword placeholder="Password" name="password" [(ngModel)]="exampleOne">
+          </clr-password-container>
+        \`
+      })
+      export class CustomPasswordComponent {}
+      `,
+      locations: [{ line: 4, column: 11 }],
+    }),
+  ],
+  valid: [
+    `
+    @Component({
+      template: \`
+        <input>
+      \`
+    })
+    export class CustomPasswordComponent {}
+    `,
+    `
+    @Component({
+      template: \`
+        <div clrPassword></div>
+      \`
+    })
+    export class CustomPasswordComponent {}
+    `,
+  ],
+});

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-radio/index.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-radio/index.ts
@@ -1,0 +1,90 @@
+import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { parseDecoratorTemplate, reportNestedDisallowedElements } from '../decorator-template-helper';
+import { HTMLElement } from '../../types/index';
+
+const disallowedDirective = 'clrRadio';
+const wrapperTagName = 'clr-radio-wrapper';
+const containerTagName = 'clr-radio-container';
+
+export const createESLintRule = ESLintUtils.RuleCreator(() => ``);
+const ruleFailureMessage = 'clrRadioFailure';
+export type MessageIds = 'clrRadioFailure';
+export default createESLintRule({
+  name: 'no-clr-radio',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow use of clrRadio',
+      category: 'Best Practices',
+      recommended: 'warn',
+    },
+    fixable: 'code',
+    messages: {
+      [ruleFailureMessage]: 'Using clr-radio is not allowed!',
+    },
+    schema: [{}],
+  },
+  defaultOptions: [{}],
+  create(context) {
+    return {
+      // report all <clr-radio-container> elements
+      [`HTMLElement[tagName="${containerTagName}"]`](node: HTMLElement): void {
+        context.report({
+          node: node as any,
+          messageId: ruleFailureMessage,
+        });
+      },
+      // report <clr-radio-wrapper> elements that AREN'T nested in <clr-radio-container> elements
+      [`:not(HTMLElement[tagName="${containerTagName}"]) > HTMLElement[tagName="${wrapperTagName}"]`](
+        node: HTMLElement
+      ): void {
+        context.report({
+          node: node as any,
+          messageId: ruleFailureMessage,
+        });
+      },
+      // report <input clrRadio> elements that AREN'T nested in <clr-radio-wrapper> elements
+      [`:not(HTMLElement[tagName="${wrapperTagName}"]) > HTMLElement[tagName="input"]`](node: HTMLElement): void {
+        const disallowedDirectiveNode = node.attributes?.find(
+          attribute => attribute.attributeName.value === disallowedDirective
+        );
+
+        if (disallowedDirectiveNode) {
+          context.report({
+            node: node as any,
+            messageId: ruleFailureMessage,
+          });
+        }
+      },
+      'ClassDeclaration > Decorator'(node: TSESTree.Decorator): void {
+        const parsedTemplate = parseDecoratorTemplate(node);
+        if (!parsedTemplate) {
+          return;
+        }
+
+        const { dom, templateContentNode } = parsedTemplate;
+
+        // report all <clr-radio-container> elements
+        reportNestedDisallowedElements(containerTagName, context, dom, templateContentNode, ruleFailureMessage);
+
+        // report <clr-radio-wrapper> elements that AREN'T nested in <clr-radio-container> elements
+        reportNestedDisallowedElements(
+          `:not(${containerTagName}) > ${wrapperTagName}`,
+          context,
+          dom,
+          templateContentNode,
+          ruleFailureMessage
+        );
+
+        // report <input clrRadio> elements that AREN'T nested in <clr-radio-wrapper> elements
+        reportNestedDisallowedElements(
+          `:not(${wrapperTagName}) > input[${disallowedDirective}]`,
+          context,
+          dom,
+          templateContentNode,
+          ruleFailureMessage
+        );
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-radio/no-clr-radio.spec.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-radio/no-clr-radio.spec.ts
@@ -1,0 +1,218 @@
+import rule from './index';
+import { getHtmlRuleTester, getInvalidTestFactory, getTsRuleTester } from '../../test-helper.spec';
+
+const tsRuleTester = getTsRuleTester();
+const htmlRuleTester = getHtmlRuleTester();
+
+const getInvalidClrRadioTest = getInvalidTestFactory('clrRadioFailure');
+
+htmlRuleTester.run('no-clr-radio', rule, {
+  invalid: [
+    getInvalidClrRadioTest({
+      code: `<input type="radio" clrRadio />`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidClrRadioTest({
+      code: `
+        <div></div>
+        <input type="radio" clrRadio />
+        <div></div>
+        <div><input type="radio" clrRadio /></div>
+        <input type="radio" clrRadio />
+      `,
+      locations: [
+        { line: 3, column: 9 },
+        { line: 5, column: 14 },
+        { line: 6, column: 9 },
+      ],
+    }),
+    getInvalidClrRadioTest({
+      code: `
+        <clr-radio-wrapper>
+          <input type="radio" clrRadio />
+          <label>Test</label>
+        </clr-radio-wrapper>
+      `,
+      locations: [{ line: 2, column: 9 }],
+    }),
+    getInvalidClrRadioTest({
+      code: `
+        <clr-radio-container clrInline *ngIf="showRadioButtons">
+          <clr-radio-wrapper *ngIf="scopeTypes.includes(ScopeType.Organization)">
+              <input type="radio" clrRadio name="options" [value]="ScopeType.Organization" [(ngModel)]="defaultOption"
+                  (ngModelChange)="emitSelection()" />
+              <label>Organization</label>
+          </clr-radio-wrapper>
+          <clr-radio-wrapper *ngIf="scopeTypes.includes(ScopeType.Projects)">
+              <input type="radio" clrRadio name="options" [value]="ScopeType.Projects" [(ngModel)]="defaultOption"
+                  (ngModelChange)="emitSelection()"/>
+              <label>Projects</label>
+          </clr-radio-wrapper>
+          <clr-radio-wrapper *ngIf="scopeTypes.includes(ScopeType.CloudAccounts)">
+              <input type="radio" clrRadio name="options" [value]="ScopeType.CloudAccounts" [(ngModel)]="defaultOption"
+                  (ngModelChange)="emitSelection()"/>
+              <label data-test="scope-selector-cloud-accounts">Cloud Accounts</label>
+          </clr-radio-wrapper>
+        </clr-radio-container>
+      `,
+      locations: [{ line: 2, column: 9 }],
+    }),
+
+    getInvalidClrRadioTest({
+      code: `
+        <div>
+          <div>
+            <clr-radio-wrapper>
+              <input type="radio" clrRadio />
+              <label>Test</label>
+            </clr-radio-wrapper>
+          </div>
+          <div></div>
+          <input type="radio" clrRadio />
+          <div></div>
+          <clr-radio-container clrInline *ngIf="showRadioButtons">
+            <clr-radio-wrapper *ngIf="scopeTypes.includes(ScopeType.Organization)">
+                <input type="radio" clrRadio name="options" [value]="ScopeType.Organization" [(ngModel)]="defaultOption"
+                    (ngModelChange)="emitSelection()" />
+                <label>Organization</label>
+            </clr-radio-wrapper>
+            <clr-radio-wrapper *ngIf="scopeTypes.includes(ScopeType.Projects)">
+                <input type="radio" clrRadio name="options" [value]="ScopeType.Projects" [(ngModel)]="defaultOption"
+                    (ngModelChange)="emitSelection()"/>
+                <label>Projects</label>
+            </clr-radio-wrapper>
+            <clr-radio-wrapper *ngIf="scopeTypes.includes(ScopeType.CloudAccounts)">
+                <input type="radio" clrRadio name="options" [value]="ScopeType.CloudAccounts" [(ngModel)]="defaultOption"
+                    (ngModelChange)="emitSelection()"/>
+                <label data-test="scope-selector-cloud-accounts">Cloud Accounts</label>
+            </clr-radio-wrapper>
+          </clr-radio-container>
+        </div>
+      `,
+      locations: [
+        { line: 4, column: 13 },
+        { line: 10, column: 11 },
+        { line: 12, column: 11 },
+      ],
+    }),
+  ],
+  valid: [`<input type="radio"></input>`],
+});
+
+tsRuleTester.run('no-clr-radio', rule, {
+  invalid: [
+    getInvalidClrRadioTest({
+      code: `
+        @Component({
+          selector: 'app-home',
+          template: \`
+            <input type="radio" clrRadio />
+          \`
+          })
+          export class HomeComponent {
+        }
+      `,
+      locations: [{ line: 5, column: 13 }],
+    }),
+    getInvalidClrRadioTest({
+      code: `
+        @Component({
+          selector: 'app-home',
+          template: \`
+            <clr-radio-wrapper>
+              <input type="radio" clrRadio />
+              <label>Test</label>
+            </clr-radio-wrapper>
+          \`
+          })
+          export class HomeComponent {
+        }
+      `,
+      locations: [{ line: 5, column: 13 }],
+    }),
+    getInvalidClrRadioTest({
+      code: `
+        @Component({
+          selector: 'app-home',
+          template: \`
+            <clr-radio-container clrInline *ngIf="showRadioButtons">
+              <clr-radio-wrapper *ngIf="scopeTypes.includes(ScopeType.Organization)">
+                  <input type="radio" clrRadio name="options" [value]="ScopeType.Organization" [(ngModel)]="defaultOption"
+                      (ngModelChange)="emitSelection()" />
+                  <label>Organization</label>
+              </clr-radio-wrapper>
+              <clr-radio-wrapper *ngIf="scopeTypes.includes(ScopeType.Projects)">
+                  <input type="radio" clrRadio name="options" [value]="ScopeType.Projects" [(ngModel)]="defaultOption"
+                      (ngModelChange)="emitSelection()"/>
+                  <label>Projects</label>
+              </clr-radio-wrapper>
+              <clr-radio-wrapper *ngIf="scopeTypes.includes(ScopeType.CloudAccounts)">
+                  <input type="radio" clrRadio name="options" [value]="ScopeType.CloudAccounts" [(ngModel)]="defaultOption"
+                      (ngModelChange)="emitSelection()"/>
+                  <label data-test="scope-selector-cloud-accounts">Cloud Accounts</label>
+              </clr-radio-wrapper>
+            </clr-radio-container>
+          \`
+          })
+          export class HomeComponent {
+        }
+      `,
+      locations: [{ line: 5, column: 13 }],
+    }),
+
+    getInvalidClrRadioTest({
+      code: `
+        @Component({
+          selector: 'app-home',
+          template: \`
+            <div>
+              <div>
+                <clr-radio-wrapper>
+                  <input type="radio" clrRadio />
+                  <label>Test</label>
+                </clr-radio-wrapper>
+              </div>
+              <div></div>
+              <input type="radio" clrRadio />
+              <div></div>
+              <clr-radio-container clrInline *ngIf="showRadioButtons">
+                <clr-radio-wrapper *ngIf="scopeTypes.includes(ScopeType.Organization)">
+                    <input type="radio" clrRadio name="options" [value]="ScopeType.Organization" [(ngModel)]="defaultOption"
+                        (ngModelChange)="emitSelection()" />
+                    <label>Organization</label>
+                </clr-radio-wrapper>
+                <clr-radio-wrapper *ngIf="scopeTypes.includes(ScopeType.Projects)">
+                    <input type="radio" clrRadio name="options" [value]="ScopeType.Projects" [(ngModel)]="defaultOption"
+                        (ngModelChange)="emitSelection()"/>
+                    <label>Projects</label>
+                </clr-radio-wrapper>
+                <clr-radio-wrapper *ngIf="scopeTypes.includes(ScopeType.CloudAccounts)">
+                    <input type="radio" clrRadio name="options" [value]="ScopeType.CloudAccounts" [(ngModel)]="defaultOption"
+                        (ngModelChange)="emitSelection()"/>
+                    <label data-test="scope-selector-cloud-accounts">Cloud Accounts</label>
+                </clr-radio-wrapper>
+              </clr-radio-container>
+            </div>
+          \`
+          })
+          export class HomeComponent {
+        }
+      `,
+      locations: [
+        { line: 7, column: 17 },
+        { line: 13, column: 15 },
+        { line: 15, column: 15 },
+      ],
+    }),
+  ],
+  valid: [
+    `
+      @Component({
+        selector: 'app-home',
+        template: \`<input type="radio" />\`
+        })
+        export class HomeComponent {
+      }
+    `,
+  ],
+});

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-range/index.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-range/index.ts
@@ -1,0 +1,73 @@
+import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { parseDecoratorTemplate, reportNestedDisallowedElements } from '../decorator-template-helper';
+import { HTMLElement } from '../../types/index';
+
+const disallowedDirective = 'clrRange';
+const containerTagName = 'clr-range-container';
+
+export const createESLintRule = ESLintUtils.RuleCreator(() => ``);
+const ruleFailureMessage = 'clrRangeFailure';
+export type MessageIds = 'clrRangeFailure';
+export default createESLintRule({
+  name: 'no-clr-range',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow use of clrRange',
+      category: 'Best Practices',
+      recommended: 'warn',
+    },
+    fixable: 'code',
+    messages: {
+      [ruleFailureMessage]: 'Using clr-range is not allowed!',
+    },
+    schema: [{}],
+  },
+  defaultOptions: [{}],
+  create(context) {
+    return {
+      // report all <clr-range-container> elements
+      [`HTMLElement[tagName="${containerTagName}"]`](node: HTMLElement): void {
+        context.report({
+          node: node as any,
+          messageId: ruleFailureMessage,
+        });
+      },
+
+      // report <input clrRange> elements that AREN'T nested in <clr-range-container> elements
+      [`:not(HTMLElement[tagName="${containerTagName}"]) > HTMLElement[tagName="input"]`](node: HTMLElement): void {
+        const disallowedDirectiveNode = node.attributes?.find(
+          attribute => attribute.attributeName.value === disallowedDirective
+        );
+
+        if (disallowedDirectiveNode) {
+          context.report({
+            node: node as any,
+            messageId: ruleFailureMessage,
+          });
+        }
+      },
+
+      'ClassDeclaration > Decorator'(node: TSESTree.Decorator): void {
+        const parsedTemplate = parseDecoratorTemplate(node);
+        if (!parsedTemplate) {
+          return;
+        }
+
+        const { dom, templateContentNode } = parsedTemplate;
+
+        // report all <clr-range-container> elements
+        reportNestedDisallowedElements(containerTagName, context, dom, templateContentNode, ruleFailureMessage);
+
+        // report <input clrRange> elements that AREN'T nested in <clr-range-container> elements
+        reportNestedDisallowedElements(
+          `:not(${containerTagName}) > input[${disallowedDirective}]`,
+          context,
+          dom,
+          templateContentNode,
+          ruleFailureMessage
+        );
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-range/no-clr-range.spec.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-range/no-clr-range.spec.ts
@@ -1,0 +1,72 @@
+import rule from './index';
+import { getHtmlRuleTester, getInvalidTestFactory, getTsRuleTester } from '../../test-helper.spec';
+
+const tsRuleTester = getTsRuleTester();
+const htmlRuleTester = getHtmlRuleTester();
+
+const getInvalidRangeTest = getInvalidTestFactory('clrRangeFailure');
+
+htmlRuleTester.run('no-clr-range', rule, {
+  invalid: [
+    getInvalidRangeTest({
+      code: `<input type="range" clrRange min="60" max="80" />`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidRangeTest({
+      code: `
+        <clr-range-container>
+          <input type="range" clrRange min="60" max="80" />
+        </clr-range-container>
+      `,
+      locations: [{ line: 2, column: 9 }],
+    }),
+  ],
+  valid: [`<input>`, `<div clrRange></div>`, `<input clrInput>`],
+});
+
+tsRuleTester.run('no-clr-range', rule, {
+  invalid: [
+    getInvalidRangeTest({
+      code: `
+      @Component({
+        template: \`
+          <input type="range" clrRange min="60" max="80" />
+        \`
+      })
+      export class CustomRangeComponent {}
+      `,
+      locations: [{ line: 4, column: 11 }],
+    }),
+    getInvalidRangeTest({
+      code: `
+      @Component({
+        template: \`
+          <clr-range-container>
+            <input type="range" clrRange min="60" max="80" />
+          </clr-range-container>
+        \`
+      })
+      export class CustomRangeComponent {}
+      `,
+      locations: [{ line: 4, column: 11 }],
+    }),
+  ],
+  valid: [
+    `
+    @Component({
+      template: \`
+        <input>
+      \`
+    })
+    export class CustomRangeComponent {}
+    `,
+    `
+    @Component({
+      template: \`
+        <div clrRange></div>
+      \`
+    })
+    export class CustomRangeComponent {}
+    `,
+  ],
+});

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-select/index.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-select/index.ts
@@ -1,0 +1,73 @@
+import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { parseDecoratorTemplate, reportNestedDisallowedElements } from '../decorator-template-helper';
+import { HTMLElement } from '../../types/index';
+
+const disallowedDirective = 'clrSelect';
+const containerTagName = 'clr-select-container';
+
+export const createESLintRule = ESLintUtils.RuleCreator(() => ``);
+const ruleFailureMessage = 'clrSelectFailure';
+export type MessageIds = 'clrSelectFailure';
+export default createESLintRule({
+  name: 'no-clr-select',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow use of clrSelect',
+      category: 'Best Practices',
+      recommended: 'warn',
+    },
+    fixable: 'code',
+    messages: {
+      [ruleFailureMessage]: 'Using clr-select is not allowed!',
+    },
+    schema: [{}],
+  },
+  defaultOptions: [{}],
+  create(context) {
+    return {
+      // report all <clr-select-container> elements
+      [`HTMLElement[tagName="${containerTagName}"]`](node: HTMLElement): void {
+        context.report({
+          node: node as any,
+          messageId: ruleFailureMessage,
+        });
+      },
+
+      // report <select clrSelect> elements that AREN'T nested in <clr-select-container> elements
+      [`:not(HTMLElement[tagName="${containerTagName}"]) > HTMLElement[tagName="select"]`](node: HTMLElement): void {
+        const disallowedDirectiveNode = node.attributes?.find(
+          attribute => attribute.attributeName.value === disallowedDirective
+        );
+
+        if (disallowedDirectiveNode) {
+          context.report({
+            node: node as any,
+            messageId: ruleFailureMessage,
+          });
+        }
+      },
+
+      'ClassDeclaration > Decorator'(node: TSESTree.Decorator): void {
+        const parsedTemplate = parseDecoratorTemplate(node);
+        if (!parsedTemplate) {
+          return;
+        }
+
+        const { dom, templateContentNode } = parsedTemplate;
+
+        // report all <clr-select-container> elements
+        reportNestedDisallowedElements(containerTagName, context, dom, templateContentNode, ruleFailureMessage);
+
+        // report <select clrSelect> elements that AREN'T nested in <clr-select-container> elements
+        reportNestedDisallowedElements(
+          `:not(${containerTagName}) > select[${disallowedDirective}]`,
+          context,
+          dom,
+          templateContentNode,
+          ruleFailureMessage
+        );
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-select/no-clr-select.spec.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-select/no-clr-select.spec.ts
@@ -1,0 +1,89 @@
+import rule from './index';
+import { getHtmlRuleTester, getInvalidTestFactory, getTsRuleTester } from '../../test-helper.spec';
+
+const tsRuleTester = getTsRuleTester();
+const htmlRuleTester = getHtmlRuleTester();
+
+const getInvalidSelectTest = getInvalidTestFactory('clrSelectFailure');
+
+htmlRuleTester.run('no-clr-select', rule, {
+  invalid: [
+    getInvalidSelectTest({
+      code: `<select clrSelect name="options" [(ngModel)]="options">
+        <option value="one">One</option>
+        <option value="two">Two</option>
+        <option value="three">Three</option>
+      </select>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidSelectTest({
+      code: `
+        <clr-select-container>
+          <label>Select options</label>
+          <select clrSelect name="options" [(ngModel)]="options">
+            <option value="one">One</option>
+            <option value="two">Two</option>
+            <option value="three">Three</option>
+          </select>
+        </clr-select-container>
+      `,
+      locations: [{ line: 2, column: 9 }],
+    }),
+  ],
+  valid: [`<select>`, `<input clrSelect>`, `<select clrInput>`],
+});
+
+tsRuleTester.run('no-clr-select', rule, {
+  invalid: [
+    getInvalidSelectTest({
+      code: `
+      @Component({
+        template: \`
+          <select clrSelect name="options" [(ngModel)]="options">
+            <option value="one">One</option>
+            <option value="two">Two</option>
+            <option value="three">Three</option>
+          </select>
+        \`
+      })
+      export class CustomSelectComponent {}
+      `,
+      locations: [{ line: 4, column: 11 }],
+    }),
+    getInvalidSelectTest({
+      code: `
+      @Component({
+        template: \`
+          <clr-select-container>
+            <select clrSelect name="options" [(ngModel)]="options">
+              <option value="one">One</option>
+              <option value="two">Two</option>
+              <option value="three">Three</option>
+            </select>
+          </clr-select-container>
+        \`
+      })
+      export class CustomSelectComponent {}
+      `,
+      locations: [{ line: 4, column: 11 }],
+    }),
+  ],
+  valid: [
+    `
+    @Component({
+      template: \`
+        <select>
+      \`
+    })
+    export class CustomSelectComponent {}
+    `,
+    `
+    @Component({
+      template: \`
+        <div clrSelect></div>
+      \`
+    })
+    export class CustomSelectComponent {}
+    `,
+  ],
+});

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-textarea/index.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-textarea/index.ts
@@ -1,0 +1,77 @@
+import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { parseDecoratorTemplate, reportNestedDisallowedElements } from '../decorator-template-helper';
+import { HTMLElement } from '../../types/index';
+
+const disallowedClass = 'clr-textarea';
+const disallowedDirective = 'clrTextarea';
+const containerTagName = 'clr-textarea-container';
+
+export const createESLintRule = ESLintUtils.RuleCreator(() => ``);
+const ruleFailureMessage = 'clrTextareaFailure';
+export type MessageIds = 'clrTextareaFailure';
+export default createESLintRule({
+  name: 'no-clr-textarea',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow use of clrTextarea',
+      category: 'Best Practices',
+      recommended: 'warn',
+    },
+    fixable: 'code',
+    messages: {
+      [ruleFailureMessage]: 'Using clr-textarea is not allowed!',
+    },
+    schema: [{}],
+  },
+  defaultOptions: [{}],
+  create(context) {
+    return {
+      // report all <clr-textarea-container> elements
+      [`HTMLElement[tagName="${containerTagName}"]`](node: HTMLElement): void {
+        context.report({
+          node: node as any,
+          messageId: ruleFailureMessage,
+        });
+      },
+
+      // report <textarea clrTextarea> elements that AREN'T nested in <clr-textarea-container> elements
+      [`:not(HTMLElement[tagName="${containerTagName}"]) > HTMLElement[tagName="textarea"]`](node: HTMLElement): void {
+        const classNode = node.attributes?.find(attribute => attribute.attributeName.value === 'class');
+        const classes = classNode?.attributeValue?.value?.split(' ') || [];
+
+        const disallowedDirectiveNode = node.attributes?.find(
+          attribute => attribute.attributeName.value === disallowedDirective
+        );
+
+        if (classes.includes(disallowedClass) || disallowedDirectiveNode) {
+          context.report({
+            node: node as any,
+            messageId: ruleFailureMessage,
+          });
+        }
+      },
+
+      'ClassDeclaration > Decorator'(node: TSESTree.Decorator): void {
+        const parsedTemplate = parseDecoratorTemplate(node);
+        if (!parsedTemplate) {
+          return;
+        }
+
+        const { dom, templateContentNode } = parsedTemplate;
+
+        // report all <clr-textarea-container> elements
+        reportNestedDisallowedElements(containerTagName, context, dom, templateContentNode, ruleFailureMessage);
+
+        // report <textarea clrTextarea> and <textarea class="clr-textarea"> elements that AREN'T nested in <clr-textarea-container> elements
+        reportNestedDisallowedElements(
+          `:not(${containerTagName}) > textarea[${disallowedDirective}],textarea.${disallowedClass}`,
+          context,
+          dom,
+          templateContentNode,
+          ruleFailureMessage
+        );
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-textarea/no-clr-textarea.spec.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-textarea/no-clr-textarea.spec.ts
@@ -1,0 +1,88 @@
+import rule from './index';
+import { getHtmlRuleTester, getInvalidTestFactory, getTsRuleTester } from '../../test-helper.spec';
+
+const tsRuleTester = getTsRuleTester();
+const htmlRuleTester = getHtmlRuleTester();
+
+const getInvalidTextareaTest = getInvalidTestFactory('clrTextareaFailure');
+
+htmlRuleTester.run('no-clr-textarea', rule, {
+  invalid: [
+    getInvalidTextareaTest({
+      code: `<textarea clrTextarea>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidTextareaTest({
+      code: `
+        <clr-textarea-container>
+          <textarea clrTextarea>
+        </clr-textarea-container>
+      `,
+      locations: [{ line: 2, column: 9 }],
+    }),
+
+    getInvalidTextareaTest({
+      code: `<textarea class="clr-textarea">`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+  ],
+  valid: [`<textarea>`, `<div clrTextarea></div>`],
+});
+
+tsRuleTester.run('no-clr-textarea', rule, {
+  invalid: [
+    getInvalidTextareaTest({
+      code: `
+      @Component({
+        template: \`
+          <textarea clrTextarea>
+        \`
+      })
+      export class CustomTextareaComponent {}
+      `,
+      locations: [{ line: 4, column: 11 }],
+    }),
+    getInvalidTextareaTest({
+      code: `
+      @Component({
+        template: \`
+          <clr-textarea-container>
+            <textarea clrTextarea>
+          </clr-textarea-container>
+        \`
+      })
+      export class CustomTextareaComponent {}
+      `,
+      locations: [{ line: 4, column: 11 }],
+    }),
+    getInvalidTextareaTest({
+      code: `
+      @Component({
+        template: \`
+          <textarea class="clr-textarea">
+        \`
+      })
+      export class CustomTextareaComponent {}
+      `,
+      locations: [{ line: 4, column: 11 }],
+    }),
+  ],
+  valid: [
+    `
+    @Component({
+      template: \`
+        <textarea>
+      \`
+    })
+    export class CustomTextareaComponent {}
+    `,
+    `
+    @Component({
+      template: \`
+        <div clrTextarea></div>
+      \`
+    })
+    export class CustomTextareaComponent {}
+    `,
+  ],
+});

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-toggle/index.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-toggle/index.ts
@@ -1,0 +1,90 @@
+import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { parseDecoratorTemplate, reportNestedDisallowedElements } from '../decorator-template-helper';
+import { HTMLElement } from '../../types/index';
+
+const disallowedDirective = 'clrToggle';
+const wrapperTagName = 'clr-toggle-wrapper';
+const containerTagName = 'clr-toggle-container';
+
+export const createESLintRule = ESLintUtils.RuleCreator(() => ``);
+const ruleFailureMessage = 'clrToggleFailure';
+export type MessageIds = 'clrToggleFailure';
+export default createESLintRule({
+  name: 'no-clr-toggle',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow use of clrToggle',
+      category: 'Best Practices',
+      recommended: 'warn',
+    },
+    fixable: 'code',
+    messages: {
+      [ruleFailureMessage]: 'Using clr-toggle is not allowed!',
+    },
+    schema: [{}],
+  },
+  defaultOptions: [{}],
+  create(context) {
+    return {
+      // report all <clr-toggle-container> elements
+      [`HTMLElement[tagName="${containerTagName}"]`](node: HTMLElement): void {
+        context.report({
+          node: node as any,
+          messageId: ruleFailureMessage,
+        });
+      },
+      // report <clr-toggle-wrapper> elements that AREN'T nested in <clr-toggle-container> elements
+      [`:not(HTMLElement[tagName="${containerTagName}"]) > HTMLElement[tagName="${wrapperTagName}"]`](
+        node: HTMLElement
+      ): void {
+        context.report({
+          node: node as any,
+          messageId: ruleFailureMessage,
+        });
+      },
+      // report <input clrToggle> elements that AREN'T nested in <clr-toggle-wrapper> elements
+      [`:not(HTMLElement[tagName="${wrapperTagName}"]) > HTMLElement[tagName="input"]`](node: HTMLElement): void {
+        const disallowedDirectiveNode = node.attributes?.find(
+          attribute => attribute.attributeName.value === disallowedDirective
+        );
+
+        if (disallowedDirectiveNode) {
+          context.report({
+            node: node as any,
+            messageId: ruleFailureMessage,
+          });
+        }
+      },
+      'ClassDeclaration > Decorator'(node: TSESTree.Decorator): void {
+        const parsedTemplate = parseDecoratorTemplate(node);
+        if (!parsedTemplate) {
+          return;
+        }
+
+        const { dom, templateContentNode } = parsedTemplate;
+
+        // report all <clr-toggle-container> elements
+        reportNestedDisallowedElements(containerTagName, context, dom, templateContentNode, ruleFailureMessage);
+
+        // report <clr-toggle-wrapper> elements that AREN'T nested in <clr-toggle-container> elements
+        reportNestedDisallowedElements(
+          `:not(${containerTagName}) > ${wrapperTagName}`,
+          context,
+          dom,
+          templateContentNode,
+          ruleFailureMessage
+        );
+
+        // report <input clrToggle> elements that AREN'T nested in <clr-toggle-wrapper> elements
+        reportNestedDisallowedElements(
+          `:not(${wrapperTagName}) > input[${disallowedDirective}]`,
+          context,
+          dom,
+          templateContentNode,
+          ruleFailureMessage
+        );
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-toggle/no-clr-toggle.spec.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-toggle/no-clr-toggle.spec.ts
@@ -1,0 +1,218 @@
+import rule from './index';
+import { getHtmlRuleTester, getInvalidTestFactory, getTsRuleTester } from '../../test-helper.spec';
+
+const tsRuleTester = getTsRuleTester();
+const htmlRuleTester = getHtmlRuleTester();
+
+const getInvalidClrToggleTest = getInvalidTestFactory('clrToggleFailure');
+
+htmlRuleTester.run('no-clr-toggle', rule, {
+  invalid: [
+    getInvalidClrToggleTest({
+      code: `<input type="checkbox" clrToggle />`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidClrToggleTest({
+      code: `
+        <div></div>
+        <input type="checkbox" clrToggle />
+        <div></div>
+        <div><input type="checkbox" clrToggle /></div>
+        <input type="checkbox" clrToggle />
+      `,
+      locations: [
+        { line: 3, column: 9 },
+        { line: 5, column: 14 },
+        { line: 6, column: 9 },
+      ],
+    }),
+    getInvalidClrToggleTest({
+      code: `
+        <clr-toggle-wrapper>
+          <input type="checkbox" clrToggle />
+          <label>Test</label>
+        </clr-toggle-wrapper>
+      `,
+      locations: [{ line: 2, column: 9 }],
+    }),
+    getInvalidClrToggleTest({
+      code: `
+        <clr-toggle-container>
+          <label>Default</label>
+          <clr-toggle-wrapper>
+            <label>One</label>
+            <input clrToggle type="checkbox" [(ngModel)]="options" name="options" />
+          </clr-toggle-wrapper>
+          <clr-toggle-wrapper>
+            <label>Two</label>
+            <input clrToggle type="checkbox" [(ngModel)]="options" name="options" />
+          </clr-toggle-wrapper>
+          <clr-toggle-wrapper>
+            <label>Three</label>
+            <input clrToggle type="checkbox" [(ngModel)]="options" name="options" />
+          </clr-toggle-wrapper>
+          <clr-control-helper>Helper text</clr-control-helper>
+          <clr-control-error>There was an error</clr-control-error>
+        </clr-toggle-container>
+      `,
+      locations: [{ line: 2, column: 9 }],
+    }),
+
+    getInvalidClrToggleTest({
+      code: `
+        <div>
+          <div>
+            <clr-toggle-wrapper>
+              <input type="checkbox" clrToggle />
+              <label>Test</label>
+            </clr-toggle-wrapper>
+          </div>
+          <div></div>
+          <input type="checkbox" clrToggle />
+          <div></div>
+          <clr-toggle-container>
+            <label>Default</label>
+            <clr-toggle-wrapper>
+              <label>One</label>
+              <input clrToggle type="checkbox" [(ngModel)]="options" name="options" />
+            </clr-toggle-wrapper>
+            <clr-toggle-wrapper>
+              <label>Two</label>
+              <input clrToggle type="checkbox" [(ngModel)]="options" name="options" />
+            </clr-toggle-wrapper>
+            <clr-toggle-wrapper>
+              <label>Three</label>
+              <input clrToggle type="checkbox" [(ngModel)]="options" name="options" />
+            </clr-toggle-wrapper>
+            <clr-control-helper>Helper text</clr-control-helper>
+            <clr-control-error>There was an error</clr-control-error>
+          </clr-toggle-container>
+        </div>
+      `,
+      locations: [
+        { line: 4, column: 13 },
+        { line: 10, column: 11 },
+        { line: 12, column: 11 },
+      ],
+    }),
+  ],
+  valid: [`<input type="checkbox"></input>`],
+});
+
+tsRuleTester.run('no-clr-toggle', rule, {
+  invalid: [
+    getInvalidClrToggleTest({
+      code: `
+        @Component({
+          selector: 'app-home',
+          template: \`
+            <input type="checkbox" clrToggle />
+          \`
+          })
+          export class HomeComponent {
+        }
+      `,
+      locations: [{ line: 5, column: 13 }],
+    }),
+    getInvalidClrToggleTest({
+      code: `
+        @Component({
+          selector: 'app-home',
+          template: \`
+            <clr-toggle-wrapper>
+              <input type="checkbox" clrToggle />
+              <label>Test</label>
+            </clr-toggle-wrapper>
+          \`
+          })
+          export class HomeComponent {
+        }
+      `,
+      locations: [{ line: 5, column: 13 }],
+    }),
+    getInvalidClrToggleTest({
+      code: `
+        @Component({
+          selector: 'app-home',
+          template: \`
+            <clr-toggle-container>
+              <label>Default</label>
+              <clr-toggle-wrapper>
+                <label>One</label>
+                <input clrToggle type="checkbox" [(ngModel)]="options" name="options" />
+              </clr-toggle-wrapper>
+              <clr-toggle-wrapper>
+                <label>Two</label>
+                <input clrToggle type="checkbox" [(ngModel)]="options" name="options" />
+              </clr-toggle-wrapper>
+              <clr-toggle-wrapper>
+                <label>Three</label>
+                <input clrToggle type="checkbox" [(ngModel)]="options" name="options" />
+              </clr-toggle-wrapper>
+              <clr-control-helper>Helper text</clr-control-helper>
+              <clr-control-error>There was an error</clr-control-error>
+            </clr-toggle-container>
+          \`
+          })
+          export class HomeComponent {
+        }
+      `,
+      locations: [{ line: 5, column: 13 }],
+    }),
+
+    getInvalidClrToggleTest({
+      code: `
+        @Component({
+          selector: 'app-home',
+          template: \`
+            <div>
+              <div>
+                <clr-toggle-wrapper>
+                  <input type="checkbox" clrToggle />
+                  <label>Test</label>
+                </clr-toggle-wrapper>
+              </div>
+              <div></div>
+              <input type="checkbox" clrToggle />
+              <div></div>
+              <clr-toggle-container>
+                <label>Default</label>
+                <clr-toggle-wrapper>
+                  <label>One</label>
+                  <input clrToggle type="checkbox" [(ngModel)]="options" name="options" />
+                </clr-toggle-wrapper>
+                <clr-toggle-wrapper>
+                  <label>Two</label>
+                  <input clrToggle type="checkbox" [(ngModel)]="options" name="options" />
+                </clr-toggle-wrapper>
+                <clr-toggle-wrapper>
+                  <label>Three</label>
+                  <input clrToggle type="checkbox" [(ngModel)]="options" name="options" />
+                </clr-toggle-wrapper>
+                <clr-control-helper>Helper text</clr-control-helper>
+                <clr-control-error>There was an error</clr-control-error>
+              </clr-toggle-container>
+            </div>
+          \`
+          })
+          export class HomeComponent {
+        }
+      `,
+      locations: [
+        { line: 7, column: 17 },
+        { line: 13, column: 15 },
+        { line: 15, column: 15 },
+      ],
+    }),
+  ],
+  valid: [
+    `
+      @Component({
+        selector: 'app-home',
+        template: \`<input type="checkbox" />\`
+        })
+        export class HomeComponent {
+      }
+    `,
+  ],
+});


### PR DESCRIPTION
## Rules

This PR adds the following rules to the `@clr/eslint-plugin-clarity-adoption` package:

- `no-clr-datalist`
- `no-clr-form`
- `no-clr-input`
- `no-clr-list`
- `no-clr-modal`
- `no-clr-password`
- `no-clr-radio`
- `no-clr-range`
- `no-clr-select`
- `no-clr-textarea`
- `no-clr-toggle`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

Issue Number: #5528

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
