### PR TITLE
chore(modal): remove vestigal overlayIsActive getter and related test

### DIFF
--- a/packages/core/src/internal-components/overlay/overlay.element.ts
+++ b/packages/core/src/internal-components/overlay/overlay.element.ts
@@ -171,10 +171,6 @@ export class CdsInternalOverlay extends CdsBaseFocusTrap implements Animatable {
     `;
   }
 
-  get overlayIsActive() {
-    return FocusTrapTracker.getCurrentTrapId() === this.focusTrapId;
-  }
-
   protected fireEventOnBackdropClick = () => {
     if (overlayIsActive(this.focusTrapId)) {
       this.closeOverlay('backdrop-click');


### PR DESCRIPTION
Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been ~added~updated (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
There is a public property for the internal overlay component that is showing up in the modal component documentation. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
This change removes the `overlayIsActive` getter which is no longer used in the internal core overlay component. (The internal component exports a helper util function. The result is that the modal API should no longer show this on the website. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
