### PR TITLE
docs: add Adoption tooling page to the Adoption guide

### DIFF
--- a/packages/angular/projects/clarity-adoption/src/app/app-routing.module.ts
+++ b/packages/angular/projects/clarity-adoption/src/app/app-routing.module.ts
@@ -9,6 +9,7 @@ import { ListPage } from './pages/list/list.page';
 import { IconsPage } from './pages/icons/icons.page';
 import { AccordionPage } from './pages/accordion/accordion.page';
 import { CheckboxPage } from './pages/checkbox/checkbox.page';
+import { AdoptionToolingPage } from './pages/adoption-tooling/adoption-tooling.page';
 
 const routes: Routes = [
   { path: '', redirectTo: '/getting-started', pathMatch: 'full' },
@@ -21,6 +22,7 @@ const routes: Routes = [
   { path: 'button', component: ButtonPage },
   { path: 'label', component: LabelPage },
   { path: 'list', component: ListPage },
+  { path: 'adoption-tooling', component: AdoptionToolingPage },
 ];
 
 @NgModule({

--- a/packages/angular/projects/clarity-adoption/src/app/app.component.html
+++ b/packages/angular/projects/clarity-adoption/src/app/app.component.html
@@ -42,6 +42,15 @@
         </clr-vertical-nav-group-children>
       </clr-vertical-nav-group>
 
+      <a
+        clrVerticalNavLink
+        routerLink="/adoption-tooling"
+        routerLinkActive="active"
+        [routerLinkActiveOptions]="{ exact: true }"
+      >
+        <clr-icon shape="wrench" clrVerticalNavIcon></clr-icon> Adoption tooling
+      </a>
+
       <cds-divider cds-layout="m-y:md"></cds-divider>
 
       <a class="npm-reference" href="https://www.npmjs.com/package/@clr/angular" target="_blank">

--- a/packages/angular/projects/clarity-adoption/src/app/app.module.ts
+++ b/packages/angular/projects/clarity-adoption/src/app/app.module.ts
@@ -23,6 +23,7 @@ import '@cds/core/divider/register.js';
 import { IconsPage } from './pages/icons/icons.page';
 import { AccordionPage } from './pages/accordion/accordion.page';
 import { CheckboxPage } from './pages/checkbox/checkbox.page';
+import { AdoptionToolingPage } from './pages/adoption-tooling/adoption-tooling.page';
 
 @NgModule({
   declarations: [
@@ -38,6 +39,7 @@ import { CheckboxPage } from './pages/checkbox/checkbox.page';
     IconsPage,
     LabelPage,
     ListPage,
+    AdoptionToolingPage,
 
     /* helpers */
     SourceCodeComponent,

--- a/packages/angular/projects/clarity-adoption/src/app/components/sourcecode.component.ts
+++ b/packages/angular/projects/clarity-adoption/src/app/components/sourcecode.component.ts
@@ -5,6 +5,7 @@ import * as Prism from 'prismjs';
 import 'prismjs/components/prism-typescript';
 import 'prismjs/components/prism-javascript';
 import 'prismjs/components/prism-json';
+import 'prismjs/components/prism-bash';
 
 const MAP_TYPE_HIGHLIGHT = {
   ts: 'typescript',

--- a/packages/angular/projects/clarity-adoption/src/app/pages/adoption-tooling/adoption-tooling.page.html
+++ b/packages/angular/projects/clarity-adoption/src/app/pages/adoption-tooling/adoption-tooling.page.html
@@ -1,0 +1,140 @@
+<h1>Adoption tooling</h1>
+
+<h3>Clarity Adoption ESLint plugin</h3>
+<p>
+  The
+  <a href="https://www.npmjs.com/package/@clr/eslint-plugin-clarity-adoption">Clarity Adoption ESLint plugin</a> helps
+  with the adoption of Clarity Core components. The plugin provides ESLint rules to detect and warn against the usage of
+  Clarity Angular components. A few rules also have fixers that replace the Clarity Angular components with their
+  Clarity Core alternatives. You can enable rules with project configuration. For example, you can start with a
+  configuration listing only the <i>no-clr-badge</i> rule to warn against the usage of badges and gradually, add more
+  rules.
+</p>
+
+<h4>Installation</h4>
+<p>
+  The plugin is distributed as npm package -
+  <a href="https://www.npmjs.com/package/@clr/eslint-plugin-clarity-adoption">@clr/eslint-plugin-clarity-adoption</a>.
+  To start using it, add the following dependencies to your project.
+</p>
+<sourcecode [content]="eslintInstallation" language="bash"></sourcecode>
+
+<h4>Configuration</h4>
+<p>
+  Create an ESLint configuration file named <code>.eslintrc.json</code> in the root directory of your project. Add the
+  following content.
+  <sourcecode [content]="eslintConfiguration" language="json"></sourcecode>
+</p>
+<p>
+  The configuration above enables all rules distributed with the Clarity Adoption plugin. To turn off a rule, remove it
+  from the rules list. The plugin uses <b>@clr/eslint-plugin-clarity-adoption/html-parser</b> to lint HTML files and
+  <b>@typescript-eslint/parser</b> to lint inlined Angular component templates.
+</p>
+
+<p>Finally, you'll need to run eslint with the <code>--ext</code> flag to enable HTML scanning.</p>
+<sourcecode [content]="eslintCommand" language="bash"></sourcecode>
+
+<p>You can tell ESLint to fix any detected problems with the <code>--fix</code> option.</p>
+<sourcecode [content]="eslintFixCommand" language="bash"></sourcecode>
+
+<h4>Rules</h4>
+
+<table class="table">
+  <caption>
+    Rules distributed with the Clarity Adoption ESLint plugin.
+  </caption>
+  <thead>
+    <tr>
+      <th>Component</th>
+      <th>Rule</th>
+      <th>Fixer</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Accordion</td>
+      <td><code>no-clr-accordion</code></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Alert</td>
+      <td><code>no-clr-alert</code></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Badge</td>
+      <td><code>no-clr-badge</code></td>
+      <td><cds-icon shape="plus"></cds-icon></td>
+    </tr>
+    <tr>
+      <td>Button</td>
+      <td><code>no-clr-button</code></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Checkbox</td>
+      <td><code>no-clr-checkbox</code></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Datalist</td>
+      <td><code>no-clr-datalist</code></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Form</td>
+      <td><code>no-clr-form</code></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Icon</td>
+      <td><code>no-clr-icon</code></td>
+      <td><cds-icon shape="plus"></cds-icon></td>
+    </tr>
+    <tr>
+      <td>Input</td>
+      <td><code>no-clr-input</code></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>List</td>
+      <td><code>no-clr-list</code></td>
+      <td><cds-icon shape="plus"></cds-icon></td>
+    </tr>
+    <tr>
+      <td>Modal</td>
+      <td><code>no-clr-modal</code></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Password</td>
+      <td><code>no-clr-password</code></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Radio</td>
+      <td><code>no-clr-radio</code></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Range</td>
+      <td><code>no-clr-range</code></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Select</td>
+      <td><code>no-clr-select</code></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Textarea</td>
+      <td><code>no-clr-textarea</code></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Toggle</td>
+      <td><code>no-clr-toggle</code></td>
+      <td></td>
+    </tr>
+  </tbody>
+</table>

--- a/packages/angular/projects/clarity-adoption/src/app/pages/adoption-tooling/adoption-tooling.page.ts
+++ b/packages/angular/projects/clarity-adoption/src/app/pages/adoption-tooling/adoption-tooling.page.ts
@@ -1,0 +1,53 @@
+import { Component } from '@angular/core';
+import '@cds/core/icon/register.js';
+import { ClarityIcons, plusIcon } from '@cds/core/icon';
+
+ClarityIcons.addIcons(plusIcon);
+
+@Component({
+  templateUrl: './adoption-tooling.page.html',
+})
+export class AdoptionToolingPage {
+  eslintInstallation = `
+npm install --save-dev @clr/eslint-plugin-clarity-adoption @typescript-eslint/parser eslint
+`;
+
+  eslintConfiguration = `
+{
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "sourceType": "module",
+    "ecmaVersion": 2015
+  },
+  "plugins": ["@clr/clarity-adoption"],
+  "rules": {
+    "@clr/clarity-adoption/no-clr-accordion": "warn",
+    "@clr/clarity-adoption/no-clr-alert": "warn",
+    "@clr/clarity-adoption/no-clr-badge": "warn",
+    "@clr/clarity-adoption/no-clr-button": "warn",
+    "@clr/clarity-adoption/no-clr-checkbox": "warn",
+    "@clr/clarity-adoption/no-clr-datalist": "warn",
+    "@clr/clarity-adoption/no-clr-form": "warn",
+    "@clr/clarity-adoption/no-clr-icon": "warn",
+    "@clr/clarity-adoption/no-clr-input": "warn",
+    "@clr/clarity-adoption/no-clr-list": "warn",
+    "@clr/clarity-adoption/no-clr-modal": "warn",
+    "@clr/clarity-adoption/no-clr-password": "warn",
+    "@clr/clarity-adoption/no-clr-radio": "warn",
+    "@clr/clarity-adoption/no-clr-range": "warn",
+    "@clr/clarity-adoption/no-clr-select": "warn",
+    "@clr/clarity-adoption/no-clr-textarea": "warn",
+    "@clr/clarity-adoption/no-clr-toggle": "warn"
+  },
+  "overrides": [
+    {
+      "files": ["*.html"],
+      "parser": "@clr/eslint-plugin-clarity-adoption/html-parser"
+    }
+  ]
+}
+`;
+
+  eslintCommand = `npx eslint --ext=ts,html src/`;
+  eslintFixCommand = `npx eslint --ext=ts,html --fix src/`;
+}


### PR DESCRIPTION
This PR adds an `Adoption tooling` page to the Adoption guide. The page contains setup instructions for the Clarity Adoption ESLint plugin along with a table listing all rules included in the plugin.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

