### PR TITLE
fix: deprecated warning in dark theme

### DIFF
--- a/packages/angular/projects/clr-angular/src/utils/_theme.dark.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/utils/_theme.dark.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -470,7 +470,7 @@ $clr-combobox-input-background-color: hsl(198, 28%, 18%);
 $clr-combobox-pill-background-color: hsl(201, 30%, 15%);
 $clr-combobox-pill-border-color: hsl(208, 16%, 34%);
 $clr-combobox-pill-font-color: hsl(0, 0%, 75%);
-$clr-combobox-filter-highlight: hsl(198, 16, 93%);
+$clr-combobox-filter-highlight: hsl(198, 16%, 93%);
 
 /**********
   * Header
@@ -555,7 +555,7 @@ $clr-login-background: '%3C%3Fxml%20version%3D%221.0%22%20encoding%3D%22UTF-8%22
   */
 $clr-modal-close-color: hsl(203, 16%, 72%);
 $clr-modal-bg-color: hsl(198, 28%, 18%);
-$clr-modal-backdrop-color: hsla(0, 0, 0, 0.85);
+$clr-modal-backdrop-color: hsla(0, 0%, 0%, 0.85);
 // END Modal
 
 /***************


### PR DESCRIPTION
Since saas v1.32.0 using hsl() without % sign has been deprecated and warnings output. From saas 2.0 this will result in errors.
Fixing three places (two lines) where we needed to add the missing % sign. We already had it in most places, which is good.

Close: #5833

Signed-off-by: Ron Birk <rbirk@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Have compile warnings

Issue Number: 5833

## What is the new behavior?

No compile warnings

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

