### PR TITLE
fix(modal): making modal content items focusable

### DIFF
--- a/packages/core/src/modal/modal-content.element.spec.ts
+++ b/packages/core/src/modal/modal-content.element.spec.ts
@@ -20,7 +20,7 @@ describe('modal-content element', () => {
   beforeEach(async () => {
     testElement = await createTestElement(html`<cds-modal-content>${placeholderContent}</cds-modal-content>`);
     testElementWithLayout = await createTestElement(
-      html`<cds-modal-content tabindex="0" cds-layout="elliptical">${placeholderContent}</cds-modal-content>`
+      html`<cds-modal-content tabindex="1" cds-layout="elliptical">${placeholderContent}</cds-modal-content>`
     );
     component = testElement.querySelector<CdsModalContent>('cds-modal-content');
     componentWithLayout = testElementWithLayout.querySelector<CdsModalContent>('cds-modal-content');
@@ -48,9 +48,10 @@ describe('modal-content element', () => {
     });
   });
 
-  it('should have tabindex "-1"', async () => {
+  it('should have tabindex "0" and delegatesFocus set to true', async () => {
     await componentIsStable(component);
-    expect(component.getAttribute('tabindex')).toBe('-1');
+    expect(component.getAttribute('tabindex')).toBe('0');
+    expect((component.shadowRoot as any).delegatesFocus).toBe(true);
   });
 
   it('should override layout and tabindex defaults', async () => {
@@ -60,6 +61,6 @@ describe('modal-content element', () => {
       true,
       `carries through overridden layout`
     );
-    expect(componentWithLayout.getAttribute('tabindex')).toBe('0', `can override tabindex`);
+    expect(componentWithLayout.getAttribute('tabindex')).toBe('1', `can override tabindex`);
   });
 });

--- a/packages/core/src/modal/modal-content.element.ts
+++ b/packages/core/src/modal/modal-content.element.ts
@@ -31,7 +31,14 @@ import { html, LitElement } from 'lit-element';
  * @element cds-modal-content
  */
 export class CdsModalContent extends LitElement {
-  @internalProperty({ type: Number, attribute: 'tabindex', reflect: true }) protected tabIndexAttr = -1; // don't override native prop as it stops native focus behavior
+  // renderRoot needs delegatesFocus so that focus can cross the shadowDOM
+  // inside modal-content with a tabindex of -1. we need the tabindex so a
+  // modal's content can scroll if it needs to.
+  protected createRenderRoot(): Element | ShadowRoot {
+    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+  }
+
+  @internalProperty({ type: Number, attribute: 'tabindex', reflect: true }) protected tabIndexAttr = 0; // don't override native prop as it stops native focus behavior
 
   render() {
     return this.hasAttribute('cds-layout')

--- a/packages/core/src/modal/modal.element.spec.ts
+++ b/packages/core/src/modal/modal.element.spec.ts
@@ -38,7 +38,7 @@ describe('modal element', () => {
     await componentIsStable(component);
     const slots = getComponentSlotContent(component);
     expect(slots.default).toBe(
-      `<cds-modal-content tabindex="-1"><p><!---->${placeholderContent}<!----></p></cds-modal-content>`
+      `<cds-modal-content tabindex="0"><p><!---->${placeholderContent}<!----></p></cds-modal-content>`
     );
     expect(slots['modal-header']).toBe(
       `<cds-modal-header slot="modal-header"><!---->${placeholderHeader}<!----></cds-modal-header>`


### PR DESCRIPTION
• previously modal content could not be focused using the tab key
• this included form fields and buttons in the content area of a modal
• this fixes that issue by changing the modal content wrapper's tabindex to 0
• ...and setting delegatesFocus to true

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

Users can now tab down into the modal-content area.

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Right now, users can't tab down into the modal-content area's shadow DOM.

## What is the new behavior?

Now they can.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
