### PR TITLE
Allowing multiple specs, incognito browser and DOM manipulation

### DIFF
--- a/tools/visual-tester/index.js
+++ b/tools/visual-tester/index.js
@@ -16,6 +16,8 @@ const argv = require('minimist')(process.argv.slice(2), {
     baseUrl: 'http://localhost:4200/',
     reporter: RUNNER_CONFIG.REPORTER,
     overwrite: false,
+    openBrowser: false,
+    disableIncognito: false,
     basePath: RUNNER_CONFIG.BASE_PATH,
     currentPath: RUNNER_CONFIG.TMP_PATH,
     diffPath: RUNNER_CONFIG.DIFF_PATH,
@@ -25,6 +27,8 @@ const argv = require('minimist')(process.argv.slice(2), {
 const r = new Runner({
   baseUrl: argv.baseUrl,
   overwrite: argv.overwrite,
+  openBrowser: argv.openBrowser,
+  disableIncognito: argv.disableIncognito,
   reporter: argv.reporter,
   basePath: argv.basePath,
   currentPath: argv.currentPath,
@@ -36,6 +40,7 @@ global.it = r.it.bind(r);
 global.xit = r.xit.bind(r);
 global.fit = r.fit.bind(r);
 global.setup = r.setup.bind(r);
+global.specOptions = r.specOptions.bind(r);
 
 const specs = glob.sync(path.join(__dirname, './specs/**/*.spec.js'));
 

--- a/tools/visual-tester/package.json
+++ b/tools/visual-tester/package.json
@@ -13,7 +13,7 @@
     "minimist": "^1.2.5",
     "mkdirp": "^1.0.4",
     "mz": "^2.7.0",
-    "puppeteer": "^5.3.1",
+    "puppeteer": "^8.0.0",
     "resemblejs": "^3.2.5"
   }
 }

--- a/tools/visual-tester/specs/dev.spec.js
+++ b/tools/visual-tester/specs/dev.spec.js
@@ -1,5 +1,9 @@
 setup({
+
+});
+specOptions({
   selector: 'main.content-area',
+  removeFromDom: ['cds-icon[shape=\'vm-bug\']', 'cds-icon[shape=\'cog\']']
 });
 
 it('accordion');
@@ -51,7 +55,7 @@ it('buttons/icon-buttons');
 it('buttons/buttons-test');
 
 it('card/grid');
-it('card/clickable');
+it('card/clickable', {hoverOver: 'a.card.clickable'});
 it('card/dropdown');
 it('card/images');
 it('card/layout');

--- a/tools/visual-tester/src/config.js
+++ b/tools/visual-tester/src/config.js
@@ -24,4 +24,6 @@ module.exports = {
   basePath: '',
   currentPath: '',
   diffPath: '',
+  openBrowser: false,
+  disableIncognito: false
 };

--- a/tools/visual-tester/src/reporters/console-reporter.js
+++ b/tools/visual-tester/src/reporters/console-reporter.js
@@ -9,7 +9,7 @@ module.exports = class ConsoleReporter extends BaseReporter {
     console.log(`${test} passed.`);
   }
   fail(test, options) {
-    console.error(`${test} faild. ${options.mismatch}`);
+    console.error(`${test} failed. ${options.mismatch}`);
   }
   retry(test, times) {
     console.warn(`${test} retries ${times} times`);
@@ -31,8 +31,17 @@ module.exports = class ConsoleReporter extends BaseReporter {
           console.log(`\t diff    : ${path.join(this.config.diffPath, error.filename)}`);
         }
       });
-      console.log(`\n\t${errors.length} faild tests\n`);
+      console.log(`\n\t${errors.length} failed tests\n`);
     }
+
+    process.stdout.write(
+      `Summary:
+      Total   tests: ${info.total}
+      Skipped tests: ${info.skipped}
+      Focused tests: ${info.focused}
+      Failed  tests: ${info.failed}
+      Passed  tests: ${info.passed}\n`
+    );
     console.log(`\n everything is OK no failing tests`);
   }
 };

--- a/tools/visual-tester/src/reporters/dot-reporter.js
+++ b/tools/visual-tester/src/reporters/dot-reporter.js
@@ -44,10 +44,18 @@ module.exports = class DotReporter extends BaseReporter {
         }
       });
 
-      process.stdout.write(`\n\t${errors.length} faild tests\n`);
+      process.stdout.write(`\n\t${errors.length} failed tests\n`);
 
       return;
     }
+    process.stdout.write(
+      `Summary:
+      Total   tests: ${info.total}
+      Skipped tests: ${info.skipped}
+      Focused tests: ${info.focused}
+      Failed  tests: ${info.failed}
+      Passed  tests: ${info.passed}\n`
+    );
     process.stdout.write(`\n${this.mascot} everything is OK no failing tests`);
   }
 


### PR DESCRIPTION
In this PR:
1) The visual-tester now reads multiple specs;
2) The testing is performed in incognito mode;
3) The visual-tester now supports 'hiding' elements in the page prior to snapshot;
4) The visual-tester now can hover over an element;
5) The visual-tester supports opening the browser so now the test can be seen;
6) Improved the performance of the test specs by closing the tab of each test.
