### PR TITLE
fix: core cds-text="truncate" is cutting letter descenders

### DIFF
--- a/packages/core/src/styles/typography/_typography.scss
+++ b/packages/core/src/styles/typography/_typography.scss
@@ -261,6 +261,7 @@
   overflow: hidden !important;
   text-overflow: ellipsis !important;
   white-space: nowrap !important;
+  @include remove-line-height-erasers;
 }
 
 // alignment


### PR DESCRIPTION
- the final solution will be to use leading-trim once it's available in all browsers
- the current solution is to disable the erases, which can have effect on alignment, but the drawbacks are smaller than having truncated and unreadable texts

Fixes: #5708

Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Truncated letters are cut vertically.

Issue Number: 5708

## What is the new behavior?

Truncated letters are not cut vertically.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
