### PR TITLE
fix: combobox popover not repositioned after selection

### DIFF
--- a/packages/angular/projects/clr-angular/src/forms/combobox/combobox.ts
+++ b/packages/angular/projects/clr-angular/src/forms/combobox/combobox.ts
@@ -266,6 +266,9 @@ export class ClrCombobox<T> extends WrappedFormControl<ClrComboboxContainer>
     this.subscriptions.push(
       this.optionSelectionService.selectionChanged.subscribe((newSelection: ComboboxModel<T>) => {
         this.updateInputValue(newSelection);
+        if (this.multiSelect) {
+          this.positionService.realign();
+        }
         if (!this.multiSelect && newSelection && !newSelection.isEmpty()) {
           this.toggleService.open = false;
         }


### PR DESCRIPTION
closes #5364
Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfils the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When the selection in multi-select mode grows and occupies new lines, the popover does not get repositioned and overlaps the selection
<img width="614" alt="Screenshot 2021-02-25 at 14 40 44" src="https://user-images.githubusercontent.com/1798828/109155178-f038cd00-7777-11eb-93e8-5ac9e18cd69f.png">


Issue Number: #5364

## What is the new behavior?

The dropdown gets repositioned

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
It is possible to cause a minor flickering while selecting new items, even if it does cause reposition. This is coming from a workaround addressing async load, which is more visible. With the current architecture of the popovers, we have to chose one over the other.