### PR TITLE
fix: website modal demos not working

### DIFF
--- a/apps/website/.vuepress/code/core-usage-demos/modal/sizes.html
+++ b/apps/website/.vuepress/code/core-usage-demos/modal/sizes.html
@@ -1,21 +1,3 @@
-<script type="text/javascript">
-  var smModal = document.getElementById('sm-modal');
-  var mdModal = document.getElementById('md-modal');
-  var lgModal = document.getElementById('lg-modal');
-  var xlModal = document.getElementById('xl-modal');
-  function toggleSm() {
-    smModal.hidden = !smModal.hidden;
-  }
-  function toggleMd() {
-    mdModal.hidden = !mdModal.hidden;
-  }
-  function toggleLg() {
-    lgModal.hidden = !lgModal.hidden;
-  }
-  function toggleXl() {
-    xlModal.hidden = !xlModal.hidden;
-  }
-</script>
 <div cds-layout="horizontal gap:sm align:fill m-y:md">
   <div cds-layout="horizontal wrap:none">
     <div
@@ -124,7 +106,7 @@
       <span cds-text="subsection semibold" cds-layout="m-t:sm">X-Large Modal</span>
       <span cds-text="secondary" cds-layout="p-b:xs">Width: 1152px</span>
       <cds-button onclick="toggleXl()" size="sm" action="outline">Launch</cds-button>
-      <cds-modal id="xl-modal" size="sm" hidden closable="false">
+      <cds-modal id="xl-modal" size="xl" hidden closable="false">
         <cds-modal-header>
           <h3 cds-text="heading">X-large Modal</h3>
         </cds-modal-header>
@@ -138,3 +120,21 @@
     </div>
   </div>
 </div>
+<script type="text/javascript">
+  var smModal = document.getElementById('sm-modal');
+  var mdModal = document.getElementById('md-modal');
+  var lgModal = document.getElementById('lg-modal');
+  var xlModal = document.getElementById('xl-modal');
+  function toggleSm() {
+    smModal.hidden = !smModal.hidden;
+  }
+  function toggleMd() {
+    mdModal.hidden = !mdModal.hidden;
+  }
+  function toggleLg() {
+    lgModal.hidden = !lgModal.hidden;
+  }
+  function toggleXl() {
+    xlModal.hidden = !xlModal.hidden;
+  }
+</script>


### PR DESCRIPTION
• they were assigning an element to a var before the element was introduced in the DOM
• xl modal was set to small not xl

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
