### PR TITLE
fix: core accordion header layout overflow

### DIFF
--- a/packages/core/src/accordion/accordion-header.element.scss
+++ b/packages/core/src/accordion/accordion-header.element.scss
@@ -14,6 +14,7 @@
   --icon-transform: rotate(90deg);
   cursor: pointer;
   width: 100%;
+  contain: inherit;
 }
 
 .private-host {


### PR DESCRIPTION
  - allow layout overflow for positioning content items in cds accordion headers (same fix for content and panel was applied in #5710)

Signed-off-by: Devin Nguyen <devin@cloudhealthtech.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Similar change that was introduced in https://github.com/vmware/clarity/commit/3e5b965292405605b9fd5b8014dfcb66a293edae for https://github.com/vmware/clarity/pull/5713 to fix Accordion content overflow, but the change was only made for Accordion Panel and Accordion Content. This adds the same fix for the Accordion Header element.
