### PR TITLE
docs: add version info for icons

### DIFF
--- a/apps/website/.vuepress/theme/global-components/DocIcon.vue
+++ b/apps/website/.vuepress/theme/global-components/DocIcon.vue
@@ -8,17 +8,28 @@
       :class="{ 'is-active': isActive }"
       :aria-label="`Demo ${iconName}, button`"
     >
-      <slot></slot> {{ iconName }}
+      <slot></slot> {{ iconName }} &nbsp;&nbsp;<cds-icon
+        shape="new"
+        size="24"
+        style="--color: var(--cds-alias-status-alt);"
+        v-if="isNew"
+      ></cds-icon>
     </button>
   </div>
 </template>
 
 <script>
+import IconInventory from '../../../data/icon-inventory';
 export default {
   name: 'DocIcon',
   props: {
     iconName: String,
     isActive: Boolean,
+  },
+  computed: {
+    isNew: function () {
+      return IconInventory.isNew(this.iconName);
+    },
   },
   methods: {
     openDetail: function (event, iconName) {

--- a/apps/website/.vuepress/theme/global-components/DocIconDetail.vue
+++ b/apps/website/.vuepress/theme/global-components/DocIconDetail.vue
@@ -1,9 +1,11 @@
 <template>
-  <div class="clr-col-12">
+  <div cds-layout="vertical">
     <div class="card">
       <div class="card-block">
-        <h4 class="card-title">
-          {{ iconName }} <span class="aliases" v-if="hasAliases">aliases: {{ iconAliases }}</span>
+        <h4 class="card-title" cds-layout="horizontal gap:sm">
+          <div>{{ iconName }}</div>
+          <div class="aliases" v-if="hasAliases">aliases: {{ iconAliases }}</div>
+          <cds-tag cds-layout="align:right" readonly>Since {{ version }}</cds-tag>
         </h4>
         <div class="card-text">
           <div class="icon-snippet">
@@ -79,6 +81,17 @@ export default {
       }
 
       return variants;
+    },
+    version: function () {
+      // We look up the icons added since v1, if we find it use that version, otherwise send v1
+      const version = Object.entries(IconInventory.versionMap).find(entry => {
+        if (entry[1].indexOf(this.iconName) > -1) {
+          return entry[0];
+        }
+        return false;
+      });
+
+      return version ? version[0] : 'v1.0.0';
     },
   },
   data: function () {

--- a/apps/website/data/icon-inventory.js
+++ b/apps/website/data/icon-inventory.js
@@ -143,4 +143,55 @@ export default {
     ...arrAliasesToObjAliases(technologyAliases),
     ...arrAliasesToObjAliases(chartAliases),
   },
+  latest: 'v5.0.0',
+  isNew: function (shape) {
+    return this.versionMap[this.latest].indexOf(shape) > -1;
+  },
+  versionMap: {
+    // In the future, you can add a new icons to define what version they were added.
+    // Volume 13 and before were added before v1, and we just don't care to track that far back.
+    'v1.1.0': [
+      'bell-curve',
+      'fish',
+      'form',
+      'fuel',
+      'snowflake',
+      'tabke',
+      'dot-circle',
+      'volume',
+      'crosshairs',
+      'capacitor',
+      'squid',
+      'inductor',
+      'resistor',
+    ], // vol 14 https://github.com/vmware/clarity/pull/3099
+    'v2.1.0': [
+      'text-edit',
+      'highlighter',
+      'indent',
+      'outdent',
+      'strikethrough',
+      'subscript',
+      'superscript',
+      'storage-adapter',
+      'node-group',
+      'nodes',
+      'namespace',
+      'node',
+      'pod',
+      'beta',
+    ], // vol 15 https://github.com/vmware/clarity/pull/3539
+    'v3.0.0': ['first-aid', 'crown', 'hashtag'], // vol 16 https://github.com/vmware/clarity/pull/3965
+    'v4.0.0': [
+      'employee',
+      'employee-group',
+      'factory',
+      'color-palette',
+      'animation',
+      'ci-cd',
+      'file-share2',
+      'on-holiday',
+    ], // vol 17 https://github.com/vmware/clarity/pull/4218
+    'v5.0.0': ['announcement', 'birthday-cake', 'pdf-file', 'script-execute', 'script-schedule', 'xls-file'], // vol 18 https://github.com/vmware/clarity/issues/4839
+  },
 };


### PR DESCRIPTION
This adds a tag for each icon added to Clarity after v1, defaulting to v1 for the rest.

closes #1808

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1808

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
