### PR TITLE
fix(icons): fix the size of clr-icons positioned inside small buttons

### DIFF
--- a/packages/angular/projects/clr-angular/src/button/_buttons.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/button/_buttons.clarity.scss
@@ -374,7 +374,8 @@
 
   //Small Icon Button
   .btn-sm:not(.btn-link) {
-    cds-icon {
+    cds-icon,
+    clr-icon {
       @include css-var(width, clr-btn-appearance-standard-icon-size, $clr_baselineRem_0_5, $clr-use-custom-properties);
       @include css-var(height, clr-btn-appearance-standard-icon-size, $clr_baselineRem_0_5, $clr-use-custom-properties);
       transform: translate3d(0, -1 * $clr_baselineRem_1px, 0);


### PR DESCRIPTION
Signed-off-by: Stanimira Vlaeva <stanimira.vlaeva@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The style that makes the icon smaller when nested inside a small button is applied only to `cds-icon`s:

```
  .btn-sm:not(.btn-link) {
    cds-icon {
      @include css-var(width, clr-btn-appearance-standard-icon-size, $clr_baselineRem_0_5, $clr-use-custom-properties);
      @include css-var(height, clr-btn-appearance-standard-icon-size, $clr_baselineRem_0_5, $clr-use-custom-properties);
      transform: translate3d(0, -1 * $clr_baselineRem_1px, 0);
    }
  }

```

Issue Number: #5832

## What is the new behavior?

The style is now applied to both `cds-icon`s and `clr-icon`s:

```
  .btn-sm:not(.btn-link) {
    cds-icon,
    clr-icon {
      @include css-var(width, clr-btn-appearance-standard-icon-size, $clr_baselineRem_0_5, $clr-use-custom-properties);
      @include css-var(height, clr-btn-appearance-standard-icon-size, $clr_baselineRem_0_5, $clr-use-custom-properties);
      transform: translate3d(0, -1 * $clr_baselineRem_1px, 0);
    }
  }
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
