### PR TITLE
fix(header): dark theme header-7/8 workaround

### DIFF
--- a/packages/angular/projects/clr-angular/src/layout/main-container/_properties.header.scss
+++ b/packages/angular/projects/clr-angular/src/layout/main-container/_properties.header.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -16,6 +16,7 @@
       --clr-header-5-bg-color: var(--clr-color-action-800);
       --clr-header-6-bg-color: var(--clr-color-action-1000);
       --clr-header-7-bg-color: #{$clr-header-7-bg-color};
+      --clr-header-8-bg-color: #{$clr-header-8-bg-color};
       --clr-header-font-color: var(--clr-color-neutral-50);
       --clr-header-title-color: var(--clr-header-font-color);
       --clr-header-title-font-weight: var(--clr-h5-font-weight);

--- a/packages/angular/projects/clr-angular/src/layout/main-container/_variables.header.scss
+++ b/packages/angular/projects/clr-angular/src/layout/main-container/_variables.header.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -35,6 +35,7 @@ $clr-header-7-bg-color: hsl(
   25%,
   25%
 ) !default; // Hard coded because this color is not in the color palette. Its reserved for headers only
+$clr-header-8-bg-color: #0f161c !default; // dark theme only header added by external team to workaround lack of header-7 in dark theme
 
 $clr-header-font-color: $clr-color-neutral-50 !default;
 

--- a/packages/angular/projects/clr-angular/src/layout/nav/_header.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/layout/nav/_header.clarity.scss
@@ -56,6 +56,11 @@
   &.header-7 {
     @include css-var(background-color, clr-header-7-bg-color, $clr-header-7-bg-color, $clr-use-custom-properties);
   }
+
+  // dark theme only header added by external team to workaround lack of header-7 in dark theme
+  &.header-8 {
+    @include css-var(background-color, clr-header-8-bg-color, $clr-header-8-bg-color, $clr-use-custom-properties);
+  }
 }
 
 @mixin header-branding() {


### PR DESCRIPTION
Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [x] Other... Please describe:

During an internal slack discussion the following information was surfaced:
1. The OG Clarity ng dark theme didn't implement a header -7 color
2. header-7 was added for specific apps that needed it in light theme
3. Teams have been working around this by implementing a workaround with a class called header-8

This change brings that workaround inside the Clarity css so that consuming apps can simplify the css on their end.

NOTE: this workaround has the opposite behavior of header-7:
- .header-7 is a class that is only used with light theme
- .header-8 is a class that is only used with dark themes.

## What is the current behavior?
@clr/ui .header-7 doesn't have a specific dark theme color. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
The change adds a `.header-8` color for themes that have been working around the issue with a custom class called `.header-8`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
