### PR TITLE
fix: core test utilities export

### DIFF
--- a/packages/core/build/build.package.ts
+++ b/packages/core/build/build.package.ts
@@ -41,6 +41,7 @@ function createPackageFile() {
     "./global.min.css": "./global.min.css",
     "./styles/*": "./styles/*",
     "./list/*": "./list/*",
+    "./test": "./test/index.js",
     "./internal": "./internal/index.js",
     "./icon/shapes/*": "./icon/shapes/*",
     "./icon/icon.service.js": "./icon/icon.service.js",

--- a/packages/core/docs/development/unit-testing.stories.mdx
+++ b/packages/core/docs/development/unit-testing.stories.mdx
@@ -36,7 +36,7 @@ Here is a basic starter test for a Clarity Web Component.
 import { html } from 'lit-html';
 import '@cds/core/badge/register.js';
 import { CdsBadge } from '@cds/core/badge';
-import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
 
 describe('badge element', () => {
   let testElement: HTMLElement;

--- a/packages/core/import-map.importmap
+++ b/packages/core/import-map.importmap
@@ -84,7 +84,7 @@
     "@cds/core/tag/register.js": "/base/dist/core/tag/register.js",
     "@cds/core/test-dropdown": "/base/dist/core/test-dropdown/index.js",
     "@cds/core/test-dropdown/register.js": "/base/dist/core/test-dropdown/register.js",
-    "@cds/core/test/utils": "/base/dist/core/test/utils.js",
+    "@cds/core/test": "/base/dist/core/test/index.js",
     "@cds/core/textarea": "/base/dist/core/textarea/index.js",
     "@cds/core/textarea/register.js": "/base/dist/core/textarea/register.js",
     "@cds/core/time": "/base/dist/core/time/index.js",

--- a/packages/core/src/accordion/accordion-content.element.spec.ts
+++ b/packages/core/src/accordion/accordion-content.element.spec.ts
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { html } from 'lit-html';
 import '@cds/core/accordion/register.js';
 import { CdsAccordionContent } from '@cds/core/accordion';
-import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
 
 describe('accordion-content element', () => {
   let testElement: HTMLElement;

--- a/packages/core/src/accordion/accordion-header.element.spec.ts
+++ b/packages/core/src/accordion/accordion-header.element.spec.ts
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { html } from 'lit-html';
 import '@cds/core/accordion/register.js';
 import { CdsAccordionHeader } from '@cds/core/accordion';
-import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
 
 describe('accordion-header element', () => {
   let testElement: HTMLElement;

--- a/packages/core/src/accordion/accordion-panel.element.spec.ts
+++ b/packages/core/src/accordion/accordion-panel.element.spec.ts
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { html } from 'lit-html';
 import '@cds/core/accordion/register.js';
 import { CdsAccordionPanel } from '@cds/core/accordion';
-import { componentIsStable, createTestElement, getComponentSlotContent, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, getComponentSlotContent, removeTestElement } from '@cds/core/test';
 
 describe('accordion-panel element', () => {
   let testElement: HTMLElement;

--- a/packages/core/src/accordion/accordion.element.spec.ts
+++ b/packages/core/src/accordion/accordion.element.spec.ts
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { html } from 'lit-html';
 import '@cds/core/accordion/register.js';
 import { CdsAccordion } from '@cds/core/accordion';
-import { componentIsStable, createTestElement, getComponentSlotContent, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, getComponentSlotContent, removeTestElement } from '@cds/core/test';
 
 describe('accordion element', () => {
   let testElement: HTMLElement;

--- a/packages/core/src/alert/alert-actions.element.spec.ts
+++ b/packages/core/src/alert/alert-actions.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -8,7 +8,7 @@ import { html } from 'lit-html';
 import '@cds/core/alert/register.js';
 import '@cds/core/button/register.js';
 import { CdsAlertActions } from '@cds/core/alert';
-import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
 
 describe('alert-actions element', () => {
   describe(' - the basics: ', () => {

--- a/packages/core/src/alert/alert-group.element.spec.ts
+++ b/packages/core/src/alert/alert-group.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -8,7 +8,7 @@ import { html } from 'lit-html';
 import '@cds/core/alert/register.js';
 import '@cds/core/icon/register.js';
 import { CdsAlert, CdsAlertGroup } from '@cds/core/alert';
-import { componentIsStable, createTestElement, getComponentSlotContent, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, getComponentSlotContent, removeTestElement } from '@cds/core/test';
 
 describe('Alert groups – ', () => {
   let testElement: HTMLElement;

--- a/packages/core/src/alert/alert.element.spec.ts
+++ b/packages/core/src/alert/alert.element.spec.ts
@@ -9,7 +9,7 @@ import '@cds/core/alert/register.js';
 import '@cds/core/icon/register.js';
 import { CdsAlert, getIconStatusTuple, iconShapeIsAlertStatusType } from '@cds/core/alert';
 import { CdsIcon, infoStandardIcon } from '@cds/core/icon';
-import { componentIsStable, createTestElement, getComponentSlotContent, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, getComponentSlotContent, removeTestElement } from '@cds/core/test';
 import { CdsInternalCloseButton } from '@cds/core/internal-components/close-button';
 import { I18nService } from '@cds/core/internal';
 

--- a/packages/core/src/badge/badge.element.spec.ts
+++ b/packages/core/src/badge/badge.element.spec.ts
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { html } from 'lit-html';
 import '@cds/core/badge/register.js';
 import { CdsBadge } from '@cds/core/badge';
-import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
 
 describe('badge element', () => {
   let testElement: HTMLElement;

--- a/packages/core/src/button/button.element.spec.ts
+++ b/packages/core/src/button/button.element.spec.ts
@@ -8,7 +8,7 @@ import { html } from 'lit-html';
 import { CdsButton, ClrLoadingState, iconSpinner } from '@cds/core/button';
 import '@cds/core/badge/register.js';
 import '@cds/core/button/register.js';
-import { componentIsStable, createTestElement, getComponentSlotContent, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, getComponentSlotContent, removeTestElement } from '@cds/core/test';
 import { listenForAttributeChange } from '@cds/core/internal';
 
 describe('button element', () => {

--- a/packages/core/src/button/icon-button.element.spec.ts
+++ b/packages/core/src/button/icon-button.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -8,7 +8,7 @@ import { html } from 'lit-html';
 import '@cds/core/button/register.js';
 import '@cds/core/icon/register.js';
 import { CdsIconButton, ClrLoadingState } from '@cds/core/button';
-import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
 
 describe('Icon button element – ', () => {
   let testElement: HTMLElement;

--- a/packages/core/src/button/inline-button.element.spec.ts
+++ b/packages/core/src/button/inline-button.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -9,7 +9,7 @@ import '@cds/core/button/register.js';
 import '@cds/core/icon/register.js';
 import { CdsInlineButton } from '@cds/core/button';
 import { CdsIcon } from '@cds/core/icon';
-import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
 
 describe('Inline button element', () => {
   let testElement: HTMLElement;

--- a/packages/core/src/checkbox/checkbox-group.element.spec.ts
+++ b/packages/core/src/checkbox/checkbox-group.element.spec.ts
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { html } from 'lit-html';
-import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test';
 import { CdsCheckboxGroup } from '@cds/core/checkbox';
 import '@cds/core/checkbox/register.js';
 

--- a/packages/core/src/checkbox/checkbox.element.spec.ts
+++ b/packages/core/src/checkbox/checkbox.element.spec.ts
@@ -5,7 +5,7 @@
  */
 
 import { html } from 'lit-html';
-import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test';
 import { CdsCheckbox } from '@cds/core/checkbox';
 import '@cds/core/checkbox/register.js';
 

--- a/packages/core/src/datalist/datalist.element.spec.ts
+++ b/packages/core/src/datalist/datalist.element.spec.ts
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { html } from 'lit-html';
-import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test';
 import { CdsDatalist } from '@cds/core/datalist';
 import '@cds/core/datalist/register.js';
 

--- a/packages/core/src/date/date.element.spec.ts
+++ b/packages/core/src/date/date.element.spec.ts
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { html } from 'lit-html';
-import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test';
 import { CdsDate } from '@cds/core/date';
 import '@cds/core/date/register.js';
 

--- a/packages/core/src/divider/divider.element.spec.ts
+++ b/packages/core/src/divider/divider.element.spec.ts
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { html } from 'lit-html';
 import { CdsDivider } from '@cds/core/divider';
-import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
 import '@cds/core/divider/register.js';
 
 describe('divider element', () => {

--- a/packages/core/src/file/file.element.spec.ts
+++ b/packages/core/src/file/file.element.spec.ts
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { html } from 'lit-html';
-import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test';
 import { CdsButton } from '@cds/core/button';
 import { CdsFile } from '@cds/core/file';
 import '@cds/core/file/register.js';

--- a/packages/core/src/forms/control-action/control-action.element.spec.ts
+++ b/packages/core/src/forms/control-action/control-action.element.spec.ts
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { html } from 'lit-html';
 import { CdsControlAction } from '@cds/core/forms';
-import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test';
 import { LogService } from '@cds/core/internal';
 
 describe('cds-control-action', () => {

--- a/packages/core/src/forms/control-group/control-group.element.spec.ts
+++ b/packages/core/src/forms/control-group/control-group.element.spec.ts
@@ -5,7 +5,7 @@
  */
 
 import { html } from 'lit-html';
-import { removeTestElement, createTestElement, componentIsStable } from '@cds/core/test/utils';
+import { removeTestElement, createTestElement, componentIsStable } from '@cds/core/test';
 import { CdsControl, CdsInternalControlGroup } from '@cds/core/forms';
 import '@cds/core/forms/register.js';
 import { CdsControlMessage } from '../control-message/control-message.element';

--- a/packages/core/src/forms/control-inline/control-inline.element.spec.ts
+++ b/packages/core/src/forms/control-inline/control-inline.element.spec.ts
@@ -5,7 +5,7 @@
  */
 
 import { html } from 'lit-html';
-import { removeTestElement, createTestElement, componentIsStable } from '@cds/core/test/utils';
+import { removeTestElement, createTestElement, componentIsStable } from '@cds/core/test';
 import { CdsInternalControlInline } from '@cds/core/forms';
 import '@cds/core/forms/register.js';
 

--- a/packages/core/src/forms/control-label/control-label.element.spec.ts
+++ b/packages/core/src/forms/control-label/control-label.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -7,7 +7,7 @@
 import { html } from 'lit-html';
 import { CdsInternalControlLabel } from '@cds/core/forms';
 import '@cds/core/forms/register.js';
-import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
 
 describe('cds-internal-control-label element', () => {
   let testElement: HTMLElement;

--- a/packages/core/src/forms/control-message/control-message.element.spec.ts
+++ b/packages/core/src/forms/control-message/control-message.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -7,7 +7,7 @@
 import { html } from 'lit-html';
 import '@cds/core/forms/register.js';
 import { CdsControlMessage } from '@cds/core/forms';
-import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
 
 describe('cds-control-message element', () => {
   let testElement: HTMLElement;

--- a/packages/core/src/forms/control/control.element.spec.ts
+++ b/packages/core/src/forms/control/control.element.spec.ts
@@ -5,7 +5,7 @@
  */
 
 import { html } from 'lit-html';
-import { removeTestElement, createTestElement, componentIsStable } from '@cds/core/test/utils';
+import { removeTestElement, createTestElement, componentIsStable } from '@cds/core/test';
 import { CdsIcon } from '@cds/core/icon';
 import { CdsControl } from '@cds/core/forms';
 import '@cds/core/forms/register.js';

--- a/packages/core/src/forms/form-group/form-group.element.spec.ts
+++ b/packages/core/src/forms/form-group/form-group.element.spec.ts
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { html } from 'lit-html';
-import { removeTestElement, createTestElement, componentIsStable } from '@cds/core/test/utils';
+import { removeTestElement, createTestElement, componentIsStable } from '@cds/core/test';
 import { CdsControl } from '@cds/core/forms';
 import '@cds/core/forms/register.js';
 import { CdsFormGroup } from './form-group.element';

--- a/packages/core/src/forms/utils/index.spec.ts
+++ b/packages/core/src/forms/utils/index.spec.ts
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { render, html } from 'lit-html';
-import { createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement } from '@cds/core/test';
 import { associateInputAndLabel, associateInputToDatalist, getStatusIcon, isVerticalLayout } from './index.js';
 
 describe('form internal utilities', () => {

--- a/packages/core/src/forms/utils/validate.spec.ts
+++ b/packages/core/src/forms/utils/validate.spec.ts
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { html } from 'lit-html';
-import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test';
 import { CdsControlMessage } from '@cds/core/forms';
 import { CdsInput } from '@cds/core/input';
 import '@cds/core/input/register.js';

--- a/packages/core/src/icon/icon.element.spec.ts
+++ b/packages/core/src/icon/icon.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -7,7 +7,7 @@
 import { html } from 'lit-html';
 import '@cds/core/icon/register.js';
 import { CdsIcon } from '@cds/core/icon';
-import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
 import { renderIcon } from './icon.renderer.js';
 import { ClarityIcons } from './icon.service.js';
 

--- a/packages/core/src/icon/utils/icon.classnames.spec.ts
+++ b/packages/core/src/icon/utils/icon.classnames.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -8,7 +8,7 @@ import '@cds/core/icon/register.js';
 
 import { html } from 'lit-html';
 import { CdsIcon } from '@cds/core/icon';
-import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
 import { renderIcon } from '../icon.renderer.js';
 import { ClarityIcons } from '../icon.service.js';
 

--- a/packages/core/src/icon/utils/icon.svg-helpers.spec.ts
+++ b/packages/core/src/icon/utils/icon.svg-helpers.spec.ts
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
 import { html } from 'lit-element';
 import { ClarityIcons } from '../icon.service.js';
 import { CdsIcon } from '../index.js';

--- a/packages/core/src/input/input-group.element.spec.ts
+++ b/packages/core/src/input/input-group.element.spec.ts
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { html } from 'lit-html';
 import { CdsInputGroup, CdsInput } from '@cds/core/input';
-import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test';
 
 describe('cds-input-group', () => {
   let component: CdsInputGroup;

--- a/packages/core/src/input/input.element.spec.ts
+++ b/packages/core/src/input/input.element.spec.ts
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { html } from 'lit-html';
 import { CdsInput } from '@cds/core/input';
-import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test';
 
 describe('cds-input', () => {
   let component: CdsInput;

--- a/packages/core/src/internal-components/close-button/close-button.element.spec.ts
+++ b/packages/core/src/internal-components/close-button/close-button.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -12,7 +12,7 @@ import {
   appendCloseButton,
   removeCloseButton,
 } from '@cds/core/internal-components/close-button';
-import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
 import { HTMLAttributeTuple } from '@cds/core/internal/utils/dom.js';
 
 describe('internal close button element', () => {

--- a/packages/core/src/internal-components/overlay/overlay.element.spec.ts
+++ b/packages/core/src/internal-components/overlay/overlay.element.spec.ts
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { html } from 'lit-html';
 import '@cds/core/internal-components/overlay/register.js';
 import { CdsInternalOverlay, isNestedOverlay } from '@cds/core/internal-components/overlay';
-import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
 
 describe('Overlay helper functions: ', () => {
   describe('isNestedOverlay() - ', () => {

--- a/packages/core/src/internal/base/css-gap.base.spec.ts
+++ b/packages/core/src/internal/base/css-gap.base.spec.ts
@@ -5,7 +5,7 @@
  */
 
 import { LitElement, html } from 'lit-element';
-import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test';
 import { applyCSSGapShim } from './css-gap.base.js';
 import { browserFeatures } from '../utils/supports.js';
 

--- a/packages/core/src/internal/base/focus-trap.base.spec.ts
+++ b/packages/core/src/internal/base/focus-trap.base.spec.ts
@@ -5,7 +5,7 @@
  */
 
 import { html } from 'lit-html';
-import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test';
 import { registerElementSafely } from '../utils/register.js';
 import { CdsBaseFocusTrap } from './focus-trap.base.js';
 

--- a/packages/core/src/internal/decorators/event.spec.ts
+++ b/packages/core/src/internal/decorators/event.spec.ts
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { LitElement, html } from 'lit-element';
 import { event, EventEmitter, registerElementSafely } from '@cds/core/internal';
-import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
 
 /** @element test-event-decorator */
 export class TestElement extends LitElement {

--- a/packages/core/src/internal/decorators/global-style.spec.ts
+++ b/packages/core/src/internal/decorators/global-style.spec.ts
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { LitElement, html, css } from 'lit-element';
 import { registerElementSafely } from '@cds/core/internal';
-import { createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement } from '@cds/core/test';
 import { globalStyle } from './global-style.js';
 
 declare global {

--- a/packages/core/src/internal/decorators/i18n.spec.ts
+++ b/packages/core/src/internal/decorators/i18n.spec.ts
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { registerElementSafely } from '@cds/core/internal';
 import { html, LitElement } from 'lit-element';
-import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
 import { i18n } from '@cds/core/internal';
 
 const i18nValues = {

--- a/packages/core/src/internal/decorators/property.spec.ts
+++ b/packages/core/src/internal/decorators/property.spec.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
 import { html, LitElement } from 'lit-element';
 import { registerElementSafely } from '../utils/register.js';
 import { getDefaultOptions, requirePropertyCheck, internalProperty } from './property.js';

--- a/packages/core/src/internal/decorators/query-slot.spec.ts
+++ b/packages/core/src/internal/decorators/query-slot.spec.ts
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { registerElementSafely } from '@cds/core/internal';
 import { html, LitElement } from 'lit-element';
-import { createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement } from '@cds/core/test';
 import { querySlot, querySlotAll } from './query-slot.js';
 
 /** @element test-element */

--- a/packages/core/src/internal/directives/spread-props.spec.ts
+++ b/packages/core/src/internal/directives/spread-props.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -8,7 +8,7 @@ import { LitElement, html } from 'lit-element';
 import { render } from 'lit-html';
 import { registerElementSafely, property } from '@cds/core/internal';
 import { spreadProps } from './spread-props.js';
-import { createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement } from '@cds/core/test';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/core/src/internal/i18n/utils.spec.ts
+++ b/packages/core/src/internal/i18n/utils.spec.ts
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { getElementLanguageDirection } from './utils.js';
-import { createTestElement } from '@cds/core/test/utils';
+import { createTestElement } from '@cds/core/test';
 
 describe('getElementLanguageDirection', () => {
   it('should return the current element level language direction', async () => {

--- a/packages/core/src/internal/services/focus-trap-tracker.service.spec.ts
+++ b/packages/core/src/internal/services/focus-trap-tracker.service.spec.ts
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { html } from 'lit-html';
-import { createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement } from '@cds/core/test';
 import {
   CDS_FOCUS_TRAP_DOCUMENT_ATTR,
   CDS_FOCUS_TRAP_ID_ATTR,

--- a/packages/core/src/internal/utils/a11y.spec.ts
+++ b/packages/core/src/internal/utils/a11y.spec.ts
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { describeElementByElements } from './a11y.js';
-import { createTestElement } from '@cds/core/test/utils';
+import { createTestElement } from '@cds/core/test';
 
 describe('a11y utilities', () => {
   it('describeElementByElements', async () => {

--- a/packages/core/src/internal/utils/async.spec.ts
+++ b/packages/core/src/internal/utils/async.spec.ts
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { sleep } from './async.js';
-import { createTestElement } from '@cds/core/test/utils';
+import { createTestElement } from '@cds/core/test';
 
 describe('async utilities: ', () => {
   describe('sleep()', () => {

--- a/packages/core/src/internal/utils/dom.spec.ts
+++ b/packages/core/src/internal/utils/dom.spec.ts
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { html } from 'lit-html';
-import { createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement } from '@cds/core/test';
 import {
   addAttributeValue,
   assignSlotNames,

--- a/packages/core/src/internal/utils/focus-trap.spec.ts
+++ b/packages/core/src/internal/utils/focus-trap.spec.ts
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { html } from 'lit-element';
-import { createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement } from '@cds/core/test';
 import { registerElementSafely, sleep } from '@cds/core/internal';
 import {
   addReboundElementsToFocusTrapElement,

--- a/packages/core/src/internal/utils/responsive.spec.ts
+++ b/packages/core/src/internal/utils/responsive.spec.ts
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { html } from 'lit-html';
-import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test';
 import { CdsControl } from '@cds/core/forms/index.js';
 
 describe('responsive utilities', () => {

--- a/packages/core/src/modal/modal-actions.element.spec.ts
+++ b/packages/core/src/modal/modal-actions.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -7,7 +7,7 @@
 import { html } from 'lit-html';
 import '@cds/core/modal/register.js';
 import { CdsModalActions } from '@cds/core/modal';
-import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
 
 describe('modal-actions element', () => {
   let testElement: HTMLElement;

--- a/packages/core/src/modal/modal-content.element.spec.ts
+++ b/packages/core/src/modal/modal-content.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -7,7 +7,7 @@
 import { html } from 'lit-html';
 import '@cds/core/modal/register.js';
 import { CdsModalContent } from '@cds/core/modal';
-import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
 
 describe('modal-content element', () => {
   let testElement: HTMLElement;

--- a/packages/core/src/modal/modal-header-actions.element.spec.ts
+++ b/packages/core/src/modal/modal-header-actions.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -7,7 +7,7 @@
 import { html } from 'lit-html';
 import '@cds/core/modal/register.js';
 import { CdsModalHeaderActions } from '@cds/core/modal';
-import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
 
 describe('modal-header-actions element', () => {
   let testElement: HTMLElement;

--- a/packages/core/src/modal/modal-header.element.spec.ts
+++ b/packages/core/src/modal/modal-header.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -7,7 +7,7 @@
 import { html } from 'lit-html';
 import '@cds/core/modal/register.js';
 import { CdsModalHeader } from '@cds/core/modal';
-import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
 
 describe('modal-header element', () => {
   let testElement: HTMLElement;

--- a/packages/core/src/modal/modal.element.spec.ts
+++ b/packages/core/src/modal/modal.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -9,7 +9,7 @@ import '@cds/core/modal/register.js';
 import { I18nService, HTMLAttributeTuple } from '@cds/core/internal';
 import { CdsInternalCloseButton } from '@cds/core/internal-components/close-button';
 import { CdsModal } from '@cds/core/modal';
-import { componentIsStable, createTestElement, getComponentSlotContent, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, getComponentSlotContent, removeTestElement } from '@cds/core/test';
 
 describe('modal element', () => {
   let testElement: HTMLElement;

--- a/packages/core/src/password/password.element.spec.ts
+++ b/packages/core/src/password/password.element.spec.ts
@@ -5,7 +5,7 @@
  */
 
 import { html } from 'lit-html';
-import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test';
 import { CdsPassword } from '@cds/core/password';
 import '@cds/core/password/register.js';
 

--- a/packages/core/src/progress-circle/progress-circle.element.spec.ts
+++ b/packages/core/src/progress-circle/progress-circle.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -7,7 +7,7 @@
 import { html } from 'lit-html';
 import '@cds/core/progress-circle/register.js';
 import { CdsProgressCircle } from '@cds/core/progress-circle';
-import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
 
 describe('progress circle element – ', () => {
   let testElementUnset: HTMLElement;

--- a/packages/core/src/radio/radio-group.element.spec.ts
+++ b/packages/core/src/radio/radio-group.element.spec.ts
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { html } from 'lit-html';
-import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test';
 import { CdsRadioGroup } from '@cds/core/radio';
 import '@cds/core/radio/register.js';
 

--- a/packages/core/src/radio/radio.element.spec.ts
+++ b/packages/core/src/radio/radio.element.spec.ts
@@ -5,7 +5,7 @@
  */
 
 import { html } from 'lit-html';
-import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test';
 import { CdsRadio } from '@cds/core/radio';
 import '@cds/core/radio/register.js';
 

--- a/packages/core/src/range/range.element.spec.ts
+++ b/packages/core/src/range/range.element.spec.ts
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { html } from 'lit-html';
-import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test';
 import { CdsRange } from '@cds/core/range';
 import '@cds/core/range/register.js';
 

--- a/packages/core/src/search/search.element.spec.ts
+++ b/packages/core/src/search/search.element.spec.ts
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { html } from 'lit-html';
-import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test';
 import { CdsSearch } from '@cds/core/search';
 import '@cds/core/search/register.js';
 

--- a/packages/core/src/select/select.element.spec.ts
+++ b/packages/core/src/select/select.element.spec.ts
@@ -5,7 +5,7 @@
  */
 
 import { html } from 'lit-html';
-import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test';
 import { CdsSelect } from '@cds/core/select';
 import '@cds/core/select/register.js';
 

--- a/packages/core/src/tag/tag.element.spec.ts
+++ b/packages/core/src/tag/tag.element.spec.ts
@@ -8,7 +8,7 @@ import { html } from 'lit-html';
 import '@cds/core/tag/register.js';
 import '@cds/core/icon/register.js';
 import { CdsTag } from '@cds/core/tag';
-import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
 
 describe('tag element', () => {
   let testElement: HTMLElement;

--- a/packages/core/src/test-dropdown/test-dropdown.element.spec.ts
+++ b/packages/core/src/test-dropdown/test-dropdown.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -7,7 +7,7 @@
 import { html } from 'lit-html';
 import '@cds/core/test-dropdown';
 import { CdsTestDropdown } from '@cds/core/test-dropdown';
-import { componentIsStable, createTestElement, getComponentSlotContent, removeTestElement } from '@cds/core/test/utils';
+import { componentIsStable, createTestElement, getComponentSlotContent, removeTestElement } from '@cds/core/test';
 
 describe('dropdown test element', () => {
   let testElement: HTMLElement;

--- a/packages/core/src/test/index.ts
+++ b/packages/core/src/test/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+/** @internal testing utilities */
+export * from './utils.js';

--- a/packages/core/src/test/utils.ts
+++ b/packages/core/src/test/utils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -24,7 +24,7 @@ export function removeTestElement(element: HTMLElement) {
 }
 
 export function getComponentSlotContent(component: HTMLElement): { [name: string]: string } {
-  return Array.from(component.shadowRoot.querySelectorAll('slot')).reduce(
+  return Array.from(component.shadowRoot?.querySelectorAll('slot') as NodeListOf<HTMLSlotElement>).reduce(
     (acc: { [name: string]: string }, slot: HTMLSlotElement) => {
       const name = slot.name.length > 0 ? slot.name : 'default';
       acc[name] = (slot.assignedNodes() as any[]).reduce((p, n) => {
@@ -38,12 +38,16 @@ export function getComponentSlotContent(component: HTMLElement): { [name: string
   );
 }
 
-function retry(fn: any, maxTries = 10, promise?: Promise<any>, promiseObject?: { resolve: any; reject: any }) {
-  maxTries--;
-  promiseObject = promiseObject || {
+function retry(
+  fn: any,
+  maxTries = 10,
+  promise?: Promise<any>,
+  promiseObject: { resolve: any; reject: any } = {
     resolve: null,
     reject: null,
-  };
+  }
+) {
+  maxTries--;
 
   promise =
     promise ||

--- a/packages/core/src/textarea/textarea.element.spec.ts
+++ b/packages/core/src/textarea/textarea.element.spec.ts
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { html } from 'lit-html';
-import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test';
 import { CdsTextarea } from '@cds/core/textarea';
 import '@cds/core/textarea/register.js';
 

--- a/packages/core/src/time/time.element.spec.ts
+++ b/packages/core/src/time/time.element.spec.ts
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { html } from 'lit-html';
-import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test';
 import { CdsTime } from '@cds/core/time';
 import '@cds/core/time/register.js';
 

--- a/packages/core/src/toggle/toggle-group.element.spec.ts
+++ b/packages/core/src/toggle/toggle-group.element.spec.ts
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { html } from 'lit-html';
-import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test';
 import { CdsToggleGroup } from '@cds/core/toggle';
 import '@cds/core/toggle/register.js';
 

--- a/packages/core/src/toggle/toggle.element.spec.ts
+++ b/packages/core/src/toggle/toggle.element.spec.ts
@@ -5,7 +5,7 @@
  */
 
 import { html } from 'lit-html';
-import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test/utils';
+import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test';
 import { CdsToggle } from '@cds/core/toggle';
 import '@cds/core/toggle/register.js';
 

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -28,7 +28,6 @@
     "baseUrl": "./",
     "rootDir": "./",
     "paths": {
-      "@cds/core/test/*": ["./src/test/*"],
       "@cds/core/*": ["./src/*"]
     },
     "plugins": [

--- a/packages/core/tsconfig.lib.json
+++ b/packages/core/tsconfig.lib.json
@@ -6,5 +6,5 @@
     "rootDir": "./src"
   },
   "allowSyntheticDefaultImports": false,
-  "exclude": ["**/test/*.ts", "**/*.spec.ts", "dist", "node_modules", "./storybook", "**/*.stories.ts", "./build"]
+  "exclude": ["**/*.spec.ts", "dist", "node_modules", "./storybook", "**/*.stories.ts", "./build"]
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The core test utilities were missing from the module exports making it impossible to import in certain build tools. 

Issue Number: N/A

## What is the new behavior?
- fix broken export path for test utils
- cleanup test utils module path from `@cds/core/test/utils.js` to `@cds/core/test` 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
