### PR TITLE
fix: update dark theme border and box shadow sizes to match the light theme

### DIFF
--- a/packages/angular/projects/clr-angular/src/utils/_theme.dark.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/utils/_theme.dark.clarity.scss
@@ -35,6 +35,27 @@
 $clr-use-custom-properties: false;
 
 /*********
+ * Baseline Rem Variables
+ */
+
+$clr-baseline-int: 24 !default; // used by design for relational sizing
+$clr-baseline-denominator: 20 !default; // used in code to reduce impact of browser rounding
+
+@function convertBaselineToBase20($size: 24) {
+  $clr-baseline-to-basefontsize-multiplier: $clr-baseline-int/$clr-baseline-denominator;
+  @return $size/$clr-baseline-int * $clr-baseline-to-basefontsize-multiplier * 1rem;
+}
+
+// Core rem values
+$clr_baselineRem_0_125: convertBaselineToBase20(3); // 3px
+$clr_baselineRem_0_25: convertBaselineToBase20(6); // 6px
+$clr_baselineRem_0_5: convertBaselineToBase20(12); // 12px
+
+// Pixel-based utilities
+$clr_baselineRem_1px: convertBaselineToBase20(1);
+$clr_baselineRem_2px: convertBaselineToBase20(2);
+
+/*********
  * $clr-global-app-background
  * Change the background for the clarity application.
  * Usage: clarity-root/src/clr-angular/layout/main-container/_layout.clarity.scss
@@ -333,7 +354,7 @@ $clr-btn-inverse-disabled-border-color: $clr-btn-disabled-border-color; // disab
 $clr-card-bg-color: hsl(198, 28%, 18%);
 $clr-card-border-color: hsl(203, 30%, 8%);
 $clr-card-title-color: hsl(210, 16%, 93%);
-$clr-card-box-shadow: 0 0.15rem 0 0 $clr-card-border-color;
+$clr-card-box-shadow: 0 $clr_baselineRem_0_125 0 0 $clr-card-border-color;
 $clr-card-divider-color: $clr-card-border-color;
 // END: Card
 
@@ -446,7 +467,7 @@ $clr-forms-select-option-color: hsl(201, 30%, 13%); // Option bg color on chrome
 // Checkbox
 $clr-forms-checkbox-label-color: hsl(203, 16%, 72%);
 $clr-forms-checkbox-background-color: hsl(198, 65%, 57%); // Use color here
-$clr-forms-checkbox-checked-shadow: inset 0 0 0 0.3rem $clr-forms-checkbox-background-color;
+$clr-forms-checkbox-checked-shadow: inset 0 0 0 $clr_baselineRem_0_25 $clr-forms-checkbox-background-color;
 $clr-forms-checkbox-indeterminate-border-color: hsl(203, 16%, 72%);
 $clr-forms-checkbox-mark-color: hsl(0, 0%, 0%);
 $clr-forms-checkbox-disabled-background-color: hsl(204, 10%, 60%);
@@ -455,7 +476,7 @@ $clr-forms-checkbox-disabled-mark-color: hsl(0, 0%, 0%);
 // Radio
 $clr-forms-radio-label-color: hsl(203, 16%, 72%);
 $clr-forms-radio-selected-shadow: $clr-forms-checkbox-checked-shadow;
-$clr-forms-radio-focused-shadow: 0 0 0.1rem 0.1rem $clr-link-active-color;
+$clr-forms-radio-focused-shadow: 0 0 $clr_baselineRem_2px $clr_baselineRem_2px $clr-link-active-color;
 $clr-forms-radio-disabled-background-color: hsl(0, 0%, 0%);
 $clr-forms-radio-disabled-mark-color: $clr-forms-checkbox-disabled-mark-color;
 $clr-forms-radio-disabled-shadow: $clr-forms-checkbox-checked-shadow;
@@ -591,7 +612,7 @@ $clr-sidenav-border-color: hsl(200, 30%, 12%);
 $clr-sidenav-link-hover-color: $clr-global-selection-color;
 
 $clr-subnav-bgColor: hsl(201, 30%, 13%);
-$clr-nav-shadow: 0 -0.05rem 0 hsl(208, 16%, 34%) inset;
+$clr-nav-shadow: 0 (-1 * $clr_baselineRem_1px) 0 hsl(208, 16%, 34%) inset;
 // END Nav
 
 /**************
@@ -618,7 +639,7 @@ $clr-signpost-action-color: hsl(210, 16%, 93%);
 $clr-signpost-action-hover-color: hsl(198, 65%, 57%);
 $clr-signpost-content-bg-color: hsl(198, 28%, 18%);
 $clr-signpost-content-border-color: hsl(0, 0%, 0%);
-$clr-signpost-border-size: 0.5rem;
+$clr-signpost-border-size: $clr_baselineRem_0_5;
 $clr-signpost-pointer-border: $clr-signpost-border-size solid $clr-signpost-content-border-color;
 $clr-signpost-pointer-invisible-border: $clr-signpost-border-size solid transparent;
 $clr-signpost-pointer-psuedo-border: $clr-signpost-border-size solid $clr-signpost-content-bg-color;
@@ -679,7 +700,7 @@ $clr-table-footer-border-top-color: $clr-datagrid-default-border-color;
 $clr-tablerow-bordercolor: $clr-datagrid-default-border-color;
 $clr-table-border-color: $clr-datagrid-default-border-color;
 $clr-table-bordercolor: $clr-datagrid-default-border-color;
-$clr-table-borderstyle: 0.05rem solid $clr-datagrid-default-border-color;
+$clr-table-borderstyle: $clr_baselineRem_1px solid $clr-datagrid-default-border-color;
 // END: Table
 
 /**********


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The dark theme uses old rem sizes.

Issue Number: #5837

## What is the new behavior?

The dark theme uses the same rem variables as the light theme.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
