### PR TITLE
feat(button): add a neutral variant to buttons

### DIFF
--- a/packages/core/src/button/base-button.element.scss
+++ b/packages/core/src/button/base-button.element.scss
@@ -132,6 +132,10 @@
   --background: #{$cds-alias-status-danger};
 }
 
+:host([status='neutral']) {
+  --background: #{$cds-alias-status-neutral};
+}
+
 :host([action='outline']) {
   --color: #{$cds-alias-status-info};
   --border-color: var(--color);
@@ -143,6 +147,10 @@
 
 :host([status='danger'][action='outline']) {
   --color: #{$cds-alias-status-danger};
+}
+
+:host([status='neutral'][action='outline']) {
+  --color: #{$cds-alias-status-neutral};
 }
 
 :host([status='inverse']) {

--- a/packages/core/src/button/button.element.scss
+++ b/packages/core/src/button/button.element.scss
@@ -42,6 +42,12 @@
   --color: #{$cds-global-typography-color-100};
 }
 
+:host([action='outline'][status='neutral']) ::slotted(cds-badge) {
+  --border-color: #{$cds-alias-status-neutral};
+  --background: #{$cds-alias-status-neutral};
+  --color: #{$cds-global-typography-color-100};
+}
+
 :host(:not([action='outline']):not([action='flat'])) ::slotted(cds-badge) {
   --background: #{$cds-alias-object-opacity-0};
   --border-color: #{$cds-global-typography-color-100};

--- a/packages/core/src/button/button.element.ts
+++ b/packages/core/src/button/button.element.ts
@@ -76,7 +76,7 @@ export class CdsButton extends CdsBaseButton {
    * Sets the color of the button to match the following string statuses
    */
   @property({ type: String })
-  status: 'primary' | 'success' | 'warning' | 'danger' | 'inverse' = 'primary';
+  status: 'primary' | 'success' | 'warning' | 'danger' | 'neutral' | 'inverse' = 'primary';
 
   /**
    * Sets the overall height and width of the button based on the following string values:

--- a/packages/core/src/button/button.stories.ts
+++ b/packages/core/src/button/button.stories.ts
@@ -84,7 +84,8 @@ export function status() {
       <cds-button>primary</cds-button>
       <cds-button status="success">success</cds-button>
       <cds-button status="danger">danger</cds-button>
-      <cds-button status="danger" disabled>disabled</cds-button>
+      <cds-button status="neutral">neutral</cds-button>
+      <cds-button disabled>disabled</cds-button>
       <div style="background: var(--cds-global-typography-color-500)" cds-layout="p:sm">
         <cds-button status="inverse">inverse</cds-button>
       </div>
@@ -99,6 +100,7 @@ export function statusOutline() {
       <cds-button action="outline">primary</cds-button>
       <cds-button action="outline" status="success">success</cds-button>
       <cds-button action="outline" status="danger">danger</cds-button>
+      <cds-button action="outline" status="neutral">neutral</cds-button>
       <cds-button action="outline" disabled>disabled</cds-button>
     </div>
   `;
@@ -170,6 +172,10 @@ export function textAndBadge() {
       <div cds-layout="horizontal gap:sm">
         <cds-button status="success">Click Me <cds-badge>10</cds-badge></cds-button>
         <cds-button status="success" action="outline">Click Me <cds-badge>10</cds-badge></cds-button>
+      </div>
+      <div cds-layout="horizontal gap:sm">
+        <cds-button status="neutral">Click Me <cds-badge>10</cds-badge></cds-button>
+        <cds-button status="neutral" action="outline">Click Me <cds-badge>10</cds-badge></cds-button>
       </div>
       <div cds-layout="horizontal gap:sm p:xs p-b:none" style="background: #313131">
         <cds-button status="inverse">Click Me <cds-badge>10</cds-badge></cds-button>
@@ -275,9 +281,8 @@ export function darkTheme() {
         <cds-button><cds-icon shape="user"></cds-icon>primary<cds-badge>10</cds-badge></cds-button>
         <cds-button status="success"><cds-icon shape="user"></cds-icon>success<cds-badge>10</cds-badge></cds-button>
         <cds-button status="danger"><cds-icon shape="user"></cds-icon>danger<cds-badge>10</cds-badge></cds-button>
-        <cds-button status="danger" disabled
-          ><cds-icon shape="user"></cds-icon>disabled<cds-badge>10</cds-badge></cds-button
-        >
+        <cds-button status="neutral"><cds-icon shape="user"></cds-icon>neutral<cds-badge>10</cds-badge></cds-button>
+        <cds-button disabled><cds-icon shape="user"></cds-icon>disabled<cds-badge>10</cds-badge></cds-button>
       </div>
       <div cds-layout="horizontal gap:sm">
         <cds-button action="outline"><cds-icon shape="user"></cds-icon>primary<cds-badge>10</cds-badge></cds-button>
@@ -287,7 +292,10 @@ export function darkTheme() {
         <cds-button action="outline" status="danger"
           ><cds-icon shape="user"></cds-icon>danger<cds-badge>10</cds-badge></cds-button
         >
-        <cds-button action="outline" status="danger" disabled
+        <cds-button action="outline" status="neutral"
+          ><cds-icon shape="user"></cds-icon>neutral<cds-badge>10</cds-badge></cds-button
+        >
+        <cds-button action="outline" disabled
           ><cds-icon shape="user"></cds-icon>disabled<cds-badge>10</cds-badge></cds-button
         >
         <cds-button action="flat"><cds-icon shape="user"></cds-icon>flat<cds-badge>10</cds-badge></cds-button>

--- a/packages/core/src/styles/tokens/tokens.stories.ts
+++ b/packages/core/src/styles/tokens/tokens.stories.ts
@@ -1147,14 +1147,16 @@ export const statusColors = () => {
         <cds-button>primary</cds-button>
         <cds-button status="success">success</cds-button>
         <cds-button status="danger">danger</cds-button>
-        <cds-button status="danger" disabled>disabled</cds-button>
+        <cds-button status="neutral">neutral</cds-button>
+        <cds-button disabled>disabled</cds-button>
       </div>
 
       <div cds-layout="horizontal gap:sm">
         <cds-button action="outline">primary</cds-button>
         <cds-button status="success" action="outline">success</cds-button>
         <cds-button status="danger" action="outline">danger</cds-button>
-        <cds-button status="danger" action="outline" disabled>disabled</cds-button>
+        <cds-button status="neutral" action="outline">neutral</cds-button>
+        <cds-button action="outline" disabled>disabled</cds-button>
       </div>
 
       <div cds-layout="horizontal gap:sm">
@@ -1374,14 +1376,16 @@ export const statusColorsDarkTheme = () => {
         <cds-button>primary</cds-button>
         <cds-button status="success">success</cds-button>
         <cds-button status="danger">danger</cds-button>
-        <cds-button status="danger" disabled>disabled</cds-button>
+        <cds-button status="neutral">neutral</cds-button>
+        <cds-button disabled>disabled</cds-button>
       </div>
 
       <div cds-layout="horizontal gap:sm">
         <cds-button action="outline">primary</cds-button>
         <cds-button status="success" action="outline">success</cds-button>
         <cds-button status="danger" action="outline">danger</cds-button>
-        <cds-button status="danger" action="outline" disabled>disabled</cds-button>
+        <cds-button status="neutral" action="outline">neutral</cds-button>
+        <cds-button action="outline" disabled>disabled</cds-button>
       </div>
 
       <div cds-layout="horizontal gap:sm">


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

There is no `neutral` status for the button.

Not exactly the corresponding issue for this, but it was discussed at https://github.com/vmware/clarity/issues/5851.

## What is the new behavior?

There is a `neutral` status for the button :)

<img width="420" alt="Screen Shot 2021-04-15 at 11 37 53 PM" src="https://user-images.githubusercontent.com/113730/114941780-41963c00-9e4c-11eb-9947-ddc60dd55531.png">
<img width="416" alt="Screen Shot 2021-04-15 at 11 37 59 PM" src="https://user-images.githubusercontent.com/113730/114941781-422ed280-9e4c-11eb-8ac7-641a79e29442.png">
<img width="286" alt="Screen Shot 2021-04-15 at 11 38 08 PM" src="https://user-images.githubusercontent.com/113730/114941784-42c76900-9e4c-11eb-9f59-fd19fa1bfd05.png">
<img width="620" alt="Screen Shot 2021-04-15 at 11 38 16 PM" src="https://user-images.githubusercontent.com/113730/114941788-435fff80-9e4c-11eb-85dc-1c4da4c36e88.png">
<img width="504" alt="Screen Shot 2021-04-15 at 11 38 39 PM" src="https://user-images.githubusercontent.com/113730/114941790-43f89600-9e4c-11eb-9c90-79b49f62da32.png">
<img width="536" alt="Screen Shot 2021-04-15 at 11 38 51 PM" src="https://user-images.githubusercontent.com/113730/114941791-4529c300-9e4c-11eb-9a9e-5c38ee7d6b1a.png">


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
