### PR TITLE
feat(button): use bright colors on dark theme for inverse button

### DIFF
--- a/packages/core/src/button/base-button.element.scss
+++ b/packages/core/src/button/base-button.element.scss
@@ -154,7 +154,7 @@
 }
 
 :host([status='inverse']) {
-  --color: #{$cds-global-typography-color-100};
+  --color: #{$cds-global-color-white};
   --background: #{$cds-alias-object-opacity-0};
   --border-color: var(--color);
 }
@@ -206,6 +206,12 @@
 :host([disabled][action='flat']) {
   --border-color: #{$cds-alias-object-opacity-0};
   --background: #{$cds-alias-object-opacity-0};
+}
+
+:host([disabled][status='inverse']) {
+  --background: #{$cds-alias-object-opacity-0};
+  --border-color: #{$cds-global-color-construction-700};
+  --color: #{$cds-global-color-construction-600};
 }
 
 :host([block]) {

--- a/packages/core/src/button/button.element.scss
+++ b/packages/core/src/button/button.element.scss
@@ -61,9 +61,9 @@
 }
 
 :host([status='inverse']) ::slotted(cds-badge) {
-  --border-color: #{$cds-global-typography-color-100} !important;
+  --border-color: #{$cds-global-color-white} !important;
   --background: #{$cds-alias-object-opacity-0} !important;
-  --color: #{$cds-global-typography-color-100} !important;
+  --color: #{$cds-global-color-white} !important;
   --font-weight: #{$cds-global-typography-font-weight-semibold} !important;
 }
 

--- a/packages/core/src/button/button.stories.mdx
+++ b/packages/core/src/button/button.stories.mdx
@@ -43,6 +43,12 @@ import '@cds/core/button/register.js';
   <Story id="stories-button--status-outline" />
 </Preview>
 
+## Status Inverse
+
+<Preview>
+  <Story id="stories-button--status-inverse" />
+</Preview>
+
 ## Icon With Text
 
 <cds-alert status="info">

--- a/packages/core/src/button/button.stories.ts
+++ b/packages/core/src/button/button.stories.ts
@@ -86,9 +86,6 @@ export function status() {
       <cds-button status="danger">danger</cds-button>
       <cds-button status="neutral">neutral</cds-button>
       <cds-button disabled>disabled</cds-button>
-      <div style="background: var(--cds-global-typography-color-500)" cds-layout="p:sm">
-        <cds-button status="inverse">inverse</cds-button>
-      </div>
     </div>
   `;
 }
@@ -103,6 +100,16 @@ export function statusOutline() {
       <cds-button action="outline" status="neutral">neutral</cds-button>
       <cds-button action="outline" disabled>disabled</cds-button>
     </div>
+  `;
+}
+
+/** @website */
+export function statusInverse() {
+  return html`
+    <cds-demo cds-layout="horizontal gap:sm p:sm" inverse>
+      <cds-button status="inverse">inverse</cds-button>
+      <cds-button status="inverse" disabled>disabled</cds-button>
+    </cds-demo>
   `;
 }
 
@@ -177,7 +184,7 @@ export function textAndBadge() {
         <cds-button status="neutral">Click Me <cds-badge>10</cds-badge></cds-button>
         <cds-button status="neutral" action="outline">Click Me <cds-badge>10</cds-badge></cds-button>
       </div>
-      <div cds-layout="horizontal gap:sm p:xs p-b:none" style="background: #313131">
+      <div cds-layout="horizontal gap:sm p:sm" style="background: var(--cds-global-color-construction-800)">
         <cds-button status="inverse">Click Me <cds-badge>10</cds-badge></cds-button>
       </div>
       <div cds-layout="horizontal gap:sm">
@@ -283,6 +290,7 @@ export function darkTheme() {
         <cds-button status="danger"><cds-icon shape="user"></cds-icon>danger<cds-badge>10</cds-badge></cds-button>
         <cds-button status="neutral"><cds-icon shape="user"></cds-icon>neutral<cds-badge>10</cds-badge></cds-button>
         <cds-button disabled><cds-icon shape="user"></cds-icon>disabled<cds-badge>10</cds-badge></cds-button>
+        <cds-button status="inverse"><cds-icon shape="user"></cds-icon>inverse<cds-badge>10</cds-badge></cds-button>
       </div>
       <div cds-layout="horizontal gap:sm">
         <cds-button action="outline"><cds-icon shape="user"></cds-icon>primary<cds-badge>10</cds-badge></cds-button>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Light theme | Dark theme
--- | ---
<img width="527" alt="Screen Shot 2021-04-15 at 10 21 19 PM" src="https://user-images.githubusercontent.com/113730/114933957-f9721c00-9e41-11eb-8a9a-973f857ffa56.png"> | <img width="517" alt="Screen Shot 2021-04-15 at 10 21 32 PM" src="https://user-images.githubusercontent.com/113730/114933962-faa34900-9e41-11eb-945c-3fbabaa94de7.png">


Issue Number: https://github.com/vmware/clarity/issues/5851

## What is the new behavior?

Light theme | Dark theme
--- | ---
<img width="310" alt="Screen Shot 2021-04-15 at 10 22 03 PM" src="https://user-images.githubusercontent.com/113730/114934024-0d1d8280-9e42-11eb-895a-ae8725b726fe.png"> | <img width="283" alt="Screen Shot 2021-04-15 at 10 22 11 PM" src="https://user-images.githubusercontent.com/113730/114934030-0db61900-9e42-11eb-9242-5bbfd353bc48.png">
<img width="299" alt="Screen Shot 2021-04-15 at 10 22 33 PM" src="https://user-images.githubusercontent.com/113730/114934032-0e4eaf80-9e42-11eb-92bc-e2e1b53dbb56.png"> | <img width="282" alt="Screen Shot 2021-04-15 at 10 22 50 PM" src="https://user-images.githubusercontent.com/113730/114934036-0f7fdc80-9e42-11eb-8e1f-c42ea1a131ac.png">
<img width="1040" alt="Screen Shot 2021-04-15 at 10 24 32 PM" src="https://user-images.githubusercontent.com/113730/114934040-10187300-9e42-11eb-9fac-93eca26ea0c0.png"> | <img width="1025" alt="Screen Shot 2021-04-15 at 10 24 41 PM" src="https://user-images.githubusercontent.com/113730/114934042-10b10980-9e42-11eb-9934-8f8984915a47.png">

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Inverse buttons in dark themes will now have the opposite colors as previously.