### PR TITLE
chore: disable Ivy distribution mode

### DIFF
--- a/packages/angular/golden/clr-angular.d.ts
+++ b/packages/angular/golden/clr-angular.d.ts
@@ -1,12 +1,7 @@
 export declare class CdsIconCustomTag {
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdsIconCustomTag, "cds-icon", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<CdsIconCustomTag, never>;
 }
 
 export declare class ClarityModule {
-    static ɵfac: i0.ɵɵFactoryDef<ClarityModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClarityModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClarityModule, never, never, [typeof i1.ClrEmphasisModule, typeof i2.ClrDataModule, typeof i3.ClrIconModule, typeof i4.ClrModalModule, typeof i5.ClrLoadingModule, typeof i6.ClrConditionalModule, typeof i7.ClrFocusTrapModule, typeof i8.ClrFocusOnViewInitModule, typeof i9.ClrButtonModule, typeof i10.ClrFormsModule, typeof i11.ClrLayoutModule, typeof i12.ClrPopoverModule, typeof i13.ClrWizardModule, typeof i14.ClrDragAndDropModule, typeof i15.ClrStepperModule, typeof i16.ClrSpinnerModule, typeof i17.ClrProgressBarModule, typeof i18.ClrPopoverModuleNext, typeof i19.ClrTimelineModule]>;
 }
 
 export declare const CLR_ALERT_DIRECTIVES: Type<any>[];
@@ -73,8 +68,6 @@ export declare abstract class ClrAbstractContainer implements DynamicWrapper, On
     controlClass(): string;
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrAbstractContainer, never, never, {}, {}, ["label", "controlSuccessComponent", "controlErrorComponent", "controlHelperComponent"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrAbstractContainer, [null, { optional: true; }, null, null]>;
 }
 
 export declare class ClrAccordion implements OnInit, OnChanges, AfterViewInit, OnDestroy {
@@ -86,25 +79,16 @@ export declare class ClrAccordion implements OnInit, OnChanges, AfterViewInit, O
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrAccordion, "clr-accordion", never, { "multiPanel": "clrAccordionMultiPanel"; }, {}, ["panels"], ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrAccordion, never>;
 }
 
 export declare class ClrAccordionContent {
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrAccordionContent, "clr-accordion-content, clr-step-content", never, {}, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrAccordionContent, never>;
 }
 
 export declare class ClrAccordionDescription {
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrAccordionDescription, "clr-accordion-description, clr-step-description", never, {}, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrAccordionDescription, never>;
 }
 
 export declare class ClrAccordionModule {
     constructor();
-    static ɵfac: i0.ɵɵFactoryDef<ClrAccordionModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrAccordionModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrAccordionModule, [typeof i1.ClrAccordion, typeof i2.ClrAccordionPanel, typeof i3.ClrAccordionTitle, typeof i4.ClrAccordionDescription, typeof i5.ClrAccordionContent, typeof i6.AccordionOompaLoompa, typeof i7.AccordionWillyWonka], [typeof i8.CommonModule, typeof i9.ClrIconModule], [typeof i1.ClrAccordion, typeof i2.ClrAccordionPanel, typeof i3.ClrAccordionTitle, typeof i4.ClrAccordionDescription, typeof i5.ClrAccordionContent, typeof i6.AccordionOompaLoompa, typeof i7.AccordionWillyWonka]>;
 }
 
 export declare class ClrAccordionPanel implements OnInit, OnChanges {
@@ -126,13 +110,9 @@ export declare class ClrAccordionPanel implements OnInit, OnChanges {
     ngOnChanges(changes: SimpleChanges): void;
     ngOnInit(): void;
     togglePanel(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrAccordionPanel, "clr-accordion-panel", never, { "disabled": "clrAccordionPanelDisabled"; "panelOpen": "clrAccordionPanelOpen"; }, { "panelOpenChange": "clrAccordionPanelOpenChange"; }, ["accordionDescription"], ["clr-accordion-title, clr-step-title", "clr-accordion-description, clr-step-description", "*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrAccordionPanel, never>;
 }
 
 export declare class ClrAccordionTitle {
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrAccordionTitle, "clr-accordion-title, clr-step-title", never, {}, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrAccordionTitle, never>;
 }
 
 export declare class ClrAlert implements OnInit, OnDestroy {
@@ -153,22 +133,15 @@ export declare class ClrAlert implements OnInit, OnDestroy {
     ngOnDestroy(): void;
     ngOnInit(): void;
     open(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrAlert, "clr-alert", never, { "isSmall": "clrAlertSizeSmall"; "closable": "clrAlertClosable"; "isAppLevel": "clrAlertAppLevel"; "clrCloseButtonAriaLabel": "clrCloseButtonAriaLabel"; "_closed": "clrAlertClosed"; "alertType": "clrAlertType"; "alertIconShape": "clrAlertIcon"; }, { "_closedChanged": "clrAlertClosedChange"; }, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrAlert, [null, null, { optional: true; }, null]>;
 }
 
 export declare class ClrAlertItem {
     iconService: AlertIconAndTypesService;
     constructor(iconService: AlertIconAndTypesService);
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrAlertItem, "clr-alert-item", never, {}, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrAlertItem, never>;
 }
 
 export declare class ClrAlertModule {
     constructor();
-    static ɵfac: i0.ɵɵFactoryDef<ClrAlertModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrAlertModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrAlertModule, [typeof i1.ClrAlert, typeof i2.ClrAlertItem, typeof i3.ClrAlerts, typeof i4.ClrAlertsPager, typeof i5.ClrAlertText], [typeof i6.CommonModule, typeof i7.ClrIconModule, typeof i8.ClrDropdownModule], [typeof i1.ClrAlert, typeof i2.ClrAlertItem, typeof i3.ClrAlerts, typeof i4.ClrAlertsPager, typeof i5.ClrAlertText]>;
 }
 
 export declare class ClrAlerts implements AfterContentInit, OnDestroy {
@@ -186,8 +159,6 @@ export declare class ClrAlerts implements AfterContentInit, OnDestroy {
     constructor(multiAlertService: MultiAlertService);
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrAlerts, "clr-alerts", never, { "_inputCurrentIndex": "clrCurrentAlertIndex"; "currentAlert": "clrCurrentAlert"; }, { "currentAlertIndexChange": "clrCurrentAlertIndexChange"; "currentAlertChange": "clrCurrentAlertChange"; }, ["allAlerts"], ["clr-alert"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrAlerts, never>;
 }
 
 export declare class ClrAlertsPager implements OnInit, OnDestroy {
@@ -204,13 +175,9 @@ export declare class ClrAlertsPager implements OnInit, OnDestroy {
     ngOnInit(): void;
     pageDown(): void;
     pageUp(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrAlertsPager, "clr-alerts-pager", never, { "currentAlert": "clrCurrentAlert"; "currentAlertIndex": "clrCurrentAlertIndex"; }, { "currentAlertChange": "clrCurrentAlertChange"; "currentAlertIndexChange": "clrCurrentAlertIndexChange"; }, never, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrAlertsPager, never>;
 }
 
 export declare class ClrAlertText {
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrAlertText, ".alert-text", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrAlertText, never>;
 }
 
 export declare enum ClrAlignment {
@@ -230,8 +197,6 @@ export declare class ClrAriaLiveService implements OnDestroy {
     constructor(ngZone: NgZone, _document: any, platformId: any);
     announce(message: string | HTMLElement, politeness?: ClrAriaLivePoliteness): void;
     ngOnDestroy(): void;
-    static ɵfac: i0.ɵɵFactoryDef<ClrAriaLiveService, never>;
-    static ɵprov: i0.ɵɵInjectableDef<ClrAriaLiveService>;
 }
 
 export declare enum ClrAxis {
@@ -260,8 +225,6 @@ export declare class ClrButton implements LoadingListener {
     emitClick($event: Event): void;
     loadingStateChange(state: ClrLoadingState): void;
     ngAfterViewInit(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrButton, "clr-button", never, { "inMenu": "clrInMenu"; "classNames": "class"; "name": "name"; "type": "type"; "id": "id"; "disabled": "disabled"; }, { "_click": "click"; }, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrButton, [{ optional: true; skipSelf: true; }, null]>;
 }
 
 export declare class ClrButtonGroup {
@@ -280,21 +243,13 @@ export declare class ClrButtonGroup {
     initializeButtons(): void;
     ngAfterContentInit(): void;
     rearrangeButton(button: ClrButton): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrButtonGroup, "clr-button-group", never, { "menuPosition": "clrMenuPosition"; }, {}, ["buttons"], never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrButtonGroup, never>;
 }
 
 export declare class ClrButtonGroupModule {
-    static ɵfac: i0.ɵɵFactoryDef<ClrButtonGroupModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrButtonGroupModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrButtonGroupModule, [typeof i1.ClrButton, typeof i2.ClrButtonGroup], [typeof i3.CommonModule, typeof i4.ClrIconModule, typeof i5.ClrPopoverModuleNext], [typeof i1.ClrButton, typeof i2.ClrButtonGroup]>;
 }
 
 export declare class ClrButtonModule {
     constructor();
-    static ɵfac: i0.ɵɵFactoryDef<ClrButtonModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrButtonModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrButtonModule, never, never, [typeof i1.ClrLoadingButtonModule, typeof i2.ClrButtonGroupModule]>;
 }
 
 export declare class ClrCalendar implements OnDestroy {
@@ -308,15 +263,11 @@ export declare class ClrCalendar implements OnDestroy {
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
     onKeyDown(event: KeyboardEvent): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrCalendar, "clr-calendar", never, {}, {}, never, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrCalendar, never>;
 }
 
 export declare class ClrCheckbox extends WrappedFormControl<ClrCheckboxWrapper> {
     constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef, toggle: string);
     ngOnInit(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrCheckbox, "[clrCheckbox],[clrToggle]", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrCheckbox, [null, null, { optional: true; self: true; }, null, null, { attribute: "clrToggle"; }]>;
 }
 
 export declare class ClrCheckboxContainer extends ClrAbstractContainer implements AfterContentInit {
@@ -330,15 +281,10 @@ export declare class ClrCheckboxContainer extends ClrAbstractContainer implement
     role: string;
     constructor(layoutService: LayoutService, controlClassService: ControlClassService, ngControlService: NgControlService, ifControlStateService: IfControlStateService);
     ngAfterContentInit(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrCheckboxContainer, "clr-checkbox-container,clr-toggle-container", never, { "clrInline": "clrInline"; }, {}, ["checkboxes"], ["label", "clr-checkbox-wrapper,clr-toggle-wrapper", "clr-control-helper", "clr-control-error", "clr-control-success"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrCheckboxContainer, [{ optional: true; }, null, null, null]>;
 }
 
 export declare class ClrCheckboxModule {
     constructor();
-    static ɵfac: i0.ɵɵFactoryDef<ClrCheckboxModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrCheckboxModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrCheckboxModule, [typeof i1.ClrCheckbox, typeof i2.ClrCheckboxContainer, typeof i3.ClrCheckboxWrapper], [typeof i4.CommonModule, typeof i5.ClrIconModule, typeof i6.ClrCommonFormsModule, typeof i7.ClrHostWrappingModule], [typeof i6.ClrCommonFormsModule, typeof i1.ClrCheckbox, typeof i2.ClrCheckboxContainer, typeof i3.ClrCheckboxWrapper]>;
 }
 
 export declare class ClrCheckboxWrapper implements DynamicWrapper, OnInit, OnDestroy {
@@ -348,8 +294,6 @@ export declare class ClrCheckboxWrapper implements DynamicWrapper, OnInit, OnDes
     constructor(toggleService: BehaviorSubject<boolean>);
     ngOnDestroy(): void;
     ngOnInit(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrCheckboxWrapper, "clr-checkbox-wrapper,clr-toggle-wrapper", never, {}, {}, ["label"], ["[clrCheckbox],[clrToggle]", "label"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrCheckboxWrapper, never>;
 }
 
 export declare class ClrCombobox<T> extends WrappedFormControl<ClrComboboxContainer> implements ControlValueAccessor, LoadingListener, AfterContentInit {
@@ -400,8 +344,6 @@ export declare class ClrCombobox<T> extends WrappedFormControl<ClrComboboxContai
     setDisabledState(): void;
     unselect(item: T): void;
     writeValue(value: T | T[]): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrCombobox<any>, "clr-combobox", never, { "placeholder": "placeholder"; "multiSelect": "clrMulti"; }, { "clrInputChange": "clrInputChange"; "clrOpenChange": "clrOpenChange"; "clrSelectionChange": "clrSelectionChange"; }, ["optionSelected"], ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrCombobox<any>, [null, null, { optional: true; self: true; }, null, null, null, null, null, null, { optional: true; }, { optional: true; }, null, null, null, null]>;
 }
 
 export declare class ClrComboboxContainer extends ClrAbstractContainer implements AfterContentInit, AfterViewInit {
@@ -410,22 +352,14 @@ export declare class ClrComboboxContainer extends ClrAbstractContainer implement
     constructor(ifControlStateService: IfControlStateService, layoutService: LayoutService, controlClassService: ControlClassService, ngControlService: NgControlService, containerService: ComboboxContainerService, el: ElementRef);
     ngAfterContentInit(): void;
     ngAfterViewInit(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrComboboxContainer, "clr-combobox-container", never, {}, {}, ["label"], ["label", "clr-combobox", "clr-control-helper", "clr-control-error", "clr-control-success"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrComboboxContainer, [null, { optional: true; }, null, null, null, null]>;
 }
 
 export declare class ClrComboboxModule {
     constructor();
-    static ɵfac: i0.ɵɵFactoryDef<ClrComboboxModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrComboboxModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrComboboxModule, [typeof i1.ClrCombobox, typeof i2.ClrComboboxContainer, typeof i3.ClrOptions, typeof i4.ClrOption, typeof i5.ClrOptionSelected, typeof i6.ClrOptionItems], [typeof i7.CommonModule, typeof i8.FormsModule, typeof i9.ClrIconModule, typeof i10.ClrKeyFocusModule, typeof i11.ClrCommonFormsModule, typeof i12.ClrConditionalModule, typeof i13.ClrPopoverModuleNext, typeof i14.ClrSpinnerModule], [typeof i11.ClrCommonFormsModule, typeof i1.ClrCombobox, typeof i2.ClrComboboxContainer, typeof i3.ClrOptions, typeof i4.ClrOption, typeof i5.ClrOptionSelected, typeof i12.ClrConditionalModule, typeof i6.ClrOptionItems]>;
 }
 
 export declare class ClrCommonFormsModule {
     constructor();
-    static ɵfac: i0.ɵɵFactoryDef<ClrCommonFormsModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrCommonFormsModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrCommonFormsModule, [typeof i1.ClrLabel, typeof i2.ClrControlError, typeof i3.ClrControlSuccess, typeof i4.ClrControlHelper, typeof i5.ClrIfError, typeof i6.ClrIfSuccess, typeof i7.ClrForm, typeof i8.ClrLayout, typeof i9.ClrControlContainer, typeof i10.ClrControl], [typeof i11.CommonModule, typeof i12.ClrIconModule], [typeof i1.ClrLabel, typeof i2.ClrControlError, typeof i3.ClrControlSuccess, typeof i4.ClrControlHelper, typeof i5.ClrIfError, typeof i6.ClrIfSuccess, typeof i7.ClrForm, typeof i8.ClrLayout, typeof i9.ClrControlContainer, typeof i10.ClrControl]>;
 }
 
 export interface ClrCommonStrings {
@@ -511,26 +445,17 @@ export declare class ClrCommonStringsService {
     parse(source: string, tokens?: {
         [key: string]: string;
     }): string;
-    static ɵfac: i0.ɵɵFactoryDef<ClrCommonStringsService, never>;
-    static ɵprov: i0.ɵɵInjectableDef<ClrCommonStringsService>;
 }
 
 export declare class ClrConditionalModule {
-    static ɵfac: i0.ɵɵFactoryDef<ClrConditionalModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrConditionalModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrConditionalModule, [typeof i1.ClrIfActive, typeof i2.ClrIfOpen, typeof i3.ClrIfExpanded], [typeof i4.CommonModule], [typeof i1.ClrIfActive, typeof i2.ClrIfOpen, typeof i3.ClrIfExpanded]>;
 }
 
 export declare class ClrControl extends WrappedFormControl<ClrControlContainer> {
     protected index: number;
     constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef);
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrControl, "[clrControl]", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrControl, [null, null, { optional: true; self: true; }, null, null]>;
 }
 
 export declare class ClrControlContainer extends ClrAbstractContainer {
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrControlContainer, "clr-control-container", never, {}, {}, never, ["label", "*", "clr-control-helper", "clr-control-error", "clr-control-success"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrControlContainer, never>;
 }
 
 export declare class ClrControlError extends ClrAbstractControl {
@@ -538,8 +463,6 @@ export declare class ClrControlError extends ClrAbstractControl {
     protected controlIdService: ControlIdService;
     controlIdSuffix: string;
     constructor(controlIdService: ControlIdService, containerIdService: ContainerIdService);
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrControlError, "clr-control-error", never, {}, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrControlError, [{ optional: true; }, { optional: true; }]>;
 }
 
 export declare class ClrControlHelper extends ClrAbstractControl {
@@ -547,8 +470,6 @@ export declare class ClrControlHelper extends ClrAbstractControl {
     protected controlIdService: ControlIdService;
     controlIdSuffix: string;
     constructor(controlIdService: ControlIdService, containerIdService: ContainerIdService);
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrControlHelper, "clr-control-helper", never, {}, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrControlHelper, [{ optional: true; }, { optional: true; }]>;
 }
 
 export declare class ClrControlSuccess extends ClrAbstractControl {
@@ -556,8 +477,6 @@ export declare class ClrControlSuccess extends ClrAbstractControl {
     protected controlIdService: ControlIdService;
     controlIdSuffix: string;
     constructor(controlIdService: ControlIdService, containerIdService: ContainerIdService);
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrControlSuccess, "clr-control-success", never, {}, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrControlSuccess, [{ optional: true; }, { optional: true; }]>;
 }
 
 export declare class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, OnDestroy {
@@ -600,13 +519,9 @@ export declare class ClrDatagrid<T = any> implements AfterContentInit, AfterView
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
     resize(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDatagrid<any>, "clr-datagrid", never, { "loading": "clrDgLoading"; "selected": "clrDgSelected"; "singleSelected": "clrDgSingleSelected"; "clrDgSingleSelectionAriaLabel": "clrDgSingleSelectionAriaLabel"; "clrDgSingleActionableAriaLabel": "clrDgSingleActionableAriaLabel"; "clrDetailExpandableAriaLabel": "clrDetailExpandableAriaLabel"; "clrDgDisablePageFocus": "clrDgDisablePageFocus"; "clrDgPreserveSelection": "clrDgPreserveSelection"; "rowSelectionMode": "clrDgRowSelection"; }, { "refresh": "clrDgRefresh"; "selectedChanged": "clrDgSelectedChange"; "singleSelectedChanged": "clrDgSingleSelectedChange"; }, ["iterator", "placeholder", "columns", "rows"], ["clr-dg-action-bar", "clr-dg-placeholder", "clr-dg-footer", "[clrIfDetail],clr-dg-detail"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatagrid<any>, never>;
 }
 
 export declare class ClrDatagridActionBar {
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDatagridActionBar, "clr-dg-action-bar", never, {}, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatagridActionBar, never>;
 }
 
 export declare class ClrDatagridActionOverflow implements OnDestroy {
@@ -619,8 +534,6 @@ export declare class ClrDatagridActionOverflow implements OnDestroy {
     constructor(rowActionService: RowActionService, commonStrings: ClrCommonStringsService, platformId: any, zone: NgZone, smartToggleService: ClrPopoverToggleService, popoverId: string);
     closeOverflowContent(event: Event): void;
     ngOnDestroy(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDatagridActionOverflow, "clr-dg-action-overflow", never, { "open": "clrDgActionOverflowOpen"; }, { "openChange": "clrDgActionOverflowOpenChange"; }, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatagridActionOverflow, never>;
 }
 
 export declare class ClrDatagridCell implements OnInit {
@@ -628,8 +541,6 @@ export declare class ClrDatagridCell implements OnInit {
     signpost: QueryList<ClrSignpost>;
     constructor(vcr: ViewContainerRef);
     ngOnInit(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDatagridCell, "clr-dg-cell", never, {}, {}, ["signpost"], ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatagridCell, never>;
 }
 
 export declare class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<T, ClrDatagridFilterInterface<T>> implements OnDestroy, OnInit, OnChanges {
@@ -663,8 +574,6 @@ export declare class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<
     ngOnDestroy(): void;
     ngOnInit(): void;
     sort(reverse?: boolean): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDatagridColumn<any>, "clr-dg-column", never, { "colType": "clrDgColType"; "field": "clrDgField"; "sortBy": "clrDgSortBy"; "sorted": "clrDgSorted"; "sortOrder": "clrDgSortOrder"; "updateFilterValue": "clrFilterValue"; }, { "sortedChange": "clrDgSortedChange"; "sortOrderChange": "clrDgSortOrderChange"; "filterValueChange": "clrFilterValueChange"; }, ["projectedFilter"], ["clr-dg-filter, clr-dg-string-filter, clr-dg-numeric-filter", "*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatagridColumn<any>, never>;
 }
 
 export declare class ClrDatagridColumnSeparator implements AfterViewInit, OnDestroy {
@@ -677,8 +586,6 @@ export declare class ClrDatagridColumnSeparator implements AfterViewInit, OnDest
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
     showTracker(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDatagridColumnSeparator, "clr-dg-column-separator", never, {}, {}, never, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatagridColumnSeparator, never>;
 }
 
 export declare class ClrDatagridColumnToggle {
@@ -698,8 +605,6 @@ export declare class ClrDatagridColumnToggle {
     toggleColumnState(columnState: ColumnState, event: boolean): void;
     toggleSwitchPanel(): void;
     trackByFn(index: number): number;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDatagridColumnToggle, "clr-dg-column-toggle", never, {}, {}, ["customToggleTitle", "customToggleButton"], ["clr-dg-column-toggle-title", "clr-dg-column-toggle-button"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatagridColumnToggle, never>;
 }
 
 export declare class ClrDatagridColumnToggleButton {
@@ -707,13 +612,9 @@ export declare class ClrDatagridColumnToggleButton {
     get clrAllSelected(): Observable<boolean>;
     constructor(columnsService: ColumnsService);
     selectAll(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDatagridColumnToggleButton, "clr-dg-column-toggle-button", never, {}, { "clrAllSelected": "clrAllSelected"; }, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatagridColumnToggleButton, never>;
 }
 
 export declare class ClrDatagridColumnToggleTitle {
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDatagridColumnToggleTitle, "clr-dg-column-toggle-title", never, {}, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatagridColumnToggleTitle, never>;
 }
 
 export interface ClrDatagridComparatorInterface<T> {
@@ -726,13 +627,9 @@ export declare class ClrDatagridDetail {
     header: ClrDatagridDetailHeader;
     constructor(detailService: DetailService, commonStrings: ClrCommonStringsService);
     closeCheck(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDatagridDetail, "clr-dg-detail", never, {}, {}, ["header"], ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatagridDetail, never>;
 }
 
 export declare class ClrDatagridDetailBody {
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDatagridDetailBody, "clr-dg-detail-body", never, {}, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatagridDetailBody, never>;
 }
 
 export declare class ClrDatagridDetailHeader {
@@ -740,8 +637,6 @@ export declare class ClrDatagridDetailHeader {
     detailService: DetailService;
     get titleId(): string;
     constructor(detailService: DetailService, commonStrings: ClrCommonStringsService);
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDatagridDetailHeader, "clr-dg-detail-header", never, {}, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatagridDetailHeader, never>;
 }
 
 export declare class ClrDatagridFilter<T = any> extends DatagridFilterRegistrar<T, ClrDatagridFilterInterface<T>> implements CustomFilter, OnDestroy {
@@ -757,8 +652,6 @@ export declare class ClrDatagridFilter<T = any> extends DatagridFilterRegistrar<
     smartPosition: ClrPopoverPosition;
     constructor(_filters: FiltersProvider<T>, commonStrings: ClrCommonStringsService, smartToggleService: ClrPopoverToggleService, platformId: any, popoverId: string);
     ngOnDestroy(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDatagridFilter<any>, "clr-dg-filter", never, { "open": "clrDgFilterOpen"; "customFilter": "clrDgFilter"; }, { "openChange": "clrDgFilterOpenChange"; }, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatagridFilter<any>, never>;
 }
 
 export interface ClrDatagridFilterInterface<T, S = any> {
@@ -776,8 +669,6 @@ export declare class ClrDatagridFooter<T = any> {
     selection: Selection<T>;
     toggle: ClrDatagridColumnToggle;
     constructor(selection: Selection<T>, detailService: DetailService, columnsService: ColumnsService);
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDatagridFooter<any>, "clr-dg-footer", never, {}, {}, ["toggle"], ["clr-dg-column-toggle", "*", "clr-dg-pagination"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatagridFooter<any>, never>;
 }
 
 export declare class ClrDatagridHideableColumn implements OnDestroy {
@@ -789,8 +680,6 @@ export declare class ClrDatagridHideableColumn implements OnDestroy {
     constructor(titleTemplateRef: TemplateRef<any>, viewContainerRef: ViewContainerRef, columnsService: ColumnsService, columnState: BehaviorSubject<ColumnState>);
     ngOnDestroy(): void;
     ngOnInit(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrDatagridHideableColumn, "[clrDgHideableColumn]", never, { "clrDgHideableColumn": "clrDgHideableColumn"; "clrDgHidden": "clrDgHidden"; }, { "hiddenChange": "clrDgHiddenChange"; }, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatagridHideableColumn, [null, null, null, { optional: true; }]>;
 }
 
 export declare class ClrDatagridItems<T> implements DoCheck, OnDestroy {
@@ -800,22 +689,15 @@ export declare class ClrDatagridItems<T> implements DoCheck, OnDestroy {
     constructor(template: TemplateRef<NgForOfContext<T>>, differs: IterableDiffers, items: Items, vcr: ViewContainerRef);
     ngDoCheck(): void;
     ngOnDestroy(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrDatagridItems<any>, "[clrDgItems][clrDgItemsOf]", never, { "rawItems": "clrDgItemsOf"; "trackBy": "clrDgItemsTrackBy"; }, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatagridItems<any>, never>;
 }
 
 export declare class ClrDatagridItemsTrackBy<T = any> {
     set trackBy(value: TrackByFunction<T>);
     constructor(_items: Items<T>);
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrDatagridItemsTrackBy<any>, "[ngForTrackBy]", never, { "trackBy": "ngForTrackBy"; }, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatagridItemsTrackBy<any>, [{ optional: true; }]>;
 }
 
 export declare class ClrDatagridModule {
     constructor();
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatagridModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrDatagridModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrDatagridModule, [typeof i1.ClrDatagrid, typeof i2.ClrDatagridActionBar, typeof i3.ClrDatagridActionOverflow, typeof i4.ClrDatagridColumn, typeof i5.ClrDatagridColumnSeparator, typeof i6.ClrDatagridColumnToggle, typeof i7.ClrDatagridHideableColumn, typeof i8.ClrDatagridFilter, typeof i9.ClrDatagridItems, typeof i10.ClrDatagridItemsTrackBy, typeof i11.ClrDatagridRow, typeof i12.ClrDatagridRowDetail, typeof i13.DatagridDetailRegisterer, typeof i14.ClrDatagridCell, typeof i15.ClrDatagridFooter, typeof i16.ClrDatagridPagination, typeof i17.ClrDatagridPageSize, typeof i18.ClrDatagridPlaceholder, typeof i19.ClrDatagridColumnToggleButton, typeof i20.ClrDatagridColumnToggleTitle, typeof i21.ClrDatagridDetail, typeof i22.ClrIfDetail, typeof i23.ClrDatagridDetailHeader, typeof i24.ClrDatagridDetailBody, typeof i25.WrappedCell, typeof i26.WrappedColumn, typeof i27.WrappedRow, typeof i28.DatagridMainRenderer, typeof i29.DatagridHeaderRenderer, typeof i30.DatagridRowRenderer, typeof i31.DatagridCellRenderer, typeof i32.DatagridWillyWonka, typeof i33.ActionableOompaLoompa, typeof i34.ExpandableOompaLoompa, typeof i35.DatagridStringFilter, typeof i36.DatagridNumericFilter], [typeof i37.CommonModule, typeof i38.ClrIconModule, typeof i39.ClrFormsModule, typeof i40.FormsModule, typeof i41.ClrLoadingModule, typeof i42.ClrConditionalModule, typeof i43.ClrOutsideClickModule, typeof i44.ClrExpandableAnimationModule, typeof i45.ClrDragAndDropModule, typeof i46.ClrSpinnerModule, typeof i47.ClrPopoverModuleNext, typeof i48.ClrFocusTrapModule, typeof i49.ClrFocusOnViewInitModule], [typeof i1.ClrDatagrid, typeof i2.ClrDatagridActionBar, typeof i3.ClrDatagridActionOverflow, typeof i4.ClrDatagridColumn, typeof i5.ClrDatagridColumnSeparator, typeof i6.ClrDatagridColumnToggle, typeof i7.ClrDatagridHideableColumn, typeof i8.ClrDatagridFilter, typeof i9.ClrDatagridItems, typeof i10.ClrDatagridItemsTrackBy, typeof i11.ClrDatagridRow, typeof i12.ClrDatagridRowDetail, typeof i13.DatagridDetailRegisterer, typeof i14.ClrDatagridCell, typeof i15.ClrDatagridFooter, typeof i16.ClrDatagridPagination, typeof i17.ClrDatagridPageSize, typeof i18.ClrDatagridPlaceholder, typeof i19.ClrDatagridColumnToggleButton, typeof i20.ClrDatagridColumnToggleTitle, typeof i21.ClrDatagridDetail, typeof i22.ClrIfDetail, typeof i23.ClrDatagridDetailHeader, typeof i24.ClrDatagridDetailBody, typeof i25.WrappedCell, typeof i26.WrappedColumn, typeof i27.WrappedRow, typeof i28.DatagridMainRenderer, typeof i29.DatagridHeaderRenderer, typeof i30.DatagridRowRenderer, typeof i31.DatagridCellRenderer, typeof i32.DatagridWillyWonka, typeof i33.ActionableOompaLoompa, typeof i34.ExpandableOompaLoompa, typeof i35.DatagridStringFilter, typeof i36.DatagridNumericFilter]>;
 }
 
 export interface ClrDatagridNumericFilterInterface<T> {
@@ -827,8 +709,6 @@ export declare class ClrDatagridPageSize {
     pageSizeOptions: number[];
     constructor(page: Page);
     ngOnInit(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDatagridPageSize, "clr-dg-page-size", never, { "pageSizeOptions": "clrPageSizeOptions"; }, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatagridPageSize, never>;
 }
 
 export declare class ClrDatagridPagination implements OnDestroy, OnInit {
@@ -856,15 +736,11 @@ export declare class ClrDatagridPagination implements OnDestroy, OnInit {
     ngOnInit(): void;
     previous(): void;
     updateCurrentPage(event: any): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDatagridPagination, "clr-dg-pagination", never, { "disableCurrentPageInput": "clrDgPageInputDisabled"; "pageSize": "clrDgPageSize"; "totalItems": "clrDgTotalItems"; "lastPage": "clrDgLastPage"; "currentPage": "clrDgPage"; }, { "currentChanged": "clrDgPageChange"; }, ["_pageSizeComponent"], ["clr-dg-page-size", "*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatagridPagination, never>;
 }
 
 export declare class ClrDatagridPlaceholder<T = any> {
     get emptyDatagrid(): boolean;
     constructor(items: Items<T>);
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDatagridPlaceholder<any>, "clr-dg-placeholder", never, {}, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatagridPlaceholder<any>, never>;
 }
 
 export declare class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit {
@@ -909,8 +785,6 @@ export declare class ClrDatagridRow<T = any> implements AfterContentInit, AfterV
     ngOnInit(): void;
     toggle(selected?: boolean): void;
     toggleExpand(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDatagridRow<any>, "clr-dg-row", never, { "item": "clrDgItem"; "selected": "clrDgSelected"; "clrDgSelectable": "clrDgSelectable"; "expanded": "clrDgExpanded"; "clrDgDetailOpenLabel": "clrDgDetailOpenLabel"; "clrDgDetailCloseLabel": "clrDgDetailCloseLabel"; }, { "selectedChanged": "clrDgSelectedChange"; "expandedChange": "clrDgExpandedChange"; }, ["dgCells"], ["clr-dg-row-detail", "clr-dg-action-overflow", "clr-dg-cell"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatagridRow<any>, never>;
 }
 
 export declare class ClrDatagridRowDetail implements AfterContentInit, OnDestroy {
@@ -930,8 +804,6 @@ export declare class ClrDatagridRowDetail implements AfterContentInit, OnDestroy
     constructor(selection: Selection, rowActionService: RowActionService, expand: DatagridIfExpandService, expandableRows: ExpandableRowsCount, commonStrings: ClrCommonStringsService);
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDatagridRowDetail, "clr-dg-row-detail", never, { "replace": "clrDgReplace"; "_beginningOfExpandableContentAriaText": "clrRowDetailBeginningAriaText"; "_endOfExpandableContentAriaText": "clrRowDetailEndAriaText"; }, {}, ["cells"], ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatagridRowDetail, never>;
 }
 
 export declare enum ClrDatagridSortOrder {
@@ -964,16 +836,12 @@ export declare class ClrDatalist implements AfterContentInit {
     constructor(datalistIdService: DatalistIdService);
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrDatalist, "datalist", never, { "id": "id"; }, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatalist, [{ optional: true; }]>;
 }
 
 export declare class ClrDatalistContainer extends ClrAbstractContainer {
     focus: boolean;
     protected ifControlStateService: IfControlStateService;
     constructor(controlClassService: ControlClassService, layoutService: LayoutService, ngControlService: NgControlService, focusService: FocusService, ifControlStateService: IfControlStateService);
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDatalistContainer, "clr-datalist-container", never, {}, {}, never, ["label", "[clrDatalistInput]", "datalist", "clr-control-helper", "clr-control-error", "clr-control-success"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatalistContainer, [null, { optional: true; }, null, null, null]>;
 }
 
 export declare class ClrDatalistInput extends WrappedFormControl<ClrDatalistContainer> implements AfterContentInit {
@@ -982,21 +850,13 @@ export declare class ClrDatalistInput extends WrappedFormControl<ClrDatalistCont
     ngAfterContentInit(): void;
     triggerFocus(): void;
     triggerValidation(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrDatalistInput, "[clrDatalistInput]", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatalistInput, [{ optional: true; }, null, null, { optional: true; self: true; }, null, null, null]>;
 }
 
 export declare class ClrDatalistModule {
     constructor();
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatalistModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrDatalistModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrDatalistModule, [typeof i1.ClrDatalist, typeof i2.ClrDatalistInput, typeof i3.ClrDatalistContainer], [typeof i4.CommonModule, typeof i5.ClrInputModule, typeof i6.ClrIconModule], [typeof i1.ClrDatalist, typeof i2.ClrDatalistInput, typeof i3.ClrDatalistContainer]>;
 }
 
 export declare class ClrDataModule {
-    static ɵfac: i0.ɵɵFactoryDef<ClrDataModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrDataModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrDataModule, never, never, [typeof i1.ClrDatagridModule, typeof i2.ClrStackViewModule, typeof i3.ClrTreeViewModule]>;
 }
 
 export declare class ClrDateContainer extends ClrAbstractContainer implements AfterViewInit {
@@ -1014,8 +874,6 @@ export declare class ClrDateContainer extends ClrAbstractContainer implements Af
     get popoverPosition(): ClrPopoverPosition;
     constructor(toggleService: ClrPopoverToggleService, dateNavigationService: DateNavigationService, datepickerEnabledService: DatepickerEnabledService, dateFormControlService: DateFormControlService, commonStrings: ClrCommonStringsService, focusService: FocusService, viewManagerService: ViewManagerService, controlClassService: ControlClassService, layoutService: LayoutService, ngControlService: NgControlService, ifControlStateService: IfControlStateService);
     ngAfterViewInit(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDateContainer, "clr-date-container", never, { "clrPosition": "clrPosition"; }, {}, never, ["label", "[clrDate]", "clr-control-helper", "clr-control-error", "clr-control-success"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDateContainer, [null, null, null, null, null, null, null, null, { optional: true; }, null, null]>;
 }
 
 export declare class ClrDateInput extends WrappedFormControl<ClrDateContainer> implements OnInit, AfterViewInit, OnDestroy {
@@ -1039,15 +897,10 @@ export declare class ClrDateInput extends WrappedFormControl<ClrDateContainer> i
     setFocusStates(): void;
     triggerValidation(): void;
     static ngAcceptInputType_date: Date | null | string;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrDateInput, "[clrDate]", never, { "placeholder": "placeholder"; "date": "clrDate"; "min": "min"; "max": "max"; "disabled": "disabled"; }, { "dateChange": "clrDateChange"; }, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDateInput, [null, null, null, null, { optional: true; self: true; }, { optional: true; }, { optional: true; }, { optional: true; }, { optional: true; }, { optional: true; }, null, { optional: true; }, null]>;
 }
 
 export declare class ClrDatepickerModule {
     constructor();
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatepickerModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrDatepickerModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrDatepickerModule, [typeof i1.ClrDay, typeof i2.ClrDateContainer, typeof i3.ClrDateInput, typeof i4.ClrDatepickerViewManager, typeof i5.ClrMonthpicker, typeof i6.ClrYearpicker, typeof i7.ClrDaypicker, typeof i8.ClrCalendar], [typeof i9.CommonModule, typeof i10.ClrHostWrappingModule, typeof i11.ClrConditionalModule, typeof i12.ClrPopoverModuleNext, typeof i13.ClrIconModule, typeof i14.ClrFocusTrapModule, typeof i15.ClrCommonFormsModule], [typeof i1.ClrDay, typeof i2.ClrDateContainer, typeof i3.ClrDateInput, typeof i4.ClrDatepickerViewManager, typeof i5.ClrMonthpicker, typeof i6.ClrYearpicker, typeof i7.ClrDaypicker, typeof i8.ClrCalendar]>;
 }
 
 export declare class ClrDatepickerViewManager {
@@ -1055,8 +908,6 @@ export declare class ClrDatepickerViewManager {
     get isMonthView(): boolean;
     get isYearView(): boolean;
     constructor(viewManagerService: ViewManagerService);
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDatepickerViewManager, "clr-datepicker-view-manager", never, {}, {}, never, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDatepickerViewManager, never>;
 }
 
 export declare class ClrDay {
@@ -1066,8 +917,6 @@ export declare class ClrDay {
     constructor(_dateNavigationService: DateNavigationService, _toggleService: ClrPopoverToggleService, dateFormControlService: DateFormControlService);
     onDayViewFocus(): void;
     selectDay(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDay, "clr-day", never, { "dayView": "clrDayView"; }, {}, never, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDay, never>;
 }
 
 export declare class ClrDaypicker {
@@ -1082,14 +931,9 @@ export declare class ClrDaypicker {
     currentMonth(): void;
     nextMonth(): void;
     previousMonth(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDaypicker, "clr-daypicker", never, {}, {}, never, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDaypicker, never>;
 }
 
 export declare class ClrDragAndDropModule {
-    static ɵfac: i0.ɵɵFactoryDef<ClrDragAndDropModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrDragAndDropModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrDragAndDropModule, [typeof i1.ClrDraggable, typeof i2.ClrDroppable, typeof i3.ClrIfDragged, typeof i4.ClrDragHandle, typeof i5.ClrDraggableGhost], [typeof i6.CommonModule], [typeof i1.ClrDraggable, typeof i2.ClrDroppable, typeof i3.ClrIfDragged, typeof i4.ClrDragHandle, typeof i5.ClrDraggableGhost]>;
 }
 
 export declare class ClrDragEvent<T> {
@@ -1112,8 +956,6 @@ export declare class ClrDraggable<T> implements AfterContentInit, OnDestroy {
     constructor(el: ElementRef, dragEventListener: DragEventListenerService<T>, dragHandleRegistrar: DragHandleRegistrarService<T>, viewContainerRef: ViewContainerRef, cfr: ComponentFactoryResolver, injector: Injector, draggableSnapshot: DraggableSnapshotService<T>, globalDragMode: GlobalDragModeService);
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrDraggable<any>, "[clrDraggable]", never, { "dataTransfer": "clrDraggable"; "group": "clrGroup"; "dragStartDelay": "clrDragStartDelay"; }, { "dragStartEmitter": "clrDragStart"; "dragMoveEmitter": "clrDragMove"; "dragEndEmitter": "clrDragEnd"; }, ["customGhost"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDraggable<any>, never>;
 }
 
 export declare class ClrDraggableGhost<T> implements OnDestroy {
@@ -1126,15 +968,11 @@ export declare class ClrDraggableGhost<T> implements OnDestroy {
     };
     constructor(el: ElementRef, dragEventListener: DragEventListenerService<T>, draggableSnapshot: DraggableSnapshotService<T>, renderer: Renderer2, ngZone: NgZone);
     ngOnDestroy(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDraggableGhost<any>, "clr-draggable-ghost", never, {}, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDraggableGhost<any>, [null, { optional: true; }, { optional: true; }, null, null]>;
 }
 
 export declare class ClrDragHandle<T> implements OnDestroy {
     constructor(el: ElementRef, dragHandleRegistrar: DragHandleRegistrarService<T>);
     ngOnDestroy(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrDragHandle<any>, "[clrDragHandle]", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDragHandle<any>, [null, { optional: true; }]>;
 }
 
 export declare class ClrDropdown implements OnDestroy {
@@ -1143,8 +981,6 @@ export declare class ClrDropdown implements OnDestroy {
     toggleService: ClrPopoverToggleService;
     constructor(parent: ClrDropdown, toggleService: ClrPopoverToggleService, cdr: ChangeDetectorRef, dropdownService: RootDropdownService);
     ngOnDestroy(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDropdown, "clr-dropdown", never, { "isMenuClosable": "clrCloseMenuOnItemClick"; }, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDropdown, [{ optional: true; skipSelf: true; }, null, null, null]>;
 }
 
 export declare class ClrDropdownItem implements AfterViewInit {
@@ -1159,8 +995,6 @@ export declare class ClrDropdownItem implements AfterViewInit {
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
     onDropdownItemClick(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrDropdownItem, "[clrDropdownItem]", never, { "disabled": "clrDisabled"; "disabledDeprecated": "disabled"; "dropdownItemId": "id"; }, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDropdownItem, never>;
 }
 
 export declare class ClrDropdownMenu extends AbstractPopover implements AfterContentInit, OnDestroy {
@@ -1169,14 +1003,9 @@ export declare class ClrDropdownMenu extends AbstractPopover implements AfterCon
     constructor(injector: Injector, parentHost: ElementRef<HTMLElement>, nested: ClrDropdownMenu, focusHandler: DropdownFocusHandler);
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrDropdownMenu, "clr-dropdown-menu", never, { "position": "clrPosition"; }, {}, ["items"], ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDropdownMenu, [null, { optional: true; }, { optional: true; skipSelf: true; }, null]>;
 }
 
 export declare class ClrDropdownModule {
-    static ɵfac: i0.ɵɵFactoryDef<ClrDropdownModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrDropdownModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrDropdownModule, [typeof i1.ClrDropdown, typeof i2.ClrDropdownMenu, typeof i3.ClrDropdownTrigger, typeof i4.ClrDropdownItem], [typeof i5.CommonModule], [typeof i1.ClrDropdown, typeof i2.ClrDropdownMenu, typeof i3.ClrDropdownTrigger, typeof i4.ClrDropdownItem, typeof i6.ClrConditionalModule, typeof i7.ClrIconModule]>;
 }
 
 export declare class ClrDropdownTrigger {
@@ -1184,8 +1013,6 @@ export declare class ClrDropdownTrigger {
     isRootLevelToggle: boolean;
     constructor(dropdown: ClrDropdown, toggleService: ClrPopoverToggleService, el: ElementRef<HTMLElement>, focusHandler: DropdownFocusHandler);
     onDropdownTriggerClick(event: any): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrDropdownTrigger, "[clrDropdownTrigger],[clrDropdownToggle]", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDropdownTrigger, never>;
 }
 
 export declare class ClrDroppable<T> implements OnInit, OnDestroy {
@@ -1202,8 +1029,6 @@ export declare class ClrDroppable<T> implements OnInit, OnDestroy {
     constructor(el: ElementRef, eventBus: DragAndDropEventBusService<T>, domAdapter: DomAdapter, renderer: Renderer2);
     ngOnDestroy(): void;
     ngOnInit(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrDroppable<any>, "[clrDroppable]", never, { "group": "clrGroup"; "dropTolerance": "clrDropTolerance"; }, { "dragStartEmitter": "clrDragStart"; "dragMoveEmitter": "clrDragMove"; "dragEndEmitter": "clrDragEnd"; "dragLeaveEmitter": "clrDragLeave"; "dragEnterEmitter": "clrDragEnter"; "dropEmitter": "clrDrop"; }, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrDroppable<any>, never>;
 }
 
 export interface ClrDropToleranceInterface {
@@ -1214,9 +1039,6 @@ export interface ClrDropToleranceInterface {
 }
 
 export declare class ClrEmphasisModule {
-    static ɵfac: i0.ɵɵFactoryDef<ClrEmphasisModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrEmphasisModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrEmphasisModule, never, never, [typeof i1.ClrAlertModule]>;
 }
 
 export declare class ClrExpandableAnimation {
@@ -1231,8 +1053,6 @@ export declare class ClrExpandableAnimation {
     constructor(element: ElementRef, domAdapter: DomAdapter);
     animationDone(): void;
     updateStartHeight(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrExpandableAnimation, "clr-expandable-animation", never, { "clrExpandTrigger": "clrExpandTrigger"; }, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrExpandableAnimation, never>;
 }
 
 export declare class ClrFocusOnViewInit implements AfterViewInit {
@@ -1240,14 +1060,9 @@ export declare class ClrFocusOnViewInit implements AfterViewInit {
     constructor(el: ElementRef, platformId: any, focusOnViewInit: boolean, document: any, renderer: Renderer2);
     ngAfterViewInit(): void;
     onFocusout(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrFocusOnViewInit, "[clrFocusOnViewInit]", never, { "isEnabled": "clrFocusOnViewInit"; }, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrFocusOnViewInit, never>;
 }
 
 export declare class ClrFocusOnViewInitModule {
-    static ɵfac: i0.ɵɵFactoryDef<ClrFocusOnViewInitModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrFocusOnViewInitModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrFocusOnViewInitModule, [typeof i1.ClrFocusOnViewInit], [typeof i2.CommonModule], [typeof i1.ClrFocusOnViewInit]>;
 }
 
 export declare class ClrForm {
@@ -1257,8 +1072,6 @@ export declare class ClrForm {
     constructor(layoutService: LayoutService, markControlService: MarkControlService);
     markAsTouched(): void;
     onFormSubmit(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrForm, "[clrForm]", never, { "labelSize": "clrLabelSize"; }, {}, ["labels"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrForm, never>;
 }
 
 export declare enum ClrFormLayout {
@@ -1268,9 +1081,6 @@ export declare enum ClrFormLayout {
 }
 
 export declare class ClrFormsModule {
-    static ɵfac: i0.ɵɵFactoryDef<ClrFormsModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrFormsModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrFormsModule, never, [typeof i1.CommonModule], [typeof i2.ClrCommonFormsModule, typeof i3.ClrCheckboxModule, typeof i4.ClrComboboxModule, typeof i5.ClrDatepickerModule, typeof i6.ClrInputModule, typeof i7.ClrPasswordModule, typeof i8.ClrRadioModule, typeof i9.ClrSelectModule, typeof i10.ClrTextareaModule, typeof i11.ClrRangeModule, typeof i12.ClrDatalistModule]>;
 }
 
 export declare class ClrHeader implements OnDestroy {
@@ -1285,19 +1095,12 @@ export declare class ClrHeader implements OnDestroy {
     ngOnDestroy(): void;
     resetNavTriggers(): void;
     toggleNav(navLevel: number): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrHeader, "clr-header", never, {}, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrHeader, never>;
 }
 
 export declare class ClrIconCustomTag {
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrIconCustomTag, "clr-icon", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrIconCustomTag, never>;
 }
 
 export declare class ClrIconModule {
-    static ɵfac: i0.ɵɵFactoryDef<ClrIconModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrIconModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrIconModule, [typeof i1.ClrIconCustomTag, typeof i1.CdsIconCustomTag], [typeof i2.CommonModule], [typeof i1.ClrIconCustomTag, typeof i1.CdsIconCustomTag]>;
 }
 
 export declare class ClrIfActive implements OnDestroy {
@@ -1307,8 +1110,6 @@ export declare class ClrIfActive implements OnDestroy {
     constructor(ifActiveService: IfActiveService, id: number, template: TemplateRef<any>, container: ViewContainerRef);
     ngOnDestroy(): void;
     updateView(value: boolean): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrIfActive, "[clrIfActive]", never, { "active": "clrIfActive"; }, { "activeChange": "clrIfActiveChange"; }, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrIfActive, never>;
 }
 
 export declare class ClrIfDetail implements OnInit, OnDestroy {
@@ -1317,23 +1118,17 @@ export declare class ClrIfDetail implements OnInit, OnDestroy {
     constructor(templateRef: TemplateRef<any>, viewContainer: ViewContainerRef, detailService: DetailService);
     ngOnDestroy(): void;
     ngOnInit(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrIfDetail, "[clrIfDetail]", never, { "state": "clrIfDetail"; }, { "stateChange": "clrIfDetailChange"; }, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrIfDetail, never>;
 }
 
 export declare class ClrIfDragged<T> implements OnDestroy {
     constructor(template: TemplateRef<any>, container: ViewContainerRef, dragEventListener: DragEventListenerService<T>);
     ngOnDestroy(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrIfDragged<any>, "[clrIfDragged]", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrIfDragged<any>, [null, { optional: true; skipSelf: true; }, { optional: true; }]>;
 }
 
 export declare class ClrIfError extends AbstractIfState {
     error: string;
     constructor(ifControlStateService: IfControlStateService, ngControlService: NgControlService, template: TemplateRef<any>, container: ViewContainerRef);
     protected handleState(state: CONTROL_STATE): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrIfError, "[clrIfError]", never, { "error": "clrIfError"; }, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrIfError, [{ optional: true; }, { optional: true; }, null, null]>;
 }
 
 export declare class ClrIfExpanded implements OnInit, OnDestroy {
@@ -1343,8 +1138,6 @@ export declare class ClrIfExpanded implements OnInit, OnDestroy {
     constructor(template: TemplateRef<any>, container: ViewContainerRef, el: ElementRef, renderer: Renderer2, expand: IfExpandService);
     ngOnDestroy(): void;
     ngOnInit(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrIfExpanded, "[clrIfExpanded]", never, { "expanded": "clrIfExpanded"; }, { "expandedChange": "clrIfExpandedChange"; }, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrIfExpanded, [{ optional: true; }, null, null, null, null]>;
 }
 
 export declare class ClrIfOpen implements OnDestroy {
@@ -1355,34 +1148,23 @@ export declare class ClrIfOpen implements OnDestroy {
     ngOnDestroy(): void;
     updateView(value: boolean): void;
     static ngAcceptInputType_open: boolean | '';
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrIfOpen, "[clrIfOpen]", never, { "open": "clrIfOpen"; }, { "openChange": "clrIfOpenChange"; }, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrIfOpen, never>;
 }
 
 export declare class ClrIfSuccess extends AbstractIfState {
     constructor(ifControlStateService: IfControlStateService, ngControlService: NgControlService, template: TemplateRef<any>, container: ViewContainerRef);
     protected handleState(state: CONTROL_STATE): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrIfSuccess, "[clrIfSuccess]", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrIfSuccess, [{ optional: true; }, { optional: true; }, null, null]>;
 }
 
 export declare class ClrInput extends WrappedFormControl<ClrInputContainer> {
     protected index: number;
     constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef);
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrInput, "[clrInput]", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrInput, [null, null, { optional: true; self: true; }, null, null]>;
 }
 
 export declare class ClrInputContainer extends ClrAbstractContainer {
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrInputContainer, "clr-input-container", never, {}, {}, never, ["label", "[clrInput]", "clr-control-helper", "clr-control-error", "clr-control-success"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrInputContainer, never>;
 }
 
 export declare class ClrInputModule {
     constructor();
-    static ɵfac: i0.ɵɵFactoryDef<ClrInputModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrInputModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrInputModule, [typeof i1.ClrInput, typeof i2.ClrInputContainer], [typeof i3.CommonModule, typeof i4.FormsModule, typeof i5.ClrIconModule, typeof i6.ClrCommonFormsModule], [typeof i6.ClrCommonFormsModule, typeof i1.ClrInput, typeof i2.ClrInputContainer]>;
 }
 
 export declare class ClrLabel implements OnInit, OnDestroy {
@@ -1392,8 +1174,6 @@ export declare class ClrLabel implements OnInit, OnDestroy {
     disableGrid(): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrLabel, "label", never, { "forAttr": "for"; }, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrLabel, [{ optional: true; }, { optional: true; }, { optional: true; }, null, null]>;
 }
 
 export declare class ClrLayout implements OnInit {
@@ -1401,14 +1181,9 @@ export declare class ClrLayout implements OnInit {
     layoutService: LayoutService;
     constructor(layoutService: LayoutService);
     ngOnInit(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrLayout, "[clrForm][clrLayout]", never, { "layout": "clrLayout"; }, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrLayout, never>;
 }
 
 export declare class ClrLayoutModule {
-    static ɵfac: i0.ɵɵFactoryDef<ClrLayoutModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrLayoutModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrLayoutModule, never, never, [typeof i1.ClrMainContainerModule, typeof i2.ClrNavigationModule, typeof i3.ClrTabsModule, typeof i4.ClrVerticalNavModule]>;
 }
 
 export declare class ClrLoading implements OnDestroy {
@@ -1417,8 +1192,6 @@ export declare class ClrLoading implements OnDestroy {
     constructor(listener: LoadingListener);
     ngOnDestroy(): void;
     static ngAcceptInputType_loadingState: boolean | ClrLoadingState | null | string;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrLoading, "[clrLoading]", never, { "loadingState": "clrLoading"; }, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrLoading, [{ optional: true; }]>;
 }
 
 export declare class ClrLoadingButton implements LoadingListener {
@@ -1429,20 +1202,12 @@ export declare class ClrLoadingButton implements LoadingListener {
     state: ClrLoadingState;
     constructor(el: ElementRef, renderer: Renderer2);
     loadingStateChange(state: ClrLoadingState): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrLoadingButton, "button[clrLoading]", never, { "disabled": "disabled"; }, { "clrLoadingChange": "clrLoadingChange"; }, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrLoadingButton, never>;
 }
 
 export declare class ClrLoadingButtonModule {
-    static ɵfac: i0.ɵɵFactoryDef<ClrLoadingButtonModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrLoadingButtonModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrLoadingButtonModule, [typeof i1.ClrLoadingButton], [typeof i2.CommonModule], [typeof i1.ClrLoadingButton]>;
 }
 
 export declare class ClrLoadingModule {
-    static ɵfac: i0.ɵɵFactoryDef<ClrLoadingModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrLoadingModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrLoadingModule, [typeof i1.ClrLoading], [typeof i2.CommonModule], [typeof i1.ClrLoading]>;
 }
 
 export declare enum ClrLoadingState {
@@ -1458,14 +1223,9 @@ export declare class ClrMainContainer implements OnDestroy, OnInit {
     ngOnDestroy(): void;
     ngOnInit(): void;
     processMessage(message: ResponsiveNavControlMessage): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrMainContainer, "clr-main-container", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrMainContainer, never>;
 }
 
 export declare class ClrMainContainerModule {
-    static ɵfac: i0.ɵɵFactoryDef<ClrMainContainerModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrMainContainerModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrMainContainerModule, [typeof i1.ClrMainContainer], [typeof i2.CommonModule, typeof i3.ClrIconModule], [typeof i1.ClrMainContainer]>;
 }
 
 export declare class ClrModal implements OnChanges, OnDestroy {
@@ -1489,22 +1249,15 @@ export declare class ClrModal implements OnChanges, OnDestroy {
     }): void;
     ngOnDestroy(): void;
     open(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrModal, "clr-modal", never, { "_open": "clrModalOpen"; "closable": "clrModalClosable"; "size": "clrModalSize"; "staticBackdrop": "clrModalStaticBackdrop"; "skipAnimation": "clrModalSkipAnimation"; "bypassScrollService": "clrModalOverrideScrollService"; "stopClose": "clrModalPreventClose"; }, { "_openChanged": "clrModalOpenChange"; "altClose": "clrModalAlternateClose"; }, never, [".modal-nav", ".modal-title", ".modal-body", ".modal-footer"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrModal, never>;
 }
 
 export declare class ClrModalBody implements OnDestroy {
     constructor(ngZone: NgZone, renderer: Renderer2, host: ElementRef<HTMLElement>);
     ngOnDestroy(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrModalBody, ".modal-body", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrModalBody, never>;
 }
 
 export declare class ClrModalModule {
     constructor();
-    static ɵfac: i0.ɵɵFactoryDef<ClrModalModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrModalModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrModalModule, [typeof i1.ClrModal, typeof i2.ClrModalBody], [typeof i3.CommonModule, typeof i4.ClrIconModule, typeof i5.ClrFocusTrapModule, typeof i6.ClrFocusOnViewInitModule], [typeof i1.ClrModal, typeof i2.ClrModalBody, typeof i4.ClrIconModule, typeof i6.ClrFocusOnViewInitModule]>;
 }
 
 export declare class ClrMonthpicker implements AfterViewInit {
@@ -1515,14 +1268,9 @@ export declare class ClrMonthpicker implements AfterViewInit {
     getTabIndex(monthIndex: number): number;
     ngAfterViewInit(): void;
     onKeyDown(event: KeyboardEvent): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrMonthpicker, "clr-monthpicker", never, {}, {}, never, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrMonthpicker, never>;
 }
 
 export declare class ClrNavigationModule {
-    static ɵfac: i0.ɵɵFactoryDef<ClrNavigationModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrNavigationModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrNavigationModule, [typeof i1.ClrHeader, typeof i2.ClrNavLevel, typeof i3.NavDetectionOompaLoompa, typeof i4.MainContainerWillyWonka], [typeof i5.CommonModule, typeof i6.ClrIconModule, typeof i7.ClrDropdownModule], [typeof i1.ClrHeader, typeof i2.ClrNavLevel, typeof i3.NavDetectionOompaLoompa, typeof i4.MainContainerWillyWonka]>;
 }
 
 export declare class ClrNavLevel implements OnInit {
@@ -1536,8 +1284,6 @@ export declare class ClrNavLevel implements OnInit {
     ngOnInit(): void;
     onMouseClick(target: any): void;
     open(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrNavLevel, "[clr-nav-level]", never, { "_level": "clr-nav-level"; }, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrNavLevel, never>;
 }
 
 export declare class ClrOption<T> implements OnInit {
@@ -1553,8 +1299,6 @@ export declare class ClrOption<T> implements OnInit {
     constructor(elRef: ElementRef, commonStrings: ClrCommonStringsService, focusHandler: ComboboxFocusHandler<T>, optionSelectionService: OptionSelectionService<T>, autoId: string);
     ngOnInit(): void;
     onClick(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrOption<any>, "clr-option", never, { "optionId": "id"; "value": "clrValue"; }, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrOption<any>, never>;
 }
 
 export declare class ClrOptionItems<T> implements DoCheck, OnDestroy {
@@ -1565,8 +1309,6 @@ export declare class ClrOptionItems<T> implements DoCheck, OnDestroy {
     constructor(template: TemplateRef<NgForOfContext<T>>, differs: IterableDiffers, optionService: OptionSelectionService<T>, positionService: ClrPopoverPositionService, vcr: ViewContainerRef);
     ngDoCheck(): void;
     ngOnDestroy(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrOptionItems<any>, "[clrOptionItems][clrOptionItemsOf]", never, { "rawItems": "clrOptionItemsOf"; "trackBy": "clrOptionItemsTrackBy"; "field": "clrOptionItemsField"; }, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrOptionItems<any>, never>;
 }
 
 export declare class ClrOptions<T> implements AfterViewInit, LoadingListener, OnDestroy {
@@ -1585,8 +1327,6 @@ export declare class ClrOptions<T> implements AfterViewInit, LoadingListener, On
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
     searchText(input: string): string;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrOptions<any>, "clr-options", never, { "optionsId": "id"; }, {}, ["items"], ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrOptions<any>, [null, null, null, null, null, null, null, { optional: true; }, null]>;
 }
 
 export declare class ClrOptionSelected<T> {
@@ -1597,8 +1337,6 @@ export declare class ClrOptionSelected<T> {
     constructor(template: TemplateRef<{
         $implicit: T;
     }>);
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrOptionSelected<any>, "[clrOptionSelected]", never, { "selected": "clrOptionSelected"; }, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrOptionSelected<any>, never>;
 }
 
 export declare class ClrPassword extends WrappedFormControl<ClrPasswordContainer> implements OnInit, OnDestroy {
@@ -1606,8 +1344,6 @@ export declare class ClrPassword extends WrappedFormControl<ClrPasswordContainer
     constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef, focusService: FocusService, toggleService: BehaviorSubject<boolean>);
     triggerFocus(): void;
     triggerValidation(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrPassword, "[clrPassword]", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrPassword, [null, null, { optional: true; self: true; }, null, null, { optional: true; }, { optional: true; }]>;
 }
 
 export declare class ClrPasswordContainer extends ClrAbstractContainer {
@@ -1619,21 +1355,14 @@ export declare class ClrPasswordContainer extends ClrAbstractContainer {
     show: boolean;
     constructor(ifControlStateService: IfControlStateService, layoutService: LayoutService, controlClassService: ControlClassService, ngControlService: NgControlService, focusService: FocusService, toggleService: BehaviorSubject<boolean>, commonStrings: ClrCommonStringsService);
     toggle(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrPasswordContainer, "clr-password-container", never, { "clrToggle": "clrToggle"; }, {}, never, ["label", "[clrPassword]", "clr-control-helper", "clr-control-error", "clr-control-success"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrPasswordContainer, [null, { optional: true; }, null, null, null, null, null]>;
 }
 
 export declare class ClrPasswordModule {
     constructor();
-    static ɵfac: i0.ɵɵFactoryDef<ClrPasswordModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrPasswordModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrPasswordModule, [typeof i1.ClrPassword, typeof i2.ClrPasswordContainer], [typeof i3.CommonModule, typeof i4.FormsModule, typeof i5.ClrIconModule, typeof i6.ClrCommonFormsModule], [typeof i6.ClrCommonFormsModule, typeof i1.ClrPassword, typeof i2.ClrPasswordContainer]>;
 }
 
 export declare class ClrPopoverAnchor {
     constructor(smartEventService: ClrPopoverEventsService, element: ElementRef);
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrPopoverAnchor, "[clrPopoverAnchor]", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrPopoverAnchor, never>;
 }
 
 export declare class ClrPopoverContent implements AfterContentChecked, OnDestroy {
@@ -1645,8 +1374,6 @@ export declare class ClrPopoverContent implements AfterContentChecked, OnDestroy
     ngAfterContentChecked(): void;
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrPopoverContent, "[clrPopoverContent]", never, { "open": "clrPopoverContent"; "contentAt": "clrPopoverContentAt"; "outsideClickClose": "clrPopoverContentOutsideClickToClose"; "scrollToClose": "clrPopoverContentScrollToClose"; }, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrPopoverContent, never>;
 }
 
 export declare class ClrPopoverEventsService implements OnDestroy {
@@ -1669,14 +1396,9 @@ export declare class ClrPopoverEventsService implements OnDestroy {
     removeScrollListener(): void;
     setAnchorFocus(): void;
     setCloseFocus(): void;
-    static ɵfac: i0.ɵɵFactoryDef<ClrPopoverEventsService, never>;
-    static ɵprov: i0.ɵɵInjectableDef<ClrPopoverEventsService>;
 }
 
 export declare class ClrPopoverModule {
-    static ɵfac: i0.ɵɵFactoryDef<ClrPopoverModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrPopoverModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrPopoverModule, never, never, [typeof i1.ClrDropdownModule, typeof i2.ClrSignpostModule, typeof i3.ClrTooltipModule]>;
 }
 
 export interface ClrPopoverPosition {
@@ -1694,8 +1416,6 @@ export declare class ClrPopoverPositionService {
     constructor(eventService: ClrPopoverEventsService, platformId: any);
     alignContent(content: HTMLElement): ClrPopoverContentOffset;
     realign(): void;
-    static ɵfac: i0.ɵɵFactoryDef<ClrPopoverPositionService, never>;
-    static ɵprov: i0.ɵɵInjectableDef<ClrPopoverPositionService>;
 }
 
 export declare class ClrPopoverToggleService {
@@ -1709,8 +1429,6 @@ export declare class ClrPopoverToggleService {
     getEventChange(): Observable<Event>;
     popoverAlignedEmit(popoverNode: HTMLElement): void;
     toggleWithEvent(event: any): void;
-    static ɵfac: i0.ɵɵFactoryDef<ClrPopoverToggleService, never>;
-    static ɵprov: i0.ɵɵInjectableDef<ClrPopoverToggleService>;
 }
 
 export declare class ClrProgressBar {
@@ -1738,20 +1456,13 @@ export declare class ClrProgressBar {
     get value(): number | string;
     set value(value: number | string);
     displayStringValue(): boolean;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrProgressBar, "clr-progress-bar", never, { "id": "id"; "max": "clrMax"; "displayval": "clrDisplayval"; "value": "clrValue"; "clrLabeled": "clrLabeled"; "clrFade": "clrFade"; "clrLoop": "clrLoop"; "clrSuccess": "clrSuccess"; "clrDanger": "clrDanger"; "clrFlash": "clrFlash"; "clrFlashDanger": "clrFlashDanger"; }, {}, never, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrProgressBar, never>;
 }
 
 export declare class ClrProgressBarModule {
-    static ɵfac: i0.ɵɵFactoryDef<ClrProgressBarModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrProgressBarModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrProgressBarModule, [typeof i1.ClrProgressBar], [typeof i2.CommonModule], [typeof i1.ClrProgressBar]>;
 }
 
 export declare class ClrRadio extends WrappedFormControl<ClrRadioWrapper> {
     constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef);
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrRadio, "[clrRadio]", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrRadio, [null, null, { optional: true; self: true; }, null, null]>;
 }
 
 export declare class ClrRadioContainer extends ClrAbstractContainer implements AfterContentInit {
@@ -1765,29 +1476,20 @@ export declare class ClrRadioContainer extends ClrAbstractContainer implements A
     role: string;
     constructor(layoutService: LayoutService, controlClassService: ControlClassService, ngControlService: NgControlService, ifControlStateService: IfControlStateService);
     ngAfterContentInit(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrRadioContainer, "clr-radio-container", never, { "clrInline": "clrInline"; }, {}, ["radios"], ["label", "clr-radio-wrapper", "clr-control-helper", "clr-control-error", "clr-control-success"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrRadioContainer, [{ optional: true; }, null, null, null]>;
 }
 
 export declare class ClrRadioModule {
     constructor();
-    static ɵfac: i0.ɵɵFactoryDef<ClrRadioModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrRadioModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrRadioModule, [typeof i1.ClrRadio, typeof i2.ClrRadioContainer, typeof i3.ClrRadioWrapper], [typeof i4.CommonModule, typeof i5.ClrCommonFormsModule, typeof i6.ClrHostWrappingModule, typeof i7.ClrIconModule], [typeof i5.ClrCommonFormsModule, typeof i1.ClrRadio, typeof i2.ClrRadioContainer, typeof i3.ClrRadioWrapper]>;
 }
 
 export declare class ClrRadioWrapper implements DynamicWrapper, OnInit {
     _dynamic: boolean;
     label: ClrLabel;
     ngOnInit(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrRadioWrapper, "clr-radio-wrapper", never, {}, {}, ["label"], ["[clrRadio]", "label"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrRadioWrapper, never>;
 }
 
 export declare class ClrRange extends WrappedFormControl<ClrRangeContainer> {
     constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef);
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrRange, "[clrRange]", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrRange, [null, null, { optional: true; self: true; }, null, null]>;
 }
 
 export declare class ClrRangeContainer extends ClrAbstractContainer {
@@ -1796,15 +1498,10 @@ export declare class ClrRangeContainer extends ClrAbstractContainer {
     protected ifControlStateService: IfControlStateService;
     constructor(layoutService: LayoutService, controlClassService: ControlClassService, ngControlService: NgControlService, renderer: Renderer2, idService: ControlIdService, ifControlStateService: IfControlStateService);
     getRangeProgressFillWidth(): string;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrRangeContainer, "clr-range-container", never, { "hasProgress": "clrRangeHasProgress"; }, {}, never, ["label", "[clrRange]", "clr-control-helper", "clr-control-error", "clr-control-success"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrRangeContainer, [{ optional: true; }, null, null, null, null, null]>;
 }
 
 export declare class ClrRangeModule {
     constructor();
-    static ɵfac: i0.ɵɵFactoryDef<ClrRangeModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrRangeModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrRangeModule, [typeof i1.ClrRange, typeof i2.ClrRangeContainer], [typeof i3.CommonModule, typeof i4.ClrCommonFormsModule, typeof i5.ClrHostWrappingModule, typeof i6.ClrIconModule], [typeof i4.ClrCommonFormsModule, typeof i1.ClrRange, typeof i2.ClrRangeContainer]>;
 }
 
 export declare class ClrRecursiveForOf<T> implements OnChanges, OnDestroy {
@@ -1813,8 +1510,6 @@ export declare class ClrRecursiveForOf<T> implements OnChanges, OnDestroy {
     constructor(template: TemplateRef<ClrRecursiveForOfContext<T>>, featuresService: TreeFeaturesService<T>, cdr: ChangeDetectorRef);
     ngOnChanges(): void;
     ngOnDestroy(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrRecursiveForOf<any>, "[clrRecursiveFor][clrRecursiveForOf]", never, { "nodes": "clrRecursiveForOf"; "getChildren": "clrRecursiveForGetChildren"; }, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrRecursiveForOf<any>, never>;
 }
 
 export interface ClrRecursiveForOfContext<T> {
@@ -1825,8 +1520,6 @@ export interface ClrRecursiveForOfContext<T> {
 export declare class ClrSelect extends WrappedFormControl<ClrSelectContainer> {
     protected index: number;
     constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef);
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrSelect, "[clrSelect]", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrSelect, [null, null, { optional: true; self: true; }, null, null]>;
 }
 
 export declare class ClrSelectContainer extends ClrAbstractContainer {
@@ -1838,8 +1531,6 @@ export declare class ClrSelectContainer extends ClrAbstractContainer {
     constructor(layoutService: LayoutService, controlClassService: ControlClassService, ngControlService: NgControlService, ifControlStateService: IfControlStateService);
     ngOnInit(): void;
     wrapperClass(): "clr-multiselect-wrapper" | "clr-select-wrapper";
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrSelectContainer, "clr-select-container", never, {}, {}, ["multiple"], ["label", "[clrSelect]", "clr-control-helper", "clr-control-error", "clr-control-success"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrSelectContainer, [{ optional: true; }, null, null, null]>;
 }
 
 export declare enum ClrSelectedState {
@@ -1850,9 +1541,6 @@ export declare enum ClrSelectedState {
 
 export declare class ClrSelectModule {
     constructor();
-    static ɵfac: i0.ɵɵFactoryDef<ClrSelectModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrSelectModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrSelectModule, [typeof i1.ClrSelect, typeof i2.ClrSelectContainer], [typeof i3.CommonModule, typeof i4.FormsModule, typeof i5.ClrIconModule, typeof i6.ClrCommonFormsModule], [typeof i6.ClrCommonFormsModule, typeof i1.ClrSelect, typeof i2.ClrSelectContainer]>;
 }
 
 export declare enum ClrSide {
@@ -1865,8 +1553,6 @@ export declare class ClrSignpost {
     set customTrigger(trigger: ClrSignpostTrigger);
     useCustomTrigger: boolean;
     constructor(commonStrings: ClrCommonStringsService);
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrSignpost, "clr-signpost", never, {}, {}, ["customTrigger"], ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrSignpost, never>;
 }
 
 export declare class ClrSignpostContent extends AbstractPopover implements OnDestroy {
@@ -1877,15 +1563,10 @@ export declare class ClrSignpostContent extends AbstractPopover implements OnDes
     constructor(injector: Injector, parentHost: ElementRef, commonStrings: ClrCommonStringsService, signpostContentId: string, signpostIdService: SignpostIdService, signpostFocusManager: SignpostFocusManager, platformId: any, document: any);
     close(): void;
     ngOnDestroy(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrSignpostContent, "clr-signpost-content", never, { "position": "clrPosition"; }, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrSignpostContent, [null, { optional: true; }, null, null, null, null, null, null]>;
 }
 
 export declare class ClrSignpostModule {
     constructor();
-    static ɵfac: i0.ɵɵFactoryDef<ClrSignpostModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrSignpostModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrSignpostModule, [typeof i1.ClrSignpost, typeof i2.ClrSignpostContent, typeof i3.ClrSignpostTrigger], [typeof i4.CommonModule, typeof i5.ClrIconModule, typeof i6.ClrFocusOnViewInitModule], [typeof i1.ClrSignpost, typeof i2.ClrSignpostContent, typeof i3.ClrSignpostTrigger, typeof i7.ClrConditionalModule]>;
 }
 
 export declare class ClrSignpostTrigger implements OnDestroy {
@@ -1897,8 +1578,6 @@ export declare class ClrSignpostTrigger implements OnDestroy {
     ngOnDestroy(): void;
     ngOnInit(): void;
     onSignpostTriggerClick(event: Event): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrSignpostTrigger, "[clrSignpostTrigger]", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrSignpostTrigger, never>;
 }
 
 export declare class ClrSpinner {
@@ -1911,14 +1590,9 @@ export declare class ClrSpinner {
     get mediumClass(): boolean;
     get smallClass(): boolean;
     get spinnerClass(): boolean;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrSpinner, "clr-spinner", never, { "clrInline": "clrInline"; "clrInverse": "clrInverse"; "clrSmall": "clrSmall"; "clrMedium": "clrMedium"; }, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrSpinner, never>;
 }
 
 export declare class ClrSpinnerModule {
-    static ɵfac: i0.ɵɵFactoryDef<ClrSpinnerModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrSpinnerModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrSpinnerModule, [typeof i1.ClrSpinner], [typeof i2.CommonModule], [typeof i1.ClrSpinner]>;
 }
 
 export declare class ClrStackBlock implements OnInit {
@@ -1943,37 +1617,27 @@ export declare class ClrStackBlock implements OnInit {
     getStackChildrenId(): string;
     ngOnInit(): void;
     toggleExpand(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrStackBlock, "clr-stack-block", never, { "expanded": "clrSbExpanded"; "expandable": "clrSbExpandable"; "setChangedValue": "clrSbNotifyChange"; "ariaLevel": "clrStackViewLevel"; "ariaSetsize": "clrStackViewSetsize"; "ariaPosinset": "clrStackViewPosinset"; }, { "expandedChange": "clrSbExpandedChange"; }, never, ["clr-stack-label", "*", "clr-stack-block"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrStackBlock, [{ optional: true; skipSelf: true; }, null, null]>;
 }
 
 export declare class ClrStackContentInput {
     uniqueId: string;
     constructor(uniqueId: string);
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrStackContentInput, "[clrStackInput]", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrStackContentInput, never>;
 }
 
 export declare class ClrStackHeader {
     stackView: ClrStackView;
     constructor(stackView: ClrStackView);
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrStackHeader, "clr-stack-header", never, {}, {}, never, ["*", ".stack-action"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrStackHeader, never>;
 }
 
 export declare class ClrStackInput extends StackControl {
     stackView: ClrStackView;
     type: string;
     constructor(stackView: ClrStackView);
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrStackInput, "clr-stack-input", never, { "model": "clrModel"; "type": "type"; }, { "modelChange": "clrModelChange"; }, never, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrStackInput, never>;
 }
 
 export declare class ClrStackSelect extends StackControl {
     stackView: ClrStackView;
     constructor(stackView: ClrStackView);
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrStackSelect, "clr-stack-select", never, { "model": "clrModel"; }, { "modelChange": "clrModelChange"; }, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrStackSelect, never>;
 }
 
 export declare class ClrStackView {
@@ -1982,20 +1646,13 @@ export declare class ClrStackView {
     set editing(value: boolean);
     editingChange: EventEmitter<boolean>;
     save: EventEmitter<void>;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrStackView, "clr-stack-view", never, {}, { "save": "clrStackSave"; }, never, ["clr-stack-header", "*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrStackView, never>;
 }
 
 export declare class ClrStackViewCustomTags {
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrStackViewCustomTags, "clr-stack-label, clr-stack-content", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrStackViewCustomTags, never>;
 }
 
 export declare class ClrStackViewModule {
     constructor();
-    static ɵfac: i0.ɵɵFactoryDef<ClrStackViewModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrStackViewModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrStackViewModule, [typeof i1.ClrStackView, typeof i2.ClrStackHeader, typeof i3.ClrStackBlock, typeof i4.ClrStackContentInput, typeof i5.ClrStackViewCustomTags, typeof i6.ClrStackInput, typeof i7.ClrStackSelect], [typeof i8.CommonModule, typeof i9.FormsModule, typeof i10.ClrIconModule, typeof i11.ClrExpandableAnimationModule], [typeof i1.ClrStackView, typeof i2.ClrStackHeader, typeof i3.ClrStackBlock, typeof i4.ClrStackContentInput, typeof i5.ClrStackViewCustomTags, typeof i6.ClrStackInput, typeof i7.ClrStackSelect]>;
 }
 
 export declare class ClrStepButton implements OnInit {
@@ -2004,8 +1661,6 @@ export declare class ClrStepButton implements OnInit {
     constructor(clrStep: ClrStepperPanel, stepperService: StepperService);
     navigateToNextPanel(): void;
     ngOnInit(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrStepButton, "[clrStepButton]", never, { "type": "clrStepButton"; }, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrStepButton, never>;
 }
 
 export declare enum ClrStepButtonType {
@@ -2023,14 +1678,9 @@ export declare class ClrStepper implements OnInit, OnChanges, AfterViewInit, OnD
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrStepper, "form[clrStepper]", never, { "initialPanel": "clrInitialStep"; }, {}, ["panels"], ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrStepper, [{ optional: true; }, { optional: true; }, null]>;
 }
 
 export declare class ClrStepperModule {
-    static ɵfac: i0.ɵɵFactoryDef<ClrStepperModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrStepperModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrStepperModule, [typeof i1.ClrStepper, typeof i2.ClrStepButton, typeof i3.ClrStepperPanel, typeof i4.StepperOompaLoompa, typeof i5.StepperWillyWonka], [typeof i6.CommonModule, typeof i7.ClrIconModule, typeof i8.ClrAccordionModule], [typeof i1.ClrStepper, typeof i2.ClrStepButton, typeof i3.ClrStepperPanel, typeof i4.StepperOompaLoompa, typeof i5.StepperWillyWonka, typeof i8.ClrAccordionModule]>;
 }
 
 export declare class ClrStepperPanel extends ClrAccordionPanel implements OnInit {
@@ -2043,8 +1693,6 @@ export declare class ClrStepperPanel extends ClrAccordionPanel implements OnInit
     constructor(platformId: any, commonStrings: ClrCommonStringsService, formGroupName: FormGroupName, ngModelGroup: NgModelGroup, stepperService: StepperService, ifExpandService: IfExpandService, id: string);
     ngOnDestroy(): void;
     ngOnInit(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrStepperPanel, "clr-stepper-panel", never, {}, {}, never, ["clr-accordion-title, clr-step-title", "clr-accordion-description, clr-step-description", "*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrStepperPanel, [null, null, { optional: true; }, { optional: true; }, null, null, null]>;
 }
 
 export declare class ClrTab {
@@ -2055,8 +1703,6 @@ export declare class ClrTab {
     tabLink: ClrTabLink;
     constructor(ifActiveService: IfActiveService, id: number, tabsService: TabsService);
     ngOnDestroy(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrTab, "clr-tab", never, {}, {}, ["tabLink", "tabContent"], ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrTab, never>;
 }
 
 export declare class ClrTabContent implements OnDestroy {
@@ -2068,8 +1714,6 @@ export declare class ClrTabContent implements OnDestroy {
     set tabContentId(id: string);
     constructor(ifActiveService: IfActiveService, id: number, ariaService: AriaService, tabsService: TabsService);
     ngOnDestroy(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrTabContent, "clr-tab-content", never, { "tabContentId": "id"; }, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrTabContent, never>;
 }
 
 export declare class ClrTabLink {
@@ -2087,13 +1731,9 @@ export declare class ClrTabLink {
     templateRefContainer: TemplateRefContainer;
     constructor(ifActiveService: IfActiveService, id: number, ariaService: AriaService, el: ElementRef, cfr: ComponentFactoryResolver, viewContainerRef: ViewContainerRef, tabsService: TabsService, tabsId: number);
     activate(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrTabLink, "[clrTabLink]", never, { "inOverflow": "clrTabLinkInOverflow"; "tabLinkId": "id"; }, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrTabLink, never>;
 }
 
 export declare class ClrTabOverflowContent {
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrTabOverflowContent, "clr-tab-overflow-content", never, {}, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrTabOverflowContent, never>;
 }
 
 export declare class ClrTabs implements AfterContentInit, OnDestroy {
@@ -2124,41 +1764,27 @@ export declare class ClrTabs implements AfterContentInit, OnDestroy {
     resetKeyFocusCurrentToActive(event: FocusEvent): void;
     toggleOverflowOnClick(): void;
     toggleOverflowOnPosition(position: number): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrTabs, "clr-tabs", never, { "layout": "clrLayout"; }, {}, ["tabs"], never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrTabs, never>;
 }
 
 export declare class ClrTabsModule {
     constructor();
-    static ɵfac: i0.ɵɵFactoryDef<ClrTabsModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrTabsModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrTabsModule, [typeof i1.ClrTabContent, typeof i2.ClrTab, typeof i3.ClrTabs, typeof i4.ClrTabOverflowContent, typeof i5.ClrTabLink, typeof i6.TabsWillyWonka, typeof i7.ActiveOompaLoompa], [typeof i8.CommonModule, typeof i9.ClrConditionalModule, typeof i10.ClrIconModule, typeof i11.ClrTemplateRefModule, typeof i12.ClrKeyFocusModule], [typeof i1.ClrTabContent, typeof i2.ClrTab, typeof i3.ClrTabs, typeof i4.ClrTabOverflowContent, typeof i5.ClrTabLink, typeof i6.TabsWillyWonka, typeof i7.ActiveOompaLoompa, typeof i9.ClrConditionalModule]>;
 }
 
 export declare class ClrTextarea extends WrappedFormControl<ClrTextareaContainer> {
     protected index: number;
     constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef);
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrTextarea, "[clrTextarea]", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrTextarea, [null, null, { optional: true; self: true; }, null, null]>;
 }
 
 export declare class ClrTextareaContainer extends ClrAbstractContainer {
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrTextareaContainer, "clr-textarea-container", never, {}, {}, never, ["label", "[clrTextarea]", "clr-control-helper", "clr-control-error", "clr-control-success"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrTextareaContainer, never>;
 }
 
 export declare class ClrTextareaModule {
     constructor();
-    static ɵfac: i0.ɵɵFactoryDef<ClrTextareaModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrTextareaModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrTextareaModule, [typeof i1.ClrTextarea, typeof i2.ClrTextareaContainer], [typeof i3.CommonModule, typeof i4.FormsModule, typeof i5.ClrIconModule, typeof i6.ClrCommonFormsModule], [typeof i6.ClrCommonFormsModule, typeof i1.ClrTextarea, typeof i2.ClrTextareaContainer]>;
 }
 
 export declare class ClrTimeline {
     get isVertical(): boolean;
     layout: ClrTimelineLayout;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrTimeline, "clr-timeline", never, { "layout": "clrLayout"; }, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrTimeline, never>;
 }
 
 export declare enum ClrTimelineLayout {
@@ -2168,9 +1794,6 @@ export declare enum ClrTimelineLayout {
 
 export declare class ClrTimelineModule {
     constructor();
-    static ɵfac: i0.ɵɵFactoryDef<ClrTimelineModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrTimelineModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrTimelineModule, [typeof i1.ClrTimeline, typeof i2.ClrTimelineStep, typeof i3.ClrTimelineStepDescription, typeof i4.ClrTimelineStepHeader, typeof i5.ClrTimelineStepTitle], [typeof i6.CommonModule, typeof i7.ClrIconModule, typeof i8.ClrSpinnerModule], [typeof i1.ClrTimeline, typeof i2.ClrTimelineStep, typeof i3.ClrTimelineStepDescription, typeof i4.ClrTimelineStepHeader, typeof i5.ClrTimelineStepTitle, typeof i7.ClrIconModule, typeof i8.ClrSpinnerModule]>;
 }
 
 export declare class ClrTimelineStep {
@@ -2184,18 +1807,12 @@ export declare class ClrTimelineStep {
     stepTitleText: string;
     constructor(iconAttributeService: TimelineIconAttributeService, platformId: any);
     ngAfterContentInit(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrTimelineStep, "clr-timeline-step", never, { "state": "clrState"; }, {}, ["stepTitle"], ["clr-timeline-step-header", "clr-timeline-step-title", "clr-timeline-step-description"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrTimelineStep, never>;
 }
 
 export declare class ClrTimelineStepDescription {
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrTimelineStepDescription, "clr-timeline-step-description", never, {}, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrTimelineStepDescription, never>;
 }
 
 export declare class ClrTimelineStepHeader {
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrTimelineStepHeader, "clr-timeline-step-header", never, {}, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrTimelineStepHeader, never>;
 }
 
 export declare enum ClrTimelineStepState {
@@ -2207,13 +1824,9 @@ export declare enum ClrTimelineStepState {
 }
 
 export declare class ClrTimelineStepTitle {
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrTimelineStepTitle, "clr-timeline-step-title", never, {}, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrTimelineStepTitle, never>;
 }
 
 export declare class ClrTooltip {
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrTooltip, "clr-tooltip", never, {}, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrTooltip, never>;
 }
 
 export declare class ClrTooltipContent extends AbstractPopover {
@@ -2225,14 +1838,9 @@ export declare class ClrTooltipContent extends AbstractPopover {
     set size(size: string);
     uniqueId: string;
     constructor(injector: Injector, parentHost: ElementRef, uniqueId: string, tooltipIdService: TooltipIdService);
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrTooltipContent, "clr-tooltip-content", never, { "id": "id"; "position": "clrPosition"; "size": "clrSize"; }, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrTooltipContent, [null, { optional: true; }, null, null]>;
 }
 
 export declare class ClrTooltipModule {
-    static ɵfac: i0.ɵɵFactoryDef<ClrTooltipModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrTooltipModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrTooltipModule, [typeof i1.ClrTooltip, typeof i2.ClrTooltipTrigger, typeof i3.ClrTooltipContent], [typeof i4.CommonModule], [typeof i1.ClrTooltip, typeof i2.ClrTooltipTrigger, typeof i3.ClrTooltipContent, typeof i5.ClrConditionalModule, typeof i6.ClrIconModule]>;
 }
 
 export declare class ClrTooltipTrigger {
@@ -2241,8 +1849,6 @@ export declare class ClrTooltipTrigger {
     hideTooltip(): void;
     ngOnDestroy(): void;
     showTooltip(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrTooltipTrigger, "[clrTooltipTrigger]", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrTooltipTrigger, never>;
 }
 
 export declare class ClrTree<T> implements AfterContentInit, OnDestroy {
@@ -2254,8 +1860,6 @@ export declare class ClrTree<T> implements AfterContentInit, OnDestroy {
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
     onFocusIn(event: FocusEvent): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrTree<any>, "clr-tree", never, { "lazy": "clrLazy"; }, {}, ["rootNodes"], ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrTree<any>, never>;
 }
 
 export declare class ClrTreeNode<T> implements OnInit, OnDestroy {
@@ -2282,22 +1886,15 @@ export declare class ClrTreeNode<T> implements OnInit, OnDestroy {
     ngOnDestroy(): void;
     ngOnInit(): void;
     onKeyDown(event: KeyboardEvent): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrTreeNode<any>, "clr-tree-node", never, { "selected": "clrSelected"; "expandable": "clrExpandable"; "expanded": "clrExpanded"; }, { "selectedChange": "clrSelectedChange"; "expandedChange": "clrExpandedChange"; }, ["treeNodeLinkList"], ["*", "clr-tree-node", "[clrIfExpanded]"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrTreeNode<any>, [null, null, { optional: true; skipSelf: true; }, null, null, null, null, null]>;
 }
 
 export declare class ClrTreeNodeLink {
     constructor(el: ElementRef);
     activate(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrTreeNodeLink, ".clr-treenode-link", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrTreeNodeLink, never>;
 }
 
 export declare class ClrTreeViewModule {
     constructor();
-    static ɵfac: i0.ɵɵFactoryDef<ClrTreeViewModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrTreeViewModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrTreeViewModule, [typeof i1.ClrTree, typeof i2.ClrTreeNode, typeof i3.ClrRecursiveForOf, typeof i4.ClrTreeNodeLink, typeof i5.RecursiveChildren], [typeof i6.CommonModule, typeof i7.ClrIconModule, typeof i8.ClrLoadingModule], [typeof i1.ClrTree, typeof i2.ClrTreeNode, typeof i3.ClrRecursiveForOf, typeof i4.ClrTreeNodeLink]>;
 }
 
 export declare class ClrVerticalNav implements OnDestroy {
@@ -2312,8 +1909,6 @@ export declare class ClrVerticalNav implements OnDestroy {
     constructor(_navService: VerticalNavService, _navIconService: VerticalNavIconService, _navGroupRegistrationService: VerticalNavGroupRegistrationService, commonStrings: ClrCommonStringsService);
     ngOnDestroy(): void;
     toggleByButton(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrVerticalNav, "clr-vertical-nav", never, { "collapsible": "clrVerticalNavCollapsible"; "collapsed": "clrVerticalNavCollapsed"; }, { "_collapsedChanged": "clrVerticalNavCollapsedChange"; }, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrVerticalNav, never>;
 }
 
 export declare class ClrVerticalNavGroup implements AfterContentInit, OnDestroy {
@@ -2331,34 +1926,23 @@ export declare class ClrVerticalNavGroup implements AfterContentInit, OnDestroy 
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
     toggleExpand(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrVerticalNavGroup, "clr-vertical-nav-group", never, { "userExpandedInput": "clrVerticalNavGroupExpanded"; }, { "expandedChange": "clrVerticalNavGroupExpandedChange"; }, never, ["[clrVerticalNavLink]", "[clrVerticalNavIcon]", "*", "[clrIfExpanded], clr-vertical-nav-group-children"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrVerticalNavGroup, never>;
 }
 
 export declare class ClrVerticalNavGroupChildren {
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrVerticalNavGroupChildren, "clr-vertical-nav-group-children", never, {}, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrVerticalNavGroupChildren, never>;
 }
 
 export declare class ClrVerticalNavIcon implements OnDestroy {
     constructor(_verticalNavIconService: VerticalNavIconService);
     ngOnDestroy(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrVerticalNavIcon, "[clrVerticalNavIcon]", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrVerticalNavIcon, never>;
 }
 
 export declare class ClrVerticalNavLink {
     constructor(_navGroupService: VerticalNavGroupService);
     expandParentNavGroup(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrVerticalNavLink, "[clrVerticalNavLink]", never, {}, {}, never, ["[clrVerticalNavIcon]", "*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrVerticalNavLink, [{ optional: true; }]>;
 }
 
 export declare class ClrVerticalNavModule {
     constructor();
-    static ɵfac: i0.ɵɵFactoryDef<ClrVerticalNavModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrVerticalNavModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrVerticalNavModule, [typeof i1.ClrVerticalNav, typeof i2.ClrVerticalNavLink, typeof i3.ClrVerticalNavGroup, typeof i4.ClrVerticalNavGroupChildren, typeof i5.ClrVerticalNavIcon], [typeof i6.CommonModule, typeof i7.ClrIconModule, typeof i8.ClrConditionalModule, typeof i9.ClrFocusOnViewInitModule], [typeof i1.ClrVerticalNav, typeof i2.ClrVerticalNavLink, typeof i3.ClrVerticalNavGroup, typeof i4.ClrVerticalNavGroupChildren, typeof i5.ClrVerticalNavIcon, typeof i8.ClrConditionalModule, typeof i7.ClrIconModule, typeof i9.ClrFocusOnViewInitModule]>;
 }
 
 export declare class ClrWizard implements OnDestroy, AfterContentInit, DoCheck {
@@ -2414,8 +1998,6 @@ export declare class ClrWizard implements OnDestroy, AfterContentInit, DoCheck {
     previous(): void;
     reset(): void;
     toggle(open: boolean): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrWizard, "clr-wizard", never, { "size": "clrWizardSize"; "closable": "clrWizardClosable"; "forceForward": "clrWizardForceForwardNavigation"; "clrWizardOpen": "clrWizardOpen"; "stopNext": "clrWizardPreventDefaultNext"; "stopCancel": "clrWizardPreventDefaultCancel"; "stopNavigation": "clrWizardPreventNavigation"; "disableStepnav": "clrWizardDisableStepnav"; "_stopModalAnimations": "clrWizardPreventModalAnimation"; }, { "_openChanged": "clrWizardOpenChange"; "onCancel": "clrWizardOnCancel"; "wizardFinished": "clrWizardOnFinish"; "onReset": "clrWizardOnReset"; "currentPageChanged": "clrWizardCurrentPageChanged"; "onMoveNext": "clrWizardOnNext"; "onMovePrevious": "clrWizardOnPrevious"; }, ["pages", "headerActions"], ["clr-wizard-title", "clr-wizard-header-action", "*", "clr-wizard-button"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrWizard, never>;
 }
 
 export declare class ClrWizardButton {
@@ -2436,13 +2018,9 @@ export declare class ClrWizardButton {
     wasClicked: EventEmitter<string>;
     constructor(navService: WizardNavigationService, buttonService: ButtonHubService);
     click(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrWizardButton, "clr-wizard-button", never, { "type": "type"; "disabled": "clrWizardButtonDisabled"; "hidden": "clrWizardButtonHidden"; }, { "wasClicked": "clrWizardButtonClicked"; }, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrWizardButton, never>;
 }
 
 export declare class ClrWizardCustomTags {
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrWizardCustomTags, "clr-wizard-title, clr-wizard-pagetitle", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrWizardCustomTags, never>;
 }
 
 export declare class ClrWizardHeaderAction {
@@ -2452,15 +2030,10 @@ export declare class ClrWizardHeaderAction {
     get id(): string;
     title: string;
     click(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrWizardHeaderAction, "clr-wizard-header-action", never, { "title": "title"; "_id": "id"; "disabled": "clrWizardHeaderActionDisabled"; }, { "headerActionClicked": "actionClicked"; }, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrWizardHeaderAction, never>;
 }
 
 export declare class ClrWizardModule {
     constructor();
-    static ɵfac: i0.ɵɵFactoryDef<ClrWizardModule, never>;
-    static ɵinj: i0.ɵɵInjectorDef<ClrWizardModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<ClrWizardModule, [typeof i1.ClrWizard, typeof i2.ClrWizardPage, typeof i3.ClrWizardStepnav, typeof i4.ClrWizardStepnavItem, typeof i5.ClrWizardButton, typeof i6.ClrWizardHeaderAction, typeof i7.ClrWizardCustomTags, typeof i8.ClrWizardPageTitle, typeof i9.ClrWizardPageNavTitle, typeof i10.ClrWizardPageButtons, typeof i11.ClrWizardPageHeaderActions], [typeof i12.CommonModule, typeof i13.ClrModalModule, typeof i14.ClrAlertModule], [typeof i1.ClrWizard, typeof i2.ClrWizardPage, typeof i3.ClrWizardStepnav, typeof i4.ClrWizardStepnavItem, typeof i5.ClrWizardButton, typeof i6.ClrWizardHeaderAction, typeof i7.ClrWizardCustomTags, typeof i8.ClrWizardPageTitle, typeof i9.ClrWizardPageNavTitle, typeof i10.ClrWizardPageButtons, typeof i11.ClrWizardPageHeaderActions]>;
 }
 
 export declare class ClrWizardPage implements OnInit {
@@ -2512,43 +2085,31 @@ export declare class ClrWizardPage implements OnInit {
     constructor(navService: WizardNavigationService, pageCollection: PageCollectionService, buttonService: ButtonHubService);
     makeCurrent(): void;
     ngOnInit(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrWizardPage, "clr-wizard-page", never, { "nextStepDisabled": "clrWizardPageNextDisabled"; "previousStepDisabled": "clrWizardPagePreviousDisabled"; "hasError": "clrWizardPageHasError"; "preventDefault": "clrWizardPagePreventDefault"; "stopCancel": "clrWizardPagePreventDefaultCancel"; "stopNext": "clrWizardPagePreventDefaultNext"; "_id": "id"; }, { "nextStepDisabledChange": "clrWizardPageNextDisabledChange"; "previousStepDisabledChange": "clrWizardPagePreviousDisabledChange"; "stopCancelChange": "clrWizardPagePreventDefaultCancelChange"; "onCommit": "clrWizardPageOnCommit"; "onLoad": "clrWizardPageOnLoad"; "pageOnCancel": "clrWizardPageOnCancel"; "finishButtonClicked": "clrWizardPageFinish"; "previousButtonClicked": "clrWizardPagePrevious"; "nextButtonClicked": "clrWizardPageNext"; "dangerButtonClicked": "clrWizardPageDanger"; "primaryButtonClicked": "clrWizardPagePrimary"; "customButtonClicked": "clrWizardPageCustomButton"; }, ["pageTitle", "pageNavTitle", "_buttons", "_headerActions"], ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrWizardPage, never>;
 }
 
 export declare class ClrWizardPageButtons {
     pageButtonsTemplateRef: TemplateRef<any>;
     constructor(pageButtonsTemplateRef: TemplateRef<any>);
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrWizardPageButtons, "[clrPageButtons]", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrWizardPageButtons, never>;
 }
 
 export declare class ClrWizardPageHeaderActions {
     pageHeaderActionsTemplateRef: TemplateRef<any>;
     constructor(pageHeaderActionsTemplateRef: TemplateRef<any>);
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrWizardPageHeaderActions, "[clrPageHeaderActions]", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrWizardPageHeaderActions, never>;
 }
 
 export declare class ClrWizardPageNavTitle {
     pageNavTitleTemplateRef: TemplateRef<any>;
     constructor(pageNavTitleTemplateRef: TemplateRef<any>);
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrWizardPageNavTitle, "[clrPageNavTitle]", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrWizardPageNavTitle, never>;
 }
 
 export declare class ClrWizardPageTitle {
     pageTitleTemplateRef: TemplateRef<any>;
     constructor(pageTitleTemplateRef: TemplateRef<any>);
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<ClrWizardPageTitle, "[clrPageTitle]", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrWizardPageTitle, never>;
 }
 
 export declare class ClrWizardStepnav {
     pageService: PageCollectionService;
     constructor(pageService: PageCollectionService);
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrWizardStepnav, "clr-wizard-stepnav", never, {}, {}, never, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrWizardStepnav, never>;
 }
 
 export declare class ClrWizardStepnavItem {
@@ -2564,8 +2125,6 @@ export declare class ClrWizardStepnavItem {
     get stepAriaCurrent(): string;
     constructor(navService: WizardNavigationService, pageCollection: PageCollectionService);
     click(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrWizardStepnavItem, "[clr-wizard-stepnav-item]", never, { "page": "page"; }, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrWizardStepnavItem, never>;
 }
 
 export declare class ClrYearpicker implements AfterViewInit {
@@ -2580,8 +2139,6 @@ export declare class ClrYearpicker implements AfterViewInit {
     ngAfterViewInit(): void;
     onKeyDown(event: KeyboardEvent): void;
     previousDecade(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<ClrYearpicker, "clr-yearpicker", never, {}, {}, never, never>;
-    static ɵfac: i0.ɵɵFactoryDef<ClrYearpicker, never>;
 }
 
 export declare function collapse(): AnimationMetadata[];
@@ -2608,8 +2165,6 @@ export declare class DatagridNumericFilter<T = any> extends DatagridFilterRegist
     constructor(filters: FiltersProvider<T>, domAdapter: DomAdapter, commonStrings: ClrCommonStringsService, popoverToggleService: ClrPopoverToggleService);
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<DatagridNumericFilter<any>, "clr-dg-numeric-filter", never, { "customNumericFilter": "clrDgNumericFilter"; "value": "clrFilterValue"; }, { "filterValueChange": "clrFilterValueChange"; }, never, never>;
-    static ɵfac: i0.ɵɵFactoryDef<DatagridNumericFilter<any>, never>;
 }
 
 export declare class DatagridPropertyComparator<T = any> implements ClrDatagridComparatorInterface<T> {
@@ -2644,8 +2199,6 @@ export declare class DatagridStringFilter<T = any> extends DatagridFilterRegistr
     constructor(filters: FiltersProvider<T>, domAdapter: DomAdapter, commonStrings: ClrCommonStringsService, smartToggleService: ClrPopoverToggleService);
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<DatagridStringFilter<any>, "clr-dg-string-filter", never, { "customStringFilter": "clrDgStringFilter"; "value": "clrFilterValue"; }, { "filterValueChange": "clrFilterValueChange"; }, never, never>;
-    static ɵfac: i0.ɵɵFactoryDef<DatagridStringFilter<any>, never>;
 }
 
 export declare const DEFAULT_BUTTON_TYPES: any;
@@ -2674,15 +2227,11 @@ export declare abstract class LoadingListener {
 }
 
 export declare class MainContainerWillyWonka extends WillyWonka {
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MainContainerWillyWonka, "clr-main-container", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<MainContainerWillyWonka, never>;
 }
 
 export declare class NavDetectionOompaLoompa extends OompaLoompa {
     get flavor(): number;
     constructor(cdr: ChangeDetectorRef, willyWonka: MainContainerWillyWonka, responsiveNavService: ResponsiveNavigationService);
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<NavDetectionOompaLoompa, "clr-header", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<NavDetectionOompaLoompa, [null, { optional: true; }, null]>;
 }
 
 export declare function slide(direction: string): AnimationMetadata[];
@@ -2713,6 +2262,4 @@ export declare class WrappedFormControl<W extends DynamicWrapper> implements OnI
     ngOnDestroy(): void;
     ngOnInit(): void;
     triggerValidation(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<WrappedFormControl<any>, never, never, { "id": "id"; }, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<WrappedFormControl<any>, never>;
 }

--- a/packages/angular/projects/cds-angular/tsconfig.lib.prod.json
+++ b/packages/angular/projects/cds-angular/tsconfig.lib.prod.json
@@ -5,7 +5,6 @@
     "declarationMap": false
   },
   "angularCompilerOptions": {
-    "enableIvy": true,
-    "compilationMode": "partial"
+    "enableIvy": false
   }
 }

--- a/packages/angular/projects/clr-angular/tsconfig.lib.prod.json
+++ b/packages/angular/projects/clr-angular/tsconfig.lib.prod.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.lib.json",
   "angularCompilerOptions": {
-    "enableIvy": true,
-    "compilationMode": "partial"
+    "enableIvy": false
   }
 }


### PR DESCRIPTION
Currently, you can't publish Angular libraries with the Ivy distribution mode. That will be enabled in Angular v12. This PR disables the Ivy distribution mode for `@clr/angular` and `@cds/angular` so we can continue publishing versions until Angular 12 is released.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No
