### PR TITLE
feat: add ESLint rule fixers for the `List` and `Badge` components

### DIFF
--- a/packages/eslint-plugin-clarity-adoption/README.md
+++ b/packages/eslint-plugin-clarity-adoption/README.md
@@ -61,25 +61,28 @@ yarn
 yarn run watch
 ```
 
-2. Open another terminal window/tab, navigate to the `dist` directory and execute `yarn link`:
+2. Open another terminal window/tab, navigate to the `dist` directory and execute `npm link`:
 
 ```
 cd ../../dist/eslint-plugin-clarity-adoption
-yarn link
+npm link
 ```
+
+**NB:** `yarn link` doesn't work properly for linking the plugin. Please use `npm link` instead.
 
 3. Create a demo project, navigate to it and link the ESLint plugin:
 
 ```bash
 ng new linter-test-project
 cd linter-test-project
-yarn link @clr/eslint-plugin-clarity-adoption
+npm link @clr/eslint-plugin-clarity-adoption
 ```
 
 4. Install the other linter dependencies
 
 ```bash
-yarn add -D @typescript-eslint/parser eslint
+npm i -D @typescript-eslint/parser eslint
+npm i
 ```
 
 5. Add ESLint configuration for TypeScript and HTML.

--- a/packages/eslint-plugin-clarity-adoption/src/html-parser.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/html-parser.ts
@@ -163,10 +163,13 @@ export function parseForESLint(code: string, options = {}): ESLintHtmlParseResul
       tagName: name,
       parent: currentElement,
       value: '',
-      range: [htmlParser.startIndex, -1],
+      // @ts-ignore
+      range: [htmlParser.tokenizer.sectionStart - 1, -1],
       loc: {
-        start: getLineAndColumn(htmlParser.startIndex),
-        end: getLineAndColumn(htmlParser.startIndex),
+        // @ts-ignore
+        start: getLineAndColumn(htmlParser.tokenizer.sectionStart),
+        // @ts-ignore
+        end: getLineAndColumn(htmlParser.tokenizer.sectionStart),
       },
     };
 
@@ -232,9 +235,12 @@ export function parseForESLint(code: string, options = {}): ESLintHtmlParseResul
     },
 
     onclosetag: () => {
-      currentElement.range[1] = (htmlParser.endIndex || 0) + 1;
-      currentElement.loc.end = getLineAndColumn((htmlParser.endIndex || 0) + 1);
-      currentElement.value = code.substr(currentElement.range[0], currentElement.range[1] - currentElement.range[0]);
+      const startIndex = currentElement.range[0];
+      const endIndex = htmlParser.endIndex || 0;
+
+      currentElement.loc.end = getLineAndColumn(endIndex);
+      currentElement.value = code.substr(startIndex, endIndex - startIndex + 1);
+      currentElement.range[1] = endIndex;
 
       currentElement = currentElement.parent as HTMLElement;
     },

--- a/packages/eslint-plugin-clarity-adoption/src/rules/html-fixer-helpers.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/html-fixer-helpers.ts
@@ -1,0 +1,96 @@
+import { RuleFixer, RuleFix } from '@typescript-eslint/experimental-utils/dist/ts-eslint';
+import { HTMLAttribute, HTMLElement } from '../types';
+
+function getSingleDeprecatedClassFix(
+  oldStatus: string,
+  classAttribute: HTMLAttribute,
+  deprecatedClassToAttributeMap: any,
+  fixer: RuleFixer
+): RuleFix | undefined {
+  const statusAttribute = deprecatedClassToAttributeMap[oldStatus];
+  if (!statusAttribute) {
+    return;
+  }
+
+  const newAttributeFixer = fixer.insertTextAfter(classAttribute as any, ` ${statusAttribute}`);
+
+  return newAttributeFixer;
+}
+
+export function isDeprecatedClassFactory(deprecatedClassToAttributeMap): (value: string) => boolean {
+  const deprecatedClassNames = Object.keys(deprecatedClassToAttributeMap);
+
+  return (value: string): boolean => deprecatedClassNames.some(oldStatus => oldStatus === value);
+}
+
+export function getDeprecatedClassFixes(
+  fixer: RuleFixer,
+  classAttribute: HTMLAttribute | undefined,
+  deprecatedClassToAttributeMap: { [key: string]: string }
+): Array<RuleFix> {
+  if (!classAttribute) {
+    return [];
+  }
+
+  const isDeprecatedClass = isDeprecatedClassFactory(deprecatedClassToAttributeMap);
+  const fixers: Array<RuleFix> = [];
+  const value = classAttribute.attributeValue.value;
+  const classes = value.split(' ');
+  const deprecatedClasses = classes.filter(isDeprecatedClass);
+  if (!deprecatedClasses.length) {
+    return [];
+  }
+
+  const otherClasses = classes.filter(cls => !isDeprecatedClass(cls)).join(' ');
+  const newAttributesFixers = deprecatedClasses
+    .map(status => getSingleDeprecatedClassFix(status, classAttribute, deprecatedClassToAttributeMap, fixer))
+    .filter(fix => !!fix) as Array<RuleFix>; // remove undefined values
+  let classRemoveFixer: RuleFix;
+  // If there are any other classes,
+  // remove only the deprecated class value from the "class" attribute
+  if (otherClasses.length) {
+    classRemoveFixer = fixer.replaceText(classAttribute.attributeValue as any, otherClasses);
+  } else {
+    // If there are no other classes, remove the whole "class" attribute from the node
+    classRemoveFixer = fixer.removeRange([classAttribute.range[0] - 1, classAttribute.range[1]]);
+  }
+
+  fixers.push(classRemoveFixer, ...newAttributesFixers);
+
+  return fixers;
+}
+
+export function getAttributeNameFixes(
+  fixer: RuleFixer,
+  attributes: Array<HTMLAttribute>,
+  oldName: string,
+  newName: string
+): Array<RuleFix> {
+  const attributeToFix = attributes.find(attribute => attribute.attributeName.value === oldName);
+  if (!attributeToFix) {
+    return [];
+  }
+
+  const start = attributeToFix?.range[0];
+  const end = start + oldName.length;
+
+  return [fixer.replaceTextRange([start, end], newName)];
+}
+
+export function getTagFixes(fixer: RuleFixer, node: HTMLElement, oldTag: string, newTag: string): Array<RuleFix> {
+  const openingTag = `<${oldTag}`;
+  const closingTag = `</${oldTag}>`;
+
+  const { value, range } = node;
+  const openingTagStart = range[0];
+  const openingTagEnd = openingTagStart + openingTag.length;
+
+  const closingTagStart = value.lastIndexOf(closingTag) + openingTagStart;
+
+  const closingTagEnd = closingTagStart + closingTag.length - 1;
+
+  return [
+    fixer.replaceTextRange([openingTagStart, openingTagEnd], `<${newTag}`),
+    fixer.replaceTextRange([closingTagStart, closingTagEnd], `</${newTag}`),
+  ];
+}

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-badge/index.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-badge/index.ts
@@ -1,15 +1,36 @@
 import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
-import { HTMLElement } from '../../types/index';
+import { HTMLElement } from '../../types';
 import { lintDecoratorTemplate } from '../decorator-template-helper';
+import { getDeprecatedClassFixes, getTagFixes } from '../html-fixer-helpers';
 
 export const createESLintRule = ESLintUtils.RuleCreator(() => ``);
 export type MessageIds = 'clrBadgeFailure';
 
+const disallowedBadgeElementSelector = `span.badge`;
+
+const deprecatedClassToAttributeMap = {
+  badge: '', // remove extraneous badge classes
+
+  'badge-purple': 'color="purple"',
+  'badge-blue': 'color="blue"',
+  'badge-orange': 'color="orange"',
+  'badge-light-blue': 'color="light-blue"',
+
+  'badge-1': 'color="gray"',
+  'badge-2': 'color="purple"',
+  'badge-3': 'color="blue"',
+  'badge-4': 'color="orange"',
+  'badge-5': 'color="light-blue"',
+
+  'badge-info': 'status="info"',
+  'badge-success': 'status="success"',
+  'badge-warning': 'status="warning"',
+  'badge-danger': 'status="danger"',
+};
+
 function hasDisallowedClass(classes: Array<string>): boolean {
   return classes.includes('badge');
 }
-
-const disallowedBadgeElementSelector = `span.badge`;
 
 export default createESLintRule({
   name: 'no-clr-badge',
@@ -36,6 +57,12 @@ export default createESLintRule({
           context.report({
             node: node as any,
             messageId: 'clrBadgeFailure',
+            fix: fixer => {
+              const tagFixes = getTagFixes(fixer, node, 'span', 'cds-badge');
+              const attributeFixes = getDeprecatedClassFixes(fixer, classNode, deprecatedClassToAttributeMap);
+
+              return [...tagFixes, ...attributeFixes];
+            },
           });
         }
       },

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-badge/no-clr-badge.spec.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-badge/no-clr-badge.spec.ts
@@ -9,48 +9,163 @@ const getInvalidBadgeTest = getInvalidTestFactory('clrBadgeFailure');
 htmlRuleTester.run('no-clr-badge', rule, {
   invalid: [
     getInvalidBadgeTest({
-      code: `<span class="badge"></span>`,
+      code: `<span class="badge">1</span>`,
+      output: `<cds-badge>1</cds-badge>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    /**
+     * Color
+     */
+    getInvalidBadgeTest({
+      code: `<span class="badge badge-1">1</span>`,
+      output: `<cds-badge color="gray">1</cds-badge>`,
       locations: [{ line: 1, column: 1 }],
     }),
     getInvalidBadgeTest({
+      code: `<span class="badge badge-2">1</span>`,
+      output: `<cds-badge color="purple">1</cds-badge>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidBadgeTest({
+      code: `<span class="badge badge-3">1</span>`,
+      output: `<cds-badge color="blue">1</cds-badge>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidBadgeTest({
+      code: `<span class="badge badge-4">1</span>`,
+      output: `<cds-badge color="orange">1</cds-badge>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidBadgeTest({
+      code: `<span class="badge badge-5">1</span>`,
+      output: `<cds-badge color="light-blue">1</cds-badge>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidBadgeTest({
+      code: `<span class="badge badge-purple">1</span>`,
+      output: `<cds-badge color="purple">1</cds-badge>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidBadgeTest({
+      code: `<span class="badge badge-blue">1</span>`,
+      output: `<cds-badge color="blue">1</cds-badge>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidBadgeTest({
+      code: `<span class="badge badge-orange">1</span>`,
+      output: `<cds-badge color="orange">1</cds-badge>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidBadgeTest({
+      code: `<span class="badge badge-light-blue">1</span>`,
+      output: `<cds-badge color="light-blue">1</cds-badge>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    /**
+     * Status
+     */
+    getInvalidBadgeTest({
+      code: `<span class="badge badge-info">1</span>`,
+      output: `<cds-badge status="info">1</cds-badge>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidBadgeTest({
+      code: `<span class="badge badge-success">1</span>`,
+      output: `<cds-badge status="success">1</cds-badge>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidBadgeTest({
+      code: `<span class="badge badge-warning">1</span>`,
+      output: `<cds-badge status="warning">1</cds-badge>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidBadgeTest({
+      code: `<span class="badge badge-danger">1</span>`,
+      output: `<cds-badge status="danger">1</cds-badge>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    /**
+     * Additional classes
+     */
+    getInvalidBadgeTest({
+      code: `<span class="badge custom">1</span>`,
+      output: `<cds-badge class="custom">1</cds-badge>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidBadgeTest({
+      code: `<span class="badge custom badge-info">1</span>`,
+      output: `<cds-badge class="custom" status="info">1</cds-badge>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidBadgeTest({
+      code: `<span class="custom badge badge-purple">1</span>`,
+      output: `<cds-badge class="custom" color="purple">1</cds-badge>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    /**
+     * Multiple components
+     */
+    getInvalidBadgeTest({
       code: `
-                <div>
-                    <span class="badge"></span>
-                </div>
-            `,
-      locations: [{ line: 3, column: 21 }],
+        <div>
+          <span class="badge"></span>
+        </div>
+      `,
+      output: `
+        <div>
+          <cds-badge></cds-badge>
+        </div>
+      `,
+      locations: [{ line: 3, column: 11 }],
     }),
     getInvalidBadgeTest({
       code: `
-                <div>
-                </div>
-                <span class="badge"></span>
-            `,
-      locations: [{ line: 4, column: 17 }],
+        <div>
+        </div>
+        <span class="badge"></span>
+      `,
+      output: `
+        <div>
+        </div>
+        <cds-badge></cds-badge>
+      `,
+      locations: [{ line: 4, column: 9 }],
     }),
     getInvalidBadgeTest({
       code: `<div><span class="badge"></span></div>`,
+      output: `<div><cds-badge></cds-badge></div>`,
       locations: [{ line: 1, column: 6 }],
     }),
     getInvalidBadgeTest({
+      code: `
+        <div></div>
+        <span class="badge"></span>
+        <span class="badge badge-info">
+        </span>
+        <div><span class="badge badge-1"></span></div>
+      `,
+      output: `
+        <div></div>
+        <cds-badge></cds-badge>
+        <cds-badge status="info">
+        </cds-badge>
+        <div><cds-badge color="gray"></cds-badge></div>
+      `,
+      locations: [
+        { line: 3, column: 9 },
+        { line: 4, column: 9 },
+        { line: 6, column: 14 },
+      ],
+    }),
+    /**
+     * Two components on the same line
+     */
+    getInvalidBadgeTest({
       code: `<div><span class="badge"></span><span class="badge badge-info"></span></div>`,
+      output: `<div><cds-badge></cds-badge><cds-badge status="info"></cds-badge></div>`,
       locations: [
         { line: 1, column: 6 },
         { line: 1, column: 33 },
-      ],
-    }),
-    getInvalidBadgeTest({
-      code: `
-                <div></div>
-                <span class="badge"></span>
-                <span class="badge badge-info">
-                </span>
-                <div><span class="badge badge-1"></span></div>
-            `,
-      locations: [
-        { line: 3, column: 17 },
-        { line: 4, column: 17 },
-        { line: 6, column: 22 },
       ],
     }),
   ],

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-icon/index.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-icon/index.ts
@@ -1,6 +1,12 @@
 import { ESLintUtils } from '@typescript-eslint/experimental-utils';
 import { RuleFixer, RuleFix } from '@typescript-eslint/experimental-utils/dist/ts-eslint';
 import { HTMLElement, HTMLAttributeName, HTMLAttribute } from '../../types';
+import {
+  isDeprecatedClassFactory,
+  getAttributeNameFixes,
+  getDeprecatedClassFixes,
+  getTagFixes,
+} from '../html-fixer-helpers';
 
 export const createESLintRule = ESLintUtils.RuleCreator(() => ``);
 
@@ -30,68 +36,6 @@ const deprecatedClassToAttributeMap = {
   'has-alert': 'badge="triangle"',
 };
 
-const deprecatedClassNames = Object.keys(deprecatedClassToAttributeMap);
-const isDeprecatedClass = (value: string): boolean => deprecatedClassNames.some(oldStatus => oldStatus === value);
-
-function getSingleDeprecatedClassFix(oldStatus: string, classAttribute: HTMLAttribute, fixer: RuleFixer): RuleFix {
-  const statusAttribute = ` ${deprecatedClassToAttributeMap[oldStatus]}`;
-  const newAttributeFixer = fixer.insertTextAfter(classAttribute as any, statusAttribute);
-
-  return newAttributeFixer;
-}
-
-function getDeprecatedClassFixes(
-  fixer: RuleFixer,
-  classAttribute: HTMLAttribute | undefined
-): Array<RuleFix> | undefined {
-  if (!classAttribute) {
-    return;
-  }
-
-  const fixers: Array<RuleFix> = [];
-  const value = classAttribute.attributeValue.value;
-  const classes = value.split(' ');
-  const deprecatedClasses = classes.filter(isDeprecatedClass);
-  if (!deprecatedClasses.length) {
-    return;
-  }
-
-  const otherClasses = classes.filter(cls => !isDeprecatedClass(cls)).join(' ');
-  const newAttributesFixers = deprecatedClasses.map(status =>
-    getSingleDeprecatedClassFix(status, classAttribute, fixer)
-  );
-  let classRemoveFixer: RuleFix;
-  // If there are any other classes,
-  // remove only the deprecated class value from the "class" attribute
-  if (otherClasses.length) {
-    classRemoveFixer = fixer.replaceText(classAttribute.attributeValue as any, otherClasses);
-  } else {
-    // If there are no other classes, remove the whole "class" attribute from the node
-    classRemoveFixer = fixer.removeRange([classAttribute.range[0] - 1, classAttribute.range[1]]);
-  }
-
-  fixers.push(classRemoveFixer, ...newAttributesFixers);
-
-  return fixers;
-}
-
-function getAttributeNameFixes(
-  fixer: RuleFixer,
-  attributes: Array<HTMLAttribute>,
-  oldName: string,
-  newName: string
-): Array<RuleFix> | undefined {
-  const attributeToFix = attributes.find(attribute => attribute.attributeName.value === oldName);
-  if (!attributeToFix) {
-    return;
-  }
-
-  const start = attributeToFix?.range[0];
-  const end = start + oldName.length;
-
-  return [fixer.replaceTextRange([start, end], newName)];
-}
-
 function isDeprecatedShape(value: string): boolean {
   const isValidDirection = (val: string): boolean =>
     ['up', 'down', 'left', 'right'].some(direction => direction === val);
@@ -101,36 +45,38 @@ function isDeprecatedShape(value: string): boolean {
   return shapes && shapes.length === 2 && shapes[0] === 'caret' && isValidDirection(shapes[1]);
 }
 
-function getShapeFixes(fixer: RuleFixer, attributes: Array<HTMLAttribute>): Array<RuleFix> | undefined {
+function getShapeFixes(fixer: RuleFixer, attributes: Array<HTMLAttribute>): Array<RuleFix> {
   const shapeAttribute = attributes.find(attribute => attribute.attributeName.value === 'shape');
   if (!shapeAttribute) {
-    return;
+    return [];
   }
 
   const attributeValue = shapeAttribute.attributeValue.value || '';
 
-  if (isDeprecatedShape(attributeValue)) {
-    const shapeFix = fixer.replaceText(shapeAttribute.attributeValue as any, 'angle');
-
-    const direction = attributeValue.split(' ')[1];
-    const insertedDirectionFix = fixer.insertTextAfter(shapeAttribute as any, ` direction="${direction}"`);
-
-    return [shapeFix, insertedDirectionFix];
+  if (!isDeprecatedShape(attributeValue)) {
+    return [];
   }
+
+  const shapeFix = fixer.replaceText(shapeAttribute.attributeValue as any, 'angle');
+
+  const direction = attributeValue.split(' ')[1];
+  const insertedDirectionFix = fixer.insertTextAfter(shapeAttribute as any, ` direction="${direction}"`);
+
+  return [shapeFix, insertedDirectionFix];
 }
 
 export default createESLintRule({
-  name: 'no-clr-icons',
+  name: 'no-clr-icon',
   meta: {
     type: 'problem',
     docs: {
-      description: 'Disallow use of clr-icons',
+      description: 'Disallow use of clr-icon',
       category: 'Best Practices',
       recommended: 'warn',
     },
     fixable: 'code',
     messages: {
-      clrIconFailure: 'Using clr-icons is not allowed!',
+      clrIconFailure: 'Using clr-icon is not allowed!',
     },
     schema: [{}],
   },
@@ -139,37 +85,20 @@ export default createESLintRule({
     return {
       // Detects and fixes elements with name "clr-icon" and their attributes
       'HTMLElement[tagName="clr-icon"]': (node: HTMLElement): void => {
-        const { value, range } = node;
-        const nodeStart = range[0];
-        const openingTag = '<clr-icon';
-        const openingTagStart = value.indexOf(openingTag) + nodeStart;
-        const openingTagEnd = openingTagStart + openingTag.length;
-
-        const closingTag = '</clr-icon>';
-        const closingTagStart = value.indexOf(closingTag) + nodeStart;
-        const closingTagEnd = closingTagStart + closingTag.length;
-
         context.report({
           node: node as any,
           messageId: 'clrIconFailure',
           fix: fixer => {
-            const openingTagFixer = fixer.replaceTextRange([openingTagStart, openingTagEnd], '<cds-icon');
-            const closingTagFixer = fixer.replaceTextRange([closingTagStart, closingTagEnd], '</cds-icon>');
+            const tagFixes = getTagFixes(fixer, node, 'clr-icon', 'cds-icon');
 
             const attributes = node.attributes || [];
-            const directionAttributeFixes = getAttributeNameFixes(fixer, attributes, 'dir', 'direction') || [];
-            const shapeFixes = getShapeFixes(fixer, attributes) || [];
+            const directionAttributeFixes = getAttributeNameFixes(fixer, attributes, 'dir', 'direction');
+            const shapeFixes = getShapeFixes(fixer, attributes);
 
             const classAttribute = attributes.find(a => a.attributeName.value === 'class');
-            const deprecatedClassFixes = getDeprecatedClassFixes(fixer, classAttribute) || [];
+            const deprecatedClassFixes = getDeprecatedClassFixes(fixer, classAttribute, deprecatedClassToAttributeMap);
 
-            return [
-              openingTagFixer,
-              closingTagFixer,
-              ...directionAttributeFixes,
-              ...shapeFixes,
-              ...deprecatedClassFixes,
-            ];
+            return [...tagFixes, ...directionAttributeFixes, ...shapeFixes, ...deprecatedClassFixes];
           },
         });
       },
@@ -186,16 +115,16 @@ export default createESLintRule({
         const classAttributeNode = node.parent;
         const classValueNode = classAttributeNode.attributeValue;
         const { value = '' } = classValueNode;
+        const isDeprecatedClass = isDeprecatedClassFactory(deprecatedClassToAttributeMap);
         const hasDeprecatedClass = value.split(' ').some(isDeprecatedClass);
-        if (!hasDeprecatedClass) {
-          return;
-        }
 
-        context.report({
-          node: classValueNode as any,
-          messageId: 'clrIconFailure',
-          fix: fixer => getDeprecatedClassFixes(fixer, classAttributeNode) || [],
-        });
+        if (hasDeprecatedClass) {
+          context.report({
+            node: classValueNode as any,
+            messageId: 'clrIconFailure',
+            fix: fixer => getDeprecatedClassFixes(fixer, classAttributeNode, deprecatedClassToAttributeMap),
+          });
+        }
       },
       // Case: the tag name is migrated ("cds-icon") but the shape attribute is not
       'HTMLElement[tagName="cds-icon"] HTMLAttributeName[value="shape"]': (node: HTMLAttributeName): void => {
@@ -206,7 +135,7 @@ export default createESLintRule({
           context.report({
             node: node as any,
             messageId: 'clrIconFailure',
-            fix: fixer => getShapeFixes(fixer, [shapeAttribute]) || [],
+            fix: fixer => getShapeFixes(fixer, [shapeAttribute]),
           });
         }
       },

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-icon/no-clr-icon.spec.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-icon/no-clr-icon.spec.ts
@@ -2,11 +2,11 @@ import rule from '.';
 import { getHtmlRuleTester, getInvalidTestFactory } from '../../test-helper.spec';
 
 const htmlRuleTester = getHtmlRuleTester();
-const getInvalidAlertTest = getInvalidTestFactory('clrIconFailure');
+const getInvalidIconTest = getInvalidTestFactory('clrIconFailure');
 
 htmlRuleTester.run('no-clr-icon', rule, {
   invalid: [
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon></clr-icon>`,
       output: `<cds-icon></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
@@ -14,46 +14,45 @@ htmlRuleTester.run('no-clr-icon', rule, {
     /**
      * Direction attribute
      */
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon dir="left"></clr-icon>`,
       output: `<cds-icon direction="left"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon dir="right"></clr-icon>`,
       output: `<cds-icon direction="right"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon dir="up"></clr-icon>`,
       output: `<cds-icon direction="up"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon dir="down"></clr-icon>`,
       output: `<cds-icon direction="down"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
-
     /**
      * Direction attribute: already migrated tag (cds-icon)
      */
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<cds-icon dir="left"></cds-icon>`,
       output: `<cds-icon direction="left"></cds-icon>`,
       locations: [{ line: 1, column: 11 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<cds-icon dir="right"></cds-icon>`,
       output: `<cds-icon direction="right"></cds-icon>`,
       locations: [{ line: 1, column: 11 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<cds-icon dir="up"></cds-icon>`,
       output: `<cds-icon direction="up"></cds-icon>`,
       locations: [{ line: 1, column: 11 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<cds-icon dir="down"></cds-icon>`,
       output: `<cds-icon direction="down"></cds-icon>`,
       locations: [{ line: 1, column: 11 }],
@@ -61,57 +60,57 @@ htmlRuleTester.run('no-clr-icon', rule, {
     /**
      * Status attribute
      */
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon class="is-green"></clr-icon>`,
       output: `<cds-icon status="success"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon class="is-success"></clr-icon>`,
       output: `<cds-icon status="success"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon class="is-danger"></clr-icon>`,
       output: `<cds-icon status="danger"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon class="is-red"></clr-icon>`,
       output: `<cds-icon status="danger"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon class="is-warning"></clr-icon>`,
       output: `<cds-icon status="warning"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon class="is-info"></clr-icon>`,
       output: `<cds-icon status="info"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon class="is-blue"></clr-icon>`,
       output: `<cds-icon status="info"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon class="is-highlight"></clr-icon>`,
       output: `<cds-icon status="highlight"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon class="is-white"></clr-icon>`,
       output: `<cds-icon inverse></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon class="is-inverse"></clr-icon>`,
       output: `<cds-icon inverse></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon class="is-solid"></clr-icon>`,
       output: `<cds-icon solid></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
@@ -119,22 +118,22 @@ htmlRuleTester.run('no-clr-icon', rule, {
     /**
      * Status attribute: already migrated tag (cds-icon)
      */
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<cds-icon class="is-inverse"></cds-icon>`,
       output: `<cds-icon inverse></cds-icon>`,
       locations: [{ line: 1, column: 18 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<cds-icon random-attribute class="is-success"></cds-icon>`,
       output: `<cds-icon random-attribute status="success"></cds-icon>`,
       locations: [{ line: 1, column: 35 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<cds-icon random-attribute class="is-success is-inverse is-solid"></cds-icon>`,
       output: `<cds-icon random-attribute status="success" inverse solid></cds-icon>`,
       locations: [{ line: 1, column: 35 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<cds-icon random-attribute class="is-success my-class is-inverse is-solid"></cds-icon>`,
       output: `<cds-icon random-attribute class="my-class" status="success" inverse solid></cds-icon>`,
       locations: [{ line: 1, column: 35 }],
@@ -142,17 +141,17 @@ htmlRuleTester.run('no-clr-icon', rule, {
     /**
      * Status attribute: More than one class
      */
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon class="is-inverse my-class"></clr-icon>`,
       output: `<cds-icon class="my-class" inverse></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon class="is-inverse is-solid is-success my-class"></clr-icon>`,
       output: `<cds-icon class="my-class" inverse solid status="success"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon class="is-inverse is-solid is-success"></clr-icon>`,
       output: `<cds-icon inverse solid status="success"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
@@ -160,27 +159,27 @@ htmlRuleTester.run('no-clr-icon', rule, {
     /**
      * Badge attribute
      */
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon class="has-badge"></clr-icon>`,
       output: `<cds-icon badge></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon class="has-badge--success"></clr-icon>`,
       output: `<cds-icon badge="success"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon class="has-badge--error"></clr-icon>`,
       output: `<cds-icon badge="error"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon class="has-badge--info"></clr-icon>`,
       output: `<cds-icon badge="info"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon class="has-alert"></clr-icon>`,
       output: `<cds-icon badge="triangle"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
@@ -188,27 +187,27 @@ htmlRuleTester.run('no-clr-icon', rule, {
     /**
      * Badge attribute: already migrated tag (cds-icon)
      */
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<cds-icon class="has-badge"></cds-icon>`,
       output: `<cds-icon badge></cds-icon>`,
       locations: [{ line: 1, column: 18 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<cds-icon class="has-badge--success"></cds-icon>`,
       output: `<cds-icon badge="success"></cds-icon>`,
       locations: [{ line: 1, column: 18 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<cds-icon class="has-badge--info"></cds-icon>`,
       output: `<cds-icon badge="info"></cds-icon>`,
       locations: [{ line: 1, column: 18 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<cds-icon class="has-badge--error"></cds-icon>`,
       output: `<cds-icon badge="error"></cds-icon>`,
       locations: [{ line: 1, column: 18 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<cds-icon class="has-alert"></cds-icon>`,
       output: `<cds-icon badge="triangle"></cds-icon>`,
       locations: [{ line: 1, column: 18 }],
@@ -216,22 +215,22 @@ htmlRuleTester.run('no-clr-icon', rule, {
     /**
      * Shape attribute
      */
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon shape="caret up"></clr-icon>`,
       output: `<cds-icon shape="angle" direction="up"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon shape="caret down"></clr-icon>`,
       output: `<cds-icon shape="angle" direction="down"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon shape="caret left"></clr-icon>`,
       output: `<cds-icon shape="angle" direction="left"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon shape="caret right"></clr-icon>`,
       output: `<cds-icon shape="angle" direction="right"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
@@ -239,22 +238,22 @@ htmlRuleTester.run('no-clr-icon', rule, {
     /**
      * Shape attribute: already migrated tag (cds-icon)
      */
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<cds-icon shape="caret up"></cds-icon>`,
       output: `<cds-icon shape="angle" direction="up"></cds-icon>`,
       locations: [{ line: 1, column: 11 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<cds-icon shape="caret down"></cds-icon>`,
       output: `<cds-icon shape="angle" direction="down"></cds-icon>`,
       locations: [{ line: 1, column: 11 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<cds-icon shape="caret left"></cds-icon>`,
       output: `<cds-icon shape="angle" direction="left"></cds-icon>`,
       locations: [{ line: 1, column: 11 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<cds-icon shape="caret right"></cds-icon>`,
       output: `<cds-icon shape="angle" direction="right"></cds-icon>`,
       locations: [{ line: 1, column: 11 }],
@@ -262,21 +261,20 @@ htmlRuleTester.run('no-clr-icon', rule, {
     /**
      * All attributes
      */
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon dir="left" class="is-inverse my-class is-solid has-badge--info"></clr-icon>`,
       output: `<cds-icon direction="left" class="my-class" inverse solid badge="info"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon shape="caret up" class="is-inverse my-class is-solid has-badge--info"></clr-icon>`,
       output: `<cds-icon shape="angle" direction="up" class="my-class" inverse solid badge="info"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
-
     /**
      * Multiple root elements
      */
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `
       <div></div>
       <clr-icon shape="caret up" class="is-inverse my-class is-solid has-badge--info"></clr-icon>
@@ -287,19 +285,29 @@ htmlRuleTester.run('no-clr-icon', rule, {
       `,
       locations: [{ line: 3, column: 7 }],
     }),
-
     /**
      * Persisting extra attributes
      */
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon *ngIf="true"></clr-icon>`,
       output: `<cds-icon *ngIf="true"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
-    getInvalidAlertTest({
+    getInvalidIconTest({
       code: `<clr-icon dir="left" *ngIf="true"></clr-icon>`,
       output: `<cds-icon direction="left" *ngIf="true"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
+    }),
+    /**
+     * Two components on the same line
+     */
+    getInvalidIconTest({
+      code: `<clr-icon></clr-icon><clr-icon></clr-icon>`,
+      output: `<cds-icon></cds-icon><cds-icon></cds-icon>`,
+      locations: [
+        { line: 1, column: 1 },
+        { line: 1, column: 22 },
+      ],
     }),
   ],
   valid: [],

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-list/index.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-list/index.ts
@@ -1,16 +1,47 @@
 import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { RuleFix, RuleFixer } from '@typescript-eslint/experimental-utils/dist/ts-eslint';
+import { HTMLAttribute } from 'eslint-html-parser';
+import { Context } from 'vm';
 import { HTMLElement } from '../../types/index';
 import { lintDecoratorTemplate } from '../decorator-template-helper';
+import { getDeprecatedClassFixes } from '../html-fixer-helpers';
 
 export const createESLintRule = ESLintUtils.RuleCreator(() => ``);
 export type MessageIds = 'clrListFailure';
 
+const unstyledListClassToAttributeMap = {
+  'list-unstyled': 'cds-list="unstyled"',
+  list: '', // Remove extraneous "list" classes
+};
+
+const styledListClassToAttributeMap = {
+  list: 'cds-list',
+};
+
 const disallowedClasses = ['list', 'list-unstyled'];
+const disallowedListElementSelector = disallowedClasses.map(cls => `.${cls}`).join(',');
 
 function hasDisallowedClass(classes: Array<string>): boolean {
   return disallowedClasses.some(cls => classes.includes(cls));
 }
-const disallowedListElementSelector = disallowedClasses.map(cls => `.${cls}`).join(',');
+
+function getClassFixes(fixer: RuleFixer, classNode: HTMLAttribute | undefined, classes: Array<string>): Array<RuleFix> {
+  const fixerMap = classes.includes('list-unstyled') ? unstyledListClassToAttributeMap : styledListClassToAttributeMap;
+
+  return getDeprecatedClassFixes(fixer, classNode, fixerMap);
+}
+
+function lintListElement(context: Context, node: HTMLElement): void {
+  const classNode = node.attributes?.find(attribute => attribute.attributeName.value === 'class');
+  const classes = classNode?.attributeValue?.value?.split(' ') || [];
+  if (hasDisallowedClass(classes)) {
+    context.report({
+      node: node as any,
+      messageId: 'clrListFailure',
+      fix: fixer => getClassFixes(fixer, classNode, classes),
+    });
+  }
+}
 
 export default createESLintRule({
   name: 'no-clr-list',
@@ -31,26 +62,11 @@ export default createESLintRule({
   create(context) {
     return {
       'HTMLElement[tagName="ul"]'(node: HTMLElement): void {
-        const classNode = node.attributes?.find(attribute => attribute.attributeName.value === 'class');
-        const classes = classNode?.attributeValue?.value?.split(' ') || [];
-        if (hasDisallowedClass(classes)) {
-          context.report({
-            node: node as any,
-            messageId: 'clrListFailure',
-          });
-        }
+        lintListElement(context, node);
       },
       'HTMLElement[tagName="ol"]'(node: HTMLElement): void {
-        const classNode = node.attributes?.find(attribute => attribute.attributeName.value === 'class');
-        const classes = classNode?.attributeValue?.value?.split(' ') || [];
-        if (hasDisallowedClass(classes)) {
-          context.report({
-            node: node as any,
-            messageId: 'clrListFailure',
-          });
-        }
+        lintListElement(context, node);
       },
-
       'ClassDeclaration > Decorator'(node: TSESTree.Decorator): void {
         lintDecoratorTemplate(context, node, disallowedListElementSelector, 'clrListFailure');
       },

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-list/no-clr-list.spec.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-list/no-clr-list.spec.ts
@@ -10,42 +10,52 @@ htmlRuleTester.run('no-clr-list', rule, {
   invalid: [
     getInvalidListTest({
       code: `<ul class="list"></ul>`,
+      output: `<ul cds-list></ul>`,
       locations: [{ line: 1, column: 1 }],
     }),
     getInvalidListTest({
       code: `<ul class="list-unstyled"></ul>`,
+      output: `<ul cds-list="unstyled"></ul>`,
       locations: [{ line: 1, column: 1 }],
     }),
     getInvalidListTest({
       code: `<ul class="list list-unstyled"></ul>`,
+      output: `<ul cds-list="unstyled"></ul>`,
       locations: [{ line: 1, column: 1 }],
     }),
     getInvalidListTest({
       code: `<ul class="list compact"></ul>`,
+      output: `<ul class="compact" cds-list></ul>`,
       locations: [{ line: 1, column: 1 }],
     }),
     getInvalidListTest({
       code: `<ul class="compact list-unstyled"></ul>`,
+      output: `<ul class="compact" cds-list="unstyled"></ul>`,
       locations: [{ line: 1, column: 1 }],
     }),
     getInvalidListTest({
       code: `<ol class="list"></ol>`,
+      output: `<ol cds-list></ol>`,
       locations: [{ line: 1, column: 1 }],
     }),
     getInvalidListTest({
       code: `<ol class="list-unstyled"></ol>`,
+      output: `<ol cds-list="unstyled"></ol>`,
       locations: [{ line: 1, column: 1 }],
     }),
     getInvalidListTest({
       code: `<ol class="list list-unstyled"></ol>`,
+      output: `<ol cds-list="unstyled"></ol>`,
       locations: [{ line: 1, column: 1 }],
     }),
     getInvalidListTest({
       code: `<ol class="list compact"></ol>`,
+      output: `<ol class="compact" cds-list></ol>`,
       locations: [{ line: 1, column: 1 }],
     }),
     getInvalidListTest({
       code: `<ol class="compact list-unstyled"></ol>`,
+      output: `<ol class="compact" cds-list="unstyled"></ol>`,
       locations: [{ line: 1, column: 1 }],
     }),
   ],


### PR DESCRIPTION
This PR adds fixers to the ESLint rules for the `List` and `Badge` components. The fixers convert the Clarity Angular components to Clarity Core components. For example, if you have the rule in your ESLint configuration and run ESLint with the `--fix` option, the following code:

```html
<span class="badge badge-info">1</span>
```

will be replaced by:
```html
<cds-badge status="info">1</cds-badge>
```

This PR also:
- updates the local development instructions to recommend using `npm link` instead of `yarn link`. The latter doesn't resolve properly the package dependencies.
- fixes a bug in the html parser which was causing problems when multiple components on the same line need to be replaced - `<span class="badge"></span><span class="badge"></span>`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

Issue Number: #5528 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
