### PR TITLE
chore: fix dark theme config in Angular dev app

### DIFF
--- a/packages/angular/angular.json
+++ b/packages/angular/angular.json
@@ -208,7 +208,7 @@
             "dark": {
               "styles": [
                 "projects/clr-angular/src/dark-theme.scss",
-                "../icons/src/clr-icons.scss",
+                "node_modules/@clr/icons/clr-icons.min.css",
                 "projects/dev/src/styles.scss"
               ],
               "fileReplacements": [


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Starting the dev app in dark mode (`yarn serve:dark`) fails with:

```
Error: ../icons/src/clr-icons.scss
Module build failed (from ./node_modules/mini-css-extract-plugin/dist/loader.js):
ModuleError: Module Error (from ./node_modules/@angular-devkit/build-angular/node_modules/postcss-loader/dist/cjs.js):
Loading PostCSS "" parser failed: The argument 'id' must be a non-empty string. Received ''
```

Issue Number: N/A

## What is the new behavior?

Starting the dev app in dark mode works fine. Thanks, @bdryanovski for providing the solution!

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

