### PR TITLE
fix(datagrid): align datagrid selected count checkbox

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -11,6 +11,7 @@
     "serve:watch": "ng serve dev",
     "serve:adoption": "ng serve clarity-adoption",
     "serve:dark": "ng serve dev -c dark",
+    "start:stmux:dev": "stmux -w always -e ERROR -m beep,system [ \"yarn start:dev\" : \"sleep 25 && yarn serve:watch\" : \"yarn --cwd ../ui run build:watch\" ]",
     "storybook": "start-storybook -s .storybook/public -p 6006",
     "storybook:build": "build-storybook -s .storybook/public -c .storybook -o ../../dist/website/storybook/angular --quiet",
     "build": "npm-run-all build:lib:cds build:lib:clr build:update:cds build:update:clr",

--- a/packages/angular/projects/clr-angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/_datagrid.clarity.scss
@@ -1172,6 +1172,8 @@
     .column-switch-wrapper {
       position: relative;
       flex: 0 0 auto;
+      display: flex;
+      align-items: center;
 
       &.active {
         .column-toggle--action {
@@ -1346,8 +1348,13 @@
     }
   }
 
+  .clr-form-control-disabled {
+    display: flex;
+    align-items: center;
+    height: 100%;
+  }
+
   .clr-form-control-disabled .datagrid-footer-select.clr-checkbox-wrapper input[type='checkbox']:checked + label {
-    top: $clr_baselineRem_4px;
     cursor: default;
 
     margin-right: $clr_baselineRem_0_375;
@@ -1463,6 +1470,7 @@
     white-space: nowrap;
     display: block;
     text-align: right;
+    margin: auto 0;
   }
 
   // Yes, this is not .datagrid-pagination on purpose.


### PR DESCRIPTION
This change updates the css for datagrid checkbox and label when multi selection is active. It algins the checkbox and label with the column toggle button.

closes #5777

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?
Small change to datagrid footer css for multiselect count checkbox and label. This change will center the element instead of using top positioning to manually place it. It also adds a bit more css to also center align content inside the toggle and description containers no matter how tall the footer is. This will keep the various content elements on the same line as each other. 
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
footer contents of selection count and description are not centered with the toggle button and the pagaination component. 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5777

## What is the new behavior?
Footer content is centered an inline with each of the sections declared inteh footer: multi-selection count, hide/show toggle button, description & pagination component.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No 

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
