### PR TITLE
fix(form): core control group to disable all children

### DIFF
--- a/packages/core/src/forms/control-group/control-group.element.spec.ts
+++ b/packages/core/src/forms/control-group/control-group.element.spec.ts
@@ -91,6 +91,22 @@ describe('cds-internal-control-group', () => {
     expect(controls[1].status).toBe('error');
   });
 
+  it('should set the disabled style on all cds-controls and native html inputs if group is disabled', async () => {
+    controlGroup.disabled = true;
+
+    await componentIsStable(controlGroup);
+    await componentIsStable(controls[0]);
+    await componentIsStable(controls[1]);
+
+    // cds-control has style hook attr '_disabled'
+    expect(controls[0].hasAttribute('_disabled')).toBe(true);
+    expect(controls[1].hasAttribute('_disabled')).toBe(true);
+
+    // native html input has attr 'disabled'
+    expect(controls[0].inputControl.hasAttribute('disabled')).toBe(true);
+    expect(controls[1].inputControl.hasAttribute('disabled')).toBe(true);
+  });
+
   it('should adjust for compact layouts and messages', async () => {
     controlGroup.layout = 'compact';
     await componentIsStable(controlGroup);

--- a/packages/core/src/forms/control/control.element.ts
+++ b/packages/core/src/forms/control/control.element.ts
@@ -280,6 +280,8 @@ export class CdsControl extends LitElement {
   updated(props: Map<string, any>) {
     super.updated(props);
     this.messages.forEach(message => syncProps(message, this, { disabled: props.has('disabled') }));
+
+    syncProps(this.inputControl, this, { disabled: props.has('disabled') });
   }
 
   disconnectedCallback() {


### PR DESCRIPTION
Closes #5734

Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #5734 

## What is the new behavior?

The controls inside a group are all disabled when a `disabled` attribute is set on the group.

https://user-images.githubusercontent.com/15037947/111314944-90449080-866a-11eb-8279-cdb3a3cdfbcf.mov

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
