### PR TITLE
docs(tooltip): fix css that was hiding tooltips

### DIFF
--- a/apps/website/.vuepress/theme/global-components/DocDemo.vue
+++ b/apps/website/.vuepress/theme/global-components/DocDemo.vue
@@ -16,12 +16,8 @@ export default {
 
 <style lang="scss">
 .demo-wrapper {
-  // @TODO Why did we have these? They break tooltips
-  // position: relative;
-  // overflow: hidden;
   margin: 0.6rem 0 1.2rem;
   padding: 0.2rem;
-  overflow: auto;
 
   &.center {
     text-align: center;


### PR DESCRIPTION
Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?
Small css change to the DocDemo website component that was hiding content in the overflow. 

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Angular Tooltips are not showing on the website. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Angular Tooltips are visible on the website. 
