### PR TITLE
fix(accordion): adds css to fix cds-icon clr-accordion toggle animation

### DIFF
--- a/packages/angular/projects/clr-angular/src/accordion/_accordion.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/accordion/_accordion.clarity.scss
@@ -158,6 +158,7 @@
 
   .clr-accordion-angle {
     transition: all 200ms ease-in-out;
+    transform: rotate(90);
   }
 
   .clr-accordion-error-icon,
@@ -176,7 +177,7 @@
 
     .clr-accordion-angle {
       visibility: visible;
-      transform: rotate(90deg);
+      transform: rotate(180deg);
     }
 
     .clr-accordion-header {


### PR DESCRIPTION
closes #5808

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?
Changes the css to animate cds-icon in accordion panel toggle button.

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
accordion panel icon does not rotate.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5808

## What is the new behavior?
Accordion panel icon rotates when panel is opened and closed. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
