### PR TITLE
docs: fix Modal binding description in the API docs

### DIFF
--- a/apps/website/data/angular-api.json
+++ b/apps/website/data/angular-api.json
@@ -2234,11 +2234,11 @@
       },
       {
         "name": "clrModalSkipAnimation",
-        "accepts": "boolean",
+        "accepts": "string",
         "type": "input",
-        "options": "true, false",
-        "description": "WHen true the modal will not animate opening and closing.",
-        "default": "false"
+        "options": "the strings \"true\" and \"false\"",
+        "description": "When \"true\" the modal will not animate opening and closing.",
+        "default": "\"false\""
       }
     ],
     "methods": [


### PR DESCRIPTION

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The API incorrectly lists the `clrModalSkipAnimation` binding as `boolean` type. In fact, the property's of type `string`.

<img width="910" alt="Screenshot 2021-04-12 at 10 32 02" src="https://user-images.githubusercontent.com/7893485/114357358-5340c080-9b7a-11eb-8662-be49d0f78728.png">

Issue Number: ##5825

## What is the new behavior?

The binding's type is updated in the API docs:

<img width="910" alt="Screenshot 2021-04-12 at 10 32 39" src="https://user-images.githubusercontent.com/7893485/114357446-694e8100-9b7a-11eb-9729-c7927e3f52f4.png">


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
