### PR TITLE
fix(stepper): update stepper if user jumps back and invalidates form

### DIFF
--- a/packages/angular/golden/clr-angular.d.ts
+++ b/packages/angular/golden/clr-angular.d.ts
@@ -1690,6 +1690,7 @@ export declare class ClrStepperPanel extends ClrAccordionPanel implements OnInit
     get id(): string;
     set id(_value: string);
     isAccordion: boolean;
+    stepCompleted: boolean;
     constructor(platformId: any, commonStrings: ClrCommonStringsService, formGroupName: FormGroupName, ngModelGroup: NgModelGroup, stepperService: StepperService, ifExpandService: IfExpandService, id: string);
     ngOnDestroy(): void;
     ngOnInit(): void;

--- a/packages/angular/golden/clr-angular.d.ts
+++ b/packages/angular/golden/clr-angular.d.ts
@@ -1690,7 +1690,6 @@ export declare class ClrStepperPanel extends ClrAccordionPanel implements OnInit
     get id(): string;
     set id(_value: string);
     isAccordion: boolean;
-    stepCompleted: boolean;
     constructor(platformId: any, commonStrings: ClrCommonStringsService, formGroupName: FormGroupName, ngModelGroup: NgModelGroup, stepperService: StepperService, ifExpandService: IfExpandService, id: string);
     ngOnDestroy(): void;
     ngOnInit(): void;

--- a/packages/angular/projects/clr-angular/src/accordion/stepper/stepper.spec.ts
+++ b/packages/angular/projects/clr-angular/src/accordion/stepper/stepper.spec.ts
@@ -104,13 +104,11 @@ describe('ClrStepper', () => {
 
       // we navigated to the second panel
       expect(group1.valid).toBe(true, 'first panel form is now valid');
-      expect(testComponent.panel1.stepCompleted).toBe(true, 'first panel marked as completed');
 
       group1.controls.name.setValue(''); // set required input to invalid value
       fixture.detectChanges();
 
       expect(group1.valid).toBe(false, 'first panel form is now invalid');
-      expect(testComponent.panel1.stepCompleted).toBe(false, 'first panel is set back to incomplete');
       // making a previously valid form invalid forces navigation; called once earlier and only once after this
       expect(stepperService.navigateToNextPanel).toHaveBeenCalledTimes(2);
     });


### PR DESCRIPTION
• reported through VMware support channel
• example of breakage is here: https://stackblitz.com/edit/clarity-v4-dark-theme-yyefbb?file=src/app/app.component.ts
  1. Fill in first two inputs and move to the next page
  2. Fill in the two additional inputs and move to the next page
  3. While on the third page, click on the first step
  4. Erase the value from one of the inputs and click somewhere outside
• added check to see if previously completed step has been invalidated
• running the navigate routine if so
• this forces the stepper to figure itself out
• verified this fix addresses the issue above
• added tests

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
