### PR TITLE
feat(modal): reduce change detection cycles for the modal body

### DIFF
--- a/packages/angular/golden/clr-angular.d.ts
+++ b/packages/angular/golden/clr-angular.d.ts
@@ -1247,10 +1247,9 @@ export declare class ClrModal implements OnChanges, OnDestroy {
     open(): void;
 }
 
-export declare class ClrModalBody {
-    tabindex: number;
-    mouseDown(): void;
-    mouseUp(): void;
+export declare class ClrModalBody implements OnDestroy {
+    constructor(ngZone: NgZone, renderer: Renderer2, host: ElementRef<HTMLElement>);
+    ngOnDestroy(): void;
 }
 
 export declare class ClrModalModule {

--- a/packages/angular/projects/clr-angular/src/modal/modal-body.spec.ts
+++ b/packages/angular/projects/clr-angular/src/modal/modal-body.spec.ts
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, ViewChild, ElementRef } from '@angular/core';
+import { Component, ViewChild, ElementRef, ApplicationRef } from '@angular/core';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { ClrModalBody } from './modal-body';
 
@@ -27,10 +27,8 @@ describe('ClrModalBody Directive', () => {
 
   it('toggles tabindex="0" on mousedown and mouseup events', () => {
     modalBodyEl.dispatchEvent(new Event('mousedown'));
-    fixture.detectChanges();
     expect(modalBodyEl.getAttribute('tabindex')).toBeNull();
     modalBodyEl.dispatchEvent(new Event('mouseup'));
-    fixture.detectChanges();
     expect(modalBodyEl.getAttribute('tabindex')).toBe('0');
   });
 
@@ -39,6 +37,18 @@ describe('ClrModalBody Directive', () => {
   it('focuses modal body on tab only, does not focus parent on inner content click', () => {
     fixture.componentInstance.testLabel.nativeElement.click();
     expect(fixture.componentInstance.testElement.nativeElement === document.activeElement).toBe(false);
+  });
+
+  it('should not run change detection when the mouseup or mousedown event occurs', () => {
+    const appRef = TestBed.inject(ApplicationRef);
+    const spy = spyOn(appRef, 'tick');
+
+    modalBodyEl.dispatchEvent(new Event('mousedown'));
+    modalBodyEl.dispatchEvent(new Event('mouseup'));
+    modalBodyEl.dispatchEvent(new Event('mousedown'));
+    modalBodyEl.dispatchEvent(new Event('mouseup'));
+
+    expect(spy.calls.count()).toEqual(0);
   });
 });
 

--- a/packages/angular/projects/clr-angular/src/modal/modal-body.ts
+++ b/packages/angular/projects/clr-angular/src/modal/modal-body.ts
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Directive, HostListener } from '@angular/core';
+import { Directive, ElementRef, NgZone, OnDestroy, Renderer2 } from '@angular/core';
 
 /**
  * Allows modal overflow area to be scrollable via keyboard.
@@ -12,25 +12,32 @@ import { Directive, HostListener } from '@angular/core';
  * This allows inner focusable items to be focused without
  * the overflow scroll being focused.
  */
-@Directive({
-  selector: '.modal-body',
-  host: {
-    '[attr.tabindex]': 'tabindex',
-  },
-})
-export class ClrModalBody {
-  tabindex = 0;
+@Directive({ selector: '.modal-body' })
+export class ClrModalBody implements OnDestroy {
+  private tabindex = '0';
+  private unlisteners: VoidFunction[] = [];
 
-  @HostListener('mousedown')
-  mouseDown() {
-    // tabindex = 0 binding should be removed
-    // so it won't be focused when click starts with mousedown
-    delete this.tabindex;
+  constructor(ngZone: NgZone, renderer: Renderer2, host: ElementRef<HTMLElement>) {
+    renderer.setAttribute(host.nativeElement, 'tabindex', this.tabindex);
+
+    ngZone.runOutsideAngular(() => {
+      this.unlisteners.push(
+        renderer.listen(host.nativeElement, 'mouseup', () => {
+          // set the tabindex binding back when click is completed with mouseup
+          renderer.setAttribute(host.nativeElement, 'tabindex', this.tabindex);
+        }),
+        renderer.listen(host.nativeElement, 'mousedown', () => {
+          // tabindex = 0 binding should be removed
+          // so it won't be focused when click starts with mousedown
+          renderer.removeAttribute(host.nativeElement, 'tabindex');
+        })
+      );
+    });
   }
 
-  @HostListener('mouseup')
-  mouseUp() {
-    // set the tabindex binding back when click is completed with mouseup
-    this.tabindex = 0;
+  ngOnDestroy(): void {
+    while (this.unlisteners.length) {
+      this.unlisteners.pop()();
+    }
   }
 }


### PR DESCRIPTION
This PR reduces change detection cycles for the modal body by replacing
`HostListener` with `Renderer.listen` outside of the zone. Updating `tabindex`
on the host element can be done through the DOM API and that would not require
Angular to run `ApplicationRef.tick()`. Note that the `HostListener` wraps the
actual listener under the hood into the internal Angular function which runs
`markDirty()` before running the actual listener (the decorated class method).

Signed-off-by: Artur Androsovych <arthurandrosovich@gmail.com>

## PR Checklist
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
- [x] Feature

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No