### PR TITLE
fix(website): sidenav buttons did not had unique ids

### DIFF
--- a/apps/website/.vuepress/theme/components/Sidebar.vue
+++ b/apps/website/.vuepress/theme/components/Sidebar.vue
@@ -6,7 +6,7 @@
           <template v-for="(item, index) in items">
             <div class="nav-group" v-if="item.children">
               <div class="nav-group-content" v-bind:class="{ active: !states[index] && childActive(item) }">
-                <button id="sidenav" class="nav-group-trigger" type="button" @click="toggle(index)">
+                <button :id="'sidenav_' + index" class="nav-group-trigger" type="button" @click="toggle(index)">
                   <span class="nav-group-text">{{ item.title }}</span>
                   <cds-icon
                     class="nav-group-trigger-icon"


### PR DESCRIPTION
Sidenav buttons did not have unique ids - this is breaking accessibility and HTML rules - that a page must not have more than one ID-name per page.

The fix is just providing `index` number to every sidenav#button_<index>


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
