### PR TITLE
feat(icons): add xs size to icon t-shirt sizes

### DIFF
--- a/packages/core/src/icon/icon.element.scss
+++ b/packages/core/src/icon/icon.element.scss
@@ -28,6 +28,10 @@ svg {
 }
 
 // sizing
+:host([size='xs']) {
+  @include equilateral(#{$cds-global-space-5});
+}
+
 :host([size='sm']) {
   // weirdly, the default... 16px
   @include equilateral(#{$cds-global-space-7});

--- a/packages/core/src/icon/icon.element.ts
+++ b/packages/core/src/icon/icon.element.ts
@@ -72,7 +72,7 @@ export class CdsIcon extends LitElement {
   }
 
   /**
-   * @type {string | sm | md | lg | xl | xxl}
+   * @type {string | xs | sm | md | lg | xl | xxl}
    * Apply numerical width-height or a t-shirt-sized CSS classname
    */
   @property({ type: String })

--- a/packages/core/src/icon/icon.stories.ts
+++ b/packages/core/src/icon/icon.stories.ts
@@ -78,7 +78,7 @@ export function all() {
   const search = text('search', '', propertiesGroup);
   const size = select(
     'size',
-    { 'sm (default)': 'sm', md: 'md', lg: 'lg', xl: 'xl', xxl: 'xxl' },
+    { xs: 'xs', 'sm (default)': 'sm', md: 'md', lg: 'lg', xl: 'xl', xxl: 'xxl' },
     'lg',
     propertiesGroup
   );
@@ -228,6 +228,11 @@ export function icon() {
 /** @website */
 export function sizes() {
   return html`
+    <cds-icon
+      shape="house"
+      size="xs"
+      aria-label="This is an example of an icon using a pre-defined extra small size"
+    ></cds-icon>
     <cds-icon
       shape="house"
       size="sm"


### PR DESCRIPTION
Consistent with the general size tokens for Clarity core, this change
adds an xs t-shirt size to the icons size api. My use case is in the
cds-navigation component when in vertical layout, not expanded the icon
needs to be about 1/2 the size of the `sm` icon.

I'm adding the change here to keep these changes separate from the
cds-navigation branch changes.

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
