### PR TITLE
fix(tree-view): error EHCAIWC for lazy expandable nodes

### DIFF
--- a/packages/angular/golden/clr-angular.d.ts
+++ b/packages/angular/golden/clr-angular.d.ts
@@ -1874,6 +1874,7 @@ export declare class ClrTreeNode<T> implements OnInit, OnDestroy {
     set expanded(value: boolean);
     expandedChange: EventEmitter<boolean>;
     featuresService: TreeFeaturesService<T>;
+    isModelLoading: boolean;
     nodeId: string;
     get selected(): ClrSelectedState | boolean;
     set selected(value: ClrSelectedState | boolean);

--- a/packages/angular/projects/clr-angular/src/data/tree-view/models/tree-node.model.ts
+++ b/packages/angular/projects/clr-angular/src/data/tree-view/models/tree-node.model.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -27,7 +27,17 @@ export abstract class TreeNodeModel<T> {
    * right now for them to know which kind of model they are using. So I'm lifting the public properties to this
    * abstract parent class for now and we can revisit it later, when we're not facing such a close deadline.
    */
-  loading = false;
+  private _loading = false;
+  loading$ = new BehaviorSubject<boolean>(false);
+
+  get loading() {
+    return this._loading;
+  }
+
+  set loading(isLoading: boolean) {
+    this._loading = isLoading;
+    this.loading$.next(isLoading);
+  }
 
   destroy() {
     // Just to be safe

--- a/packages/angular/projects/clr-angular/src/data/tree-view/tree-node.html
+++ b/packages/angular/projects/clr-angular/src/data/tree-view/tree-node.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -15,7 +15,7 @@
   (focus)="broadcastFocusOnContainer()"
 >
   <button
-    *ngIf="isExpandable() && !_model.loading && !expandService.loading"
+    *ngIf="isExpandable() && !isModelLoading && !expandService.loading"
     aria-hidden="true"
     type="button"
     tabindex="-1"
@@ -29,7 +29,7 @@
       [attr.direction]="expandService.expanded ? 'down' : 'right'"
     ></cds-icon>
   </button>
-  <div class="clr-treenode-spinner-container" *ngIf="expandService.loading || _model.loading">
+  <div class="clr-treenode-spinner-container" *ngIf="expandService.loading || isModelLoading">
     <span class="clr-treenode-spinner spinner"></span>
   </div>
   <div class="clr-checkbox-wrapper clr-treenode-checkbox" *ngIf="featuresService.selectable">

--- a/packages/angular/projects/clr-angular/src/data/tree-view/tree-node.spec.ts
+++ b/packages/angular/projects/clr-angular/src/data/tree-view/tree-node.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -256,7 +256,7 @@ export default function (): void {
       });
 
       it('replaces the caret with a spinner when the model is loading', function (this: Context) {
-        this.clarityDirective._model.loading = true;
+        this.clarityDirective.isModelLoading = true;
         this.detectChanges();
         expect(this.clarityElement.querySelector('.clr-treenode-caret')).toBeNull();
         expect(this.clarityElement.querySelector('.clr-treenode-spinner')).not.toBeNull();

--- a/packages/angular/projects/clr-angular/src/data/tree-view/tree-node.ts
+++ b/packages/angular/projects/clr-angular/src/data/tree-view/tree-node.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -24,7 +24,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import { Subscription } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { debounceTime, filter } from 'rxjs/operators';
 
 import { KeyCodes } from './../../utils/enums/key-codes.enum';
 import { IfExpandService } from '../../utils/conditional/if-expanded.service';
@@ -66,6 +66,7 @@ const LVIEW_CONTEXT_INDEX = 8;
 export class ClrTreeNode<T> implements OnInit, OnDestroy {
   STATES = ClrSelectedState;
   private skipEmitChange = false;
+  isModelLoading = false;
 
   constructor(
     @Inject(UNIQUE_ID) public nodeId: string,
@@ -179,6 +180,10 @@ export class ClrTreeNode<T> implements OnInit, OnDestroy {
       this.focusManager.focusChange.subscribe(nodeId => {
         this.checkTabIndex(nodeId);
       })
+    );
+
+    this.subscriptions.push(
+      this._model.loading$.pipe(debounceTime(0)).subscribe(isLoading => (this.isModelLoading = isLoading))
     );
   }
 

--- a/packages/angular/projects/clr-angular/src/utils/conditional/if-expanded.directive.ts
+++ b/packages/angular/projects/clr-angular/src/utils/conditional/if-expanded.directive.ts
@@ -45,7 +45,6 @@ export class ClrIfExpanded implements OnInit, OnDestroy {
     private renderer: Renderer2,
     private expand: IfExpandService
   ) {
-    expand.expandable++;
     this._subscriptions.push(
       expand.expandChange.subscribe(() => {
         this.updateView();
@@ -90,6 +89,7 @@ export class ClrIfExpanded implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
+    this.expand.expandable++;
     this.updateView();
   }
 


### PR DESCRIPTION
The main reason for EHCAIWC was that [in this function](https://github.com/vmware/clarity/blob/next/packages/angular/projects/clr-angular/src/data/tree-view/models/recursive-tree-node.model.ts#L46) the Promise or the Observable can be resolved too quickly and the `loading` property value can be changed before the next change detection cycle. 

I'm resolving the issue with a pattern we used for the [datagrid selection](https://github.com/vmware/clarity/blob/next/packages/angular/projects/clr-angular/src/data/datagrid/providers/selection.ts#L164) that in first case it was producing a EHCAIWC, then we did a fix and the fix was skipping a change detection cycle and we end up with out last solution that seems to be the best one so far.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5927

## What is the new behavior?

EHCAIWC is not produced anymore.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

A way to see the issue is not available anymore is:

1. Go to the `dev` app 
2. Navigate to `tree-view`
3. Select the `Lazy recursive tree`
4. Expand on item from the `Asynchronous, loading exactly what's visible` example
5. Take a look at the console for EHCAIWC error
