### PR TITLE
fix: core accordion header layout

### DIFF
--- a/packages/core/src/accordion/accordion-header.element.ts
+++ b/packages/core/src/accordion/accordion-header.element.ts
@@ -49,7 +49,7 @@ export class CdsAccordionHeader extends LitElement {
   render() {
     return html`<div class="private-host" cds-layout="horizontal gap:md align:vertical-center">
       <cds-icon class="accordion-angle" shape="angle" size="9" inner-offset="2"></cds-icon>
-      <span cds-text="secondary"><slot></slot></span>
+      <div cds-text="secondary" cds-layout="align:stretch"><slot></slot></div>
     </div>`;
   }
 

--- a/packages/core/src/accordion/accordion.stories.mdx
+++ b/packages/core/src/accordion/accordion.stories.mdx
@@ -54,6 +54,12 @@ import '@cds/core/accordion/register.js';
   <Story id="stories-accordion--interactive" />
 </Preview>
 
+## Stackview Accordion
+
+<Preview>
+  <Story id="stories-accordion--stackview" />
+</Preview>
+
 ## Dark Theme
 
 <Preview>

--- a/packages/core/src/accordion/accordion.stories.ts
+++ b/packages/core/src/accordion/accordion.stories.ts
@@ -267,3 +267,60 @@ export function customStyles() {
     </cds-accordion>
   `;
 }
+
+export function stackview() {
+  return html`
+    <style>
+      #stackview-demo cds-divider {
+        margin: 0 calc(var(--cds-global-space-11) * -1);
+        width: calc(100% + calc(var(--cds-global-space-11) * 2));
+      }
+    </style>
+    <cds-accordion id="stackview-demo">
+      <cds-accordion-panel>
+        <cds-accordion-header>
+          <div cds-layout="grid cols:6">
+            <p cds-text="secondary">Panel One</p>
+            <p cds-text="secondary">Content One</p>
+          </div>
+        </cds-accordion-header>
+        <cds-accordion-content></cds-accordion-content>
+      </cds-accordion-panel>
+      <cds-accordion-panel expanded>
+        <cds-accordion-header>
+          <div cds-layout="grid cols:6">
+            <p cds-text="secondary">Panel Two</p>
+            <p cds-text="secondary">Content Two</p>
+          </div>
+        </cds-accordion-header>
+        <cds-accordion-content>
+          <div cds-layout="vertical gap:md">
+            <div cds-layout="grid cols:6 gap:lg">
+              <p cds-text="secondary">Panel Two</p>
+              <p cds-text="secondary">Content Two</p>
+            </div>
+            <cds-divider></cds-divider>
+            <div cds-layout="grid cols:6 gap:lg">
+              <p cds-text="secondary">Panel Two</p>
+              <p cds-text="secondary">Content Two</p>
+            </div>
+            <cds-divider></cds-divider>
+            <div cds-layout="grid cols:6 gap:lg">
+              <p cds-text="secondary">Panel Two</p>
+              <p cds-text="secondary">Content Two</p>
+            </div>
+          </div>
+        </cds-accordion-content>
+      </cds-accordion-panel>
+      <cds-accordion-panel>
+        <cds-accordion-header>
+          <div cds-layout="grid cols:6">
+            <p cds-text="secondary">Panel Three</p>
+            <p cds-text="secondary">Content Three</p>
+          </div>
+        </cds-accordion-header>
+        <cds-accordion-content></cds-accordion-content>
+      </cds-accordion-panel>
+    </cds-accordion>
+  `;
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
The accordion header in core did not fill the component container making certain layouts not possible.

## What is the new behavior?
This fix allows the accordion header content slot to stretch and fill the component to enable complex layouts like multi column stackview. I added a demo of a stackview pattern to storybook to demonstrate the fix and enable teams to use a stackview like pattern in Core if needed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
