### PR TITLE
docs: remove CSS override for `cds-text="code"` example

### DIFF
--- a/packages/core/.storybook/public/demo.css
+++ b/packages/core/.storybook/public/demo.css
@@ -158,13 +158,6 @@ cds-card {
   background: transparent !important;
 }
 
-.sbdocs p code,
-.sbdocs li code {
-  color: var(--cds-global-typography-color-500) !important;
-  background-color: var(--cds-alias-object-app-background) !important;
-  border: 0 !important;
-}
-
 .docs-story > div:last-child button {
   background: var(--cds-alias-object-container-background) !important;
   color: var(--cds-global-typography-color-500) !important;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

I started using `cds-text="code"` from https://clarity.design/storybook/core/?path=/story/foundation-typography--page (using Clarity Core v5.1.1) and was initially very confused why my text was showing up in red, while Storybook displayed it in normal text color:

<img width="1021" alt="Screen Shot 2021-04-11 at 6 48 25 PM" src="https://user-images.githubusercontent.com/113730/114313449-3dda8080-9aff-11eb-8937-f2191ee9067d.png">
<img width="1031" alt="Screen Shot 2021-04-11 at 6 48 32 PM" src="https://user-images.githubusercontent.com/113730/114313451-42069e00-9aff-11eb-9091-b9d09dbd0092.png">

## What is the new behavior?

I think it would be a better idea to show exactly what the style is going to be to avoid confusion and set the correct expectations:

<img width="1034" alt="Screen Shot 2021-04-11 at 6 46 55 PM" src="https://user-images.githubusercontent.com/113730/114313569-b2152400-9aff-11eb-94c7-2af4fed97e33.png">
<img width="1027" alt="Screen Shot 2021-04-11 at 6 47 03 PM" src="https://user-images.githubusercontent.com/113730/114313574-b4777e00-9aff-11eb-8907-4ac8a3d9b959.png">

⚠️ I am not sure what other pages are impacted from this. I did a little bit of search and nothing obvious jumped out.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] Maybe in other stories (if so, docs only, no API breaking change)
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

