### PR TITLE
fix: core form group control width

### DIFF
--- a/packages/core/src/forms/form-group/form-group.element.spec.ts
+++ b/packages/core/src/forms/form-group/form-group.element.spec.ts
@@ -67,15 +67,27 @@ describe('cds-form-group', () => {
 
   it('should sync controlWidth prop', async () => {
     await componentIsStable(formGroup);
-    expect(formGroup.controlWidth).toBe('stretch');
+    expect(formGroup.controlWidth).toBe(undefined);
     expect(controls[0].controlWidth).toBe('stretch');
     expect(controls[1].controlWidth).toBe('stretch');
 
     formGroup.controlWidth = 'shrink';
     await componentIsStable(formGroup);
+
     expect(formGroup.controlWidth).toBe('shrink');
     expect(controls[0].controlWidth).toBe('shrink');
     expect(controls[1].controlWidth).toBe('shrink');
+  });
+
+  it('should not override initial control width if set by child control and no parent width defined', async () => {
+    controls[1].setAttribute('control-width', 'shrink');
+
+    await componentIsStable(formGroup);
+    await componentIsStable(controls[0]);
+    await componentIsStable(controls[1]);
+
+    expect(controls[0].controlWidth).toBe('stretch');
+    expect(controls[1].getAttribute('control-width')).toBe('shrink');
   });
 
   it('should sync validate prop', async () => {

--- a/packages/core/src/forms/form-group/form-group.element.ts
+++ b/packages/core/src/forms/form-group/form-group.element.ts
@@ -8,22 +8,17 @@ import { LitElement, html } from 'lit-element';
 import {
   baseStyles,
   querySlotAll,
-  syncDefinedProps,
   property,
   childrenUpdateComplete,
   elementResize,
   pxToRem,
+  syncDefinedProps,
 } from '@cds/core/internal';
 import { CdsInternalControlGroup } from '../control-group/control-group.element.js';
 import { CdsInternalControlInline } from '../control-inline/control-inline.element.js';
 import { CdsControl } from '../control/control.element.js';
 import { FormLayout, ControlWidth } from '../utils/interfaces.js';
-import {
-  getLargestPrimaryLabelWidth,
-  isVerticalLayout,
-  defaultFormLayout,
-  defaultControlWidth,
-} from '../utils/index.js';
+import { getLargestPrimaryLabelWidth, isVerticalLayout, defaultFormLayout } from '../utils/index.js';
 import { styles } from './form-group.element.css.js';
 
 /**
@@ -62,7 +57,7 @@ export class CdsFormGroup extends LitElement {
    * @type {stretch | shrink}
    * Adjust the control from the default full width or the browser default width
    */
-  @property({ type: String }) controlWidth: ControlWidth = defaultControlWidth;
+  @property({ type: String }) controlWidth: ControlWidth; // no default given so child controls are not overridden unless explicity set by parent form group
 
   /**
    * By default forms will collapse to layout that prevents overflow.
@@ -102,12 +97,11 @@ export class CdsFormGroup extends LitElement {
     super.firstUpdated(props);
     this.syncLayouts();
     this.setControlLabelWidths();
-    syncDefinedProps(props, this, this.controlsAndGroups);
   }
 
   updated(props: Map<string, any>) {
     super.updated(props);
-    syncDefinedProps(props, this, Array.from(this.controlsAndGroups));
+    syncDefinedProps(props, this, this.controlsAndGroups);
   }
 
   private async setControlLabelWidths() {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When setting a child control width the form group would always override the value of the child control.

Issue Number: #5763 

## What is the new behavior?
The control width of a child control is only overridden if the parent form group is explicitly set.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
