### PR TITLE
docs: remove leftover TODOs in a `Alert` and `Form` articles

### DIFF
--- a/apps/website/angular-components/alert/README.md
+++ b/apps/website/angular-components/alert/README.md
@@ -298,7 +298,13 @@ This class must be applied with `.alert` to render an app-level alert.
 Accessibility problems related to using actionable controls inside dynamically generated alerts:
 
 - They are announced as part of the alert message, which is out of context and may be confusing. For example, the following alert will be announced as "success acknowledge":
-  TODO Fix core components (maybe it cannot be used in the markdown rendering)
+  <cds-alert-group type="default" status="success">
+  <cds-alert closable>Success
+  <cds-alert-actions>
+  <cds-button>Acknowledge</cds-button>
+  </cds-alert-actions>
+  </cds-alert>
+  </cds-alert-group>
 - There is no way for the user to directly interact with the announced action controls.
 
 It is acceptable to use actions in static alerts. The following guidelines are recommended:

--- a/apps/website/core-components/form/README.md
+++ b/apps/website/core-components/form/README.md
@@ -56,7 +56,6 @@ Clarity offers three types of forms: horizontal (our recommended default), verti
 :::
 
 :::component-section-level-two
-TODO turn this into a core form.
 Default Horizontal formats are good for the quick scanning of labels, and can be used in cases of limited vertical space. The space between label and input however can slow users down.
 
 <doc-demo>


### PR DESCRIPTION
This PR removes a couple of `TODO`s in the content of the `Alert` and `Form` articles on the website. The PR also adds a missing demo in the `Alert` article.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
