### PR TITLE
fix(dropdownmenu): keyboard accessibility issue when there is a div t…

### DIFF
--- a/packages/angular/projects/clr-angular/src/popover/dropdown/dropdown-menu.ts
+++ b/packages/angular/projects/clr-angular/src/popover/dropdown/dropdown-menu.ts
@@ -104,7 +104,7 @@ export class ClrDropdownMenu extends AbstractPopover implements AfterContentInit
   }
 
   private focusHandler: DropdownFocusHandler;
-  @ContentChildren(FocusableItem) items: QueryList<FocusableItem>;
+  @ContentChildren(FocusableItem, { descendants: true }) items: QueryList<FocusableItem>;
 
   ngAfterContentInit() {
     this.focusHandler.container = this.el.nativeElement;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Keyboard navigation with down arrow button is not working on clarity dropdown options when there is a wrapper div around dropdown items inside clarity dropdown menu. This issue is because @ContentChildren is not detecting the content with div tag in between with Angular9 and above.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Adding { descendants: true } on Content Children to get the nested items. With this change keyboard accessibility is working and focus is moving to first dropdown option on triggering dropdown menu even in the presence of nested div around dropdown items. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
