### PR TITLE
fix: combobox-set id, double esc event, click-to-close, focus-error

### DIFF
--- a/packages/angular/golden/clr-angular.d.ts
+++ b/packages/angular/golden/clr-angular.d.ts
@@ -304,6 +304,7 @@ export declare class ClrCombobox<T> extends WrappedFormControl<ClrComboboxContai
     focused: boolean;
     focusedPill: any;
     get id(): string;
+    set id(id: string);
     protected index: number;
     invalid: boolean;
     set multiSelect(value: boolean | string);
@@ -319,7 +320,7 @@ export declare class ClrCombobox<T> extends WrappedFormControl<ClrComboboxContai
     smartPosition: ClrPopoverPosition;
     textbox: ElementRef;
     trigger: ElementRef;
-    constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef, optionSelectionService: OptionSelectionService<T>, commonStrings: ClrCommonStringsService, toggleService: ClrPopoverToggleService, positionService: ClrPopoverPositionService, controlStateService: IfControlStateService, containerService: ComboboxContainerService, platformId: any, ariaService: AriaService, focusHandler: ComboboxFocusHandler<T>);
+    constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef, optionSelectionService: OptionSelectionService<T>, commonStrings: ClrCommonStringsService, toggleService: ClrPopoverToggleService, positionService: ClrPopoverPositionService, controlStateService: IfControlStateService, containerService: ComboboxContainerService, platformId: any, ariaService: AriaService, focusHandler: ComboboxFocusHandler<T>, cdr: ChangeDetectorRef);
     focusFirstActive(): void;
     focusInput(): void;
     getActiveDescendant(): string;

--- a/packages/angular/projects/clr-angular/src/forms/combobox/combobox.ts
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/combobox.ts
@@ -22,6 +22,7 @@ import {
   EventEmitter,
   AfterContentInit,
   Inject,
+  ChangeDetectorRef,
 } from '@angular/core';
 import { Subscription, Observable } from 'rxjs';
 
@@ -106,7 +107,8 @@ export class ClrCombobox<T> extends WrappedFormControl<ClrComboboxContainer>
     @Optional() private containerService: ComboboxContainerService,
     @Inject(PLATFORM_ID) private platformId: any,
     private ariaService: AriaService,
-    private focusHandler: ComboboxFocusHandler<T>
+    private focusHandler: ComboboxFocusHandler<T>,
+    private cdr: ChangeDetectorRef
   ) {
     super(vcr, ClrComboboxContainer, injector, control, renderer, el);
     if (control) {
@@ -123,6 +125,10 @@ export class ClrCombobox<T> extends WrappedFormControl<ClrComboboxContainer>
   // Otherwise the label/component connection does not work and screen readers do not read the label.
   get id() {
     return this.controlIdService.id + '-combobox';
+  }
+
+  set id(id: string) {
+    super.id = id;
   }
 
   inputId(): string {
@@ -372,6 +378,7 @@ export class ClrCombobox<T> extends WrappedFormControl<ClrComboboxContainer>
   }
 
   ngAfterViewInit() {
+    this.focusHandler.componentCdRef = this.cdr;
     this.focusHandler.textInput = this.textbox.nativeElement;
     this.focusHandler.trigger = this.trigger.nativeElement;
     // The text input is the actual element we are wrapping

--- a/packages/angular/projects/clr-angular/src/forms/combobox/option.ts
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/option.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -77,6 +77,11 @@ export class ClrOption<T> implements OnInit {
     } else {
       this.optionSelectionService.select(this.value);
     }
+    // As the popover stays open in multi-select mode now, we have to take focus back to the input
+    // This way we achieve two things:
+    // - do not lose focus
+    // - we're still able to use onBlur for "outside-click" handling
+    this.focusHandler.focusInput();
   }
 
   @HostBinding('class.clr-focus')

--- a/packages/angular/projects/dev/src/app/app.component.ts
+++ b/packages/angular/projects/dev/src/app/app.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -30,6 +30,8 @@ import {
   thermometerIcon,
   userIcon,
   warningStandardIcon,
+  sunIcon,
+  worldIcon,
 } from '@cds/core/icon';
 
 @Component({
@@ -62,7 +64,9 @@ export class AppComponent {
       flameIcon,
       thermometerIcon,
       lightbulbIcon,
-      warningStandardIcon
+      warningStandardIcon,
+      sunIcon,
+      worldIcon
     );
   }
 }


### PR DESCRIPTION
closes #5565, closes #5344, closes #5185, closes #5553
Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

1. Dropdown does not close on outside click if you first click an item in the menu.
2. Can not set id for combobox - exception is thrown
3. Hit Esc on closed combobox - two open,close events fired.
4. 'ApplicationRef.tick is called recursively' thrown under certain conditions.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5565, #5344, #5185, #5553

## What is the new behavior?

1. Dropdown closes on all outside clicks.
2. Can set id for combobox.
3. Hit Esc on closed combobox - no open events
4. 'ApplicationRef.tick is called recursively' not thrown anymore. Application ref substituted with local ChandeDetectorRef that has component scope only.
5. Fixed icons on the DEV app

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
