### PR TITLE
fix(dropdown): fixes dropdown toggle css preventing cds-icon direction

### DIFF
--- a/packages/angular/projects/clr-angular/src/popover/dropdown/_dropdown.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/popover/dropdown/_dropdown.clarity.scss
@@ -28,11 +28,20 @@
         margin: 0;
       }
 
-      cds-icon[shape^='angle'],
       clr-icon[shape^='angle'] {
         position: absolute;
         top: 50%;
         transform: translateY(-50%);
+        color: inherit;
+        @include equilateral($clr-dropdown-caret-icon-dimension);
+      }
+
+      // NOTE: cds-icon handles direction internally.
+      // No need to translate it.
+      // This results in a different top value.
+      cds-icon[shape^='angle'] {
+        position: absolute;
+        top: 45%;
         color: inherit;
         @include equilateral($clr-dropdown-caret-icon-dimension);
       }


### PR DESCRIPTION
This issue was a regression from the adoption of cds-icons in @clr/ui. 

@clr/ui dropdown css translates the icon to orient clr-icon's properly. cds-icons orient with the direction attribute and a css translate breaks that. 

This change allows cds-icons handle the icon orientation of the icon with the direction attribute and still be properly positioned in the dropdown toggle. 

closes #5791

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?
Tweaks dropdown toggle css for clr-icon and cds-icons.

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
cds-icons inside a .dropdown-toggle button will not rotate [direction] properly. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5791

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
