### PR TITLE
fix: empty value boolean properties in @cds/angular

### DIFF
--- a/apps/core-angular-cli/package.json
+++ b/apps/core-angular-cli/package.json
@@ -42,10 +42,16 @@
     "karma-coverage": "~2.0.3",
     "karma-jasmine": "~4.0.0",
     "karma-jasmine-html-reporter": "^1.5.0",
+    "postcss-cli": "7.1.0",
     "protractor": "~7.0.0",
     "sass": "1.32.8",
     "ts-node": "~8.3.0",
     "tslint": "~6.1.0",
     "typescript": "~4.1.2"
+  },
+  "postcss": {
+    "plugins": {
+      "autoprefixer": {}
+    }
   }
 }

--- a/apps/core-angular-cli/src/app/app.component.html
+++ b/apps/core-angular-cli/src/app/app.component.html
@@ -14,6 +14,8 @@
 
   <cds-button status="success" (click)="show = true">Open Alert</cds-button>
 
+  <cds-tag status="success" readonly>Should not be focusable, readonly</cds-tag>
+
   <section cds-layout="grid cols:6 gap:lg">
     <cds-accordion>
       <cds-accordion-panel [expanded]="panel1Expanded" (expandedChange)="expandedChange($event)">

--- a/apps/core-angular-cli/src/app/app.component.ts
+++ b/apps/core-angular-cli/src/app/app.component.ts
@@ -73,7 +73,7 @@ export class AppComponent {
     return this.form.controls.password.touched && this.form.controls.password.hasError('minlength');
   }
 
-  expandedChange(event): void {
+  expandedChange(event: CustomEvent): void {
     this.panel1Expanded = event.detail;
   }
 

--- a/packages/angular/projects/cds-angular/src/cds/_stubs/directive.ts.mustache
+++ b/packages/angular/projects/cds-angular/src/cds/_stubs/directive.ts.mustache
@@ -4,13 +4,25 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Directive, {{#hasProps}} Input {{/hasProps}} } from '@angular/core';
+import { Directive {{#hasProps}}, Input {{/hasProps}} {{#hasEvents}}, Output, EventEmitter {{/hasEvents}} } from '@angular/core';
 import { BaseCdsDirective } from '../../cds-base';
 
 @Directive({ selector: '{{tagName}}' })
 export class {{directiveClassName}} extends BaseCdsDirective {
   {{#props}}
   get {{name}}() { return this.element['{{name}}']; }
-  @Input() set {{name}}(value) { this.element['{{name}}'] = value; };
+  @Input() set {{name}}(value: any) { 
+    {{#isBoolean}}
+      if(value === "") {
+        this.element['{{name}}'] = true; 
+        return;    
+      }
+    {{/isBoolean}}
+    this.element['{{name}}'] = value; 
+  };
   {{/props}}
+
+  {{#events}}
+  @Output() {{name}}: EventEmitter<CustomEvent> = new EventEmitter();
+  {{/events}}
 } 

--- a/scripts/core-ng-module-generator.js
+++ b/scripts/core-ng-module-generator.js
@@ -114,8 +114,10 @@ function createDirectives(componentDirectories) {
       const templateData = {
         tagName: tag.name,
         directiveClassName: getDirectiveClassName(tag.name, '', 'Directive'),
-        props: tag.properties,
+        props: tag.properties && tag.properties.map(p => ({ ...p, isBoolean: p.type === 'boolean' })),
+        events: tag.events,
         hasProps: !!tag.properties,
+        hasEvents: !!tag.events,
       };
 
       const directory = getDiretoryName(tag.path);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features) 
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

Previously, the component with boolean properties were getting falsy due to the following:

```ts
@Input() set readonly(value) {
    this.element['readonly'] = value;
}
```

And empty attributes would be translated as `falsy`. So this PR fixes that with the following:

```ts
@Input() set readonly(value: any) {
    if (value === '') {
      this.element['readonly'] = true;
      return;
    }
    this.element['readonly'] = value;
}
```

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5916 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
