### PR TITLE
fix: remove duplicate screen-reader-only layout CSS declaration

### DIFF
--- a/packages/core/src/styles/layout/_display.scss
+++ b/packages/core/src/styles/layout/_display.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -40,21 +40,6 @@
   display: inline !important;
 }
 
-[cds-layout~='display:screen-reader-only'] {
-  position: absolute !important;
-  clip: rect(1px, 1px, 1px, 1px);
-  clip-path: inset(50%);
-  padding: 0;
-  border: 0;
-  height: 1px;
-  width: 1px;
-  overflow: hidden;
-  white-space: nowrap;
-  top: 0;
-  left: 0;
-  display: block !important;
-}
-
 @media (min-width: $cds-global-layout-width-sm-static) {
   @include display('sm');
 }
@@ -70,9 +55,6 @@
 @media (min-width: $cds-global-layout-width-xl-static) {
   @include display('xl');
 }
-
-// duplicating here b/c the form fields can't pull it in from
-// the reset module
 
 [cds-layout~='display:screen-reader-only'] {
   position: absolute !important;

--- a/packages/core/src/styles/module.reset.scss
+++ b/packages/core/src/styles/module.reset.scss
@@ -30,11 +30,6 @@ html {
   color: $cds-global-typography-color-200;
 }
 
-[cds-control] :-ms-input-placeholder {
-  /* IE 10+ */
-  color: $cds-global-typography-color-200;
-}
-
 [cds-control][_disabled] {
   --cds-global-typography-color-200: #{$cds-alias-status-disabled};
 }

--- a/packages/core/src/styles/module.reset.scss
+++ b/packages/core/src/styles/module.reset.scss
@@ -39,21 +39,6 @@ html {
   --cds-global-typography-color-200: #{$cds-alias-status-disabled};
 }
 
-[cds-layout~='display:screen-reader-only'] {
-  position: absolute !important;
-  clip: rect(1px, 1px, 1px, 1px);
-  clip-path: inset(50%);
-  padding: 0;
-  border: 0;
-  height: 1px;
-  width: 1px;
-  overflow: hidden;
-  white-space: nowrap;
-  top: 0;
-  left: 0;
-  display: block !important;
-}
-
 html[cds-focus-trap-ids*='_'] {
   overflow: hidden !important;
   width: 100vw;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes) --> Cleanup
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The `[cds-layout~='display:screen-reader-only']` declaration exists 3 times in https://unpkg.com/browse/@cds/core@5.0.3/global.css at L473, L4876, and L4959, exact duplicates.

Issue Number: https://github.com/vmware/clarity/issues/5719

## What is the new behavior?

On this branch, it only exists once at L4936 of `global.css`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

I exclusively followed the steps listed at https://github.com/vmware/clarity/issues/5719 and made sure the output was correct.

In my understanding, this declaration is not a job for a "reset" stylesheet which is why it should be removed from there + the comment I removed was resolved in the past (by moving the declaration to the `_display.scss` mixing that the form fields CSS files have access to, as `_layout.scss` is imported higher in the tree) + the same-file duplicate was most likely a merge/rebase leftover.
Does that sound correct?

Thanks for the help, @coryrylan!