### PR TITLE
fix(datagrid): pagination icons size and alignment

### DIFF
--- a/packages/angular/projects/clr-angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/_datagrid.clarity.scss
@@ -1532,7 +1532,6 @@
     .pagination-next {
       display: flex;
       align-items: center;
-      @include equilateral($clr-datagrid-icon-size);
       background-repeat: no-repeat;
       background-size: contain;
     }


### PR DESCRIPTION
Closes #5933

Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #5933

## What is the new behaviour?

Pagination icons are equally aligned.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<img width="581" alt="fixed-pagination-icons" src="https://user-images.githubusercontent.com/15037947/117676218-015d7b80-b1b6-11eb-87b3-5784cee96068.png">

