### PR TITLE
fix: core indeterminate checkbox

### DIFF
--- a/packages/core/src/checkbox/checkbox.element.scss
+++ b/packages/core/src/checkbox/checkbox.element.scss
@@ -55,7 +55,8 @@
   border-left: none;
   border-bottom-color: var(--color);
   display: inline-block;
-  transform: translateY(0.15rem);
+  transform: translateY(calc(#{$cds-global-space-1} * 0.15));
+  top: $cds-global-space-3;
 }
 
 :host([_checked]) {

--- a/packages/core/src/internal/utils/events.spec.ts
+++ b/packages/core/src/internal/utils/events.spec.ts
@@ -29,6 +29,15 @@ describe('getElementUpdates', () => {
     expect(checked).toEqual(true);
   });
 
+  it('get notified of initial attr value', async done => {
+    input.setAttribute('indeterminate', '');
+
+    getElementUpdates(input, 'indeterminate', value => {
+      expect(value).toEqual('');
+      done();
+    });
+  });
+
   it('get notified of attr changes', async done => {
     const values: any = [];
     getElementUpdates(input, 'checked', value => {

--- a/packages/core/src/internal/utils/events.ts
+++ b/packages/core/src/internal/utils/events.ts
@@ -12,9 +12,11 @@ export function stopEvent(event: Event) {
 }
 
 export const getElementUpdates = (element: HTMLElement, propertyKey: string, callback: (value: any) => void) => {
-  callback(
-    (element as any)[propertyKey] !== undefined ? (element as any)[propertyKey] : element.getAttribute(propertyKey)
-  );
+  if (element.hasAttribute(propertyKey)) {
+    callback(element.getAttribute(propertyKey));
+  } else if ((element as any)[propertyKey] !== undefined) {
+    callback((element as any)[propertyKey]);
+  }
 
   // React: disable input tracker to setup property observer. React re-creates tracker on input changes
   // https://github.com/facebook/react/blob/9198a5cec0936a21a5ba194a22fcbac03eba5d1d/packages/react-dom/src/client/inputValueTracking.js#L51


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
The initial indeterminate value of a checkbox in cds-checkbox would be ignored if using an attribute.
The indeterminate line was slightly off once rendered.

## What is the new behavior?
- Render the initial indeterminate value
- Align the indeterminate line vertically in the checkbox

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
