### PR TITLE
fix: update react-wrapper imports

### DIFF
--- a/packages/core/src/internal/motion/utils.spec.ts
+++ b/packages/core/src/internal/motion/utils.spec.ts
@@ -111,9 +111,8 @@ describe('Animation Helpers: ', () => {
     },
   ];
 
-  // TODO: LEFTOFF => Get rid of this F describe. Run local build too. Push changes.
   describe('runPropertyAnimations()', () => {
-    it('logs a warning if the element it is passed is not animatable', async () => {
+    it('logs a warning if the element it is passed is not animatable', async done => {
       const testElement = await createTestElement(html`<div>ohai</div>`);
       spyOn(LogService, 'warn');
       expect(testElement).toBeDefined();
@@ -121,9 +120,10 @@ describe('Animation Helpers: ', () => {
       expect(LogService.warn).toHaveBeenCalled();
       expect(didRun).toBe(false);
       removeTestElement(testElement);
+      done();
     });
 
-    it('bails if the host element does not have the property (weird edge case)', async () => {
+    it('bails if the host element does not have the property (weird edge case)', async done => {
       const testElement = await createTestElement(html`<div>ohai</div>`);
       const propMap: Map<string, any> = new Map();
       propMap.set('jabberwocky', 'wat');
@@ -131,9 +131,10 @@ describe('Animation Helpers: ', () => {
       const didRun = await runPropertyAnimations(propMap, (testElement as unknown) as AnimatableElement);
       expect(didRun).toBe(false);
       removeTestElement(testElement);
+      done();
     });
 
-    it('bails if the host element property and the new propval have not changed (another weird edge case)', async () => {
+    it('bails if the host element property and the new propval have not changed (another weird edge case)', async done => {
       const testElement = await createTestElement(html`<test-animate-utils-element>ohai</test-animate-utils-element>`);
       const component = testElement.querySelector<TestAnimateUtilsElement & AnimatableElement>(
         'test-animate-utils-element'
@@ -146,9 +147,10 @@ describe('Animation Helpers: ', () => {
       const didRun = await runPropertyAnimations(propMap, component);
       expect(didRun).toBe(false);
       removeTestElement(testElement);
+      done();
     });
 
-    it('bails if there is no animation associated with the property value', async () => {
+    it('bails if there is no animation associated with the property value', async done => {
       const testElement = await createTestElement(html`<div class="hayy">ohai</div>`);
       const component = testElement.querySelector('.hayy');
       const propMap: Map<string, any> = new Map();
@@ -157,9 +159,10 @@ describe('Animation Helpers: ', () => {
       const didRun = await runPropertyAnimations(propMap, (component as unknown) as AnimatableElement);
       expect(didRun).toBe(false);
       removeTestElement(testElement);
+      done();
     });
 
-    it('runs if there is an animation associated with the property value', async () => {
+    it('runs if there is an animation associated with the property value', async done => {
       const testElement = await createTestElement(html`<test-animate-utils-element>ohai</test-animate-utils-element>`);
       const component = testElement.querySelector<TestAnimateUtilsElement>('test-animate-utils-element');
       ClarityMotion.add('something', [{ animation: [{ opacity: 0 }, { opacity: 1 }] }]);
@@ -170,9 +173,10 @@ describe('Animation Helpers: ', () => {
       const didRun = await runPropertyAnimations(propMap, (component as unknown) as AnimatableElement);
       expect(didRun).toBe(true);
       removeTestElement(testElement);
+      done();
     });
 
-    it('does NOT run if there is an animation label associated with the property value but no animation in ClarityMotion', async () => {
+    it('does NOT run if there is an animation label associated with the property value but no animation in ClarityMotion', async done => {
       const testElement = await createTestElement(html`<test-animate-utils-element>ohai</test-animate-utils-element>`);
       const component = testElement.querySelector<TestAnimateUtilsElement>('test-animate-utils-element');
       component.everythingIsFine = false;
@@ -182,6 +186,7 @@ describe('Animation Helpers: ', () => {
       const didRun = await runPropertyAnimations(propMap, (component as unknown) as AnimatableElement);
       expect(didRun).toBe(false);
       removeTestElement(testElement);
+      done();
     });
   });
 

--- a/packages/react/App.tsx
+++ b/packages/react/App.tsx
@@ -1,28 +1,33 @@
 import React from 'react';
-import { CdsAccordion, CdsAccordionPanel, CdsAccordionHeader, CdsAccordionContent } from './src/accordion';
-import { CdsAlert, CdsAlertActions, CdsAlertGroup } from './src/alert';
-import { CdsButton } from './src/button';
-import { CdsBadge } from './src/badge';
-import { CdsCheckbox } from './src/checkbox';
-import { CdsControl, CdsControlMessage, CdsFormGroup } from './src/forms';
-import { CdsDatalist } from './src/datalist';
-import { CdsDate } from './src/date';
-import { CdsFile } from './src/file';
-import { CdsIcon } from './src/icon';
-import { CdsInput } from './src/input';
-import { CdsModal, CdsModalActions, CdsModalContent, CdsModalHeader } from './src/modal';
-import { CdsPassword } from './src/password';
-import { CdsProgressCircle } from './src/progress-circle';
-import { CdsRadio, CdsRadioGroup } from './src/radio';
-import { CdsRange } from './src/range';
-import { CdsSearch } from './src/search';
-import { CdsSelect } from './src/select';
-import { CdsTag } from './src/tag';
-import { CdsTime } from './src/time';
-import { CdsTextarea } from './src/textarea';
-import { CdsToggle, CdsToggleGroup } from './src/toggle';
+import {
+  CdsAccordion,
+  CdsAccordionPanel,
+  CdsAccordionHeader,
+  CdsAccordionContent,
+} from './dist/react/accordion/index.js';
+import { CdsAlert, CdsAlertActions, CdsAlertGroup } from './dist/react/alert/index.js';
+import { CdsButton } from './dist/react/button/index.js';
+import { CdsBadge } from './dist/react/badge/index.js';
+import { CdsCheckbox } from './dist/react/checkbox/index.js';
+import { CdsControl, CdsControlMessage, CdsFormGroup } from './dist/react/forms/index.js';
+import { CdsDatalist } from './dist/react/datalist/index.js';
+import { CdsDate } from './dist/react/date/index.js';
+import { CdsFile } from './dist/react/file/index.js';
+import { CdsIcon } from './dist/react/icon/index.js';
+import { CdsInput } from './dist/react/input/index.js';
+import { CdsModal, CdsModalActions, CdsModalContent, CdsModalHeader } from './dist/react/modal/index.js';
+import { CdsPassword } from './dist/react/password/index.js';
+import { CdsProgressCircle } from './dist/react/progress-circle/index.js';
+import { CdsRadio, CdsRadioGroup } from './dist/react/radio/index.js';
+import { CdsRange } from './dist/react/range/index.js';
+import { CdsSearch } from './dist/react/search/index.js';
+import { CdsSelect } from './dist/react/select/index.js';
+import { CdsTag } from './dist/react/tag/index.js';
+import { CdsTime } from './dist/react/time/index.js';
+import { CdsTextarea } from './dist/react/textarea/index.js';
+import { CdsToggle, CdsToggleGroup } from './dist/react/toggle/index.js';
 import { ClarityIcons, userIcon, timesIcon } from '@cds/core/icon';
-import { CdsDivider } from './src/divider';
+import { CdsDivider } from './dist/react/divider/index.js';
 
 ClarityIcons.addIcons(userIcon, timesIcon);
 

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
   modulePathIgnorePatterns: ['<rootDir>/dist/'],
   moduleNameMapper: {
     '@cds/(.*)': '<rootDir>/../core/dist/$1',
+    '../converter/react-wrapper.js': '<rootDir>/dist/react/converter/react-wrapper.js',
   },
   setupFilesAfterEnv: ['./jest.setup.ts'],
   snapshotSerializers: ['enzyme-to-json/serializer'],

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,19 +2,20 @@
   "name": "@cds/react",
   "version": "5.0.3",
   "scripts": {
-    "start": "npm-run-all core:build dev:start",
-    "dev:start": "yarn run clean && parcel index.html --cache-dir=./.parcel-cache",
+    "start": "npm-run-all core:build build -p build:ts:watch dev:start",
+    "dev:start": "parcel index.html --cache-dir=./.parcel-cache",
     "build": "npm-run-all -s build:ts build:package build:update",
     "build:preinstall": "mkdir -p ../../dist/react/ && cp ./package.json ../../dist/react/",
     "build:update": "node ../../scripts/update-local-packages.js /packages/react/dist/react/package.json",
     "build:package": "node ./package.js",
     "build:ts": "tsc --b ./tsconfig.project.json --force",
+    "build:ts:watch": "tsc --b ./tsconfig.project.json -w",
     "core:build": "yarn --cwd ../core run build",
     "lint": "eslint \"*/**/*.{ts,tsx}\" --ignore-pattern \"dist\"",
     "lint:fix": "eslint --fix \"*/**/*.{ts,tsx}\" --ignore-pattern \"dist\"",
     "test": "jest --coverage",
     "test:watch": "jest --watchAll",
-    "test:snap:update": "jest --updateSnapshot",
+    "test:snap:update": "yarn run build && jest --updateSnapshot",
     "clean": "del ./dist .parcel-cache"
   },
   "repository": {

--- a/packages/react/src/accordion/index.tsx
+++ b/packages/react/src/accordion/index.tsx
@@ -3,7 +3,7 @@ import { CdsAccordionContent as AccordionContent } from '@cds/core/accordion';
 import { CdsAccordionHeader as AccordionHeader } from '@cds/core/accordion';
 import { CdsAccordionPanel as AccordionPanel } from '@cds/core/accordion';
 import '@cds/core/accordion/register';
-import { createComponent } from '../converter/react-wrapper';
+import { createComponent } from '../converter/react-wrapper.js';
 
 export const CdsAccordion = createComponent('cds-accordion', Accordion);
 export const CdsAccordionPanel = createComponent('cds-accordion-panel', AccordionPanel, {

--- a/packages/react/src/alert/index.tsx
+++ b/packages/react/src/alert/index.tsx
@@ -1,6 +1,6 @@
 import { CdsAlert as Alert, CdsAlertActions as AlertActions, CdsAlertGroup as AlertGroup } from '@cds/core/alert';
 import '@cds/core/alert/register';
-import { createComponent } from '../converter/react-wrapper';
+import { createComponent } from '../converter/react-wrapper.js';
 
 export const CdsAlert = createComponent('cds-alert', Alert, { onCloseChange: 'closeChange' });
 export const CdsAlertActions = createComponent('cds-alert-actions', AlertActions);

--- a/packages/react/src/badge/index.tsx
+++ b/packages/react/src/badge/index.tsx
@@ -1,5 +1,5 @@
 import { CdsBadge as Badge } from '@cds/core/badge';
 import '@cds/core/badge/register';
-import { createComponent } from '../converter/react-wrapper';
+import { createComponent } from '../converter/react-wrapper.js';
 
 export const CdsBadge = createComponent('cds-badge', Badge);

--- a/packages/react/src/button/index.tsx
+++ b/packages/react/src/button/index.tsx
@@ -1,6 +1,6 @@
 import { CdsButton as Button, CdsIconButton as IconButton, CdsInlineButton as InlineButton } from '@cds/core/button';
 import '@cds/core/button/register';
-import { createComponent } from '../converter/react-wrapper';
+import { createComponent } from '../converter/react-wrapper.js';
 
 export const CdsButton = createComponent('cds-button', Button);
 export const CdsIconButton = createComponent('cds-icon-button', IconButton);

--- a/packages/react/src/checkbox/index.tsx
+++ b/packages/react/src/checkbox/index.tsx
@@ -1,6 +1,6 @@
 import { CdsCheckbox as Checkbox, CdsCheckboxGroup as CheckboxGroup } from '@cds/core/checkbox';
 import '@cds/core/checkbox/register';
-import { createComponent } from '../converter/react-wrapper';
+import { createComponent } from '../converter/react-wrapper.js';
 
 export const CdsCheckbox = createComponent('cds-checkbox', Checkbox);
 export const CdsCheckboxGroup = createComponent('cds-checkbox-group', CheckboxGroup);

--- a/packages/react/src/datalist/index.tsx
+++ b/packages/react/src/datalist/index.tsx
@@ -1,5 +1,5 @@
 import { CdsDatalist as Datalist } from '@cds/core/datalist';
 import '@cds/core/datalist/register';
-import { createComponent } from '../converter/react-wrapper';
+import { createComponent } from '../converter/react-wrapper.js';
 
 export const CdsDatalist = createComponent('cds-datalist', Datalist);

--- a/packages/react/src/date/index.tsx
+++ b/packages/react/src/date/index.tsx
@@ -1,5 +1,5 @@
 import { CdsDate as DateInput } from '@cds/core/date';
 import '@cds/core/date/register';
-import { createComponent } from '../converter/react-wrapper';
+import { createComponent } from '../converter/react-wrapper.js';
 
 export const CdsDate = createComponent('cds-date', DateInput);

--- a/packages/react/src/divider/index.tsx
+++ b/packages/react/src/divider/index.tsx
@@ -1,5 +1,5 @@
 import { CdsDivider as Divider } from '@cds/core/divider';
 import '@cds/core/divider/register';
-import { createComponent } from '../converter/react-wrapper';
+import { createComponent } from '../converter/react-wrapper.js';
 
 export const CdsDivider = createComponent('cds-divider', Divider);

--- a/packages/react/src/file/index.tsx
+++ b/packages/react/src/file/index.tsx
@@ -1,5 +1,5 @@
 import { CdsFile as File } from '@cds/core/file';
 import '@cds/core/file/register';
-import { createComponent } from '../converter/react-wrapper';
+import { createComponent } from '../converter/react-wrapper.js';
 
 export const CdsFile = createComponent('cds-file', File);

--- a/packages/react/src/forms/index.tsx
+++ b/packages/react/src/forms/index.tsx
@@ -6,7 +6,7 @@ import {
   CdsFormGroup as FormGroup,
 } from '@cds/core/forms';
 import '@cds/core/forms/register';
-import { createComponent } from '../converter/react-wrapper';
+import { createComponent } from '../converter/react-wrapper.js';
 
 export const CdsControlMessage = createComponent('cds-control-message', ControlMessage);
 export const CdsControlAction = createComponent('cds-control-action', ControlAction);

--- a/packages/react/src/icon/index.tsx
+++ b/packages/react/src/icon/index.tsx
@@ -1,6 +1,6 @@
 import { CdsIcon as Icon } from '@cds/core/icon';
 import '@cds/core/icon/register';
-import { createComponent } from '../converter/react-wrapper';
+import { createComponent } from '../converter/react-wrapper.js';
 
 /**
  * If using JSX or TSX, import the icon name from `@cds/core/icon` and include it in the `shape` prop to improve type safety:

--- a/packages/react/src/input/index.tsx
+++ b/packages/react/src/input/index.tsx
@@ -1,6 +1,6 @@
 import { CdsInput as Input, CdsInputGroup as InputGroup } from '@cds/core/input';
 import '@cds/core/input/register';
-import { createComponent } from '../converter/react-wrapper';
+import { createComponent } from '../converter/react-wrapper.js';
 
 export const CdsInput = createComponent('cds-input', Input);
 export const CdsInputGroup = createComponent('cds-input-group', InputGroup);

--- a/packages/react/src/modal/index.tsx
+++ b/packages/react/src/modal/index.tsx
@@ -6,7 +6,7 @@ import {
   CdsModalHeaderActions as ModalHeaderActions,
 } from '@cds/core/modal';
 import '@cds/core/modal/register';
-import { createComponent } from '../converter/react-wrapper';
+import { createComponent } from '../converter/react-wrapper.js';
 
 export const CdsModal = createComponent('cds-modal', Modal, {
   onCloseChange: 'closeChange',

--- a/packages/react/src/password/index.tsx
+++ b/packages/react/src/password/index.tsx
@@ -1,5 +1,5 @@
 import { CdsPassword as Password } from '@cds/core/password';
 import '@cds/core/password/register';
-import { createComponent } from '../converter/react-wrapper';
+import { createComponent } from '../converter/react-wrapper.js';
 
 export const CdsPassword = createComponent('cds-password', Password);

--- a/packages/react/src/progress-circle/index.tsx
+++ b/packages/react/src/progress-circle/index.tsx
@@ -1,5 +1,5 @@
 import { CdsProgressCircle as ProgressCircle } from '@cds/core/progress-circle';
 import '@cds/core/progress-circle/register';
-import { createComponent } from '../converter/react-wrapper';
+import { createComponent } from '../converter/react-wrapper.js';
 
 export const CdsProgressCircle = createComponent('cds-progress-circle', ProgressCircle);

--- a/packages/react/src/radio/index.tsx
+++ b/packages/react/src/radio/index.tsx
@@ -1,6 +1,6 @@
 import { CdsRadio as Radio, CdsRadioGroup as RadioGroup } from '@cds/core/radio';
 import '@cds/core/radio/register';
-import { createComponent } from '../converter/react-wrapper';
+import { createComponent } from '../converter/react-wrapper.js';
 
 export const CdsRadio = createComponent('cds-radio', Radio);
 export const CdsRadioGroup = createComponent('cds-radio-group', RadioGroup);

--- a/packages/react/src/range/index.tsx
+++ b/packages/react/src/range/index.tsx
@@ -1,5 +1,5 @@
 import { CdsRange as RangeInput } from '@cds/core/range';
 import '@cds/core/range/register';
-import { createComponent } from '../converter/react-wrapper';
+import { createComponent } from '../converter/react-wrapper.js';
 
 export const CdsRange = createComponent('cds-range', RangeInput);

--- a/packages/react/src/search/index.tsx
+++ b/packages/react/src/search/index.tsx
@@ -1,5 +1,5 @@
 import { CdsSearch as SearchInput } from '@cds/core/search';
 import '@cds/core/search/register';
-import { createComponent } from '../converter/react-wrapper';
+import { createComponent } from '../converter/react-wrapper.js';
 
 export const CdsSearch = createComponent('cds-search', SearchInput);

--- a/packages/react/src/select/index.tsx
+++ b/packages/react/src/select/index.tsx
@@ -1,5 +1,5 @@
 import { CdsSelect as SelectInput } from '@cds/core/select';
 import '@cds/core/select/register';
-import { createComponent } from '../converter/react-wrapper';
+import { createComponent } from '../converter/react-wrapper.js';
 
 export const CdsSelect = createComponent('cds-select', SelectInput);

--- a/packages/react/src/tag/index.tsx
+++ b/packages/react/src/tag/index.tsx
@@ -1,5 +1,5 @@
 import { CdsTag as Tag } from '@cds/core/tag';
 import '@cds/core/tag/register';
-import { createComponent } from '../converter/react-wrapper';
+import { createComponent } from '../converter/react-wrapper.js';
 
 export const CdsTag = createComponent('cds-tag', Tag);

--- a/packages/react/src/textarea/index.tsx
+++ b/packages/react/src/textarea/index.tsx
@@ -1,5 +1,5 @@
 import { CdsTextarea as Textarea } from '@cds/core/textarea';
 import '@cds/core/textarea/register';
-import { createComponent } from '../converter/react-wrapper';
+import { createComponent } from '../converter/react-wrapper.js';
 
 export const CdsTextarea = createComponent('cds-textarea', Textarea);

--- a/packages/react/src/time/index.tsx
+++ b/packages/react/src/time/index.tsx
@@ -1,5 +1,5 @@
 import { CdsTime as TimeInput } from '@cds/core/time';
 import '@cds/core/time/register';
-import { createComponent } from '../converter/react-wrapper';
+import { createComponent } from '../converter/react-wrapper.js';
 
 export const CdsTime = createComponent('cds-time', TimeInput);

--- a/packages/react/src/toggle/index.tsx
+++ b/packages/react/src/toggle/index.tsx
@@ -1,6 +1,6 @@
 import { CdsToggleGroup as ToggleGroup, CdsToggle as Toggle } from '@cds/core/toggle';
 import '@cds/core/toggle/register';
-import { createComponent } from '../converter/react-wrapper';
+import { createComponent } from '../converter/react-wrapper.js';
 
 export const CdsToggleGroup = createComponent('cds-toggle-group', ToggleGroup);
 export const CdsToggle = createComponent('cds-toggle', Toggle);


### PR DESCRIPTION
• updating react-wrapper imports to use the transpiled JS
• this was causing a problem for webpack builds
• added a build step to the dev app to transpire files into the dist folder
• relying on the new transpiled react-wrapper was crashing the dev app

Fixes: #5704

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5704

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
