### PR TITLE
fix(vertical-nav): fix the alignment of the collapse/expand icon in navigation groups

### DIFF
--- a/packages/angular/projects/clr-angular/src/layout/vertical-nav/_vertical-nav.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/layout/vertical-nav/_vertical-nav.clarity.scss
@@ -201,7 +201,6 @@
 
         //Dims
         width: $clr-vertical-nav-icon-size;
-        height: $clr-vertical-nav-item-height;
         align-self: center;
         margin-left: $clr-vertical-nav-trigger-icon-align-margin;
         margin-right: $clr-vertical-nav-trigger-icon-align-margin;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When you open a navigation group the `clr-icon` moves to the bottom of the group header item.

![image](https://user-images.githubusercontent.com/7893485/115031019-6207da00-9ed0-11eb-9fab-b8eed4e35ba4.png)


Issue Number: #5861, #5644

## What is the new behavior?

The `height` style of the icon element is removed. It causes the mentioned behavior. The positioning of the icon is already handled with `align-self: center` which was added with [this PR](https://github.com/vmware/clarity/commit/267bf8ed6010556137fca65cc30ac476ac629977#diff-ecf88d08b0c71d5451e3861edcc1482a5f8b1b64f7530184a6b7cd66be00bef5R204).

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
