### PR TITLE
fix(button): register progress-circle component on button component

### DIFF
--- a/apps/core-create-react-app/src/App.tsx
+++ b/apps/core-create-react-app/src/App.tsx
@@ -6,7 +6,6 @@ import { CdsBadge } from '@cds/react/badge';
 import { CdsAlert, CdsAlertGroup } from '@cds/react/alert';
 import { CdsIcon } from '@cds/react/icon';
 import { ClarityIcons, userIcon } from '@cds/core/icon';
-import '@cds/core/progress-circle/register.js';
 import './App.css';
 
 ClarityIcons.addIcons(userIcon);

--- a/packages/core/src/button/entrypoint.tsconfig.json
+++ b/packages/core/src/button/entrypoint.tsconfig.json
@@ -6,6 +6,7 @@
   "references": [
     { "path": "../internal/entrypoint.tsconfig.json" },
     { "path": "../badge/entrypoint.tsconfig.json" },
-    { "path": "../icon/entrypoint.tsconfig.json" }
+    { "path": "../icon/entrypoint.tsconfig.json" },
+    { "path": "../progress-circle/entrypoint.tsconfig.json" }
   ]
 }

--- a/packages/core/src/button/register.ts
+++ b/packages/core/src/button/register.ts
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import '@cds/core/icon/register.js';
+import '@cds/core/progress-circle/register.js';
 import { registerElementSafely } from '@cds/core/internal';
 import { CdsButton } from './button.element.js';
 import { CdsIconButton } from './icon-button.element.js';


### PR DESCRIPTION
closes #5797

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?
This adds the progress circle to the button for registration so that consumers do not need to manually import it when they use CdsButton with loadingState="loading"

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently users must add `import '@cds/core/progress-circle/register.js';` to use loading state on `cds-button`'s.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5797 

## What is the new behavior?
Consumers can just use 
```html
<CdsButton loadingState="loading">
  Default
</CdsButton>
```
without registering the progress circle manually. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
n/a