### PR TITLE
fix(combobox): prevent double open event on tab key

### DIFF
--- a/packages/angular/projects/clr-angular/src/utils/enums/key-codes.enum.ts
+++ b/packages/angular/projects/clr-angular/src/utils/enums/key-codes.enum.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -10,7 +10,7 @@ export enum KeyCodes {
   ArrowRight = 'ArrowRight',
   ArrowDown = 'ArrowDown',
   Backspace = 'Backspace',
-  Tab = 'TAB',
+  Tab = 'Tab',
   Enter = 'Enter',
   Escape = 'Escape',
   Space = 'Space',


### PR DESCRIPTION
closes #5693
Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When combobox input is focused (without being open) and tab key is press, two subsequent open/close events are fired.

Issue Number: 5693

## What is the new behavior?

No events are fired on Tab press

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
