### PR TITLE
Migrate Datepicker to extend ClrAbstractContainer as all other containers

### DIFF
--- a/packages/angular/golden/clr-angular.d.ts
+++ b/packages/angular/golden/clr-angular.d.ts
@@ -859,32 +859,21 @@ export declare class ClrDatalistModule {
 export declare class ClrDataModule {
 }
 
-export declare class ClrDateContainer implements DynamicWrapper, OnDestroy, AfterViewInit, AfterContentInit {
-    _dynamic: boolean;
+export declare class ClrDateContainer extends ClrAbstractContainer implements AfterViewInit {
     set actionButton(button: ElementRef);
     set clrPosition(position: string);
     commonStrings: ClrCommonStringsService;
-    control: NgControl;
-    controlErrorComponent: ClrControlError;
-    controlHelperComponent: ClrControlHelper;
-    controlSuccessComponent: ClrControlSuccess;
+    protected controlClassService: ControlClassService;
     focus: boolean;
+    protected ifControlStateService: IfControlStateService;
     get isEnabled(): boolean;
     get isInputDateDisabled(): boolean;
-    label: ClrLabel;
+    protected layoutService: LayoutService;
+    protected ngControlService: NgControlService;
     get open(): boolean;
     get popoverPosition(): ClrPopoverPosition;
-    get showHelper(): boolean;
-    get showInvalid(): boolean;
-    get showValid(): boolean;
-    state: CONTROL_STATE;
     constructor(toggleService: ClrPopoverToggleService, dateNavigationService: DateNavigationService, datepickerEnabledService: DatepickerEnabledService, dateFormControlService: DateFormControlService, commonStrings: ClrCommonStringsService, focusService: FocusService, viewManagerService: ViewManagerService, controlClassService: ControlClassService, layoutService: LayoutService, ngControlService: NgControlService, ifControlStateService: IfControlStateService);
-    addGrid(): boolean;
-    controlClass(): string;
-    ngAfterContentInit(): void;
     ngAfterViewInit(): void;
-    ngOnDestroy(): void;
-    ngOnInit(): void;
 }
 
 export declare class ClrDateInput extends WrappedFormControl<ClrDateContainer> implements OnInit, AfterViewInit, OnDestroy {

--- a/packages/angular/projects/clr-angular/src/forms/datepicker/date-container.spec.ts
+++ b/packages/angular/projects/clr-angular/src/forms/datepicker/date-container.spec.ts
@@ -55,6 +55,7 @@ export default function () {
     let enabledService: MockDatepickerEnabledService;
     let dateFormControlService: DateFormControlService;
     let toggleService: ClrPopoverToggleService;
+    let container: any;
 
     beforeEach(function () {
       TestBed.configureTestingModule({
@@ -71,6 +72,7 @@ export default function () {
       enabledService = context.getClarityProvider(DatepickerEnabledService) as MockDatepickerEnabledService;
       dateFormControlService = context.getClarityProvider(DateFormControlService);
       toggleService = context.getClarityProvider(ClrPopoverToggleService);
+      container = context.clarityDirective;
     });
 
     // @deprecated these tests refer to the old forms layout only and can be removed when its removed
@@ -179,13 +181,13 @@ export default function () {
 
       it('should add/remove success icon and text', () => {
         /* valid */
-        context.clarityDirective.state = CONTROL_STATE.VALID;
+        container.state = CONTROL_STATE.VALID;
         context.detectChanges();
         expect(context.clarityElement.querySelector('clr-control-success')).toBeTruthy();
         expect(context.clarityElement.querySelector('cds-icon[shape=check-circle]')).toBeTruthy();
 
         /* invalid */
-        context.clarityDirective.state = CONTROL_STATE.INVALID;
+        container.state = CONTROL_STATE.INVALID;
         context.detectChanges();
         expect(context.clarityElement.querySelector('clr-control-success')).toBeNull();
         expect(context.clarityElement.querySelector('cds-icon[shape=check-circle]')).toBeNull();
@@ -203,12 +205,12 @@ export default function () {
         expect(context.clarityDirective.controlClass()).toContain('clr-col-md-10');
         expect(context.clarityDirective.controlClass()).toContain('clr-col-12');
         expect(context.clarityDirective.controlClass()).not.toContain('clr-error');
-        context.clarityDirective.state = CONTROL_STATE.INVALID;
+        container.state = CONTROL_STATE.INVALID;
         expect(context.clarityDirective.controlClass()).toContain('clr-error');
         const controlClassService = context.getClarityProvider(ControlClassService);
         const layoutService = context.getClarityProvider(LayoutService);
         layoutService.layout = ClrFormLayout.VERTICAL;
-        context.clarityDirective.state = CONTROL_STATE.VALID;
+        container.state = CONTROL_STATE.VALID;
         expect(context.clarityDirective.controlClass()).not.toContain('clr-error');
         expect(context.clarityDirective.controlClass()).not.toContain('clr-col-md-10');
         controlClassService.className = 'clr-col-2';


### PR DESCRIPTION
Datepicker container is the only one that is not extending ClrAbstractContainer - this creates the need for code duplications. With this change, this duplication is no longer needed and now we could have a more compact container code.

NOTE: This PR extends the work here #5557 so when merged then this could be changed from Draft to PR.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
