### PR TITLE
fix(icons): fix the ESLint rule replacements for `is-error`, `is-highlight`, `collapse` and `arrow`

### DIFF
--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-icon/index.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-icon/index.ts
@@ -16,13 +16,13 @@ const deprecatedClassToAttributeMap = {
 
   'is-danger': 'status="danger"',
   'is-red': 'status="danger"',
+  'is-error': 'status="danger"',
 
   'is-warning': 'status="warning"',
 
   'is-info': 'status="info"',
   'is-blue': 'status="info"',
-
-  'is-highlight': 'status="highlight"',
+  'is-highlight': 'status="info"',
 
   'is-inverse': 'inverse',
   'is-white': 'inverse',
@@ -36,13 +36,20 @@ const deprecatedClassToAttributeMap = {
   'has-alert': 'badge="triangle"',
 };
 
-function isDeprecatedShape(value: string): boolean {
-  const isValidDirection = (val: string): boolean =>
-    ['up', 'down', 'left', 'right'].some(direction => direction === val);
+const deprecatedShapesMap = {
+  caret: 'angle',
+  collapse: 'angle-double',
+  arrow: 'arrow',
+};
 
+function isValidDirection(direction: string): boolean {
+  return ['up', 'down', 'left', 'right'].includes(direction);
+}
+
+function isDeprecatedShape(value: string): boolean {
   const shapes = value.split(' ');
 
-  return shapes && shapes.length === 2 && shapes[0] === 'caret' && isValidDirection(shapes[1]);
+  return shapes?.length === 2 && deprecatedShapesMap[shapes[0]] && isValidDirection(shapes[1]);
 }
 
 function getShapeFixes(fixer: RuleFixer, attributes: Array<HTMLAttribute>): Array<RuleFix> {
@@ -52,14 +59,20 @@ function getShapeFixes(fixer: RuleFixer, attributes: Array<HTMLAttribute>): Arra
   }
 
   const attributeValue = shapeAttribute.attributeValue.value || '';
+  const shapes = attributeValue.split(' ');
 
-  if (!isDeprecatedShape(attributeValue)) {
+  if (shapes?.length !== 2) {
     return [];
   }
 
-  const shapeFix = fixer.replaceText(shapeAttribute.attributeValue as any, 'angle');
+  const [value, direction] = shapes;
+  const newShape = deprecatedShapesMap[value];
 
-  const direction = attributeValue.split(' ')[1];
+  if (!newShape || !isValidDirection(direction)) {
+    return [];
+  }
+
+  const shapeFix = fixer.replaceText(shapeAttribute.attributeValue as any, newShape);
   const insertedDirectionFix = fixer.insertTextAfter(shapeAttribute as any, ` direction="${direction}"`);
 
   return [shapeFix, insertedDirectionFix];

--- a/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-icon/no-clr-icon.spec.ts
+++ b/packages/eslint-plugin-clarity-adoption/src/rules/no-clr-icon/no-clr-icon.spec.ts
@@ -81,6 +81,11 @@ htmlRuleTester.run('no-clr-icon', rule, {
       locations: [{ line: 1, column: 1 }],
     }),
     getInvalidIconTest({
+      code: `<clr-icon class="is-error"></clr-icon>`,
+      output: `<cds-icon status="danger"></cds-icon>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidIconTest({
       code: `<clr-icon class="is-warning"></clr-icon>`,
       output: `<cds-icon status="warning"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
@@ -97,7 +102,7 @@ htmlRuleTester.run('no-clr-icon', rule, {
     }),
     getInvalidIconTest({
       code: `<clr-icon class="is-highlight"></clr-icon>`,
-      output: `<cds-icon status="highlight"></cds-icon>`,
+      output: `<cds-icon status="info"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
     getInvalidIconTest({
@@ -235,6 +240,48 @@ htmlRuleTester.run('no-clr-icon', rule, {
       output: `<cds-icon shape="angle" direction="right"></cds-icon>`,
       locations: [{ line: 1, column: 1 }],
     }),
+
+    getInvalidIconTest({
+      code: `<clr-icon shape="collapse up"></clr-icon>`,
+      output: `<cds-icon shape="angle-double" direction="up"></cds-icon>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidIconTest({
+      code: `<clr-icon shape="collapse down"></clr-icon>`,
+      output: `<cds-icon shape="angle-double" direction="down"></cds-icon>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidIconTest({
+      code: `<clr-icon shape="collapse left"></clr-icon>`,
+      output: `<cds-icon shape="angle-double" direction="left"></cds-icon>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidIconTest({
+      code: `<clr-icon shape="collapse right"></clr-icon>`,
+      output: `<cds-icon shape="angle-double" direction="right"></cds-icon>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+
+    getInvalidIconTest({
+      code: `<clr-icon shape="arrow up"></clr-icon>`,
+      output: `<cds-icon shape="arrow" direction="up"></cds-icon>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidIconTest({
+      code: `<clr-icon shape="arrow down"></clr-icon>`,
+      output: `<cds-icon shape="arrow" direction="down"></cds-icon>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidIconTest({
+      code: `<clr-icon shape="arrow left"></clr-icon>`,
+      output: `<cds-icon shape="arrow" direction="left"></cds-icon>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
+    getInvalidIconTest({
+      code: `<clr-icon shape="arrow right"></clr-icon>`,
+      output: `<cds-icon shape="arrow" direction="right"></cds-icon>`,
+      locations: [{ line: 1, column: 1 }],
+    }),
     /**
      * Shape attribute: already migrated tag (cds-icon)
      */
@@ -256,6 +303,48 @@ htmlRuleTester.run('no-clr-icon', rule, {
     getInvalidIconTest({
       code: `<cds-icon shape="caret right"></cds-icon>`,
       output: `<cds-icon shape="angle" direction="right"></cds-icon>`,
+      locations: [{ line: 1, column: 11 }],
+    }),
+
+    getInvalidIconTest({
+      code: `<cds-icon shape="collapse up"></cds-icon>`,
+      output: `<cds-icon shape="angle-double" direction="up"></cds-icon>`,
+      locations: [{ line: 1, column: 11 }],
+    }),
+    getInvalidIconTest({
+      code: `<cds-icon shape="collapse down"></cds-icon>`,
+      output: `<cds-icon shape="angle-double" direction="down"></cds-icon>`,
+      locations: [{ line: 1, column: 11 }],
+    }),
+    getInvalidIconTest({
+      code: `<cds-icon shape="collapse left"></cds-icon>`,
+      output: `<cds-icon shape="angle-double" direction="left"></cds-icon>`,
+      locations: [{ line: 1, column: 11 }],
+    }),
+    getInvalidIconTest({
+      code: `<cds-icon shape="collapse right"></cds-icon>`,
+      output: `<cds-icon shape="angle-double" direction="right"></cds-icon>`,
+      locations: [{ line: 1, column: 11 }],
+    }),
+
+    getInvalidIconTest({
+      code: `<cds-icon shape="arrow up"></cds-icon>`,
+      output: `<cds-icon shape="arrow" direction="up"></cds-icon>`,
+      locations: [{ line: 1, column: 11 }],
+    }),
+    getInvalidIconTest({
+      code: `<cds-icon shape="arrow down"></cds-icon>`,
+      output: `<cds-icon shape="arrow" direction="down"></cds-icon>`,
+      locations: [{ line: 1, column: 11 }],
+    }),
+    getInvalidIconTest({
+      code: `<cds-icon shape="arrow left"></cds-icon>`,
+      output: `<cds-icon shape="arrow" direction="left"></cds-icon>`,
+      locations: [{ line: 1, column: 11 }],
+    }),
+    getInvalidIconTest({
+      code: `<cds-icon shape="arrow right"></cds-icon>`,
+      output: `<cds-icon shape="arrow" direction="right"></cds-icon>`,
       locations: [{ line: 1, column: 11 }],
     }),
     /**


### PR DESCRIPTION
The ESLint Rule for `no-clr-icon` detects and replaces `ClrIcon`s with `CdsIcon`s. See #5331 . 
This PR handles a few additional cases:
- the class `is-error` is now replaced with `status="danger"`;
- the class `is-highlight` is now replaced with `status="info"`. `CdsIcon`s don't have `status="highlight"`;
- `shape="collapse up|down|right|left"` is now replaced with `shape="angle-double" direction="up|down|right|left"`;
- `shape="arrow up|down|right|left"` is now replaced with `shape="arrow" direction="up|down|right|left"`.

Thanks @rbirkgit, for the trying out the rule and reporting these issues!

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
