### PR TITLE
fix(icons): cds-icons in clr-buttons could not rotate

### DIFF
--- a/packages/angular/projects/clr-angular/src/button/_buttons.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/button/_buttons.clarity.scss
@@ -262,9 +262,11 @@
   //Clarity Buttons
   .btn-group > .btn,
   .btn {
-    cds-icon,
     clr-icon {
       transform: translate3d(0, -1 * $clr_baselineRem_2px, 0);
+    }
+    cds-icon {
+      margin-top: -1.4 * $clr_baselineRem_2px;
     }
   }
 
@@ -374,11 +376,15 @@
 
   //Small Icon Button
   .btn-sm:not(.btn-link) {
-    cds-icon,
     clr-icon {
       @include css-var(width, clr-btn-appearance-standard-icon-size, $clr_baselineRem_0_5, $clr-use-custom-properties);
       @include css-var(height, clr-btn-appearance-standard-icon-size, $clr_baselineRem_0_5, $clr-use-custom-properties);
       transform: translate3d(0, -1 * $clr_baselineRem_1px, 0);
+    }
+    cds-icon {
+      @include css-var(width, clr-btn-appearance-standard-icon-size, $clr_baselineRem_0_5, $clr-use-custom-properties);
+      @include css-var(height, clr-btn-appearance-standard-icon-size, $clr_baselineRem_0_5, $clr-use-custom-properties);
+      margin-top: -0.1rem;
     }
   }
 

--- a/packages/angular/projects/clr-angular/src/popover/dropdown/_dropdown.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/popover/dropdown/_dropdown.clarity.scss
@@ -41,7 +41,7 @@
       // This results in a different top value.
       cds-icon[shape^='angle'] {
         position: absolute;
-        top: 45%;
+        top: 35%;
         color: inherit;
         @include equilateral($clr-dropdown-caret-icon-dimension);
       }


### PR DESCRIPTION
• transforms were being set on all icons inside clr-buttons
• they were overriding the transforms we used to rotate and flip cds-icons
• cds-icons are now repositioned with negative margin adjustments
• no change was made to clr-icons in buttons
• visually verified against clr-icons in the buttons
• also adjusted the placement of the caret icons in a dropdown button

Fixes: #5869

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
