### PR TITLE
chore(website): remove clr-icon from website

### DIFF
--- a/apps/website/.vuepress/code/core-usage-demos/icon/size-attr.html
+++ b/apps/website/.vuepress/code/core-usage-demos/icon/size-attr.html
@@ -1,6 +1,5 @@
-<cds-icon shape="info-circle" size="12"></cds-icon>
-<cds-icon shape="info-circle" size="16"></cds-icon>
-<cds-icon shape="info-circle" size="36"></cds-icon>
-<cds-icon shape="info-circle" size="48"></cds-icon>
-<cds-icon shape="info-circle" size="64"></cds-icon>
-<cds-icon shape="info-circle" size="72"></cds-icon>
+<cds-icon shape="info-circle" size="sm"></cds-icon>
+<cds-icon shape="info-circle" size="md"></cds-icon>
+<cds-icon shape="info-circle" size="lg"></cds-icon>
+<cds-icon shape="info-circle" size="xl"></cds-icon>
+<cds-icon shape="info-circle" size="xxl"></cds-icon>

--- a/apps/website/.vuepress/code/demos/alert/app-level-icon-css.html
+++ b/apps/website/.vuepress/code/demos/alert/app-level-icon-css.html
@@ -3,7 +3,7 @@
     <div class="alert-items">
       <div class="alert-item static">
         <div class="alert-icon-wrapper">
-          <clr-icon class="alert-icon" shape="download"></clr-icon>
+          <cds-icon class="alert-icon" shape="download"></cds-icon>
         </div>
         <div class="alert-text">
           A new update is now available. Upgrade to v.1234.
@@ -14,7 +14,7 @@
       </div>
     </div>
     <button type="button" class="close" aria-label="Close">
-      <clr-icon aria-hidden="true" shape="close"></clr-icon>
+      <cds-icon aria-hidden="true" shape="close"></cds-icon>
     </button>
   </div>
   <header class="header header-6">

--- a/apps/website/.vuepress/code/demos/alert/app-level-main-css.html
+++ b/apps/website/.vuepress/code/demos/alert/app-level-main-css.html
@@ -3,7 +3,7 @@
     <div class="alert-items">
       <div class="alert-item static">
         <div class="alert-icon-wrapper">
-          <clr-icon class="alert-icon" shape="info-circle"></clr-icon>
+          <cds-icon class="alert-icon" shape="info-circle"></cds-icon>
         </div>
         <div class="alert-text">
           A new update is now available. Upgrade to v.1234.
@@ -14,7 +14,7 @@
       </div>
     </div>
     <button type="button" class="close" aria-label="Close">
-      <clr-icon aria-hidden="true" shape="close"></clr-icon>
+      <cds-icon aria-hidden="true" shape="close"></cds-icon>
     </button>
   </div>
   <header class="header header-6">

--- a/apps/website/.vuepress/code/demos/alert/basic-app-level-css.html
+++ b/apps/website/.vuepress/code/demos/alert/basic-app-level-css.html
@@ -2,7 +2,7 @@
   <div class="alert-items">
     <div class="alert-item static">
       <div class="alert-icon-wrapper">
-        <clr-icon class="alert-icon" shape="exclamation-circle"></clr-icon>
+        <cds-icon class="alert-icon" shape="exclamation-circle"></cds-icon>
       </div>
       <div class="alert-text">
         Alert Type: Danger
@@ -13,14 +13,14 @@
     </div>
   </div>
   <button type="button" class="close" aria-label="Close">
-    <clr-icon aria-hidden="true" shape="close"></clr-icon>
+    <cds-icon aria-hidden="true" shape="close"></cds-icon>
   </button>
 </div>
 <div class="alert alert-app-level alert-warning" style="margin-bottom: 24px;" role="alert">
   <div class="alert-items">
     <div class="alert-item static">
       <div class="alert-icon-wrapper">
-        <clr-icon class="alert-icon" shape="exclamation-triangle"></clr-icon>
+        <cds-icon class="alert-icon" shape="exclamation-triangle"></cds-icon>
       </div>
       <div class="alert-text">
         Alert Type: Warning
@@ -31,14 +31,14 @@
     </div>
   </div>
   <button type="button" class="close" aria-label="Close">
-    <clr-icon aria-hidden="true" shape="close"></clr-icon>
+    <cds-icon aria-hidden="true" shape="close"></cds-icon>
   </button>
 </div>
 <div class="alert alert-app-level alert-info" role="alert">
   <div class="alert-items">
     <div class="alert-item static">
       <div class="alert-icon-wrapper">
-        <clr-icon class="alert-icon" shape="info-circle"></clr-icon>
+        <cds-icon class="alert-icon" shape="info-circle"></cds-icon>
       </div>
       <div class="alert-text">
         Alert Type: Info
@@ -49,6 +49,6 @@
     </div>
   </div>
   <button type="button" class="close" aria-label="Close">
-    <clr-icon aria-hidden="true" shape="close"></clr-icon>
+    <cds-icon aria-hidden="true" shape="close"></cds-icon>
   </button>
 </div>

--- a/apps/website/.vuepress/code/demos/alert/basic-app-level-ng.html
+++ b/apps/website/.vuepress/code/demos/alert/basic-app-level-ng.html
@@ -2,7 +2,7 @@
   <div class="alert-items">
     <div class="alert-item static">
       <div class="alert-icon-wrapper">
-        <clr-icon class="alert-icon" shape="exclamation-circle"></clr-icon>
+        <cds-icon class="alert-icon" shape="exclamation-circle"></cds-icon>
       </div>
       <div class="alert-text">
         Alert Type: Danger
@@ -13,14 +13,14 @@
     </div>
   </div>
   <button type="button" class="close" aria-label="Close">
-    <clr-icon aria-hidden="true" shape="close"></clr-icon>
+    <cds-icon aria-hidden="true" shape="close"></cds-icon>
   </button>
 </div>
 <div class="alert alert-app-level alert-warning" style="margin-bottom: 24px;" role="alert">
   <div class="alert-items">
     <div class="alert-item static">
       <div class="alert-icon-wrapper">
-        <clr-icon class="alert-icon" shape="exclamation-triangle"></clr-icon>
+        <cds-icon class="alert-icon" shape="exclamation-triangle"></cds-icon>
       </div>
       <div class="alert-text">
         Alert Type: Warning
@@ -31,14 +31,14 @@
     </div>
   </div>
   <button type="button" class="close" aria-label="Close">
-    <clr-icon aria-hidden="true" shape="close"></clr-icon>
+    <cds-icon aria-hidden="true" shape="close"></cds-icon>
   </button>
 </div>
 <div class="alert alert-app-level alert-info" role="alert">
   <div class="alert-items">
     <div class="alert-item static">
       <div class="alert-icon-wrapper">
-        <clr-icon class="alert-icon" shape="info-circle"></clr-icon>
+        <cds-icon class="alert-icon" shape="info-circle"></cds-icon>
       </div>
       <div class="alert-text">
         Alert Type: Info
@@ -49,6 +49,6 @@
     </div>
   </div>
   <button type="button" class="close" aria-label="Close">
-    <clr-icon aria-hidden="true" shape="close"></clr-icon>
+    <cds-icon aria-hidden="true" shape="close"></cds-icon>
   </button>
 </div>

--- a/apps/website/.vuepress/code/demos/alert/card-css.html
+++ b/apps/website/.vuepress/code/demos/alert/card-css.html
@@ -4,7 +4,7 @@
       <div class="alert-items">
         <div class="alert-item static">
           <div class="alert-icon-wrapper">
-            <clr-icon class="alert-icon" shape="exclamation-triangle"></clr-icon>
+            <cds-icon class="alert-icon" shape="exclamation-triangle"></cds-icon>
           </div>
           <div class="alert-text">
             Use small alerts in a card.
@@ -12,7 +12,7 @@
         </div>
       </div>
       <button type="button" class="close" aria-label="Close">
-        <clr-icon aria-hidden="true" shape="close"></clr-icon>
+        <cds-icon aria-hidden="true" shape="close"></cds-icon>
       </button>
     </div>
     <div class="card-media-block wrap">

--- a/apps/website/.vuepress/code/demos/alert/card-ng.html
+++ b/apps/website/.vuepress/code/demos/alert/card-ng.html
@@ -4,7 +4,7 @@
       <div class="alert-items">
         <div class="alert-item static">
           <div class="alert-icon-wrapper">
-            <clr-icon class="alert-icon" shape="exclamation-triangle"></clr-icon>
+            <cds-icon class="alert-icon" shape="exclamation-triangle"></cds-icon>
           </div>
           <div class="alert-text">
             Use small alerts in a card.
@@ -12,7 +12,7 @@
         </div>
       </div>
       <button type="button" class="close" aria-label="Close">
-        <clr-icon aria-hidden="true" shape="close"></clr-icon>
+        <cds-icon aria-hidden="true" shape="close"></cds-icon>
       </button>
     </div>
     <div class="card-media-block wrap">

--- a/apps/website/.vuepress/code/demos/alert/closable-false-ng.html
+++ b/apps/website/.vuepress/code/demos/alert/closable-false-ng.html
@@ -7,7 +7,7 @@
       <clr-dropdown>
         <button class="dropdown-toggle" clrDropdownTrigger>
           Actions
-          <clr-icon shape="caret down"></clr-icon>
+          <cds-icon shape="caret" direction="down"></cds-icon>
         </button>
         <clr-dropdown-menu clrPosition="bottom-right">
           <a href="javascript:void(0)" class="dropdown-item" clrDropdownItem>Shutdown</a>

--- a/apps/website/.vuepress/code/demos/alert/content-area-css.html
+++ b/apps/website/.vuepress/code/demos/alert/content-area-css.html
@@ -10,7 +10,7 @@
         <div class="alert-items">
           <div class="alert-item static">
             <div class="alert-icon-wrapper">
-              <clr-icon class="alert-icon" shape="exclamation-circle"></clr-icon>
+              <cds-icon class="alert-icon" shape="exclamation-circle"></cds-icon>
             </div>
             <span class="alert-text">
               This alert is at the top of the page.
@@ -29,7 +29,7 @@
         <div class="alert-items">
           <div class="alert-item static">
             <div class="alert-icon-wrapper">
-              <clr-icon class="alert-icon" shape="check-circle"></clr-icon>
+              <cds-icon class="alert-icon" shape="check-circle"></cds-icon>
             </div>
             <span class="alert-text">
               This alert is in the middle of the page.

--- a/apps/website/.vuepress/code/demos/alert/main-container-css.html
+++ b/apps/website/.vuepress/code/demos/alert/main-container-css.html
@@ -3,7 +3,7 @@
     <div class="alert-items">
       <div class="alert-item static">
         <div class="alert-icon-wrapper">
-          <clr-icon class="alert-icon" shape="download"></clr-icon>
+          <cds-icon class="alert-icon" shape="download"></cds-icon>
         </div>
         <div class="alert-text">
           A new update is now available. Upgrade to v.1234.
@@ -14,7 +14,7 @@
       </div>
     </div>
     <button type="button" class="close" aria-label="Close">
-      <clr-icon aria-hidden="true" shape="close"></clr-icon>
+      <cds-icon aria-hidden="true" shape="close"></cds-icon>
     </button>
   </div>
   <header class="header header-6">

--- a/apps/website/.vuepress/code/demos/alert/main-container-ng.html
+++ b/apps/website/.vuepress/code/demos/alert/main-container-ng.html
@@ -3,7 +3,7 @@
     <div class="alert-items">
       <div class="alert-item static">
         <div class="alert-icon-wrapper">
-          <clr-icon class="alert-icon" shape="download"></clr-icon>
+          <cds-icon class="alert-icon" shape="download"></cds-icon>
         </div>
         <div class="alert-text">
           A new update is now available. Upgrade to v.1234.
@@ -14,7 +14,7 @@
       </div>
     </div>
     <button type="button" class="close" aria-label="Close">
-      <clr-icon aria-hidden="true" shape="close"></clr-icon>
+      <cds-icon aria-hidden="true" shape="close"></cds-icon>
     </button>
   </div>
   <header class="header header-6">

--- a/apps/website/.vuepress/code/demos/alert/modal-css.html
+++ b/apps/website/.vuepress/code/demos/alert/modal-css.html
@@ -6,7 +6,7 @@
           <div class="alert-items">
             <div class="alert-item static">
               <div class="alert-icon-wrapper">
-                <clr-icon class="alert-icon" shape="exclamation-circle"></clr-icon>
+                <cds-icon class="alert-icon" shape="exclamation-circle"></cds-icon>
               </div>
               <span class="alert-text">
                 Alert in a modal.
@@ -16,7 +16,7 @@
         </div>
         <div class="modal-header">
           <button aria-label="Close" class="close" type="button">
-            <clr-icon aria-hidden="true" shape="close"></clr-icon>
+            <cds-icon aria-hidden="true" shape="close"></cds-icon>
           </button>
           <h3 class="modal-title">I have a nice title</h3>
         </div>

--- a/apps/website/.vuepress/code/demos/alert/modal-ng.html
+++ b/apps/website/.vuepress/code/demos/alert/modal-ng.html
@@ -5,7 +5,7 @@
         <div class="alert-items">
           <div class="alert-item static">
             <div class="alert-icon-wrapper">
-              <clr-icon class="alert-icon" shape="exclamation-circle"></clr-icon>
+              <cds-icon class="alert-icon" shape="exclamation-circle"></cds-icon>
             </div>
             <span class="alert-text">
               Alert in a modal.
@@ -15,7 +15,7 @@
       </div>
       <div class="modal-header">
         <button aria-label="Close" class="close" type="button">
-          <clr-icon aria-hidden="true" shape="close"></clr-icon>
+          <cds-icon aria-hidden="true" shape="close"></cds-icon>
         </button>
         <h3 class="modal-title">I have a nice title</h3>
       </div>

--- a/apps/website/.vuepress/code/demos/alert/placement-css.html
+++ b/apps/website/.vuepress/code/demos/alert/placement-css.html
@@ -3,7 +3,7 @@
     <div class="alert-items">
       <div class="alert-item static">
         <div class="alert-icon-wrapper">
-          <clr-icon class="alert-icon" shape="exclamation-circle"></clr-icon>
+          <cds-icon class="alert-icon" shape="exclamation-circle"></cds-icon>
         </div>
         <span class="alert-text">
           This alert is at the top of the page.
@@ -21,7 +21,7 @@
     <div class="alert-items">
       <div class="alert-item static">
         <div class="alert-icon-wrapper">
-          <clr-icon class="alert-icon" shape="check-circle"></clr-icon>
+          <cds-icon class="alert-icon" shape="check-circle"></cds-icon>
         </div>
         <span class="alert-text">
           This alert is in the middle of the page.

--- a/apps/website/.vuepress/code/demos/alert/placement-ng.html
+++ b/apps/website/.vuepress/code/demos/alert/placement-ng.html
@@ -3,7 +3,7 @@
     <div class="alert-items">
       <div class="alert-item static">
         <div class="alert-icon-wrapper">
-          <clr-icon class="alert-icon" shape="exclamation-circle"></clr-icon>
+          <cds-icon class="alert-icon" shape="exclamation-circle"></cds-icon>
         </div>
         <span class="alert-text">
           This alert is at the top of the page.
@@ -16,7 +16,7 @@
     <div class="alert-items">
       <div class="alert-item static">
         <div class="alert-icon-wrapper">
-          <clr-icon class="alert-icon" shape="check-circle"></clr-icon>
+          <cds-icon class="alert-icon" shape="check-circle"></cds-icon>
         </div>
         <span class="alert-text">
           This alert is in the middle of the page.

--- a/apps/website/.vuepress/code/demos/alert/size-css.html
+++ b/apps/website/.vuepress/code/demos/alert/size-css.html
@@ -2,7 +2,7 @@
   <div class="alert-items">
     <div class="alert-item static" role="alert">
       <div class="alert-icon-wrapper">
-        <clr-icon class="alert-icon" shape="exclamation-circle"></clr-icon>
+        <cds-icon class="alert-icon" shape="exclamation-circle"></cds-icon>
       </div>
       <span class="alert-text">
         This is an alert with 36px height.
@@ -10,14 +10,14 @@
     </div>
   </div>
   <button type="button" class="close" aria-label="Close">
-    <clr-icon aria-hidden="true" shape="close"></clr-icon>
+    <cds-icon aria-hidden="true" shape="close"></cds-icon>
   </button>
 </div>
 <div class="alert alert-success alert-sm" role="alert">
   <div class="alert-items">
     <div class="alert-item static">
       <div class="alert-icon-wrapper">
-        <clr-icon class="alert-icon" shape="check-circle"></clr-icon>
+        <cds-icon class="alert-icon" shape="check-circle"></cds-icon>
       </div>
       <span class="alert-text">
         This is an alert with 24px height.
@@ -25,6 +25,6 @@
     </div>
   </div>
   <button type="button" class="close" aria-label="Close">
-    <clr-icon aria-hidden="true" shape="close"></clr-icon>
+    <cds-icon aria-hidden="true" shape="close"></cds-icon>
   </button>
 </div>

--- a/apps/website/.vuepress/code/demos/alert/size-ng.html
+++ b/apps/website/.vuepress/code/demos/alert/size-ng.html
@@ -2,7 +2,7 @@
   <div class="alert-items">
     <div class="alert-item static" role="alert">
       <div class="alert-icon-wrapper">
-        <clr-icon class="alert-icon" shape="exclamation-circle"></clr-icon>
+        <cds-icon class="alert-icon" shape="exclamation-circle"></cds-icon>
       </div>
       <span class="alert-text">
         This is an alert with 36px height.
@@ -10,14 +10,14 @@
     </div>
   </div>
   <button type="button" class="close" aria-label="Close">
-    <clr-icon aria-hidden="true" shape="close"></clr-icon>
+    <cds-icon aria-hidden="true" shape="close"></cds-icon>
   </button>
 </div>
 <div class="alert alert-success alert-sm" role="alert">
   <div class="alert-items">
     <div class="alert-item static">
       <div class="alert-icon-wrapper">
-        <clr-icon class="alert-icon" shape="check-circle"></clr-icon>
+        <cds-icon class="alert-icon" shape="check-circle"></cds-icon>
       </div>
       <span class="alert-text">
         This is an alert with 24px height.
@@ -25,6 +25,6 @@
     </div>
   </div>
   <button type="button" class="close" aria-label="Close">
-    <clr-icon aria-hidden="true" shape="close"></clr-icon>
+    <cds-icon aria-hidden="true" shape="close"></cds-icon>
   </button>
 </div>

--- a/apps/website/.vuepress/code/demos/alert/types-css.html
+++ b/apps/website/.vuepress/code/demos/alert/types-css.html
@@ -2,7 +2,7 @@
   <div class="alert-items">
     <div class="alert-item static">
       <div class="alert-icon-wrapper">
-        <clr-icon class="alert-icon" shape="exclamation-circle"></clr-icon>
+        <cds-icon class="alert-icon" shape="exclamation-circle"></cds-icon>
       </div>
       <span class="alert-text">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit.
@@ -11,7 +11,7 @@
         <div class="alert-action dropdown bottom-right">
           <button class="dropdown-toggle">
             Actions
-            <clr-icon shape="caret down"></clr-icon>
+            <cds-icon shape="caret" direction="down"></cds-icon>
           </button>
           <div class="dropdown-menu">
             <a class="dropdown-item" href="javascript:void(0)">Shutdown</a>
@@ -23,7 +23,7 @@
     </div>
     <div class="alert-item static">
       <div class="alert-icon-wrapper">
-        <clr-icon class="alert-icon" shape="exclamation-circle"></clr-icon>
+        <cds-icon class="alert-icon" shape="exclamation-circle"></cds-icon>
       </div>
       <span class="alert-text">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
@@ -35,7 +35,7 @@
         <div class="alert-action dropdown bottom-right">
           <button class="dropdown-toggle">
             Actions
-            <clr-icon shape="caret down"></clr-icon>
+            <cds-icon shape="caret" direction="down"></cds-icon>
           </button>
           <div class="dropdown-menu">
             <a class="dropdown-item" href="javascript:void(0)">Shutdown</a>
@@ -51,7 +51,7 @@
   <div class="alert-items">
     <div class="alert-item static">
       <div class="alert-icon-wrapper">
-        <clr-icon class="alert-icon" shape="exclamation-triangle"></clr-icon>
+        <cds-icon class="alert-icon" shape="exclamation-triangle"></cds-icon>
       </div>
       <span class="alert-text">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
@@ -63,7 +63,7 @@
         <div class="alert-action dropdown bottom-right open">
           <button class="dropdown-toggle">
             Actions
-            <clr-icon shape="caret down"></clr-icon>
+            <cds-icon shape="caret" direction="down"></cds-icon>
           </button>
           <div class="dropdown-menu">
             <a class="dropdown-item" href="javascript:void(0)">Shutdown</a>
@@ -75,14 +75,14 @@
     </div>
   </div>
   <button type="button" class="close" aria-label="Close">
-    <clr-icon aria-hidden="true" shape="close"></clr-icon>
+    <cds-icon aria-hidden="true" shape="close"></cds-icon>
   </button>
 </div>
 <div class="alert alert-info" role="alert">
   <div class="alert-items">
     <div class="alert-item static">
       <div class="alert-icon-wrapper">
-        <clr-icon class="alert-icon" shape="info-circle"></clr-icon>
+        <cds-icon class="alert-icon" shape="info-circle"></cds-icon>
       </div>
       <span class="alert-text">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
@@ -96,14 +96,14 @@
     </div>
   </div>
   <button type="button" class="close" aria-label="Close">
-    <clr-icon aria-hidden="true" shape="close"></clr-icon>
+    <cds-icon aria-hidden="true" shape="close"></cds-icon>
   </button>
 </div>
 <div class="alert alert-success" role="alert">
   <div class="alert-items">
     <div class="alert-item static">
       <div class="alert-icon-wrapper">
-        <clr-icon class="alert-icon" shape="check-circle"></clr-icon>
+        <cds-icon class="alert-icon" shape="check-circle"></cds-icon>
       </div>
       <span class="alert-text">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit.

--- a/apps/website/.vuepress/code/demos/alert/types-ng.html
+++ b/apps/website/.vuepress/code/demos/alert/types-ng.html
@@ -2,7 +2,7 @@
   <div class="alert-items">
     <div class="alert-item static">
       <div class="alert-icon-wrapper">
-        <clr-icon class="alert-icon" shape="exclamation-circle"></clr-icon>
+        <cds-icon class="alert-icon" shape="exclamation-circle"></cds-icon>
       </div>
       <span class="alert-text">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit.
@@ -11,7 +11,7 @@
         <div class="alert-action dropdown bottom-right">
           <button class="dropdown-toggle">
             Actions
-            <clr-icon shape="caret down"></clr-icon>
+            <cds-icon shape="caret" direction="down"></cds-icon>
           </button>
           <div class="dropdown-menu">
             <a class="dropdown-item" href="javascript:void(0)">Shutdown</a>
@@ -23,7 +23,7 @@
     </div>
     <div class="alert-item static">
       <div class="alert-icon-wrapper">
-        <clr-icon class="alert-icon" shape="exclamation-circle"></clr-icon>
+        <cds-icon class="alert-icon" shape="exclamation-circle"></cds-icon>
       </div>
       <span class="alert-text">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
@@ -35,7 +35,7 @@
         <div class="alert-action dropdown bottom-right">
           <button class="dropdown-toggle">
             Actions
-            <clr-icon shape="caret down"></clr-icon>
+            <cds-icon shape="caret" direction="down"></cds-icon>
           </button>
           <div class="dropdown-menu">
             <a class="dropdown-item" href="javascript:void(0)">Shutdown</a>
@@ -51,7 +51,7 @@
   <div class="alert-items">
     <div class="alert-item static">
       <div class="alert-icon-wrapper">
-        <clr-icon class="alert-icon" shape="exclamation-triangle"></clr-icon>
+        <cds-icon class="alert-icon" shape="exclamation-triangle"></cds-icon>
       </div>
       <span class="alert-text">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
@@ -63,7 +63,7 @@
         <div class="alert-action dropdown bottom-right open">
           <button class="dropdown-toggle">
             Actions
-            <clr-icon shape="caret down"></clr-icon>
+            <cds-icon shape="caret" direction="down"></cds-icon>
           </button>
           <div class="dropdown-menu">
             <a class="dropdown-item" href="javascript:void(0)">Shutdown</a>
@@ -75,14 +75,14 @@
     </div>
   </div>
   <button type="button" class="close" aria-label="Close">
-    <clr-icon aria-hidden="true" shape="close"></clr-icon>
+    <cds-icon aria-hidden="true" shape="close"></cds-icon>
   </button>
 </div>
 <div class="alert alert-info" role="alert">
   <div class="alert-items">
     <div class="alert-item static">
       <div class="alert-icon-wrapper">
-        <clr-icon class="alert-icon" shape="info-circle"></clr-icon>
+        <cds-icon class="alert-icon" shape="info-circle"></cds-icon>
       </div>
       <span class="alert-text">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
@@ -96,14 +96,14 @@
     </div>
   </div>
   <button type="button" class="close" aria-label="Close">
-    <clr-icon aria-hidden="true" shape="close"></clr-icon>
+    <cds-icon aria-hidden="true" shape="close"></cds-icon>
   </button>
 </div>
 <div class="alert alert-success" role="alert">
   <div class="alert-items">
     <div class="alert-item static">
       <div class="alert-icon-wrapper">
-        <clr-icon class="alert-icon" shape="check-circle"></clr-icon>
+        <cds-icon class="alert-icon" shape="check-circle"></cds-icon>
       </div>
       <span class="alert-text">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit.

--- a/apps/website/.vuepress/code/demos/app-layout/content-container-css.html
+++ b/apps/website/.vuepress/code/demos/app-layout/content-container-css.html
@@ -3,7 +3,7 @@
     <div class="alert-items">
       <div class="alert-item static">
         <div class="alert-icon-wrapper">
-          <clr-icon class="alert-icon" shape="info-circle"></clr-icon>
+          <cds-icon class="alert-icon" shape="info-circle"></cds-icon>
         </div>
         <div class="alert-text">
           App Level Alert
@@ -14,22 +14,22 @@
       </div>
     </div>
     <button type="button" class="close" aria-label="Close">
-      <clr-icon aria-hidden="true" shape="close"></clr-icon>
+      <cds-icon aria-hidden="true" shape="close"></cds-icon>
     </button>
   </div>
   <header class="header header-6">
     <div class="branding">
       <a href="javascript:void(0)">
-        <clr-icon shape="vm-bug"></clr-icon>
+        <cds-icon shape="vm-bug"></cds-icon>
         <span class="title">Project Clarity</span>
       </a>
     </div>
     <div class="header-nav">
       <a href="javascript://" class="nav-link nav-icon">
-        <clr-icon shape="cloud"></clr-icon>
+        <cds-icon shape="cloud"></cds-icon>
       </a>
       <a href="javascript://" class="active nav-link nav-icon">
-        <clr-icon shape="folder"></clr-icon>
+        <cds-icon shape="folder"></cds-icon>
       </a>
     </div>
   </header>

--- a/apps/website/.vuepress/code/demos/app-layout/content-container-ng.html
+++ b/apps/website/.vuepress/code/demos/app-layout/content-container-ng.html
@@ -3,7 +3,7 @@
     <div class="alert-items">
       <div class="alert-item static">
         <div class="alert-icon-wrapper">
-          <clr-icon class="alert-icon" shape="info-circle"></clr-icon>
+          <cds-icon class="alert-icon" shape="info-circle"></cds-icon>
         </div>
         <div class="alert-text">
           App Level Alert
@@ -14,22 +14,22 @@
       </div>
     </div>
     <button type="button" class="close" aria-label="Close">
-      <clr-icon aria-hidden="true" shape="close"></clr-icon>
+      <cds-icon aria-hidden="true" shape="close"></cds-icon>
     </button>
   </div>
   <header class="header header-6">
     <div class="branding">
       <a href="javascript:void(0)">
-        <clr-icon shape="vm-bug"></clr-icon>
+        <cds-icon shape="vm-bug"></cds-icon>
         <span class="title">Project Clarity</span>
       </a>
     </div>
     <div class="header-nav">
       <a href="javascript://" class="nav-link nav-icon">
-        <clr-icon shape="cloud"></clr-icon>
+        <cds-icon shape="cloud"></cds-icon>
       </a>
       <a href="javascript://" class="active nav-link nav-icon">
-        <clr-icon shape="folder"></clr-icon>
+        <cds-icon shape="folder"></cds-icon>
       </a>
     </div>
   </header>

--- a/apps/website/.vuepress/code/demos/button-group/accessibility.html
+++ b/apps/website/.vuepress/code/demos/button-group/accessibility.html
@@ -1,11 +1,11 @@
 <div class="btn-group btn-primary btn-icon">
   <button class="btn">
-    <clr-icon shape="check" title="Check"></clr-icon>
+    <cds-icon shape="check" title="Check"></cds-icon>
   </button>
   <button class="btn">
-    <clr-icon shape="home" title="home"></clr-icon>
+    <cds-icon shape="home" title="home"></cds-icon>
   </button>
   <button class="btn">
-    <clr-icon shape="user" title="user"></clr-icon>
+    <cds-icon shape="user" title="user"></cds-icon>
   </button>
 </div>

--- a/apps/website/.vuepress/code/demos/button-group/icons-css.html
+++ b/apps/website/.vuepress/code/demos/button-group/icons-css.html
@@ -1,23 +1,23 @@
 <div class="btn-group btn-primary btn-icon">
   <button class="btn">
-    <clr-icon shape="home"></clr-icon>
+    <cds-icon shape="home"></cds-icon>
     <span class="clr-icon-title">Home</span>
   </button>
   <button class="btn">
-    <clr-icon shape="cog"></clr-icon>
+    <cds-icon shape="cog"></cds-icon>
     <span class="clr-icon-title">Settings</span>
   </button>
   <div class="btn-group-overflow open">
     <button class="btn dropdown-toggle">
-      <clr-icon shape="ellipsis-horizontal"></clr-icon>
+      <cds-icon shape="ellipsis-horizontal"></cds-icon>
     </button>
     <div class="dropdown-menu">
       <button class="btn">
-        <clr-icon shape="user"></clr-icon>
+        <cds-icon shape="user"></cds-icon>
         <span class="clr-icon-title">User</span>
       </button>
       <button class="btn">
-        <clr-icon shape="cloud"></clr-icon>
+        <cds-icon shape="cloud"></cds-icon>
         <span class="clr-icon-title">Cloud</span>
       </button>
     </div>

--- a/apps/website/.vuepress/code/demos/button-group/icons-with-text-css.html
+++ b/apps/website/.vuepress/code/demos/button-group/icons-with-text-css.html
@@ -1,23 +1,23 @@
 <div class="btn-group btn-primary">
   <button class="btn">
-    <clr-icon shape="home"></clr-icon>
+    <cds-icon shape="home"></cds-icon>
     Home
   </button>
   <button class="btn">
-    <clr-icon shape="cog"></clr-icon>
+    <cds-icon shape="cog"></cds-icon>
     Settings
   </button>
   <div class="btn-group-overflow open">
     <button class="btn dropdown-toggle">
-      <clr-icon shape="ellipsis-horizontal"></clr-icon>
+      <cds-icon shape="ellipsis-horizontal"></cds-icon>
     </button>
     <div class="dropdown-menu">
       <button class="btn">
-        <clr-icon shape="user"></clr-icon>
+        <cds-icon shape="user"></cds-icon>
         User
       </button>
       <button class="btn">
-        <clr-icon shape="cloud"></clr-icon>
+        <cds-icon shape="cloud"></cds-icon>
         Cloud
       </button>
     </div>

--- a/apps/website/.vuepress/code/demos/button-group/overflow-css.html
+++ b/apps/website/.vuepress/code/demos/button-group/overflow-css.html
@@ -3,7 +3,7 @@
   <button class="btn">Edit</button>
   <div class="btn-group-overflow open">
     <button class="btn dropdown-toggle">
-      <clr-icon shape="ellipsis-horizontal"></clr-icon>
+      <cds-icon shape="ellipsis-horizontal"></cds-icon>
     </button>
     <div class="dropdown-menu">
       <button class="btn">Download</button>

--- a/apps/website/.vuepress/code/demos/button/icon-css.html
+++ b/apps/website/.vuepress/code/demos/button/icon-css.html
@@ -1,20 +1,20 @@
 <div>
   <button type="button" class="btn btn-icon" aria-label="home">
-    <clr-icon shape="home"></clr-icon>
+    <cds-icon shape="home"></cds-icon>
   </button>
   <button type="button" class="btn btn-icon btn-primary" aria-label="settings">
-    <clr-icon shape="cog"></clr-icon>
+    <cds-icon shape="cog"></cds-icon>
   </button>
   <button type="button" class="btn btn-icon btn-warning" aria-label="warning">
-    <clr-icon shape="warning-standard"></clr-icon>
+    <cds-icon shape="warning-standard"></cds-icon>
   </button>
   <button type="button" class="btn btn-icon btn-danger" aria-label="error">
-    <clr-icon shape="error-standard"></clr-icon>
+    <cds-icon shape="error-standard"></cds-icon>
   </button>
   <button type="button" class="btn btn-icon btn-success" aria-label="done">
-    <clr-icon shape="check"></clr-icon>
+    <cds-icon shape="check"></cds-icon>
   </button>
   <button type="button" class="btn btn-icon" disabled aria-label="home">
-    <clr-icon shape="home"></clr-icon>
+    <cds-icon shape="home"></cds-icon>
   </button>
 </div>

--- a/apps/website/.vuepress/code/demos/card/dropdown-css.html
+++ b/apps/website/.vuepress/code/demos/card/dropdown-css.html
@@ -22,7 +22,7 @@
         <div class="dropdown top-left open">
           <button class="dropdown-toggle btn btn-sm btn-link">
             Dropdown 1
-            <clr-icon shape="caret" direction="down"></clr-icon>
+            <cds-icon shape="caret" direction="down"></cds-icon>
           </button>
           <div class="dropdown-menu">
             <a href="javascript:void(0)" class="dropdown-item">Item 1</a>

--- a/apps/website/.vuepress/code/demos/checkbox/disabled-css.html
+++ b/apps/website/.vuepress/code/demos/checkbox/disabled-css.html
@@ -35,7 +35,7 @@
       <label for="disabled-checkbox3" class="clr-control-label">Option 3</label>
     </div>
     <div class="clr-subtext-wrapper">
-      <clr-icon class="clr-validate-icon" shape="exclamation-circle"></clr-icon>
+      <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
       <span class="clr-subtext">Helper text</span>
     </div>
   </div>

--- a/apps/website/.vuepress/code/demos/checkbox/helper-css.html
+++ b/apps/website/.vuepress/code/demos/checkbox/helper-css.html
@@ -14,7 +14,7 @@
       <label for="helper-checkbox3" class="clr-control-label">Option 3</label>
     </div>
     <div class="clr-subtext-wrapper">
-      <clr-icon class="clr-validate-icon" shape="exclamation-circle"></clr-icon>
+      <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
       <span class="clr-subtext">This field is required!</span>
     </div>
   </div>

--- a/apps/website/.vuepress/code/demos/checkbox/inline-css.html
+++ b/apps/website/.vuepress/code/demos/checkbox/inline-css.html
@@ -14,7 +14,7 @@
       <label for="inline-checkbox3" class="clr-control-label">Option 3</label>
     </div>
     <div class="clr-subtext-wrapper">
-      <clr-icon class="clr-validate-icon" shape="exclamation-circle"></clr-icon>
+      <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
       <span class="clr-subtext">Helper Text</span>
     </div>
   </div>

--- a/apps/website/.vuepress/code/demos/combobox/async.html
+++ b/apps/website/.vuepress/code/demos/combobox/async.html
@@ -11,12 +11,12 @@
     (clrOpenChange)="$event ? fetchStates() : null"
   >
     <ng-container *clrOptionSelected="let selected"
-      ><clr-icon shape="house" role="img" aria-label="welcome home"></clr-icon> {{selected?.name}}</ng-container
+      ><cds-icon shape="house" role="img" aria-label="welcome home"></cds-icon> {{selected?.name}}</ng-container
     >
     <clr-options>
       <clr-option *clrOptionItems="let state of asyncStates$ | async; field:'name'" [clrValue]="state">
-        <clr-icon shape="world" role="img" aria-label="World is turning"></clr-icon> {{state.name}}
-        <clr-icon shape="sun" role="img" aria-label="Sun is shining"></clr-icon>
+        <cds-icon shape="world" role="img" aria-label="World is turning"></cds-icon> {{state.name}}
+        <cds-icon shape="sun" role="img" aria-label="Sun is shining"></cds-icon>
       </clr-option>
     </clr-options>
   </clr-combobox>

--- a/apps/website/.vuepress/code/demos/combobox/multi.html
+++ b/apps/website/.vuepress/code/demos/combobox/multi.html
@@ -2,12 +2,12 @@
   <label>Favorite States</label>
   <clr-combobox [(ngModel)]="selection" name="multiSelect" clrMulti="true" required [disabled]="disabled">
     <ng-container *clrOptionSelected="let selected">
-      <clr-icon shape="house" role="img" aria-label="welcome home"></clr-icon> {{selected?.name}}
+      <cds-icon shape="house" role="img" aria-label="welcome home"></cds-icon> {{selected?.name}}
     </ng-container>
     <clr-options>
       <clr-option *clrOptionItems="let state of states; field:'name'" [clrValue]="state">
-        <clr-icon shape="world" role="img" aria-label="World is turning"></clr-icon> {{state.name}}
-        <clr-icon shape="sun" role="img" aria-label="Sun is shining"></clr-icon>
+        <cds-icon shape="world" role="img" aria-label="World is turning"></cds-icon> {{state.name}}
+        <cds-icon shape="sun" role="img" aria-label="Sun is shining"></cds-icon>
       </clr-option>
     </clr-options>
   </clr-combobox>

--- a/apps/website/.vuepress/code/demos/combobox/single.html
+++ b/apps/website/.vuepress/code/demos/combobox/single.html
@@ -3,8 +3,8 @@
   <clr-combobox [(ngModel)]="selection" name="myState" required [disabled]="disabled">
     <clr-options>
       <clr-option *clrOptionItems="let state of states; field:'name'" [clrValue]="state">
-        <clr-icon shape="world" role="img" aria-label="World is turning"></clr-icon> {{state.name}}
-        <clr-icon shape="sun" role="img" aria-label="Sun is shining"></clr-icon>
+        <cds-icon shape="world" role="img" aria-label="World is turning"></cds-icon> {{state.name}}
+        <cds-icon shape="sun" role="img" aria-label="Sun is shining"></cds-icon>
       </clr-option>
     </clr-options>
   </clr-combobox>

--- a/apps/website/.vuepress/code/demos/datagrid/batch-action.html
+++ b/apps/website/.vuepress/code/demos/datagrid/batch-action.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -63,7 +63,7 @@
       <clr-dropdown>
         <button type="button" class="btn btn-sm btn-secondary" clrDropdownTrigger>
           Export
-          <clr-icon shape="caret down"></clr-icon>
+          <cds-icon shape="caret" direction="down"></cds-icon>
         </button>
         <clr-dropdown-menu clrPosition="bottom-left" *clrIfOpen>
           <button type="button" (click)="onExportAll()" clrDropdownItem>Export All</button>

--- a/apps/website/.vuepress/code/demos/datagrid/compact.html
+++ b/apps/website/.vuepress/code/demos/datagrid/compact.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -19,7 +19,7 @@
   <clr-dg-row *ngFor="let user of users; let i = index;">
     <clr-dg-cell>{{user.id}}</clr-dg-cell>
     <clr-dg-cell>
-      <clr-icon shape="user"></clr-icon>
+      <cds-icon shape="user"></cds-icon>
       {{user.name}}
     </clr-dg-cell>
     <clr-dg-cell>{{user.pokemon.name}}</clr-dg-cell>

--- a/apps/website/.vuepress/code/demos/datagrid/expandable-rows.html
+++ b/apps/website/.vuepress/code/demos/datagrid/expandable-rows.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -64,7 +64,7 @@
   <div class="alert-items">
     <div class="alert-item static">
       <div class="alert-icon-wrapper">
-        <clr-icon class="alert-icon" shape="info-circle"></clr-icon>
+        <cds-icon class="alert-icon" shape="info-circle"></cds-icon>
       </div>
       <span class="alert-text">
         Note the <code class="clr-code">ngProjectAs</code> attribute on our custom detail component. This is needed to

--- a/apps/website/.vuepress/code/demos/datagrid/sorting.html
+++ b/apps/website/.vuepress/code/demos/datagrid/sorting.html
@@ -38,7 +38,7 @@
   <div class="alert-items">
     <div class="alert-item static">
       <div class="alert-icon-wrapper">
-        <clr-icon class="alert-icon" shape="info-circle"></clr-icon>
+        <cds-icon class="alert-icon" shape="info-circle"></cds-icon>
       </div>
       <span class="alert-text">
         Why use an object instead of the function directly?

--- a/apps/website/.vuepress/code/demos/dropdown/basic-angular-css.html
+++ b/apps/website/.vuepress/code/demos/dropdown/basic-angular-css.html
@@ -2,7 +2,7 @@
   <div class="dropdown open">
     <button class="dropdown-toggle btn btn-primary" type="button">
       Dropdown
-      <clr-icon shape="caret" direction="down"></clr-icon>
+      <cds-icon shape="caret" direction="down"></cds-icon>
     </button>
     <div class="dropdown-menu">
       <h4 class="dropdown-header">Dropdown header</h4>

--- a/apps/website/.vuepress/code/demos/dropdown/basic-angular-ng.html
+++ b/apps/website/.vuepress/code/demos/dropdown/basic-angular-ng.html
@@ -1,7 +1,7 @@
 <clr-dropdown>
   <button class="btn btn-outline-primary" clrDropdownTrigger>
     Dropdown
-    <clr-icon shape="caret" direction="down"></clr-icon>
+    <cds-icon shape="caret" direction="down"></cds-icon>
   </button>
   <clr-dropdown-menu clrPosition="top-left" *clrIfOpen>
     <label class="dropdown-header" aria-hidden="true">Dropdown header</label>

--- a/apps/website/.vuepress/code/demos/dropdown/basic-css.html
+++ b/apps/website/.vuepress/code/demos/dropdown/basic-css.html
@@ -2,7 +2,7 @@
   <div class="dropdown open">
     <button class="dropdown-toggle btn btn-primary" type="button">
       Dropdown
-      <clr-icon shape="caret" direction="down"></clr-icon>
+      <cds-icon shape="caret" direction="down"></cds-icon>
     </button>
     <div class="dropdown-menu">
       <h4 class="dropdown-header">Dropdown header</h4>

--- a/apps/website/.vuepress/code/demos/dropdown/basic-ng.html
+++ b/apps/website/.vuepress/code/demos/dropdown/basic-ng.html
@@ -1,7 +1,7 @@
 <div class="dropdown open">
   <button class="dropdown-toggle btn btn-primary" type="button">
     Dropdown
-    <clr-icon shape="caret" direction="down"></clr-icon>
+    <cds-icon shape="caret" direction="down"></cds-icon>
   </button>
   <div class="dropdown-menu">
     <h4 class="dropdown-header">Dropdown header</h4>

--- a/apps/website/.vuepress/code/demos/dropdown/bottom-right-css.html
+++ b/apps/website/.vuepress/code/demos/dropdown/bottom-right-css.html
@@ -2,7 +2,7 @@
   <div class="dropdown bottom-right open">
     <button class="dropdown-toggle btn btn-primary">
       Dropdown
-      <clr-icon shape="caret" direction="down"></clr-icon>
+      <cds-icon shape="caret" direction="down"></cds-icon>
     </button>
     <div class="dropdown-menu">
       <h4 class="dropdown-header">Dropdown header</h4>

--- a/apps/website/.vuepress/code/demos/dropdown/bottom-right-ng.html
+++ b/apps/website/.vuepress/code/demos/dropdown/bottom-right-ng.html
@@ -1,7 +1,7 @@
 <div class="dropdown bottom-right open">
   <button class="dropdown-toggle btn btn-primary">
     Dropdown
-    <clr-icon shape="caret" direction="down"></clr-icon>
+    <cds-icon shape="caret" direction="down"></cds-icon>
   </button>
   <div class="dropdown-menu">
     <h4 class="dropdown-header">Dropdown header</h4>

--- a/apps/website/.vuepress/code/demos/dropdown/icon-angular-ng.html
+++ b/apps/website/.vuepress/code/demos/dropdown/icon-angular-ng.html
@@ -1,7 +1,7 @@
 <clr-dropdown [clrCloseMenuOnItemClick]="false">
   <button clrDropdownTrigger aria-label="Dropdown demo button">
-    <clr-icon shape="error" class="is-error" size="24"></clr-icon>
-    <clr-icon shape="caret" direction="down"></clr-icon>
+    <cds-icon shape="error" class="is-error" size="md"></cds-icon>
+    <cds-icon shape="caret" direction="down"></cds-icon>
   </button>
   <clr-dropdown-menu *clrIfOpen>
     <label class="dropdown-header" aria-hidden="true">Dropdown header</label>

--- a/apps/website/.vuepress/code/demos/dropdown/icon-toggle-css.html
+++ b/apps/website/.vuepress/code/demos/dropdown/icon-toggle-css.html
@@ -1,8 +1,8 @@
 <section class="custom-block" style="height: 10rem;">
   <div class="dropdown bottom-left open">
     <button class="dropdown-toggle">
-      <clr-icon shape="error" class="is-error" size="24"></clr-icon>
-      <clr-icon shape="caret" direction="down"></clr-icon>
+      <cds-icon shape="error" status="error" size="md"></cds-icon>
+      <cds-icon shape="caret" direction="down"></cds-icon>
     </button>
     <div class="dropdown-menu">
       <h4 class="dropdown-header">Dropdown header</h4>

--- a/apps/website/.vuepress/code/demos/dropdown/icon-toggle-ng.html
+++ b/apps/website/.vuepress/code/demos/dropdown/icon-toggle-ng.html
@@ -1,7 +1,7 @@
 <div class="dropdown bottom-left open">
   <button class="dropdown-toggle">
-    <clr-icon shape="error" class="is-error" size="24"></clr-icon>
-    <clr-icon shape="caret" direction="down"></clr-icon>
+    <cds-icon shape="error" status="error" size="md"></cds-icon>
+    <cds-icon shape="caret" direction="down"></cds-icon>
   </button>
   <div class="dropdown-menu">
     <h4 class="dropdown-header">Dropdown header</h4>

--- a/apps/website/.vuepress/code/demos/input/helper-css.html
+++ b/apps/website/.vuepress/code/demos/input/helper-css.html
@@ -13,7 +13,7 @@
     <div class="clr-control-container">
       <div class="clr-input-wrapper">
         <input type="text" id="demo3" placeholder="Enter value here" class="clr-input" />
-        <clr-icon class="clr-validate-icon" shape="exclamation-circle"></clr-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
       </div>
       <span class="clr-subtext">You must provide your last name!</span>
     </div>

--- a/apps/website/.vuepress/code/demos/login/login-css.html
+++ b/apps/website/.vuepress/code/demos/login/login-css.html
@@ -23,7 +23,7 @@
         <div class="clr-control-container">
           <div class="clr-input-wrapper">
             <input type="password" id="basic" placeholder="Password please!" class="clr-input" />
-            <clr-icon class="clr-validate-icon" shape="exclamation-circle"></clr-icon>
+            <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
           </div>
         </div>
       </div>

--- a/apps/website/.vuepress/code/demos/modal/modal-basic.html
+++ b/apps/website/.vuepress/code/demos/modal/modal-basic.html
@@ -3,7 +3,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <button aria-label="Close" class="close" type="button">
-          <clr-icon aria-hidden="true" shape="close"></clr-icon>
+          <cds-icon aria-hidden="true" shape="close"></cds-icon>
         </button>
         <h3 class="modal-title">I have a nice title</h3>
       </div>

--- a/apps/website/.vuepress/code/demos/navigation/header-css.html
+++ b/apps/website/.vuepress/code/demos/navigation/header-css.html
@@ -2,16 +2,16 @@
   <header class="header header-6">
     <div class="branding">
       <a href="javascript:void(0)">
-        <clr-icon shape="vm-bug"></clr-icon>
+        <cds-icon shape="vm-bug"></cds-icon>
         <span class="title">Project Clarity</span>
       </a>
     </div>
     <div class="header-nav">
       <a href="javascript://" class="nav-link nav-icon">
-        <clr-icon shape="cloud"></clr-icon>
+        <cds-icon shape="cloud"></cds-icon>
       </a>
       <a href="javascript://" class="active nav-link nav-icon">
-        <clr-icon shape="folder"></clr-icon>
+        <cds-icon shape="folder"></cds-icon>
       </a>
     </div>
   </header>

--- a/apps/website/.vuepress/code/demos/navigation/header-ng.html
+++ b/apps/website/.vuepress/code/demos/navigation/header-ng.html
@@ -2,16 +2,16 @@
   <header class="header header-6">
     <div class="branding">
       <a href="javascript:void(0)">
-        <clr-icon shape="vm-bug"></clr-icon>
+        <cds-icon shape="vm-bug"></cds-icon>
         <span class="title">Project Clarity</span>
       </a>
     </div>
     <div class="header-nav">
       <a href="javascript://" class="nav-link nav-icon">
-        <clr-icon shape="cloud"></clr-icon>
+        <cds-icon shape="cloud"></cds-icon>
       </a>
       <a href="javascript://" class="active nav-link nav-icon">
-        <clr-icon shape="folder"></clr-icon>
+        <cds-icon shape="folder"></cds-icon>
       </a>
     </div>
   </header>

--- a/apps/website/.vuepress/code/demos/navigation/header-subnav-css.html
+++ b/apps/website/.vuepress/code/demos/navigation/header-subnav-css.html
@@ -3,13 +3,13 @@
     <header class="header-6">
       <div class="branding">
         <a href="javascript://">
-          <clr-icon shape="vm-bug"></clr-icon>
+          <cds-icon shape="vm-bug"></cds-icon>
           <span class="title">Project Clarity</span>
         </a>
       </div>
       <div class="settings">
         <a href="javascript://" class="nav-link nav-icon">
-          <clr-icon shape="cog"></clr-icon>
+          <cds-icon shape="cog"></cds-icon>
         </a>
       </div>
     </header>

--- a/apps/website/.vuepress/code/demos/navigation/header-subnav-ng.html
+++ b/apps/website/.vuepress/code/demos/navigation/header-subnav-ng.html
@@ -3,13 +3,13 @@
     <header class="header-6">
       <div class="branding">
         <a href="javascript://">
-          <clr-icon shape="vm-bug"></clr-icon>
+          <cds-icon shape="vm-bug"></cds-icon>
           <span class="title">Project Clarity</span>
         </a>
       </div>
       <div class="settings">
         <a href="javascript://" class="nav-link nav-icon">
-          <clr-icon shape="cog"></clr-icon>
+          <cds-icon shape="cog"></cds-icon>
         </a>
       </div>
     </header>

--- a/apps/website/.vuepress/code/demos/navigation/sidenav-css.html
+++ b/apps/website/.vuepress/code/demos/navigation/sidenav-css.html
@@ -2,7 +2,7 @@
   <header class="header header-6">
     <div class="branding">
       <a href="javascript:void(0)">
-        <clr-icon shape="vm-bug"></clr-icon>
+        <cds-icon shape="vm-bug"></cds-icon>
         <span class="title">Project Clarity</span>
       </a>
     </div>
@@ -13,7 +13,7 @@
     </form>
     <div class="settings">
       <a href="javascript://" class="nav-link nav-icon">
-        <clr-icon shape="cog"></clr-icon>
+        <cds-icon shape="cog"></cds-icon>
       </a>
     </div>
   </header>

--- a/apps/website/.vuepress/code/demos/navigation/sidenav-ng.html
+++ b/apps/website/.vuepress/code/demos/navigation/sidenav-ng.html
@@ -2,7 +2,7 @@
   <header class="header header-6">
     <div class="branding">
       <a href="javascript:void(0)">
-        <clr-icon shape="vm-bug"></clr-icon>
+        <cds-icon shape="vm-bug"></cds-icon>
         <span class="title">Project Clarity</span>
       </a>
     </div>
@@ -13,7 +13,7 @@
     </form>
     <div class="settings">
       <a href="javascript://" class="nav-link nav-icon">
-        <clr-icon shape="cog"></clr-icon>
+        <cds-icon shape="cog"></cds-icon>
       </a>
     </div>
   </header>

--- a/apps/website/.vuepress/code/demos/navigation/subnav-sidenav-css.html
+++ b/apps/website/.vuepress/code/demos/navigation/subnav-sidenav-css.html
@@ -2,7 +2,7 @@
   <header class="header header-6">
     <div class="branding">
       <a href="javascript:void(0)">
-        <clr-icon shape="vm-bug"></clr-icon>
+        <cds-icon shape="vm-bug"></cds-icon>
         <span class="title">Project Clarity</span>
       </a>
     </div>
@@ -13,7 +13,7 @@
     </form>
     <div class="settings">
       <a href="javascript://" class="nav-link nav-icon">
-        <clr-icon shape="cog"></clr-icon>
+        <cds-icon shape="cog"></cds-icon>
       </a>
     </div>
   </header>

--- a/apps/website/.vuepress/code/demos/navigation/subnav-sidenav-ng.html
+++ b/apps/website/.vuepress/code/demos/navigation/subnav-sidenav-ng.html
@@ -2,7 +2,7 @@
   <header class="header header-6">
     <div class="branding">
       <a href="javascript:void(0)">
-        <clr-icon shape="vm-bug"></clr-icon>
+        <cds-icon shape="vm-bug"></cds-icon>
         <span class="title">Project Clarity</span>
       </a>
     </div>
@@ -13,7 +13,7 @@
     </form>
     <div class="settings">
       <a href="javascript://" class="nav-link nav-icon">
-        <clr-icon shape="cog"></clr-icon>
+        <cds-icon shape="cog"></cds-icon>
       </a>
     </div>
   </header>

--- a/apps/website/.vuepress/code/demos/password/basic-css.html
+++ b/apps/website/.vuepress/code/demos/password/basic-css.html
@@ -4,7 +4,7 @@
     <div class="clr-control-container">
       <div class="clr-input-wrapper">
         <input type="password" id="basic" placeholder="Password please!" class="clr-input" />
-        <clr-icon class="clr-validate-icon" shape="exclamation-circle"></clr-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>

--- a/apps/website/.vuepress/code/demos/password/helper-css.html
+++ b/apps/website/.vuepress/code/demos/password/helper-css.html
@@ -4,7 +4,7 @@
     <div class="clr-control-container">
       <div class="clr-input-wrapper">
         <input type="password" id="example" placeholder="Password please!" class="clr-input" />
-        <clr-icon class="clr-validate-icon" shape="exclamation-circle"></clr-icon>
+        <cds-icon class="cds-validate-icon" shape="exclamation-circle"></cds-icon>
       </div>
       <span class="clr-subtext">Error message</span>
     </div>

--- a/apps/website/.vuepress/code/demos/radio/disabled-css.html
+++ b/apps/website/.vuepress/code/demos/radio/disabled-css.html
@@ -14,7 +14,7 @@
       <label for="disabled-radio3" class="clr-control-label">Option 3</label>
     </div>
     <div class="clr-subtext-wrapper">
-      <clr-icon class="clr-validate-icon" shape="exclamation-circle"></clr-icon>
+      <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
       <span class="clr-subtext">Helper text</span>
     </div>
   </div>

--- a/apps/website/.vuepress/code/demos/radio/helper-css.html
+++ b/apps/website/.vuepress/code/demos/radio/helper-css.html
@@ -14,7 +14,7 @@
       <label for="helper-radio3" class="clr-control-label">Option 3</label>
     </div>
     <div class="clr-subtext-wrapper">
-      <clr-icon class="clr-validate-icon" shape="exclamation-circle"></clr-icon>
+      <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
       <span class="clr-subtext">Error message</span>
     </div>
   </div>

--- a/apps/website/.vuepress/code/demos/radio/inline-css.html
+++ b/apps/website/.vuepress/code/demos/radio/inline-css.html
@@ -14,7 +14,7 @@
       <label for="inline-radio3" class="clr-control-label">Option 3</label>
     </div>
     <div class="clr-subtext-wrapper">
-      <clr-icon class="clr-validate-icon" shape="exclamation-circle"></clr-icon>
+      <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
       <span class="clr-subtext">Helper Text</span>
     </div>
   </div>

--- a/apps/website/.vuepress/code/demos/select/helper-css.html
+++ b/apps/website/.vuepress/code/demos/select/helper-css.html
@@ -7,7 +7,7 @@
         <option value="2">Two</option>
         <option value="3">Three</option>
       </select>
-      <clr-icon class="clr-validate-icon" shape="exclamation-circle"></clr-icon>
+      <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
     </div>
     <span class="clr-subtext">Error message</span>
   </div>

--- a/apps/website/.vuepress/code/demos/sidenav/icons-css.html
+++ b/apps/website/.vuepress/code/demos/sidenav/icons-css.html
@@ -7,13 +7,13 @@
   <div class="content-container">
     <nav class="sidenav">
       <section class="sidenav-content">
-        <a class="nav-link nav-icon"><clr-icon shape="home"></clr-icon> Home</a>
-        <a class="nav-link"><clr-icon shape="cog"></clr-icon> Settings</a>
-        <a class="nav-link active"><clr-icon shape="user"></clr-icon> Users</a>
-        <a class="nav-link"><clr-icon shape="folder-open"></clr-icon> Files</a>
-        <a class="nav-link"><clr-icon shape="cloud"></clr-icon> Data</a>
-        <a class="nav-link"><clr-icon shape="image-gallery"> Photos</clr-icon> 6</a>
-        <a class="nav-link"><clr-icon shape="video-gallery"></clr-icon> Videos</a>
+        <a class="nav-link nav-icon"><cds-icon shape="home"></cds-icon> Home</a>
+        <a class="nav-link"><cds-icon shape="cog"></cds-icon> Settings</a>
+        <a class="nav-link active"><cds-icon shape="user"></cds-icon> Users</a>
+        <a class="nav-link"><cds-icon shape="folder-open"></cds-icon> Files</a>
+        <a class="nav-link"><cds-icon shape="cloud"></cds-icon> Data</a>
+        <a class="nav-link"><cds-icon shape="image-gallery"> Photos</cds-icon> 6</a>
+        <a class="nav-link"><cds-icon shape="video-gallery"></cds-icon> Videos</a>
       </section>
     </nav>
     <div class="content-area">

--- a/apps/website/.vuepress/code/demos/sidenav/icons-ng.html
+++ b/apps/website/.vuepress/code/demos/sidenav/icons-ng.html
@@ -5,13 +5,13 @@
   <div class="content-container">
     <nav class="sidenav">
       <section class="sidenav-content">
-        <a class="nav-link nav-icon"><clr-icon shape="home"></clr-icon> Home</a>
-        <a class="nav-link"><clr-icon shape="cog"></clr-icon> Settings</a>
-        <a class="nav-link active"><clr-icon shape="user"></clr-icon> Users</a>
-        <a class="nav-link"><clr-icon shape="Folder-open"></clr-icon> Files</a>
-        <a class="nav-link"><clr-icon shape="Cloud"></clr-icon> Data</a>
-        <a class="nav-link"><clr-icon shape="image-gallery"> Photos</clr-icon> 6</a>
-        <a class="nav-link"><clr-icon shape="video-gallery"></clr-icon> Videos</a>
+        <a class="nav-link nav-icon"><cds-icon shape="home"></cds-icon> Home</a>
+        <a class="nav-link"><cds-icon shape="cog"></cds-icon> Settings</a>
+        <a class="nav-link active"><cds-icon shape="user"></cds-icon> Users</a>
+        <a class="nav-link"><cds-icon shape="Folder-open"></cds-icon> Files</a>
+        <a class="nav-link"><cds-icon shape="Cloud"></cds-icon> Data</a>
+        <a class="nav-link"><cds-icon shape="image-gallery"> Photos</cds-icon> 6</a>
+        <a class="nav-link"><cds-icon shape="video-gallery"></cds-icon> Videos</a>
       </section>
     </nav>
     <div class="content-area">

--- a/apps/website/.vuepress/code/demos/signpost/custom-ng.html
+++ b/apps/website/.vuepress/code/demos/signpost/custom-ng.html
@@ -1,7 +1,7 @@
 <!-- TODO: turn this into a story and link to it -->
 <h6>Clarity Icon</h6>
 <clr-signpost>
-  <clr-icon shape="avatar" class="is-solid has-badge-info" clrSignpostTrigger> </clr-icon>
+  <cds-icon shape="avatar" solid badge="info" clrSignpostTrigger> </cds-icon>
   <clr-signpost-content [clrPosition]="'bottom-middle'" *clrIfOpen>
     Lorem ipsum...
   </clr-signpost-content>
@@ -21,7 +21,7 @@
 <clr-signpost>
   <button class="btn btn-link" clrSignpostTrigger>
     Button Link
-    <clr-icon shape="help-info"></clr-icon>
+    <cds-icon shape="help-info"></cds-icon>
   </button>
   <clr-signpost-content [clrPosition]="'bottom-middle'" *clrIfOpen>
     Lorem ipsum...

--- a/apps/website/.vuepress/code/demos/textarea/helper-css.html
+++ b/apps/website/.vuepress/code/demos/textarea/helper-css.html
@@ -13,7 +13,7 @@
     <div class="clr-control-container clr-error">
       <div class="clr-textarea-wrapper">
         <textarea id="textarea-basic-error-required" placeholder="Enter value here" class="clr-textarea"></textarea>
-        <clr-icon class="clr-validate-icon" shape="exclamation-circle"></clr-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
       </div>
       <span class="clr-subtext">The address is required!</span>
     </div>

--- a/apps/website/.vuepress/code/demos/tooltip/tooltip-bottom-left.html
+++ b/apps/website/.vuepress/code/demos/tooltip/tooltip-bottom-left.html
@@ -1,4 +1,4 @@
 <a href="javascript:void(0)" role="tooltip" aria-haspopup="true" class="tooltip tooltip-lg tooltip-bottom-left">
-  <clr-icon shape="info-circle" size="24"></clr-icon>
+  <cds-icon shape="info-circle" size="md"></cds-icon>
   <span class="tooltip-content">Lorem ipsum dolor sit amet, consectetur adipisicing elit</span>
 </a>

--- a/apps/website/.vuepress/code/demos/tooltip/tooltip-bottom-right.html
+++ b/apps/website/.vuepress/code/demos/tooltip/tooltip-bottom-right.html
@@ -1,4 +1,4 @@
 <a href="javascript:void(0)" role="tooltip" aria-haspopup="true" class="tooltip tooltip-md tooltip-bottom-right">
-  <clr-icon shape="info-circle" size="24"></clr-icon>
+  <cds-icon shape="info-circle" size="md"></cds-icon>
   <span class="tooltip-content">Lorem ipsum dolor sit amet, ipsum</span>
 </a>

--- a/apps/website/.vuepress/code/demos/tooltip/tooltip-left.html
+++ b/apps/website/.vuepress/code/demos/tooltip/tooltip-left.html
@@ -1,4 +1,4 @@
 <a href="javascript:void(0)" role="tooltip" aria-haspopup="true" class="tooltip tooltip-sm tooltip-left">
-  <clr-icon shape="info-circle" size="24"></clr-icon>
+  <cds-icon shape="info-circle" size="md"></cds-icon>
   <span class="tooltip-content">Lorem ipsum sit</span>
 </a>

--- a/apps/website/.vuepress/code/demos/tooltip/tooltip-lg.html
+++ b/apps/website/.vuepress/code/demos/tooltip/tooltip-lg.html
@@ -1,4 +1,4 @@
 <a href="javascript:void(0)" role="tooltip" aria-haspopup="true" class="tooltip tooltip-lg">
-  <clr-icon shape="info-circle" size="24"></clr-icon>
+  <cds-icon shape="info-circle" size="md"></cds-icon>
   <span class="tooltip-content">I am the large tooltip and very wide for long content.</span>
 </a>

--- a/apps/website/.vuepress/code/demos/tooltip/tooltip-md.html
+++ b/apps/website/.vuepress/code/demos/tooltip/tooltip-md.html
@@ -1,4 +1,4 @@
 <a href="javascript:void(0)" role="tooltip" aria-haspopup="true" class="tooltip tooltip-md">
-  <clr-icon shape="info-circle" size="24"></clr-icon>
+  <cds-icon shape="info-circle" size="md"></cds-icon>
   <span class="tooltip-content">I'm the medium sized tooltip</span>
 </a>

--- a/apps/website/.vuepress/code/demos/tooltip/tooltip-right.html
+++ b/apps/website/.vuepress/code/demos/tooltip/tooltip-right.html
@@ -1,4 +1,4 @@
 <a href="javascript:void(0)" role="tooltip" aria-haspopup="true" class="tooltip tooltip-right">
-  <clr-icon shape="info-circle" size="24"></clr-icon>
+  <cds-icon shape="info-circle" size="md"></cds-icon>
   <span class="tooltip-content">Lorem ipsum dolor sit amet, ipsum</span>
 </a>

--- a/apps/website/.vuepress/code/demos/tooltip/tooltip-sm.html
+++ b/apps/website/.vuepress/code/demos/tooltip/tooltip-sm.html
@@ -1,4 +1,4 @@
 <a href="javascript:void(0)" role="tooltip" aria-haspopup="true" class="tooltip tooltip-sm">
-  <clr-icon shape="info-circle" size="24"></clr-icon>
+  <cds-icon shape="info-circle" size="md"></cds-icon>
   <span class="tooltip-content">I'm still small.</span>
 </a>

--- a/apps/website/.vuepress/code/demos/tooltip/tooltip-top-left.html
+++ b/apps/website/.vuepress/code/demos/tooltip/tooltip-top-left.html
@@ -1,4 +1,4 @@
 <a href="javascript:void(0)" role="tooltip" aria-haspopup="true" class="tooltip tooltip-sm tooltip-top-left">
-  <clr-icon shape="info-circle" size="24"></clr-icon>
+  <cds-icon shape="info-circle" size="md"></cds-icon>
   <span class="tooltip-content">Lorem ipsum sit</span>
 </a>

--- a/apps/website/.vuepress/code/demos/tooltip/tooltip-top-right.html
+++ b/apps/website/.vuepress/code/demos/tooltip/tooltip-top-right.html
@@ -1,4 +1,4 @@
 <a href="javascript:void(0)" role="tooltip" aria-haspopup="true" class="tooltip tooltip-sm tooltip-top-right">
-  <clr-icon shape="info-circle" size="24"></clr-icon>
+  <cds-icon shape="info-circle" size="md"></cds-icon>
   <span class="tooltip-content">Lorem ipsum sit</span>
 </a>

--- a/apps/website/.vuepress/code/demos/tooltip/tooltip-xs.html
+++ b/apps/website/.vuepress/code/demos/tooltip/tooltip-xs.html
@@ -1,4 +1,4 @@
 <a href="javascript:void(0)" role="tooltip" aria-haspopup="true" class="tooltip tooltip-xs">
-  <clr-icon shape="info-circle" size="24"></clr-icon>
+  <cds-icon shape="info-circle" size="md"></cds-icon>
   <span class="tooltip-content">I'm xs</span>
 </a>

--- a/apps/website/.vuepress/code/demos/tree-view/dynamic.html
+++ b/apps/website/.vuepress/code/demos/tree-view/dynamic.html
@@ -1,10 +1,10 @@
 <clr-tree>
   <clr-tree-node *ngFor="let directory of rootDirectory" [(clrExpanded)]="directory.expanded">
-    <clr-icon [attr.shape]="directory.icon"></clr-icon>
+    <cds-icon [attr.shape]="directory.icon"></cds-icon>
     {{directory.name}}
     <clr-tree-node *ngFor="let file of directory.files">
       <button (click)="openFile(directory.name, file.name)" class="clr-treenode-link" [class.active]="file.active">
-        <clr-icon [attr.shape]="file.icon"></clr-icon>
+        <cds-icon [attr.shape]="file.icon"></cds-icon>
         {{file.name}}
       </button>
     </clr-tree-node>

--- a/apps/website/.vuepress/code/demos/tree-view/lazy-ng.html
+++ b/apps/website/.vuepress/code/demos/tree-view/lazy-ng.html
@@ -1,6 +1,6 @@
 <clr-tree [clrLazy]="true">
   <clr-tree-node [clrLoading]="loading">
-    <clr-icon shape="building"></clr-icon>
+    <cds-icon shape="building"></cds-icon>
     Office Locations
     <ng-template clrIfExpanded (clrIfExpandedChange)="$event ? fetchLocations() : null">
       <clr-tree-node *ngFor="let location of locations$ | async">

--- a/apps/website/.vuepress/code/demos/vertical-nav/collapsible-ng.html
+++ b/apps/website/.vuepress/code/demos/vertical-nav/collapsible-ng.html
@@ -1,26 +1,26 @@
 <clr-vertical-nav [clrVerticalNavCollapsible]="true" [(clrVerticalNavCollapsed)]="collapsed">
   <a clrVerticalNavLink routerLink="./normal" routerLinkActive="active">
-    <clr-icon clrVerticalNavIcon shape="user"></clr-icon>
+    <cds-icon clrVerticalNavIcon shape="user"></cds-icon>
     Normal
   </a>
   <a clrVerticalNavLink routerLink="./electric" routerLinkActive="active">
-    <clr-icon clrVerticalNavIcon shape="bolt"></clr-icon>
+    <cds-icon clrVerticalNavIcon shape="bolt"></cds-icon>
     Electric
   </a>
   <a clrVerticalNavLink routerLink="./poison" routerLinkActive="active">
-    <clr-icon clrVerticalNavIcon shape="sad-face"></clr-icon>
+    <cds-icon clrVerticalNavIcon shape="sad-face"></cds-icon>
     Poison
   </a>
   <a clrVerticalNavLink routerLink="./grass" routerLinkActive="active">
-    <clr-icon clrVerticalNavIcon shape="bug"></clr-icon>
+    <cds-icon clrVerticalNavIcon shape="bug"></cds-icon>
     Grass
   </a>
   <a clrVerticalNavLink routerLink="./fighting" routerLinkActive="active">
-    <clr-icon clrVerticalNavIcon shape="shield"></clr-icon>
+    <cds-icon clrVerticalNavIcon shape="shield"></cds-icon>
     Fighting
   </a>
   <a clrVerticalNavLink routerLink="./credit" routerLinkActive="active">
-    <clr-icon clrVerticalNavIcon shape="certificate"></clr-icon>
+    <cds-icon clrVerticalNavIcon shape="certificate"></cds-icon>
     Credit
   </a>
 </clr-vertical-nav>

--- a/apps/website/.vuepress/code/demos/vertical-nav/icon-links-ng.html
+++ b/apps/website/.vuepress/code/demos/vertical-nav/icon-links-ng.html
@@ -1,26 +1,26 @@
 <clr-vertical-nav>
   <a clrVerticalNavLink routerLink="./normal" routerLinkActive="active">
-    <clr-icon clrVerticalNavIcon shape="user"></clr-icon>
+    <cds-icon clrVerticalNavIcon shape="user"></cds-icon>
     Normal
   </a>
   <a clrVerticalNavLink routerLink="./electric" routerLinkActive="active">
-    <clr-icon clrVerticalNavIcon shape="bolt"></clr-icon>
+    <cds-icon clrVerticalNavIcon shape="bolt"></cds-icon>
     Electric
   </a>
   <a clrVerticalNavLink routerLink="./poison" routerLinkActive="active">
-    <clr-icon clrVerticalNavIcon shape="sad-face"></clr-icon>
+    <cds-icon clrVerticalNavIcon shape="sad-face"></cds-icon>
     Poison
   </a>
   <a clrVerticalNavLink routerLink="./grass" routerLinkActive="active">
-    <clr-icon clrVerticalNavIcon shape="bug"></clr-icon>
+    <cds-icon clrVerticalNavIcon shape="bug"></cds-icon>
     Grass
   </a>
   <a clrVerticalNavLink routerLink="./fighting" routerLinkActive="active">
-    <clr-icon clrVerticalNavIcon shape="shield"></clr-icon>
+    <cds-icon clrVerticalNavIcon shape="shield"></cds-icon>
     Fighting
   </a>
   <a clrVerticalNavLink routerLink="./credit" routerLinkActive="active">
-    <clr-icon clrVerticalNavIcon shape="certificate"></clr-icon>
+    <cds-icon clrVerticalNavIcon shape="certificate"></cds-icon>
     Credit
   </a>
 </clr-vertical-nav>

--- a/apps/website/.vuepress/code/demos/vertical-nav/lazy-ng.html
+++ b/apps/website/.vuepress/code/demos/vertical-nav/lazy-ng.html
@@ -1,7 +1,7 @@
 <clr-vertical-nav [clrVerticalNavCollapsible]="demoCollapsible">
   <clr-vertical-nav-group routerLinkActive="active">
     <a routerLink="./normal" hidden aria-hidden="true"> </a>
-    <clr-icon shape="user" clrVerticalNavIcon></clr-icon>
+    <cds-icon shape="user" clrVerticalNavIcon></cds-icon>
     Normal
     <clr-vertical-nav-group-children *clrIfExpanded="true">
       <a clrVerticalNavLink routerLink="./normal/pidgey" routerLinkActive="active">
@@ -14,7 +14,7 @@
   </clr-vertical-nav-group>
   <clr-vertical-nav-group routerLinkActive="active">
     <a routerLink="./fire" hidden aria-hidden="true"> </a>
-    <clr-icon shape="flame" clrVerticalNavIcon></clr-icon>
+    <cds-icon shape="flame" clrVerticalNavIcon></cds-icon>
     Fire
     <clr-vertical-nav-group-children *clrIfExpanded>
       <a clrVerticalNavLink routerLink="./fire/charmander" routerLinkActive="active">
@@ -27,7 +27,7 @@
   </clr-vertical-nav-group>
   <clr-vertical-nav-group routerLinkActive="active">
     <a routerLink="./electric" hidden aria-hidden="true"> </a>
-    <clr-icon shape="bolt" clrVerticalNavIcon></clr-icon>
+    <cds-icon shape="bolt" clrVerticalNavIcon></cds-icon>
     Electric
     <clr-vertical-nav-group-children *clrIfExpanded>
       <a clrVerticalNavLink routerLink="./electric/pikachu" routerLinkActive="active">
@@ -39,7 +39,7 @@
     </clr-vertical-nav-group-children>
   </clr-vertical-nav-group>
   <a clrVerticalNavLink routerLinkActive="active" routerLink="./credit">
-    <clr-icon shape="certificate" clrVerticalNavIcon></clr-icon>
+    <cds-icon shape="certificate" clrVerticalNavIcon></cds-icon>
     Credit
   </a>
 </clr-vertical-nav>

--- a/apps/website/.vuepress/code/demos/vertical-nav/vertical-ng.html
+++ b/apps/website/.vuepress/code/demos/vertical-nav/vertical-ng.html
@@ -1,6 +1,6 @@
 <clr-vertical-nav [clrVerticalNavCollapsible]="demoCollapsible">
   <clr-vertical-nav-group routerLinkActive="active">
-    <clr-icon shape="user" clrVerticalNavIcon></clr-icon>
+    <cds-icon shape="user" clrVerticalNavIcon></cds-icon>
     Normal
     <clr-vertical-nav-group-children>
       <a clrVerticalNavLink routerLink="./normal/pidgey" routerLinkActive="active">
@@ -12,7 +12,7 @@
     </clr-vertical-nav-group-children>
   </clr-vertical-nav-group>
   <clr-vertical-nav-group routerLinkActive="active">
-    <clr-icon shape="flame" clrVerticalNavIcon></clr-icon>
+    <cds-icon shape="flame" clrVerticalNavIcon></cds-icon>
     Fire
     <clr-vertical-nav-group-children>
       <a clrVerticalNavLink routerLink="./fire/charmander" routerLinkActive="active">
@@ -24,7 +24,7 @@
     </clr-vertical-nav-group-children>
   </clr-vertical-nav-group>
   <clr-vertical-nav-group routerLinkActive="active">
-    <clr-icon shape="bolt" clrVerticalNavIcon></clr-icon>
+    <cds-icon shape="bolt" clrVerticalNavIcon></cds-icon>
     Electric
     <clr-vertical-nav-group-children>
       <a clrVerticalNavLink routerLink="./electric/pikachu" routerLinkActive="active">
@@ -36,7 +36,7 @@
     </clr-vertical-nav-group-children>
   </clr-vertical-nav-group>
   <a clrVerticalNavLink routerLinkActive="active" routerLink="./credit">
-    <clr-icon shape="certificate" clrVerticalNavIcon></clr-icon>
+    <cds-icon shape="certificate" clrVerticalNavIcon></cds-icon>
     Credit
   </a>
 </clr-vertical-nav>

--- a/apps/website/.vuepress/code/demos/wizard/basic-ng.html
+++ b/apps/website/.vuepress/code/demos/wizard/basic-ng.html
@@ -105,7 +105,7 @@
               [class.disabled]="icon === model.weakness"
               (click)="setPower(icon)"
             >
-              <clr-icon [attr.shape]="icon"></clr-icon>
+              <cds-icon [attr.shape]="icon"></cds-icon>
             </div>
           </div>
         </div>
@@ -136,7 +136,7 @@
               [class.disabled]="icon === model.power"
               (click)="setWeakness(icon)"
             >
-              <clr-icon [attr.shape]="icon"></clr-icon>
+              <cds-icon [attr.shape]="icon"></cds-icon>
             </div>
           </div>
         </div>

--- a/apps/website/.vuepress/sidebar.js
+++ b/apps/website/.vuepress/sidebar.js
@@ -114,8 +114,7 @@ module.exports = [
       },
       {
         title: 'Older Changelogs',
-        // external: true,
-        path: 'https://clarity.design/news',
+        path: 'https://v4.clarity.design/news',
         target: '_blank',
       },
     ],

--- a/apps/website/.vuepress/theme/components/Navbar.vue
+++ b/apps/website/.vuepress/theme/components/Navbar.vue
@@ -16,16 +16,6 @@
       <AlgoliaSearchBox v-if="isAlgoliaSearch" :options="algolia" />
       <SearchBox v-else-if="$site.themeConfig.search !== false && $page.frontmatter.search !== false" />
     </template>
-
-    <!--    <div class="settings">-->
-    <!--      <a-->
-    <!--        href="https://clarity.design"-->
-    <!--        class="btn btn-outline btn-inverse"-->
-    <!--        cds-layout="m-t:md display:none display@md:block"-->
-    <!--      >-->
-    <!--        Return to Current Website <clr-icon shape="pop-out"></clr-icon>-->
-    <!--      </a>-->
-    <!--    </div>-->
   </header>
 </template>
 

--- a/apps/website/.vuepress/theme/core.js
+++ b/apps/website/.vuepress/theme/core.js
@@ -23,7 +23,6 @@ import '@cds/core/time/register.js';
 import '@cds/core/toggle/register.js';
 
 import {
-  CdsIcon,
   ClarityIcons,
   linkIcon,
   fileIcon,
@@ -77,6 +76,3 @@ ClarityIcons.addIcons(
   copyToClipboardIcon
 );
 loadCoreIconSet();
-
-class LegacyIcon extends CdsIcon {}
-customElements.define('clr-icon', LegacyIcon);

--- a/apps/website/.vuepress/theme/global-components/DocAlertClassesTable.vue
+++ b/apps/website/.vuepress/theme/global-components/DocAlertClassesTable.vue
@@ -32,7 +32,7 @@
               .alert-icon-wrapper
             </th>
             <td class="left">
-              <span>.alert-icon-wrapper</span> contains a <span>clr-icon</span> with the classname
+              <span>.alert-icon-wrapper</span> contains a <span>cds-icon</span> with the classname
               <span>.alert-icon</span> applied to it. The icons used for the different alert types of success, danger,
               warning, and info are, respectively: <span>check-circle</span>, <span>exclamation-circle</span>,
               <span>exclamation-triangle</span>, and <span>info-circle</span>.

--- a/apps/website/.vuepress/theme/global-components/DocIcon.vue
+++ b/apps/website/.vuepress/theme/global-components/DocIcon.vue
@@ -10,7 +10,7 @@
     >
       <slot></slot> {{ iconName }} &nbsp;&nbsp;<cds-icon
         shape="new"
-        size="24"
+        size="md"
         style="--color: var(--cds-alias-status-alt);"
         v-if="isNew"
       ></cds-icon>

--- a/apps/website/.vuepress/theme/global-components/DocIconDetail.vue
+++ b/apps/website/.vuepress/theme/global-components/DocIconDetail.vue
@@ -20,7 +20,7 @@
               :class="{ active: variant === activeVariant }"
               @click="activateVariant(variant)"
             >
-              <cds-icon :shape="iconName" :solid="variant.solid" :badge="variant.badge" size="24"></cds-icon>
+              <cds-icon :shape="iconName" :solid="variant.solid" :badge="variant.badge" size="md"></cds-icon>
             </button>
           </div>
         </div>

--- a/apps/website/.vuepress/theme/global-components/DocIconsSearch.vue
+++ b/apps/website/.vuepress/theme/global-components/DocIconsSearch.vue
@@ -1,9 +1,9 @@
 <template>
   <section class="sticky">
     <label for="search-icons-sticky" class="searchbar-label">
-      <cds-icon class="search-icon" shape="search" size="24"></cds-icon>
+      <cds-icon class="search-icon" shape="search" size="md"></cds-icon>
       <button aria-label="close" class="close" type="button" @click="resetSearch()" :class="{ active: !!filterValue }">
-        <cds-icon shape="close" size="24"></cds-icon>
+        <cds-icon shape="close" size="md"></cds-icon>
       </button>
       <input
         placeholder="Search for Clarity Icons..."

--- a/apps/website/.vuepress/theme/global-components/DocIconsSet.vue
+++ b/apps/website/.vuepress/theme/global-components/DocIconsSet.vue
@@ -13,7 +13,7 @@
             :solid="hasSolid(icon)"
             :badge="canBadge(icon)"
             :shape="icon.iconName"
-            size="24"
+            size="md"
           ></cds-icon>
         </DocIcon>
         <DocIconDetail

--- a/apps/website/.vuepress/theme/global-components/DocModalWrapper.vue
+++ b/apps/website/.vuepress/theme/global-components/DocModalWrapper.vue
@@ -10,7 +10,7 @@
         <div class="modal-content">
           <div class="modal-header">
             <button aria-label="Close" class="close" type="button">
-              <clr-icon aria-hidden="true" shape="close"></clr-icon>
+              <cds-icon aria-hidden="true" shape="close"></cds-icon>
             </button>
             <h3 class="modal-title">I have a nice title</h3>
           </div>

--- a/apps/website/.vuepress/theme/global-components/DocPinbox.vue
+++ b/apps/website/.vuepress/theme/global-components/DocPinbox.vue
@@ -8,7 +8,7 @@
   <section>
     <div class="pinbox" cds-layout="horizontal align:vertical-stretch wrap:none" cds-text="body">
       <div class="pin" cds-layout="p-x:lg">
-        <cds-icon shape="pin" class="pin-icon" size="24"></cds-icon>
+        <cds-icon shape="pin" class="pin-icon" size="md"></cds-icon>
       </div>
       <div cds-layout="p:lg align:top">
         <slot></slot>

--- a/apps/website/.vuepress/theme/global-components/DocPinboxVs.vue
+++ b/apps/website/.vuepress/theme/global-components/DocPinboxVs.vue
@@ -2,7 +2,7 @@
   <section>
     <div class="pinbox" cds-layout="horizontal align:vertical-stretch wrap:none" cds-text="body">
       <div class="pin" cds-layout="p-x:lg">
-        <cds-icon shape="pin" class="pin-icon" size="24"></cds-icon>
+        <cds-icon shape="pin" class="pin-icon" size="md"></cds-icon>
       </div>
       <div cds-layout="p:lg align:top">
         <slot name="left">Left</slot>

--- a/apps/website/.vuepress/theme/global-components/Release.vue
+++ b/apps/website/.vuepress/theme/global-components/Release.vue
@@ -4,7 +4,7 @@
       <h2 class="sticky" cds-text="title" cds-layout="p-y:lg">
         {{ release.version }}
         <a class="release-date" :href="commitLink(release)" target="_blank">
-          Released {{ release.date }} <cds-icon class="external-link" size="12" shape="pop-out"></cds-icon>
+          Released {{ release.date }} <cds-icon class="external-link" size="sm" shape="pop-out"></cds-icon>
         </a>
       </h2>
       <p v-if="release.description" cds-text="body" cds-layout="m-t:xs m-b:lg">{{ release.description }}</p>

--- a/apps/website/.vuepress/theme/global-components/ReleaseItem.vue
+++ b/apps/website/.vuepress/theme/global-components/ReleaseItem.vue
@@ -15,7 +15,7 @@
     <td class="breaking"><span class="label label-danger" v-if="item.breaking">Breaking Change</span></td>
     <td class="left">
       <a v-if="item.issue" :href="issueLink" target="_blank"
-        >#{{ item.issue }} <cds-icon class="external-link" size="12" shape="pop-out"></cds-icon
+        >#{{ item.issue }} <cds-icon class="external-link" size="sm" shape="pop-out"></cds-icon
       ></a>
     </td>
   </tr>

--- a/apps/website/.vuepress/theme/layouts/Layout.vue
+++ b/apps/website/.vuepress/theme/layouts/Layout.vue
@@ -11,7 +11,7 @@
           @click="toggleSidebar()"
           aria-label="Open side navigation"
         >
-          <cds-icon class="hamburger-icon" shape="bars" size="24" inverse></cds-icon>
+          <cds-icon class="hamburger-icon" shape="bars" size="md" inverse></cds-icon>
         </button>
       </template>
     </Navbar>

--- a/apps/website/.vuepress/theme/styles/overrides.scss
+++ b/apps/website/.vuepress/theme/styles/overrides.scss
@@ -53,31 +53,31 @@ div[class^='language-'] pre {
 }
 
 // Override icons in header
-.header-1 clr-icon,
-.header-2 clr-icon,
-.header-3 clr-icon,
-.header-4 clr-icon,
-.header-5 clr-icon,
-.header-6 clr-icon {
+.header-1 cds-icon,
+.header-2 cds-icon,
+.header-3 cds-icon,
+.header-4 cds-icon,
+.header-5 cds-icon,
+.header-6 cds-icon {
   --color: var(--clr-header-title-color);
   opacity: 1;
 }
 
 // Override icons in buttons
-.btn-primary.btn-icon clr-icon {
+.btn-primary.btn-icon cds-icon {
   --color: var(--clr-btn-primary-color, #fff);
 }
-.btn-icon clr-icon {
+.btn-icon cds-icon {
   --color: var(--clr-btn-default-color, #0072a3);
 }
-.btn-danger.btn-icon clr-icon,
-.btn-warning.btn-icon clr-icon {
+.btn-danger.btn-icon cds-icon,
+.btn-warning.btn-icon cds-icon {
   --color: var(--clr-btn-default-color, #0072a3);
 }
-.btn-success.btn-icon clr-icon {
+.btn-success.btn-icon cds-icon {
   --color: var(--clr-btn-success-color, #fff);
 }
-.btn-icon[disabled] clr-icon {
+.btn-icon[disabled] cds-icon {
   --color: var(--clr-btn-icon-disabled-color, #666);
 }
 

--- a/apps/website/angular-components/badge/README.md
+++ b/apps/website/angular-components/badge/README.md
@@ -28,7 +28,7 @@ Badges have a colorful, bold, and filled style that makes them stand out when ap
 <section class="inline-code">
     <div role="treeitem" tabindex="0" class="clr-tree-node-content-container" aria-expanded="false">
         <button aria-hidden="true" type="button" tabindex="-1" class="clr-treenode-caret">
-            <clr-icon shape="caret" class="clr-treenode-caret-icon" role="none" dir="right"></clr-icon>
+            <cds-icon shape="caret" direction="right" role="none"></cds-icon>
         </button>
         <div class="clr-treenode-content">
         <div class="margin-right-0_25">Inbox&nbsp;</div>
@@ -37,7 +37,7 @@ Badges have a colorful, bold, and filled style that makes them stand out when ap
     </div>
     <div role="treeitem" tabindex="0" class="clr-tree-node-content-container" aria-expanded="false">
         <button aria-hidden="true" type="button" tabindex="-1" class="clr-treenode-caret">
-            <clr-icon shape="caret" class="clr-treenode-caret-icon" role="none" dir="right"></clr-icon>
+            <cds-icon shape="caret" direction="right" role="none"></cds-icon>
         </button>
         <div class="clr-treenode-content">
         <div class="margin-right-0_25">Folders&nbsp;</div>

--- a/apps/website/angular-components/button/README.md
+++ b/apps/website/angular-components/button/README.md
@@ -65,7 +65,7 @@ There are two distinct patterns when it comes to the placement of a button.
 
 The Z-pattern is a natural way for the user to go through content within a **constrained container** and when tasks are oriented from the top-left and ending with a **primary call to action on the right bottom side** of the container. This pattern is reversed for right to left languages.
 
-<cds-icon shape="bookmark" size="24"></cds-icon> Modals and Wizards follow the Z Pattern
+<cds-icon shape="bookmark" size="md"></cds-icon> Modals and Wizards follow the Z Pattern
 
 </div>
 
@@ -78,7 +78,7 @@ The Z-pattern is a natural way for the user to go through content within a **con
 
 The F-pattern is a natural way to go through content in an **unconstrained container**, such as a form on the page itself. The user will go through the content line-by-line, arriving at a call to action at the end.
 
-<cds-icon shape="bookmark" size="24"></cds-icon> Forms and Cards follow the F Pattern
+<cds-icon shape="bookmark" size="md"></cds-icon> Forms and Cards follow the F Pattern
 
 </div>
 </div>
@@ -163,18 +163,18 @@ We recommend you **choose an icon that best describes the action** that the user
 
 <div class="clr-col-sm-12 clr-col-lg-6 doc-do">
 <div class="doc-example">
-<button class="btn btn-primary btn-icon" style="margin-right: 0.6rem"><clr-icon shape="check"></clr-icon></button>
-<button class="btn btn-icon" style="margin-right: 0.6rem"><clr-icon shape="folder"></clr-icon></button>
-<button class="btn btn-icon btn-link"><clr-icon shape="cog"></clr-icon></button>
+<button class="btn btn-primary btn-icon" style="margin-right: 0.6rem"><cds-icon shape="check"></cds-icon></button>
+<button class="btn btn-icon" style="margin-right: 0.6rem"><cds-icon shape="folder"></cds-icon></button>
+<button class="btn btn-icon btn-link"><cds-icon shape="cog"></cds-icon></button>
 </div>
 Icon buttons are available in the solid, outline, and flat types. It’s also best to use the normal (36px) sized ones. This makes them easier to recognize and to click.
 </div>
 
 <div class="clr-col-sm-12 clr-col-lg-6 doc-dont">
 <div class="doc-example">
-<button class="btn btn-sm btn-primary btn-icon" style="margin-right: 0.6rem"><clr-icon shape="check"></clr-icon></button>
-<button class="btn btn-sm btn-icon" style="margin-right: 0.6rem"><clr-icon shape="folder"></clr-icon></button>
-<button class="btn btn-icon btn-sm btn-link"><clr-icon shape="cog"></clr-icon></button>
+<button class="btn btn-sm btn-primary btn-icon" style="margin-right: 0.6rem"><cds-icon shape="check"></cds-icon></button>
+<button class="btn btn-sm btn-icon" style="margin-right: 0.6rem"><cds-icon shape="folder"></cds-icon></button>
+<button class="btn btn-icon btn-sm btn-link"><cds-icon shape="cog"></cds-icon></button>
 </div>
 Use small icon buttons in most cases. They are difficult to see and distinguish what the icon is or represents. They also create smaller click targets, making them harder to click.
 </div>

--- a/apps/website/angular-components/datagrid/README.md
+++ b/apps/website/angular-components/datagrid/README.md
@@ -636,20 +636,20 @@ Depending on the role of certain batch actions, you can choose to break button b
   <clr-dg-action-bar>
     <div class="btn-group">
       <button type="button" class="btn btn-sm btn-secondary" (click)="onAdd()">
-        <clr-icon shape="plus"></clr-icon> Add to group
+        <cds-icon shape="plus"></cds-icon> Add to group
       </button>
       <button type="button" class="btn btn-sm btn-secondary" (click)="onDelete()">
-        <clr-icon shape="close"></clr-icon> Delete
+        <cds-icon shape="close"></cds-icon> Delete
       </button>
       <button type="button" class="btn btn-sm btn-secondary" (click)="onEdit()" *ngIf="selected.length == 1">
-        <clr-icon shape="pencil"></clr-icon> Edit
+        <cds-icon shape="pencil"></cds-icon> Edit
       </button>
     </div>
     <div class="btn-group">
       <clr-dropdown>
         <button type="button" class="btn btn-sm btn-secondary" clrDropdownTrigger>
           Export
-          <clr-icon shape="caret down"></clr-icon>
+          <cds-icon shape="caret down"></cds-icon>
         </button>
         <clr-dropdown-menu clrPosition="bottom-left" *clrIfOpen>
           <button type="button" (click)="onExportAll()" clrDropdownItem>Export All</button>

--- a/apps/website/angular-components/datagrid/api.md
+++ b/apps/website/angular-components/datagrid/api.md
@@ -55,7 +55,7 @@ operate on a single row item.
   <clr-dg-row *clrDgItems="let item of items" [clrDgItem]="item">
     <clr-dg-action-overflow (clrDgActionOverflowOpenChange)="openChangeFn($event)">
       <button class="action-item">
-        <clr-icon shape="note"></clr-icon>
+        <cds-icon shape="note"></cds-icon>
         Action
       </button>
     </clr-dg-action-overflow>

--- a/apps/website/angular-components/dropdown/README.md
+++ b/apps/website/angular-components/dropdown/README.md
@@ -99,18 +99,7 @@ If screen space isn’t available to the right of the root menu, the nested menu
 
 ## Accessibility
 
-<div class="alert alert-warning" role="alert">
-    <div class="alert-items">
-      <div class="alert-item static">
-        <div class="alert-icon-wrapper">
-          <clr-icon class="alert-icon" shape="exclamation-circle"></clr-icon>
-        </div>
-        <span class="alert-text">
-          Clarity static (HTML/CSS) component does not come pre-baked with all the necessary ARIA attributes. The application developer should follow the guidelines below in their implementation.
-        </span>
-      </div>
-    </div>
-</div>
+<DocAlert :actionPop="true" status="warning">Clarity static (HTML/CSS) component does not come pre-baked with all the necessary ARIA attributes. The application developer should follow the guidelines below in their implementation.</DocAlert>
 
 Clarity Angular component follows these guidelines:
 

--- a/apps/website/angular-components/input/README.md
+++ b/apps/website/angular-components/input/README.md
@@ -33,7 +33,7 @@ Horizontal formats are good for the quick scanning of labels, and can be used in
     <div class="clr-control-container">
       <div class="clr-input-wrapper">
         <input type="text" id="demo7" placeholder="Enter value here" class="clr-input">
-        <clr-icon class="clr-validate-icon" shape="exclamation-circle"></clr-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -53,7 +53,7 @@ This option is better for scanning, mobile experiences, accessibility, and local
     <div class="clr-control-container">
       <div class="clr-input-wrapper">
         <input type="text" id="demo6" placeholder="Enter value here" class="clr-input">
-        <clr-icon class="clr-validate-icon" shape="exclamation-circle"></clr-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -73,7 +73,7 @@ For cases with highly limited space, we provide a compact form layout.
     <div class="clr-control-container">
       <div class="clr-input-wrapper">
         <input type="text" id="demo5" placeholder="Enter value here" class="clr-input">
-        <clr-icon class="clr-validate-icon" shape="exclamation-circle"></clr-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>

--- a/apps/website/angular-components/label/README.md
+++ b/apps/website/angular-components/label/README.md
@@ -107,8 +107,8 @@ A label can be dismissed. Use a close icon at the right-most side of a label to 
 </div>
 <div class="clr-col">
 <div class="doc-wrapper" cds-layout="m-t:lg">
-<a href="javascript://" class="label label-blue clickable">james@test.com <clr-icon shape="close"></clr-icon></a>
-<a href="javascript://" class="label label-blue clickable">jimmy@test.com <clr-icon shape="close"></clr-icon></a>
+<a href="javascript://" class="label label-blue clickable">james@test.com <cds-icon shape="close"></cds-icon></a>
+<a href="javascript://" class="label label-blue clickable">jimmy@test.com <cds-icon shape="close"></cds-icon></a>
 </div>
 </div>
 </div>

--- a/apps/website/angular-components/sidenav/README.md
+++ b/apps/website/angular-components/sidenav/README.md
@@ -7,7 +7,7 @@ toc: true
     <div class="alert-items">
         <div class="alert-item static" role="alert">
             <div class="alert-icon-wrapper">
-                <clr-icon class="alert-icon" shape="exclamation-circle"></clr-icon>
+                <cds-icon class="alert-icon" shape="exclamation-circle"></cds-icon>
             </div>
             <span class="alert-text">
                 Sidenav has been deprecated but does not have a targeted version for removal. The recommendation for this pattern is to use the <a href="/angular-components/vertical-nav/">vertical nav</a> component.

--- a/apps/website/angular-components/timeline/README.md
+++ b/apps/website/angular-components/timeline/README.md
@@ -77,11 +77,11 @@ It is optional to have a step description that offers additional information and
 
 Every timeline step has one of five steps. With one exception these steps are represented with a Clarity Icon. The exception is for loading state which uses the clr-spinner component.
 
-- <cds-icon size="36" shape="success-standard" aria-label="Success">Success</cds-icon> Step complete uses the success-standard shape
-- <cds-icon size="36" shape="dot-circle" aria-label="Current step">Success</cds-icon> Current step uses the dot-circle shape
-- <cds-icon size="36" shape="circle" aria-label="Not started">Success</cds-icon> Not started, available to start uses the circle shape
+- <cds-icon size="lg" shape="success-standard" aria-label="Success">Success</cds-icon> Step complete uses the success-standard shape
+- <cds-icon size="lg" shape="dot-circle" aria-label="Current step">Success</cds-icon> Current step uses the dot-circle shape
+- <cds-icon size="lg" shape="circle" aria-label="Not started">Success</cds-icon> Not started, available to start uses the circle shape
 - <span class="spinner demo-spinner">Loading...</span> Processing user initiated action uses the clr-spinner (w/ clrMedium size) component
-- <cds-icon size="36" shape="error-standard" aria-label="Error" class="is-error" role="none">Success</cds-icon> Error completing step uses the error shape
+- <cds-icon size="lg" shape="error-standard" aria-label="Error" class="is-error" role="none">Success</cds-icon> Error completing step uses the error shape
 
 ## Behavior
 

--- a/apps/website/angular-components/tooltip/api.md
+++ b/apps/website/angular-components/tooltip/api.md
@@ -53,7 +53,7 @@ Used to designate the open/close element for [ClrTooltipContent](./api/#clrtoolt
 
 ```html
 <clr-tooltip>
-  <clr-icon shape="help" clrTooltipTrigger></clr-icon>
+  <cds-icon shape="help" clrTooltipTrigger></cds-icon>
   <!-- clr-tooltip-content -->
 </clr-tooltip>
 ```

--- a/apps/website/angular-components/tree-view/api.md
+++ b/apps/website/angular-components/tree-view/api.md
@@ -53,7 +53,7 @@ Use our `*clrIfExpanded` structural directive to lazy-load node children.
 ```html
 <clr-tree [clrLazy]="true">
   <clr-tree-node [clrLoading]="loading">
-    <clr-icon shape="building"></clr-icon>
+    <cds-icon shape="building"></cds-icon>
     Office Locations
     <ng-template clrIfExpanded (clrIfExpandedChange)="$event ? fetchLocations() : null">
       <clr-tree-node *ngFor="let location of locations$ | async">

--- a/apps/website/angular-components/vertical-nav/README.md
+++ b/apps/website/angular-components/vertical-nav/README.md
@@ -95,7 +95,7 @@ Hierarchy is used to show parent-child relationship between links. If a child li
     <div class="alert-items">
         <div class="alert-item static" role="alert">
             <div class="alert-icon-wrapper">
-                <clr-icon class="alert-icon" shape="exclamation-circle"></clr-icon>
+                <cds-icon class="alert-icon" shape="exclamation-circle"></cds-icon>
             </div>
             <span class="alert-text">
                 If you need a summary or overview-type landing page for a link group, we recommend you make it as your first child link.

--- a/apps/website/angular-components/vertical-nav/api.md
+++ b/apps/website/angular-components/vertical-nav/api.md
@@ -51,7 +51,7 @@ toc: true
 ```html
 <clr-vertical-nav>
   <clr-vertical-nav-group>
-    <clr-icon shape="user" clrVerticalNavIcon></clr-icon>
+    <cds-icon shape="user" clrVerticalNavIcon></cds-icon>
     Users
     <clr-vertical-nav-group-children>
       <!-- clrVerticalNavLink elements as needed -->
@@ -92,11 +92,11 @@ toc: true
 ```html
 <clr-vertical-nav>
   <a clrVerticalNavLink routerLink="./users/1">
-    <clr-icon shape="user" clrVerticalNavIcon></clr-icon>
+    <cds-icon shape="user" clrVerticalNavIcon></cds-icon>
     User One
   </a>
   <a clrVerticalNavLink routerLink="./users/2">
-    <clr-icon shape="user" clrVerticalNavIcon></clr-icon>
+    <cds-icon shape="user" clrVerticalNavIcon></cds-icon>
     User Two
   </a>
 </clr-vertical-nav>

--- a/apps/website/angular-components/wizard/api.md
+++ b/apps/website/angular-components/wizard/api.md
@@ -59,7 +59,7 @@ toc: true
 <clr-wizard #wizardReference>
   <!-- clr-wizard-title -->
   <clr-wizard-header-action>
-    <clr-icon shape="cloud" class="is-solid"></clr-icon>
+    <cds-icon shape="cloud" class="is-solid"></cds-icon>
   </clr-wizard-header-action>
   <!-- clr-wizard-button components as needed -->
 </clr-wizard>


### PR DESCRIPTION
- update code demos with cds-icon and check API changes
- update demos with cds-icon and check API changes
- Update Usage guidelines and inline html for cds-icon and API changes
- Update theme templates for cds-icons and API changes
- fix the 'Older changelogs' sidenav link and point it to the v4.clarity.design/news page

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?
Remove clr-icon and replace with cds-icon.

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently website theme and content and demos have mixed usage of cds-icon and clr-icon. 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Remove clr-icon and update site code for cds-icon.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
