### PR TITLE
fix(alert): vertically center text in alert

### DIFF
--- a/packages/angular/projects/clr-angular/src/emphasis/alert/_alert.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/emphasis/alert/_alert.clarity.scss
@@ -152,7 +152,7 @@
   }
 
   .alert-items {
-    $vertPadding: $clr_baselineRem_8px;
+    $vertPadding: $clr_baselineRem_10px;
     $horizPadding: $clr_baselineRem_0_5 - $clr-alert-borderwidth;
     flex: 1 1 auto;
     flex-flow: column nowrap;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The `.alert-items` padding is `.4rem .55rem` which positions the alert text closer to the top border rather than in the center of the container.

```
.alert-items {
  flex: 1 1 auto;
  flex-flow: column nowrap;
  padding: .4rem .55rem;
  display: flex;
}
```

Issue Number: fixes #4460

## What is the new behavior?

With this change, the padding is `.5rem .55rem` and the text is vertically centered.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
