### PR TITLE
fix: core global css token reference

### DIFF
--- a/packages/core/build/build.tokens.ts
+++ b/packages/core/build/build.tokens.ts
@@ -176,16 +176,16 @@ function flattenTokens(theme: any) {
 function convertCSSValue(token: Token, base = 20, fallback = true) {
   let value = token.value;
 
-  if (token.config.absolute) {
+  if (token.alias instanceof Token) {
+    value = `var(--cds-${camelCaseToKebab(token.alias.name)}${
+      fallback ? `, ${convertCSSValue(token.alias, 20, fallback)}` : ''
+    })`;
+  } else if (token.config.absolute) {
     value = token.value;
   } else if (typeof token.value === 'number') {
     value = `${(token.value / base).toFixed(base === 20 ? 2 : 4)}rem`;
   } else if (isHSL(token.value)) {
     value = `hsl(${token.value[0]}, ${token.value[1]}%, ${token.value[2]}%)`;
-  } else if (token.value instanceof Token) {
-    value = `var(--cds-${camelCaseToKebab(token.value.name)}${
-      fallback ? `, ${convertCSSValue(token.value, 20, fallback)}` : ''
-    })`;
   }
 
   return value;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
For the global style sheets the theme tokens if aliases would not have the correct value of the alias but instead the raw value. 

```scss
// incorrect
--cds-alias-status-disabled: hsl(198, 14%, 36%);

// corrected
--cds-alias-status-disabled: var(--cds-global-color-construction-600);
```

## What is the new behavior?
This fixes the missing alias references for the global style sheet. Our build scripts are not really set up for unit tests unfortunately so theres no easy test right now to add.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
