### PR TITLE
fix: react value tracker bug

### DIFF
--- a/packages/core/src/forms/control-inline/control-inline.element.spec.ts
+++ b/packages/core/src/forms/control-inline/control-inline.element.spec.ts
@@ -57,23 +57,4 @@ describe('cds-internal-control-inline', () => {
     await componentIsStable(control);
     expect(control.shadowRoot.querySelector('slot[message]')).toEqual(null);
   });
-
-  // https://stackoverflow.com/questions/23892547/what-is-the-best-way-to-trigger-onchange-event-in-react-js?answertab=active#tab-top
-  it('should trigger a click event when checked or indeterminate changes for React issue', async () => {
-    await componentIsStable(control);
-
-    let eventTriggered = false;
-    control.inputControl.addEventListener('click', () => (eventTriggered = true));
-
-    control.inputControl.checked = true;
-    await componentIsStable(control);
-
-    const prior = (window as any).CDS._react.version;
-    (window as any).CDS._react.version = '1.1.1';
-    control.inputControl.checked = false;
-
-    await componentIsStable(control);
-    (window as any).CDS._react.version = prior;
-    expect(eventTriggered).toEqual(true);
-  });
 });

--- a/packages/core/src/forms/control-inline/control-inline.element.ts
+++ b/packages/core/src/forms/control-inline/control-inline.element.ts
@@ -5,14 +5,7 @@
  */
 
 import { html } from 'lit-element';
-import {
-  EventEmitter,
-  property,
-  event,
-  getElementUpdates,
-  internalProperty,
-  getReactVersion,
-} from '@cds/core/internal';
+import { EventEmitter, property, event, getElementUpdates, internalProperty } from '@cds/core/internal';
 import { styles } from './control-inline.element.css.js';
 import { CdsControl } from '../control/control.element.js';
 import { getStatusIcon } from '../utils/index.js';
@@ -106,11 +99,6 @@ export class CdsInternalControlInline extends CdsControl {
     if (props.has('checked') && props.get('checked') !== this.checked && this.checked) {
       this.indeterminate = false;
       this.checkedChange.emit(this.checked);
-    }
-
-    // workaround to trigger property updates in React https://stackoverflow.com/questions/23892547/what-is-the-best-way-to-trigger-onchange-event-in-react-js?answertab=active#tab-top
-    if (getReactVersion() && (props.has('checked') || props.has('indeterminate'))) {
-      this.inputControl.dispatchEvent(new Event('click', { bubbles: true }));
     }
   }
 }

--- a/packages/core/src/internal/utils/events.spec.ts
+++ b/packages/core/src/internal/utils/events.spec.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { html } from 'lit-html';
+import { removeTestElement, createTestElement } from '@cds/core/test';
+import { getElementUpdates } from './events';
+
+describe('getElementUpdates', () => {
+  let element: HTMLElement;
+  let input: HTMLInputElement;
+
+  beforeEach(async () => {
+    element = await createTestElement(html`<input type="checkbox" />`);
+    input = element.querySelector<HTMLInputElement>('input');
+  });
+
+  afterEach(() => {
+    removeTestElement(element);
+  });
+
+  it('get notified of property change', () => {
+    let checked = false;
+    getElementUpdates(input, 'checked', value => (checked = value));
+    input.checked = true;
+
+    expect(checked).toEqual(true);
+  });
+
+  it('get notified of attr change', () => {
+    let checked = false;
+    getElementUpdates(input, 'checked', value => (checked = value));
+    input.setAttribute('checked', '');
+
+    expect(checked).toEqual(true);
+  });
+
+  it('should reset any React value trackers if input', () => {
+    (input as any)._valueTracker = {};
+
+    let value = '';
+    getElementUpdates(input, 'value', v => (value = v));
+    input.value = 'test';
+
+    expect(value).toEqual('test');
+    expect((input as any)._valueTracker).toEqual(null);
+  });
+
+  it('should reset any React value trackers if checkable input', () => {
+    (input as any)._valueTracker = {};
+
+    let checked = false;
+    getElementUpdates(input, 'checked', value => (checked = value));
+    input.setAttribute('checked', '');
+
+    expect(checked).toEqual(true);
+    expect((input as any)._valueTracker).toEqual(null);
+  });
+});

--- a/packages/core/src/internal/utils/events.ts
+++ b/packages/core/src/internal/utils/events.ts
@@ -16,6 +16,13 @@ export const getElementUpdates = (element: HTMLElement, propertyKey: string, cal
     (element as any)[propertyKey] !== undefined ? (element as any)[propertyKey] : element.getAttribute(propertyKey)
   );
 
+  // React: disable input tracker to setup property observer. React re-creates tracker on input changes
+  // https://github.com/facebook/react/blob/9198a5cec0936a21a5ba194a22fcbac03eba5d1d/packages/react-dom/src/client/inputValueTracking.js#L51
+  // https://github.com/vmware/clarity/issues/5625
+  if ((element as any)._valueTracker && (propertyKey === 'checked' || propertyKey === 'value')) {
+    (element as any)._valueTracker = null;
+  }
+
   const updatedProp = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(element), propertyKey) as any;
 
   if (updatedProp) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When using controlled inputs in react the input gets out of sync with the React state.

Issue Number: https://github.com/vmware/clarity/issues/5625

## What is the new behavior?
This potential fix will disable the *private* value tracker react creates on the input before we set our property listener. React re-creates its value tracker overloading our property enabling our component and React to stay in sync. I am not 100% on this fix. As far as I have tested it seems to work but it does involve accessing a internal React property for it to work.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
