### PR TITLE
fix(button): typeScript type error when setting `loadingState` in React

### DIFF
--- a/apps/core-create-react-app/src/App.tsx
+++ b/apps/core-create-react-app/src/App.tsx
@@ -6,6 +6,7 @@ import { CdsBadge } from '@cds/react/badge';
 import { CdsAlert, CdsAlertGroup } from '@cds/react/alert';
 import { CdsIcon } from '@cds/react/icon';
 import { ClarityIcons, userIcon } from '@cds/core/icon';
+import '@cds/core/progress-circle/register.js';
 import './App.css';
 
 ClarityIcons.addIcons(userIcon);
@@ -65,6 +66,20 @@ export default class App extends Component<AppProps, AppState> {
           <CdsButton action="flat">flat</CdsButton>
           <CdsButton action="flat" disabled>
             flat disabled
+          </CdsButton>
+        </section>
+        <section cds-layout="horizontal gap:sm">
+          <CdsButton loadingState="default">
+            Default
+          </CdsButton>
+          <CdsButton loadingState="loading">
+            Default
+          </CdsButton>
+          <CdsButton loadingState="success">
+            Default
+          </CdsButton>
+          <CdsButton loadingState="error">
+            Default
           </CdsButton>
         </section>
 

--- a/packages/core/src/button/button.element.spec.ts
+++ b/packages/core/src/button/button.element.spec.ts
@@ -191,14 +191,14 @@ describe('button element', () => {
       await componentIsStable(component);
       component.loadingState = null;
       await componentIsStable(component);
-      expect(component.loadingState).toEqual(ClrLoadingState.DEFAULT);
+      expect(component.loadingState).toEqual(ClrLoadingState.default);
       expect(component.hasAttribute('disabled')).toEqual(false);
       expect(component.style.getPropertyValue('width')).toBe('');
     });
 
     it('should set default state as expected', async () => {
       await componentIsStable(component);
-      component.loadingState = ClrLoadingState.DEFAULT;
+      component.loadingState = ClrLoadingState.default;
       await componentIsStable(component);
       expect(component.hasAttribute('disabled')).toEqual(false);
       expect(component.getAttribute('aria-disabled')).toEqual('false');
@@ -208,7 +208,7 @@ describe('button element', () => {
     it('should set loading state as expected', async () => {
       await componentIsStable(component);
       const size = component.getBoundingClientRect().width;
-      component.loadingState = ClrLoadingState.LOADING;
+      component.loadingState = ClrLoadingState.loading;
       await componentIsStable(component);
 
       // I'm getting 152.016px and 152.015625px, so the test fails without rounding
@@ -221,7 +221,7 @@ describe('button element', () => {
       await componentIsStable(component);
       const size = component.getBoundingClientRect().width;
 
-      component.loadingState = ClrLoadingState.SUCCESS;
+      component.loadingState = ClrLoadingState.success;
       await componentIsStable(component);
 
       expect(component.getBoundingClientRect().width.toFixed(3)).toEqual(size.toFixed(3));
@@ -233,7 +233,7 @@ describe('button element', () => {
       await componentIsStable(component);
       const size = component.getBoundingClientRect().width;
 
-      component.loadingState = ClrLoadingState.ERROR;
+      component.loadingState = ClrLoadingState.error;
       await componentIsStable(component);
 
       expect(component.getBoundingClientRect().width.toFixed(3)).toEqual(size.toFixed(3));

--- a/packages/core/src/button/button.element.ts
+++ b/packages/core/src/button/button.element.ts
@@ -26,10 +26,10 @@ export const iconError = html`<span class="button-status-icon" cds-layout="horiz
 ></span>`;
 
 export const enum ClrLoadingState {
-  DEFAULT = 'default',
-  LOADING = 'loading',
-  SUCCESS = 'success',
-  ERROR = 'error',
+  default = 'default',
+  loading = 'loading',
+  success = 'success',
+  error = 'error',
 }
 
 /**
@@ -100,7 +100,7 @@ export class CdsButton extends CdsBaseButton {
    * - `error`: shows the content of the button (in the context of application, this state is usually entered from a LOADING state. the application should show appropriate error message)
    */
   @property({ type: String })
-  loadingState = ClrLoadingState.DEFAULT;
+  loadingState: keyof typeof ClrLoadingState = ClrLoadingState.default;
 
   constructor() {
     super();
@@ -113,7 +113,7 @@ export class CdsButton extends CdsBaseButton {
     // Find and wrap any text nodes into span elements
     spanWrapper(this.childNodes);
 
-    if (this.loadingState !== ClrLoadingState.DEFAULT) {
+    if (this.loadingState !== ClrLoadingState.default) {
       this.updateLoadingState();
     }
   }
@@ -129,10 +129,10 @@ export class CdsButton extends CdsBaseButton {
     const loadingState = this.loadingState;
     return html`<div class="private-host">
       <div cds-layout="horizontal gap:sm wrap:none align:center">
-        ${loadingState === ClrLoadingState.SUCCESS ? iconCheck : ''}
-        ${loadingState === ClrLoadingState.ERROR ? iconError : ''}
-        ${loadingState === ClrLoadingState.LOADING ? iconSpinner(this.size) : ''}
-        ${loadingState === ClrLoadingState.DEFAULT
+        ${loadingState === ClrLoadingState.success ? iconCheck : ''}
+        ${loadingState === ClrLoadingState.error ? iconError : ''}
+        ${loadingState === ClrLoadingState.loading ? iconSpinner(this.size) : ''}
+        ${loadingState === ClrLoadingState.default
           ? html`<slot @slotchange=${() => spanWrapper(this.childNodes)}></slot>`
           : ''}
       </div>
@@ -145,13 +145,13 @@ export class CdsButton extends CdsBaseButton {
 
   private updateLoadingState() {
     switch (this.loadingState) {
-      case ClrLoadingState.LOADING:
+      case ClrLoadingState.loading:
         this.disableButton();
         return;
-      case ClrLoadingState.SUCCESS:
+      case ClrLoadingState.success:
         this.disableButton();
         return;
-      case ClrLoadingState.ERROR:
+      case ClrLoadingState.error:
         this.disableButton();
         return;
       default:
@@ -165,7 +165,7 @@ export class CdsButton extends CdsBaseButton {
   }
 
   private enableButton() {
-    this.loadingState = ClrLoadingState.DEFAULT;
+    this.loadingState = ClrLoadingState.default;
     this.style.removeProperty('width');
     this.disabled = false;
   }

--- a/packages/core/src/button/icon-button.element.spec.ts
+++ b/packages/core/src/button/icon-button.element.spec.ts
@@ -36,7 +36,7 @@ describe('Icon button element – ', () => {
   describe('LoadingStateChange: ', () => {
     it('should set default state as expected', async () => {
       await componentIsStable(component);
-      component.loadingState = ClrLoadingState.DEFAULT;
+      component.loadingState = ClrLoadingState.default;
       await componentIsStable(component);
       expect(component.hasAttribute('disabled')).toEqual(false);
     });
@@ -44,7 +44,7 @@ describe('Icon button element – ', () => {
     it('should set loading state as expected', async () => {
       await componentIsStable(component);
       const size = component.getBoundingClientRect().width;
-      component.loadingState = ClrLoadingState.LOADING;
+      component.loadingState = ClrLoadingState.loading;
       await componentIsStable(component);
 
       // I'm getting 152.016px and 152.015625px, so the test fails without rounding
@@ -56,7 +56,7 @@ describe('Icon button element – ', () => {
       await componentIsStable(component);
       const size = component.getBoundingClientRect().width;
 
-      component.loadingState = ClrLoadingState.SUCCESS;
+      component.loadingState = ClrLoadingState.success;
       await componentIsStable(component);
 
       expect(component.getBoundingClientRect().width.toFixed(3)).toEqual(size.toFixed(3));
@@ -67,7 +67,7 @@ describe('Icon button element – ', () => {
       await componentIsStable(component);
       const size = component.getBoundingClientRect().width;
 
-      component.loadingState = ClrLoadingState.ERROR;
+      component.loadingState = ClrLoadingState.error;
       await componentIsStable(component);
 
       expect(component.getBoundingClientRect().width.toFixed(3)).toEqual(size.toFixed(3));

--- a/packages/core/src/button/icon-button.element.ts
+++ b/packages/core/src/button/icon-button.element.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -47,9 +47,9 @@ export class CdsIconButton extends CdsButton {
   render() {
     return html`
       <div class="private-host">
-        ${this.loadingState === ClrLoadingState.LOADING ? iconSpinner(this.size) : ''}
-        ${this.loadingState === ClrLoadingState.SUCCESS ? iconCheck : ''}
-        ${this.loadingState === ClrLoadingState.DEFAULT ? html`<slot></slot>` : ''}
+        ${this.loadingState === ClrLoadingState.loading ? iconSpinner(this.size) : ''}
+        ${this.loadingState === ClrLoadingState.success ? iconCheck : ''}
+        ${this.loadingState === ClrLoadingState.default ? html`<slot></slot>` : ''}
       </div>
     `;
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When setting `loadingState` to a `CdsButton` in React, the TypeScript compiler throws a type error because static string ('loading') cannot be assigned to string enum (`ClrLoadingState`).

```
Type '"loading"' is not assignable to type 'ClrLoadingState | undefined'.
```

Issue Number: #5795 

## What is the new behavior?


The enum `ClrLoadingState` is modified so that the keys match the values.

```
export const enum ClrLoadingState {
  default = 'default',
  loading = 'loading',
  success = 'success',
  error = 'error',
}
```

The property `loadingState` is set to be of type `keyof typeof ClrLoadingState`, which represents all Enum keys as strings - `'default' | 'loading' | 'success' | 'error'`.
```
loadingState: keyof typeof ClrLoadingState = ClrLoadingState.default;
```

These two changes resolve the type error described above. 

The PR also adds buttons with `loadingState` property to the React demo app.

Note that there's an issue with setting the loading state to `loading` (#5797). The spinner is not displayed unless you register the `progress-circle` element manually with:

```
import '@cds/core/progress-circle/register.js';
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
