### PR TITLE
fix: use css var in nav styles to enable theming

### DIFF
--- a/packages/angular/projects/clr-angular/src/layout/nav/_nav.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/layout/nav/_nav.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -8,10 +8,14 @@
     height: $clr-subnav-height;
     list-style-type: none;
     align-items: center;
-    box-shadow: 0 (-1 * $clr_baselineRem_1px) 0 $clr-nav-box-shadow-color inset;
     margin: 0;
     width: 100%;
     white-space: nowrap;
+    // OldIE/Edge
+    box-shadow: 0 (-1 * $clr_baselineRem_1px) 0 $clr-nav-box-shadow-color inset;
+    @if $clr-use-custom-properties == true {
+      box-shadow: 0 (-1 * $clr_baselineRem_1px) 0 var(--clr-nav-box-shadow-color, $clr-nav-box-shadow-color) inset;
+    }
 
     .nav-item {
       display: inline-block;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The nav style's not using a css variable for `box-shadow`.

Issue Number: #5841

## What is the new behavior?

The nav style now uses a css variable for that property.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
