### PR TITLE
fix: core icon render performance

### DIFF
--- a/packages/core/src/icon/utils/icon.classnames.ts
+++ b/packages/core/src/icon/utils/icon.classnames.ts
@@ -33,10 +33,11 @@ export function getUpdateSizeStrategy(size: string) {
 
 export function updateIconSizeStyle(el: CdsIcon, size: string) {
   const updateStrategy = getUpdateSizeStrategy(size);
-  const val = pxToRem(parseInt(size));
+  let val = '';
 
   switch (updateStrategy) {
     case SizeUpdateStrategies.ValidNumericString:
+      val = pxToRem(parseInt(size)); // set val in block to run expensive call only when needed
       updateElementStyles(el, ['width', val], ['height', val]);
       return;
     case SizeUpdateStrategies.ValidSizeString:

--- a/packages/core/src/internal/base/css-gap.base.spec.ts
+++ b/packages/core/src/internal/base/css-gap.base.spec.ts
@@ -12,7 +12,8 @@ import { browserFeatures } from '../utils/supports.js';
 class GapShim extends LitElement {}
 class GapShimSupports extends LitElement {}
 
-window.customElements.define('gap-shim-support', applyCSSGapShim(GapShimSupports));
+const shimSupportsClass = applyCSSGapShim(GapShimSupports);
+window.customElements.define('gap-shim-support', shimSupportsClass);
 
 (browserFeatures as any).supports.flexGap = false; // force false flex gap support
 const shimClass = applyCSSGapShim(GapShim);

--- a/packages/core/src/internal/utils/css.spec.ts
+++ b/packages/core/src/internal/utils/css.spec.ts
@@ -98,6 +98,12 @@ describe('Css utility functions - ', () => {
     it('should convert px to rem values from base font size token', () => {
       expect(pxToRem(10)).toBe('0.5rem');
     });
+
+    it('should cache the rem calculation to the HTML cds-font-size attr', () => {
+      document.documentElement.setAttribute('cds-base-font', null);
+      expect(pxToRem(20)).toBe('1rem');
+      expect(document.documentElement.getAttribute('cds-base-font')).toBe('20');
+    });
   });
 
   describe('isCssPropertyName: ', () => {

--- a/packages/core/src/internal/utils/css.ts
+++ b/packages/core/src/internal/utils/css.ts
@@ -41,9 +41,17 @@ export function updateElementStyles(el: HTMLElement, ...styleTuples: [string, st
 }
 
 export function pxToRem(pxValue: number) {
-  const baseProp = getCssPropertyValue('--cds-global-typography-base-font-size');
-  const baseFontSize = (16 * parseInt(baseProp !== '' ? baseProp : '100%')) / 100;
-  return `${pxValue / baseFontSize}rem`;
+  let base = parseInt(document.documentElement.getAttribute('cds-base-font') as string);
+
+  if (!base) {
+    const prop = window
+      .getComputedStyle(document.body, null)
+      .getPropertyValue('--cds-global-typography-base-font-size');
+    base = (16 * parseInt(prop !== '' ? prop : '100%')) / 100;
+    document.documentElement.setAttribute('cds-base-font', `${base}`);
+  }
+
+  return `${pxValue / base}rem`;
 }
 
 export function getCssPropertyValue(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When rendering icons it can cause unnecessary style calculations for size causing performance slow down.

Before:
<img width="1653" alt="before" src="https://user-images.githubusercontent.com/2021067/110169926-0588a980-7dbf-11eb-8f5d-c84a79571a54.png">

After:
<img width="1610" alt="after" src="https://user-images.githubusercontent.com/2021067/110169932-07eb0380-7dbf-11eb-9c3a-1ddff78590bf.png">


## What is the new behavior?
This PR prevents unnecessary style computation when not specifying numeric size. Also will cache font size calculation in the html attr after first check. This improves average render time by 3x

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
