### PR TITLE
fix: allowing for text inside modals and overlays to be selected

### DIFF
--- a/packages/core/src/internal-components/overlay/overlay.stories.mdx
+++ b/packages/core/src/internal-components/overlay/overlay.stories.mdx
@@ -21,6 +21,10 @@ Until an overlay is closed, interaction is limited to the contents of the overla
 
 An overlay can be closed by pressing the escape key, clicking on the backdrop behind the overlays content, or defining a custom trigger that fires the `closeOverlay()` method.
 
+### Selecting Text Inside an Overlay
+
+To enable copy-and-paste of the text inside an overlay, make sure to add `tabindex="-1"` on the wrapper element around the content. Multiple examples are given below. Note that modals do this for you already. But you will need to this for any custom overlays built using this internal component in your own application.
+
 ## Installation
 
 To use the internal component add the register import to the `register.ts` of

--- a/packages/core/src/internal-components/overlay/overlay.stories.ts
+++ b/packages/core/src/internal-components/overlay/overlay.stories.ts
@@ -37,9 +37,7 @@ export const API = (args: any) => {
     <cds-demo popover>
       <cds-button status="primary" type="button" @click=${showApiOverlay}>Show Overlay</cds-button>
       <cds-internal-overlay ...="${spreadProps(getElementStorybookArgs(args))}" hidden id="${overlayId}">
-        <div cds-layout="p:lg" style="background: white">
-          ${args.default}
-        </div>
+        <div cds-layout="p:lg" style="background: white">${args.default}</div>
       </cds-internal-overlay>
     </cds-demo>
   `;
@@ -112,7 +110,7 @@ export const interactive = () => {
     </style>
     <cds-button status="primary" type="button" @click=${showOverlay}>Show Overlay Demo</cds-button>
     <cds-internal-overlay hidden id="${overlayId}">
-      <div cds-layout="vertical gap:lg p:lg align:stretch" class="my-overlay">
+      <div cds-layout="vertical gap:lg p:lg align:stretch" class="my-overlay" tabindex="-1">
         <h1 cds-text="section">An overlay demo</h1>
         <p cds-text="body">I am an overlay.</p>
         <cds-button block status="danger" type="button" @click=${hideOverlay}>Close Overlay Demo</cds-button>
@@ -166,8 +164,8 @@ export const multiple = () => {
     </style>
     <cds-button status="primary" type="button" @click=${showMultiOverlay}>Show Layered Overlays</cds-button>
     <cds-internal-overlay hidden id="${multiOverlayId}">
-      <div cds-layout="vertical gap:lg p:lg align:stretch" class="my-multi-overlay">
-        <h1 cds-text="section">A demo of layered overlays</h1>
+      <div cds-layout="vertical gap:lg p:lg align:stretch" class="my-multi-overlay" tabindex="-1">
+        <h1 cds-text="section" tabindex="-1">A demo of layered overlays</h1>
         <p cds-text="body">
           I am a demo showing how overlays can be placed or layered on top of one another. I am the overlay on the
           bottom layer.
@@ -186,8 +184,8 @@ export const multiple = () => {
       </div>
     </cds-internal-overlay>
     <cds-internal-overlay hidden id="${multiChildOverlayId}">
-      <div cds-layout="vertical gap:lg p:lg align:stretch" class="my-multi-overlay" style="width: 300px">
-        <h1 cds-text="section">An overlay on top of another overlay</h1>
+      <div cds-layout="vertical gap:lg p:lg align:stretch" class="my-multi-overlay" style="width: 300px" tabindex="-1">
+        <h1 cds-text="section" tabindex="-1">An overlay on top of another overlay</h1>
         <p cds-text="body">I am a demo of an overlay layered over another overlay!</p>
         <cds-button block status="danger" type="button" @click=${hideChildOverlay}>Close Top Overlay</cds-button>
       </div>
@@ -226,8 +224,8 @@ export const firstFocus = () => {
     </style>
     <cds-button status="primary" type="button" @click=${showOverlay}>Show Overlay With Managed Focus</cds-button>
     <cds-internal-overlay hidden id="${overlayId}">
-      <div cds-layout="vertical gap:lg p:lg align:stretch" class="my-overlay">
-        <h1 cds-text="section" tabindex="0" cds-first-focus>Overlay with first-focus</h1>
+      <div cds-layout="vertical gap:lg p:lg align:stretch" class="my-overlay" tabindex="-1">
+        <h1 cds-text="section">Overlay with <span tabindex="-1" cds-first-focus>first-focus</span></h1>
         <p cds-text="body">
           I am an overlay with focus assigned to an element inside me. I assigned first focus to my header. It is
           assigned focus when I am opened.
@@ -267,7 +265,12 @@ export const custom = () => {
 
     <cds-demo popover>
       <cds-internal-overlay _demo-mode id="${purpleOverlayId}" class="purple-overlay">
-        <div cds-layout="vertical gap:lg p:lg align:stretch" class="my-multi-overlay" style="width: 480px">
+        <div
+          cds-layout="vertical gap:lg p:lg align:stretch"
+          class="my-multi-overlay"
+          style="width: 480px"
+          tabindex="-1"
+        >
           <h1 cds-text="section">I am a purple overlay</h1>
           <p cds-text="body">Hello, I am an overlay with a purple backdrop.</p>
           <div cds-layout="horizontal gap:md wrap:none align:stretch">
@@ -283,7 +286,7 @@ export const custom = () => {
         </div>
       </cds-internal-overlay>
       <cds-internal-overlay _demo-mode hidden id="${whiteOverlayId}" class="white-overlay">
-        <div cds-layout="vertical gap:lg p:lg align:stretch" class="my-multi-overlay">
+        <div cds-layout="vertical gap:lg p:lg align:stretch" class="my-multi-overlay" tabindex="-1">
           <h1 cds-text="section">I am whitish</h1>
           <p cds-text="body">Hello, I am an overlay with a mostly opaque white backdrop!</p>
           <div cds-layout="horizontal gap:md wrap:none align:stretch">
@@ -308,7 +311,7 @@ export const custom = () => {
         </div>
       </cds-internal-overlay>
       <cds-internal-overlay _demo-mode hidden id="${orangeOverlayId}" class="orange-overlay">
-        <div cds-layout="vertical gap:lg p:lg align:stretch" class="my-multi-overlay">
+        <div cds-layout="vertical gap:lg p:lg align:stretch" class="my-multi-overlay" tabindex="-1">
           <h1 cds-text="section" id="custom-demo-3-title">I am orange</h1>
           <p cds-text="body">Hello, I am an overlay with an opaque orange backdrop!</p>
           <cds-button
@@ -395,7 +398,7 @@ export const overrideAnimation = () => {
     </style>
     <cds-button status="primary" type="button" @click=${showOverrideOverlay}>Show Custom Exit</cds-button>
     <cds-internal-overlay hidden id="${overlayId}" cds-motion='{ "hidden": { "true": "cds-modal-hinge-exit" } }'>
-      <div cds-layout="vertical gap:lg p:lg align:stretch" class="my-overlay">
+      <div cds-layout="vertical gap:lg p:lg align:stretch" class="my-overlay" tabindex="-1">
         <h1 cds-text="section">An overlay demo</h1>
         <p cds-text="body">I am an overlay.</p>
         <cds-button block status="danger" type="button" @click=${hideOverrideOverlay}>Close Overlay Demo</cds-button>
@@ -438,7 +441,7 @@ export const lowMotion = () => {
     <div cds-theme="low-motion">
       <cds-button status="primary" type="button" @click=${showLowMotionOverlay}>Show Low Motion</cds-button>
       <cds-internal-overlay hidden id="${overlayId}" cds-motion="on">
-        <div cds-layout="vertical gap:lg p:lg align:stretch" class="my-overlay">
+        <div cds-layout="vertical gap:lg p:lg align:stretch" class="my-overlay" tabindex="-1">
           <h1 cds-text="section">An overlay demo</h1>
           <p cds-text="body">I am an overlay.</p>
           <cds-button block status="danger" type="button" @click=${hideLowMotionOverlay}

--- a/packages/core/src/modal/modal-content.element.spec.ts
+++ b/packages/core/src/modal/modal-content.element.spec.ts
@@ -20,7 +20,7 @@ describe('modal-content element', () => {
   beforeEach(async () => {
     testElement = await createTestElement(html`<cds-modal-content>${placeholderContent}</cds-modal-content>`);
     testElementWithLayout = await createTestElement(
-      html`<cds-modal-content cds-layout="elliptical">${placeholderContent}</cds-modal-content>`
+      html`<cds-modal-content tabindex="0" cds-layout="elliptical">${placeholderContent}</cds-modal-content>`
     );
     component = testElement.querySelector<CdsModalContent>('cds-modal-content');
     componentWithLayout = testElementWithLayout.querySelector<CdsModalContent>('cds-modal-content');
@@ -48,12 +48,18 @@ describe('modal-content element', () => {
     });
   });
 
-  it('should override layout defaults', async () => {
+  it('should have tabindex "-1"', async () => {
+    await componentIsStable(component);
+    expect(component.getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('should override layout and tabindex defaults', async () => {
     await componentIsStable(componentWithLayout);
     expect(componentWithLayout.shadowRoot.querySelector('div')).toBeNull('default wrapper div is not rendered');
     expect(componentWithLayout.getAttribute('cds-layout').indexOf('elliptical') > -1).toBe(
       true,
       `carries through overridden layout`
     );
+    expect(componentWithLayout.getAttribute('tabindex')).toBe('0', `can override tabindex`);
   });
 });

--- a/packages/core/src/modal/modal-content.element.ts
+++ b/packages/core/src/modal/modal-content.element.ts
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { baseStyles } from '@cds/core/internal';
+import { baseStyles, internalProperty } from '@cds/core/internal';
 import { html, LitElement } from 'lit-element';
 
 /**
@@ -31,6 +31,8 @@ import { html, LitElement } from 'lit-element';
  * @element cds-modal-content
  */
 export class CdsModalContent extends LitElement {
+  @internalProperty({ type: Number, attribute: 'tabindex', reflect: true }) protected tabIndexAttr = -1; // don't override native prop as it stops native focus behavior
+
   render() {
     return this.hasAttribute('cds-layout')
       ? html`<slot></slot>`

--- a/packages/core/src/modal/modal.element.spec.ts
+++ b/packages/core/src/modal/modal.element.spec.ts
@@ -37,7 +37,9 @@ describe('modal element', () => {
   it('should create the component', async () => {
     await componentIsStable(component);
     const slots = getComponentSlotContent(component);
-    expect(slots.default).toBe(`<cds-modal-content><p><!---->${placeholderContent}<!----></p></cds-modal-content>`);
+    expect(slots.default).toBe(
+      `<cds-modal-content tabindex="-1"><p><!---->${placeholderContent}<!----></p></cds-modal-content>`
+    );
     expect(slots['modal-header']).toBe(
       `<cds-modal-header slot="modal-header"><!---->${placeholderHeader}<!----></cds-modal-header>`
     );


### PR DESCRIPTION
• this is to allow for the copy-pasting of text inside an overlay
• the fix for vanilla overlays is manual
• added docs to demo implementing this in the overlay
• added docs informing users that this needs to happen
• some may view a modal that cannot be copy-pasted as desirable!
• made modal-content element do this by default
• updated tests in modal and modal-content
• verified that this does not conflict with a11y requirements

Tested in:
✔︎ Chrome
✔︎ Firefox
✔︎ Safari
✔︎ Edge

Fixes: #5651

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5651 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
