### PR TITLE
fix: core visibility inheritance

### DIFF
--- a/packages/core/src/internal/base/base.element.scss
+++ b/packages/core/src/internal/base/base.element.scss
@@ -16,6 +16,7 @@
 :host {
   all: initial;
   display: block;
+  visibility: inherit;
   font-family: $cds-global-typography-font-family;
   contain: layout; // https://developer.mozilla.org/en-US/docs/Web/CSS/contain
   box-sizing: border-box !important;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Components may display and remain visible even when a parent DOM node is hidden.

Issue Number: https://github.com/vmware/clarity/issues/5685

## What is the new behavior?
This change allows components to inherit visibility so if a parent is hidden the component is hidden. Typically this behavior is the default but with shadow dom its a separate layer and does not respect visibility by default.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
