### PR TITLE
fix(website): fixing landing first image on super wide screen

### DIFF
--- a/apps/website/.vuepress/theme/components/Home.vue
+++ b/apps/website/.vuepress/theme/components/Home.vue
@@ -74,7 +74,7 @@
           </cds-button>
         </router-link>
         <div cds-layout="grid">
-          <div cds-layout="col@sm:start-4 col@sm:end-12">
+          <div cds-layout="col@sm:start-2 col@sm:end-12">
             <img
               style="max-width: 720px;"
               cds-layout="fill"


### PR DESCRIPTION
When the screen is too wide, the first image is going on the right and miss-align with the other blocks below.

Screenshots below,

(On the left before, on the right after) (Smallest possible screen)
![Screenshot 2021-02-22 at 13 14 22](https://user-images.githubusercontent.com/204564/108701453-a7330f80-7510-11eb-88ed-1290a2939bdd.png)

Full width:
(Before)
![Screenshot 2021-02-22 at 13 15 15](https://user-images.githubusercontent.com/204564/108701538-c336b100-7510-11eb-9255-f8936faf10d3.png)

(After)
![Screenshot 2021-02-22 at 13 15 29 (2)](https://user-images.githubusercontent.com/204564/108701559-ca5dbf00-7510-11eb-9111-bcf041a8eb22.png)



## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
