### PR TITLE
fix(button): use darker color on disabled solid button, fix badge color on disabled outline button

### DIFF
--- a/packages/core/src/button/base-button.element.scss
+++ b/packages/core/src/button/base-button.element.scss
@@ -186,7 +186,6 @@
   --background: #{$cds-alias-status-disabled-tint};
   --border-color: #{$cds-alias-status-disabled-tint};
   --box-shadow-color: #{$cds-alias-object-opacity-0};
-  --color: #{$cds-alias-status-disabled};
 
   .private-host {
     cursor: not-allowed;
@@ -201,11 +200,13 @@
 
 :host([disabled][action='outline']) {
   --background: #{$cds-alias-object-opacity-0};
+  --color: #{$cds-alias-status-disabled};
 }
 
 :host([disabled][action='flat']) {
   --border-color: #{$cds-alias-object-opacity-0};
   --background: #{$cds-alias-object-opacity-0};
+  --color: #{$cds-alias-status-disabled};
 }
 
 :host([block]) {

--- a/packages/core/src/button/button.element.scss
+++ b/packages/core/src/button/button.element.scss
@@ -70,16 +70,15 @@
 :host([disabled]) {
   ::slotted(cds-badge) {
     --background: #{$cds-alias-object-opacity-0} !important;
-    --border-color: #{$cds-alias-status-disabled} !important;
-    --color: #{$cds-alias-status-disabled} !important;
   }
 }
 
 :host([disabled][status='inverse']),
-:host([disabled][action='outline']) {
+:host([disabled][action='outline']),
+:host([disabled][action='flat']) {
   ::slotted(cds-badge) {
-    --border-color: #{$cds-alias-status-disabled-tint} !important;
-    --color: #{$cds-alias-status-disabled-tint} !important;
+    --border-color: #{$cds-alias-status-disabled} !important;
+    --color: #{$cds-alias-status-disabled} !important;
   }
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current/new behavior?

Before | After
--- | ---
<img width="287" alt="Screen Shot 2021-05-08 at 1 57 58 AM" src="https://user-images.githubusercontent.com/113730/117560242-a6803300-b094-11eb-885f-654169037ea6.png"> | <img width="292" alt="Screen Shot 2021-05-08 at 2 01 57 AM" src="https://user-images.githubusercontent.com/113730/117560243-a718c980-b094-11eb-86bc-ec19bc5fd212.png">
<img width="153" alt="Screen Shot 2021-05-08 at 2 03 55 AM" src="https://user-images.githubusercontent.com/113730/117560244-a718c980-b094-11eb-8c92-88e2ac3d762e.png"> | <img width="153" alt="Screen Shot 2021-05-08 at 2 07 44 AM" src="https://user-images.githubusercontent.com/113730/117560245-a7b16000-b094-11eb-9561-b949a51604bb.png">

The contrast ratios increase only a tiny little (1.34 before vs 1.49 after) but I find it easier on the eyes in both light and dark themes. It's also more consistent with how Clarity buttons generally look like.

Also it turned out that when the button is disabled, the badge color in flat and outline variants differed so I fixed this as well.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

