### PR TITLE
fix(toggle): disabling animation until after initial load

### DIFF
--- a/packages/core/src/toggle/toggle.element.scss
+++ b/packages/core/src/toggle/toggle.element.scss
@@ -46,6 +46,10 @@
   transition-property: transform;
 }
 
+:host(:not([cds-motion='ready'])) {
+  --toggle-speed: 0;
+}
+
 :host([_checked]) {
   --background: #{$cds-alias-status-success};
   --border: #{$cds-alias-object-border-width-200} solid var(--background);

--- a/packages/core/src/toggle/toggle.element.spec.ts
+++ b/packages/core/src/toggle/toggle.element.spec.ts
@@ -8,6 +8,7 @@ import { html } from 'lit-html';
 import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test';
 import { CdsToggle } from '@cds/core/toggle';
 import '@cds/core/toggle/register.js';
+import { sleep } from '@cds/core/internal';
 
 describe('cds-toggle', () => {
   let component: CdsToggle;
@@ -40,5 +41,42 @@ describe('cds-toggle', () => {
     component.inputControl.click();
     await componentIsStable(component);
     expect(component.hasAttribute('_checked')).toBe(true);
+  });
+
+  it('should default to cds-motion "on" and resolve to "ready"', async () => {
+    await componentIsStable(component);
+    await sleep(25);
+    expect(component.cdsMotion).toBe('ready');
+  });
+
+  it('should not resolve to "ready" if cds-motion initialized to "off"', async () => {
+    const nomotion = await createTestElement(html`
+      <cds-toggle cds-motion="off">
+        <label>toggle</label>
+        <input type="checkbox" />
+        <cds-control-message>message text</cds-control-message>
+      </cds-toggle>
+    `);
+    const noMotionCmp = nomotion.querySelector<CdsToggle>('cds-toggle');
+    await componentIsStable(noMotionCmp);
+    await sleep(25);
+    expect(noMotionCmp.cdsMotion).toBe('off');
+    removeTestElement(nomotion);
+  });
+
+  it('should handle changing value of cds-motion', async () => {
+    await componentIsStable(component);
+    await sleep(12);
+    expect(component.cdsMotion).toBe('ready', 'defaults to on and resolves to ready');
+
+    component.setAttribute('cds-motion', 'off');
+    await componentIsStable(component);
+    await sleep(12);
+    expect(component.cdsMotion).toBe('off', 'if set to off, does not resolve to ready');
+
+    component.setAttribute('cds-motion', 'on');
+    await componentIsStable(component);
+    await sleep(12);
+    expect(component.cdsMotion).toBe('ready', 'if set back to on, resolves to ready');
   });
 });

--- a/packages/core/src/toggle/toggle.element.ts
+++ b/packages/core/src/toggle/toggle.element.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-
+import { property } from '@cds/core/internal';
 import { CdsInternalControlInline } from '@cds/core/forms';
 import { styles } from './toggle.element.css.js';
 
@@ -35,6 +35,21 @@ import { styles } from './toggle.element.css.js';
  * @cssprop --toggle-speed
  */
 export class CdsToggle extends CdsInternalControlInline {
+  @property({ type: String })
+  cdsMotion = 'on';
+
+  async updated(props: Map<string, any>) {
+    super.updated(props);
+
+    // this section fixes an issue with toggles animating when the page loads
+    // note that setting cdsMotion to 'off' will turn off all animation
+    // https://github.com/vmware/clarity/issues/5880
+    if (props.has('cdsMotion') && this.cdsMotion === 'on') {
+      await this.updateComplete;
+      this.cdsMotion = 'ready';
+    }
+  }
+
   static get styles() {
     return [...super.styles, styles];
   }


### PR DESCRIPTION
• adding cds-motion to cds-toggle
• allows us to defer the animation until after the toggle is rendered
• allows users to turn off the animation altogether

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently, the toggle animates initial values when a page loads. This causes unnecessary sliding animations. There's also no way to turn animation off.

Issue Number: #5880

## What is the new behavior?

The toggle animation is now tied into `cds-motion`. Allowing a value change to animate is deferred until after load/render. Users can now set `cds-motion` to `"off"` to prevent the animation entirely.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
