### PR TITLE
fix: cds/react examples to use clarity motion

### DIFF
--- a/packages/core/src/internal-components/overlay/overlay.element.scss
+++ b/packages/core/src/internal-components/overlay/overlay.element.scss
@@ -56,3 +56,8 @@
 :host([hidden]) {
   --animation-duration: #{$cds-global-animation-duration-secondary};
 }
+
+// we need the check against hidden='false' here because React is pushing string through instead of adding/removing the boolean attribute
+:host([hidden*='false']) {
+  display: inline-flex !important;
+}

--- a/packages/core/src/internal/base/base.element.scss
+++ b/packages/core/src/internal/base/base.element.scss
@@ -50,9 +50,14 @@ slot {
   }
 }
 
-// https://developers.google.com/web/fundamentals/web-components/best-practices#add-a-:host-display-style-that-respects-the-hidden-attribute.
+// https://developers.google.com/web/fundamentals/web-components/best-practices#add-a-:host-display-style-that-respects-the-hidden-attribute
+// we need the check against hidden='false' here because React is pushing string through instead of adding/removing the boolean attribute
 :host([hidden]) {
   display: none !important;
+}
+
+:host([hidden*='false']) {
+  display: block !important;
 }
 
 // normalize focus styles

--- a/packages/core/src/modal/modal.element.ts
+++ b/packages/core/src/modal/modal.element.ts
@@ -9,7 +9,6 @@ import {
   animate,
   Animatable,
   AnimationModalEnterName,
-  baseStyles,
   i18n,
   I18nService,
   HTMLAttributeTuple,
@@ -64,7 +63,7 @@ import { styles } from './modal.element.css.js';
 })
 export class CdsModal extends CdsInternalOverlay implements Animatable {
   static get styles() {
-    return [baseStyles, ...super.styles, styles];
+    return [...super.styles, styles];
   }
 
   @i18n() i18n = I18nService.keys.modal;

--- a/packages/react/App.tsx
+++ b/packages/react/App.tsx
@@ -29,6 +29,12 @@ ClarityIcons.addIcons(userIcon, timesIcon);
 interface AppState {
   modalOpen: boolean;
   modal2Open: boolean;
+  modalReady: boolean;
+  modal2Ready: boolean;
+  panel1Expanded: boolean;
+  panel2Expanded: boolean;
+  panel3Expanded: boolean;
+  panel4Expanded: boolean;
 }
 
 export default class App extends React.Component<{}, AppState> {
@@ -36,15 +42,20 @@ export default class App extends React.Component<{}, AppState> {
 
   constructor(props: any) {
     super(props);
-    this.state = { modalOpen: false, modal2Open: false };
+    this.state = {
+      modalOpen: false,
+      modal2Open: false,
+      modalReady: false,
+      modal2Ready: false,
+      panel1Expanded: true,
+      panel2Expanded: false,
+      panel3Expanded: false,
+      panel4Expanded: false,
+    };
     this.buttonRef = React.createRef<typeof CdsButton & HTMLButtonElement>();
   }
 
   componentDidMount() {
-    // (this.buttonRef.current as any).nativeElement.then((element: any) => {
-    //   element.focus();
-    // });
-
     this.buttonRef.current.focus();
   }
 
@@ -55,36 +66,102 @@ export default class App extends React.Component<{}, AppState> {
   render() {
     const isModalOpen = this.state.modalOpen;
     const isModal2Open = this.state.modal2Open;
+    const isModalReady = this.state.modalReady;
+    const panel1Expanded = this.state.panel1Expanded;
+    const panel2Expanded = this.state.panel2Expanded;
+    const panel3Expanded = this.state.panel3Expanded;
+    const panel4Expanded = this.state.panel4Expanded;
+
     return (
       <div>
         <h1>Rendered by React!</h1>
+        <h2>Accordion</h2>
         <CdsAccordion>
-          <CdsAccordionPanel expanded>
+          <CdsAccordionPanel
+            expanded={panel1Expanded}
+            onExpandedChange={() => {
+              const newVal = !panel1Expanded;
+              this.setState({ panel1Expanded: newVal });
+            }}
+          >
             <CdsAccordionHeader>Item 1</CdsAccordionHeader>
             <CdsAccordionContent>Content 1</CdsAccordionContent>
           </CdsAccordionPanel>
-          <CdsAccordionPanel>
+          <CdsAccordionPanel
+            expanded={panel2Expanded}
+            onExpandedChange={() => {
+              const newVal = !panel2Expanded;
+              this.setState({ panel2Expanded: newVal });
+            }}
+          >
             <CdsAccordionHeader>Item 2</CdsAccordionHeader>
             <CdsAccordionContent>
               <CdsAccordion>
-                <CdsAccordionPanel>
+                <CdsAccordionPanel
+                  expanded={panel4Expanded}
+                  onExpandedChange={() => {
+                    const newVal = !panel4Expanded;
+                    this.setState({ panel4Expanded: newVal });
+                  }}
+                >
                   <CdsAccordionHeader>Item 2-1</CdsAccordionHeader>
-                  <CdsAccordionContent>Content 2-1</CdsAccordionContent>
+                  <CdsAccordionContent>
+                    <p cds-text="body">
+                      Hundreds of thousands hydrogen atoms the sky calls to us not a sunrise but a galaxyrise culture
+                      courage of our questions. Concept of the number one courage of our questions tingling of the spine
+                      Flatland explorations are creatures of the cosmos. Finite but unbounded great turbulent clouds a
+                      still more glorious dawn awaits corpus callosum vastness is bearable only through love
+                      dispassionate extraterrestrial observer. The carbon in our apple pies extraordinary claims require
+                      extraordinary evidence a very small stage in a vast cosmic arena gathered by gravity extraordinary
+                      claims require extraordinary evidence permanence of the stars and billions upon billions upon
+                      billions upon billions upon billions upon billions upon billions.
+                    </p>
+                  </CdsAccordionContent>
                 </CdsAccordionPanel>
               </CdsAccordion>
             </CdsAccordionContent>
           </CdsAccordionPanel>
-          <CdsAccordionPanel disabled>
-            <CdsAccordionHeader>Item 3</CdsAccordionHeader>
+          <CdsAccordionPanel
+            disabled
+            expanded={panel3Expanded}
+            onExpandedChange={() => {
+              const newVal = !panel3Expanded;
+              this.setState({ panel3Expanded: newVal });
+            }}
+          >
+            <CdsAccordionHeader>Item 3 – Should Not Open</CdsAccordionHeader>
             <CdsAccordionContent>Content 3</CdsAccordionContent>
           </CdsAccordionPanel>
         </CdsAccordion>
-        <CdsButton ref={this.buttonRef} onClick={() => this.setState({ modalOpen: true })}>
-          Open Modal
-        </CdsButton>
-        {isModalOpen ? (
+        <h2>Modal</h2>
+        <div>
+          <CdsButton
+            ref={this.buttonRef}
+            onClick={() => {
+              this.setState({ modalReady: true });
+              const timer = setTimeout(() => {
+                this.setState({ modalOpen: true });
+                clearTimeout(timer);
+              }, 25);
+            }}
+          >
+            Open Modal
+          </CdsButton>
+        </div>
+        {isModalReady ? (
           <div>
-            <CdsModal hidden={!isModalOpen} onCloseChange={() => this.setState({ modalOpen: false })}>
+            <CdsModal
+              hidden={!isModalOpen}
+              onCloseChange={() => {
+                this.setState({ modalOpen: false });
+              }}
+              onCdsMotionChange={e => {
+                const motionMsg = (e as CustomEvent).detail;
+                if (motionMsg === 'cds-modal-enter-reverse animation done') {
+                  this.setState({ modalReady: false });
+                }
+              }}
+            >
               <CdsModalHeader>
                 <h3 cds-text="title">My Modal</h3>
               </CdsModalHeader>

--- a/packages/react/src/accordion/index.tsx
+++ b/packages/react/src/accordion/index.tsx
@@ -8,6 +8,7 @@ import { createComponent } from '../converter/react-wrapper';
 export const CdsAccordion = createComponent('cds-accordion', Accordion);
 export const CdsAccordionPanel = createComponent('cds-accordion-panel', AccordionPanel, {
   onExpandedChange: 'expandedChange',
+  onCdsMotionChange: 'cdsMotionChange',
 });
 export const CdsAccordionHeader = createComponent('cds-accordion-header', AccordionHeader);
 export const CdsAccordionContent = createComponent('cds-accordion-content', AccordionContent);

--- a/packages/react/src/modal/index.tsx
+++ b/packages/react/src/modal/index.tsx
@@ -8,7 +8,10 @@ import {
 import '@cds/core/modal/register';
 import { createComponent } from '../converter/react-wrapper';
 
-export const CdsModal = createComponent('cds-modal', Modal, { onCloseChange: 'closeChange' });
+export const CdsModal = createComponent('cds-modal', Modal, {
+  onCloseChange: 'closeChange',
+  onCdsMotionChange: 'cdsMotionChange',
+});
 export const CdsModalActions = createComponent('cds-modal-actions', ModalActions);
 export const CdsModalContent = createComponent('cds-modal-content', ModalContent);
 export const CdsModalHeader = createComponent('cds-modal-header', ModalHeader);


### PR DESCRIPTION
• update cds/react dev app to use clarity motion
• had to update hidden CSS styles because react isn't adding/removing boolean attrs like we expect it to
• tried to make a getter/setter attr in Lit, thinking that might be it. But it wasn't
• verified cdsMotion 'off' turns off animation as expected
• updated accordion examples to use animation
• removed duplicate style import of baseStyles in modal.element.ts

Fixes: #5692

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5692 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
