### PR TITLE
fix(button): add the missing styles for warning button status

### DIFF
--- a/packages/core/src/button/base-button.element.scss
+++ b/packages/core/src/button/base-button.element.scss
@@ -128,6 +128,11 @@
   --background: #{$cds-alias-status-success};
 }
 
+:host([status='warning']) {
+  --background: #{$cds-alias-status-warning};
+  --color: #{$cds-global-color-construction-900};
+}
+
 :host([status='danger']) {
   --background: #{$cds-alias-status-danger};
 }
@@ -143,6 +148,10 @@
 
 :host([status='success'][action='outline']) {
   --color: #{$cds-alias-status-success};
+}
+
+:host([status='warning'][action='outline']) {
+  --color: #{$cds-alias-status-warning-dark};
 }
 
 :host([status='danger'][action='outline']) {

--- a/packages/core/src/button/button.element.scss
+++ b/packages/core/src/button/button.element.scss
@@ -36,6 +36,12 @@
   --color: #{$cds-global-typography-color-100};
 }
 
+:host([action='outline'][status='warning']) ::slotted(cds-badge) {
+  --border-color: #{$cds-alias-status-warning-dark};
+  --background: #{$cds-alias-status-warning-dark};
+  --color: #{$cds-global-typography-color-100};
+}
+
 :host([action='outline'][status='danger']) ::slotted(cds-badge) {
   --border-color: #{$cds-alias-status-danger};
   --background: #{$cds-alias-status-danger};
@@ -52,6 +58,11 @@
   --background: #{$cds-alias-object-opacity-0};
   --border-color: #{$cds-global-typography-color-100};
   --color: #{$cds-global-typography-color-100};
+}
+
+:host([action='solid'][status='warning']) ::slotted(cds-badge) {
+  --border-color: #{$cds-global-color-construction-900};
+  --color: #{$cds-global-color-construction-900};
 }
 
 :host([action='flat'][disabled]) ::slotted(cds-badge) {

--- a/packages/core/src/button/button.stories.ts
+++ b/packages/core/src/button/button.stories.ts
@@ -83,6 +83,7 @@ export function status() {
     <div cds-layout="horizontal gap:sm">
       <cds-button>primary</cds-button>
       <cds-button status="success">success</cds-button>
+      <cds-button status="warning">warning</cds-button>
       <cds-button status="danger">danger</cds-button>
       <cds-button status="neutral">neutral</cds-button>
       <cds-button disabled>disabled</cds-button>
@@ -99,6 +100,7 @@ export function statusOutline() {
     <div cds-layout="horizontal gap:sm">
       <cds-button action="outline">primary</cds-button>
       <cds-button action="outline" status="success">success</cds-button>
+      <cds-button action="outline" status="warning">warning</cds-button>
       <cds-button action="outline" status="danger">danger</cds-button>
       <cds-button action="outline" status="neutral">neutral</cds-button>
       <cds-button action="outline" disabled>disabled</cds-button>
@@ -168,6 +170,10 @@ export function textAndBadge() {
       <div cds-layout="horizontal gap:sm">
         <cds-button status="danger">Click Me <cds-badge>10</cds-badge></cds-button>
         <cds-button status="danger" action="outline">Click Me <cds-badge>10</cds-badge></cds-button>
+      </div>
+      <div cds-layout="horizontal gap:sm">
+        <cds-button status="warning">Click Me <cds-badge>10</cds-badge></cds-button>
+        <cds-button status="warning" action="outline">Click Me <cds-badge>10</cds-badge></cds-button>
       </div>
       <div cds-layout="horizontal gap:sm">
         <cds-button status="success">Click Me <cds-badge>10</cds-badge></cds-button>
@@ -280,6 +286,7 @@ export function darkTheme() {
       <div cds-layout="horizontal gap:sm">
         <cds-button><cds-icon shape="user"></cds-icon>primary<cds-badge>10</cds-badge></cds-button>
         <cds-button status="success"><cds-icon shape="user"></cds-icon>success<cds-badge>10</cds-badge></cds-button>
+        <cds-button status="warning"><cds-icon shape="user"></cds-icon>warning<cds-badge>10</cds-badge></cds-button>
         <cds-button status="danger"><cds-icon shape="user"></cds-icon>danger<cds-badge>10</cds-badge></cds-button>
         <cds-button status="neutral"><cds-icon shape="user"></cds-icon>neutral<cds-badge>10</cds-badge></cds-button>
         <cds-button disabled><cds-icon shape="user"></cds-icon>disabled<cds-badge>10</cds-badge></cds-button>
@@ -288,6 +295,9 @@ export function darkTheme() {
         <cds-button action="outline"><cds-icon shape="user"></cds-icon>primary<cds-badge>10</cds-badge></cds-button>
         <cds-button action="outline" status="success"
           ><cds-icon shape="user"></cds-icon>success<cds-badge>10</cds-badge></cds-button
+        >
+        <cds-button action="outline" status="warning"
+          ><cds-icon shape="user"></cds-icon>warning<cds-badge>10</cds-badge></cds-button
         >
         <cds-button action="outline" status="danger"
           ><cds-icon shape="user"></cds-icon>danger<cds-badge>10</cds-badge></cds-button

--- a/packages/core/src/styles/tokens/tokens.stories.ts
+++ b/packages/core/src/styles/tokens/tokens.stories.ts
@@ -1146,6 +1146,7 @@ export const statusColors = () => {
       <div cds-layout="horizontal gap:sm">
         <cds-button>primary</cds-button>
         <cds-button status="success">success</cds-button>
+        <cds-button status="warning">warning</cds-button>
         <cds-button status="danger">danger</cds-button>
         <cds-button status="neutral">neutral</cds-button>
         <cds-button disabled>disabled</cds-button>
@@ -1154,6 +1155,7 @@ export const statusColors = () => {
       <div cds-layout="horizontal gap:sm">
         <cds-button action="outline">primary</cds-button>
         <cds-button status="success" action="outline">success</cds-button>
+        <cds-button status="warning" action="outline">warning</cds-button>
         <cds-button status="danger" action="outline">danger</cds-button>
         <cds-button status="neutral" action="outline">neutral</cds-button>
         <cds-button action="outline" disabled>disabled</cds-button>
@@ -1375,6 +1377,7 @@ export const statusColorsDarkTheme = () => {
       <div cds-layout="horizontal gap:sm">
         <cds-button>primary</cds-button>
         <cds-button status="success">success</cds-button>
+        <cds-button status="warning">warning</cds-button>
         <cds-button status="danger">danger</cds-button>
         <cds-button status="neutral">neutral</cds-button>
         <cds-button disabled>disabled</cds-button>
@@ -1383,6 +1386,7 @@ export const statusColorsDarkTheme = () => {
       <div cds-layout="horizontal gap:sm">
         <cds-button action="outline">primary</cds-button>
         <cds-button status="success" action="outline">success</cds-button>
+        <cds-button status="warning" action="outline">warning</cds-button>
         <cds-button status="danger" action="outline">danger</cds-button>
         <cds-button status="neutral" action="outline">neutral</cds-button>
         <cds-button action="outline" disabled>disabled</cds-button>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The prop types of the `CdsButton` advertise a `warning` status but since the styles are missing, it currently appears `primary` blue:

<img width="106" alt="Screen Shot 2021-04-15 at 11 34 49 PM" src="https://user-images.githubusercontent.com/113730/114941263-97b6af80-9e4b-11eb-8a8e-cd5c6eb1a3f3.png">

Not exactly the corresponding issue for this, but it was discussed at https://github.com/vmware/clarity/issues/5851.

## What is the new behavior?

This adds new styles, using the `shade` color variant which is a little less bad for accessibility.

<img width="425" alt="Screen Shot 2021-04-15 at 11 32 03 PM" src="https://user-images.githubusercontent.com/113730/114941323-b157f700-9e4b-11eb-875e-ebcfd8fb29dd.png"> <img width="425" alt="Screen Shot 2021-04-15 at 11 32 10 PM" src="https://user-images.githubusercontent.com/113730/114941326-b2892400-9e4b-11eb-8b23-07d965019bb8.png"> <img width="398" alt="Screen Shot 2021-04-15 at 11 32 24 PM" src="https://user-images.githubusercontent.com/113730/114941328-b321ba80-9e4b-11eb-8328-404ac5eb4080.png"> <img width="625" alt="Screen Shot 2021-04-15 at 11 32 36 PM" src="https://user-images.githubusercontent.com/113730/114941332-b3ba5100-9e4b-11eb-91aa-fb67ceb7ec85.png"> <img width="543" alt="Screen Shot 2021-04-15 at 11 32 56 PM" src="https://user-images.githubusercontent.com/113730/114941334-b452e780-9e4b-11eb-8988-f1c3cc28c068.png"> <img width="536" alt="Screen Shot 2021-04-15 at 11 33 03 PM" src="https://user-images.githubusercontent.com/113730/114941337-b5841480-9e4b-11eb-946a-b5859f39ada0.png">

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

