### PR TITLE
fix(dropdown): fix the styles for icons with shape `caret`

### DIFF
--- a/packages/angular/projects/clr-angular/src/popover/dropdown/_dropdown.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/popover/dropdown/_dropdown.clarity.scss
@@ -28,6 +28,7 @@
         margin: 0;
       }
 
+      clr-icon[shape^='caret'],
       clr-icon[shape^='angle'] {
         position: absolute;
         top: 50%;
@@ -39,6 +40,7 @@
       // NOTE: cds-icon handles direction internally.
       // No need to translate it.
       // This results in a different top value.
+      cds-icon[shape^='caret'],
       cds-icon[shape^='angle'] {
         position: absolute;
         top: 35%;
@@ -50,6 +52,8 @@
         padding-right: $clr-btn-horizontal-padding + $clr-dropdown-caret-icon-dimension +
           $clr-dropdown-caret-left-margin;
 
+        cds-icon[shape^='caret'],
+        clr-icon[shape^='caret'],
         cds-icon[shape^='angle'],
         clr-icon[shape^='angle'] {
           right: $clr-btn-horizontal-padding;
@@ -64,6 +68,8 @@
           $clr-dropdown-active-text-color,
           $clr-use-custom-properties
         );
+        cds-icon[shape^='caret'],
+        clr-icon[shape^='caret'],
         cds-icon[shape^='angle'],
         clr-icon[shape^='angle'] {
           right: 0;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Icons (both `clr-icon` and `cds-icon`) with shape `caret` inside `clr-dropdown` buttons look different to icons with shape `angle`. They should look the same because `caret` is an alias to `angle`.

Issue Number: #5941

## What is the new behavior?

The styles for both shapes are aligned.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
