### PR TITLE
docs: add react-specific documentation to storybook

### DIFF
--- a/packages/core/docs/react.stories.mdx
+++ b/packages/core/docs/react.stories.mdx
@@ -85,6 +85,26 @@ export default class App extends React.Component<{}, {}> {
 }
 ```
 
+## Boolean Attributes on Web Components
+
+There is an issue with [the way React treats boolean HTML attributes](https://github.com/facebook/react/issues/9230).
+For boolean attributes on DOM elements or Clarity components, use `attribute="true"` or `attribute=""`
+instead of just `attribute`.
+
+```typescript
+const Component = () => {
+  return (
+    <CdsControl>
+      <label>label</label>
+      <p cds-text="body" cds-control="true">
+        A custom CDS Control
+      </p>
+      <CdsControlMessage>control message</CdsControlMessage>
+    </CdsControl>
+  );
+};
+```
+
 <a href="https://github.com/vmware/clarity/tree/next/apps" target="_blank" rel="noopener">
   <cds-button>Example Apps</cds-button>
 </a>

--- a/packages/core/src/checkbox/checkbox.stories.mdx
+++ b/packages/core/src/checkbox/checkbox.stories.mdx
@@ -79,3 +79,54 @@ import '@cds/core/checkbox/register.js';
 ## Checkbox Group API
 
 <Props of={'cds-checkbox-group'} />
+
+## React Usage
+
+React doesn't expose `indeterminate` as a prop on `input` components,
+the attribute must be set using a `ref`.
+
+```typescript
+const Component = ({ indeterminate }) => {
+  const inputRef = useRef<HTMLInputElement>();
+
+  useLayoutEffect(() => {
+    if (ref.current) {
+      ref.current.indeterminate = indeterminate;
+    }
+  }, [indeterminate]);
+
+  return (
+    <CdsCheckbox>
+      <label>label</label>
+      <input type="checkbox" ref={inputRef} />
+    </CdsCheckbox>
+  );
+};
+```
+
+This can also be extracted into a custom hook for reuse:
+
+```typescript
+const useIndeterminateCheckbox = (indeterminate: boolean) => {
+  const ref = useRef<HTMLInputElement>(null);
+
+  useLayoutEffect(() => {
+    if (ref.current) {
+      ref.current.indeterminate = indeterminate;
+    }
+  }, [indeterminate]);
+
+  return [ref];
+};
+
+const Component = ({ indeterminate }) => {
+  const [inputRef] = useIndeterminateCheckbox(indeterminate);
+
+  return (
+    <CdsCheckbox>
+      <label>label</label>
+      <input type="checkbox" ref={inputRef} />
+    </CdsCheckbox>
+  );
+};
+```


### PR DESCRIPTION
Signed-off-by: Ashley Ryan <asryan@cloudhealthtech.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Individual components have no framework specific documentation even when their usage differs from the web component examples. 

## What is the new behavior?

This PR adds react-specific documentation to storybook where relevant as suggested here: https://github.com/vmware/clarity/discussions/5895

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
