### PR TITLE
Adjust colors of disabled inputs

### DIFF
--- a/packages/core/src/input/input.element.scss
+++ b/packages/core/src/input/input.element.scss
@@ -108,4 +108,5 @@
 
 :host([_disabled]) {
   --border-color: #{$cds-alias-object-border-color-tint};
+  --color: #{$cds-alias-status-disabled};
 }

--- a/packages/core/src/input/input.element.scss
+++ b/packages/core/src/input/input.element.scss
@@ -107,5 +107,5 @@
 }
 
 :host([_disabled]) {
-  --border-color: #{$cds-alias-status-disabled};
+  --border-color: #{$cds-alias-object-border-color-tint};
 }

--- a/packages/core/src/search/search.element.scss
+++ b/packages/core/src/search/search.element.scss
@@ -1,0 +1,9 @@
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
+
+@import './../styles/tokens/generated/index';
+
+:host([_disabled]) .icon {
+  --color: #{$cds-alias-status-disabled};
+}

--- a/packages/core/src/search/search.element.ts
+++ b/packages/core/src/search/search.element.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -11,6 +11,7 @@ import { inputStyles } from '@cds/core/input';
 import { ClarityIcons } from '@cds/core/icon/icon.service.js';
 import { searchIcon } from '@cds/core/icon/shapes/search.js';
 import { styles as globalStyles } from './search.global.css.js';
+import { styles } from './search.element.css.js';
 
 /**
  * Search
@@ -44,11 +45,13 @@ export class CdsSearch extends CdsControl {
   @globalStyle() protected globalStyles = globalStyles;
 
   protected get prefixDefaultTemplate() {
-    return html`<cds-control-action readonly><cds-icon shape="search" size="18"></cds-icon></cds-control-action>`;
+    return html`<cds-control-action readonly
+      ><cds-icon class="icon" shape="search" size="18"></cds-icon
+    ></cds-control-action>`;
   }
 
   static get styles() {
-    return [...super.styles, inputStyles];
+    return [...super.styles, inputStyles, styles];
   }
 
   constructor() {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the before/after behavior?

The bottom border of disabled inputs was actually darker than the bottom border of non-disabled inputs, while labels and control messages were ligther:

Before | After
--- | ---
<img width="974" alt="disabled border before" src="https://user-images.githubusercontent.com/113730/115113329-744a4c80-9f92-11eb-8f5b-23786b3ec25c.png"> | <img width="985" alt="disabled border after" src="https://user-images.githubusercontent.com/113730/115113330-74e2e300-9f92-11eb-84b5-09c9e8c284a8.png">

The icon color of the `cds-search` element was not using a disabled color when the input was disabled:

Before | After
--- | ---
<img width="199" alt="disabled search icon before" src="https://user-images.githubusercontent.com/113730/115113333-757b7980-9f92-11eb-8ae3-6c2d5c08a633.png"> | <img width="197" alt="disabled search icon after" src="https://user-images.githubusercontent.com/113730/115113334-76141000-9f92-11eb-929b-bf10c2d3c803.png">

The text value of a disabled input was using the same color than when not disabled, giving the impression it was still editable:

Before | After
--- | ---
<img width="160" alt="disabled input text color before" src="https://user-images.githubusercontent.com/113730/115113335-76aca680-9f92-11eb-9801-79b427fbf4b9.png"> | <img width="160" alt="disabled input text color after" src="https://user-images.githubusercontent.com/113730/115113336-76aca680-9f92-11eb-8846-51866ecd6575.png">


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
