### PR TITLE
fix: provide vm-bug icon for angular dev app

### DIFF
--- a/packages/angular/projects/dev/src/app/app.component.ts
+++ b/packages/angular/projects/dev/src/app/app.component.ts
@@ -8,6 +8,7 @@ import { Route } from '@angular/router';
 import { APP_ROUTES } from './app.routing';
 
 import '@cds/core/icon/register.js';
+
 import {
   bellIcon,
   boltIcon,
@@ -32,6 +33,14 @@ import {
   warningStandardIcon,
   sunIcon,
   worldIcon,
+  vmBugIcon,
+  cogIcon,
+  plusIcon,
+  errorStandardIcon,
+  floppyIcon,
+  hostIcon,
+  infoStandardIcon,
+  coreCollectionAliases,
 } from '@cds/core/icon';
 
 @Component({
@@ -66,7 +75,16 @@ export class AppComponent {
       lightbulbIcon,
       warningStandardIcon,
       sunIcon,
-      worldIcon
+      worldIcon,
+      vmBugIcon,
+      cogIcon,
+      plusIcon,
+      errorStandardIcon,
+      infoStandardIcon,
+      floppyIcon,
+      hostIcon
     );
+
+    ClarityIcons.addAliases(...coreCollectionAliases);
   }
 }

--- a/packages/angular/projects/dev/src/app/iconography/icon-selection.ts
+++ b/packages/angular/projects/dev/src/app/iconography/icon-selection.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -14,6 +14,32 @@ import { SocialShapes } from '@clr/icons/shapes/social-shapes';
 import { TechnologyShapes } from '@clr/icons/shapes/technology-shapes';
 import { TextEditShapes } from '@clr/icons/shapes/text-edit-shapes';
 import { TravelShapes } from '@clr/icons/shapes/travel-shapes';
+
+/**
+ * @NOTE importing all icons because into the iconography page we require all of them.
+ */
+import {
+  ClarityIcons,
+  chartCollectionIcons,
+  commerceCollectionIcons,
+  coreCollectionIcons,
+  essentialCollectionIcons,
+  socialCollectionIcons,
+  technologyCollectionIcons,
+  textEditCollectionIcons,
+  travelCollectionIcons,
+  mediaCollectionIcons,
+  chartCollectionAliases,
+  commerceCollectionAliases,
+  coreCollectionAliases,
+  essentialCollectionAliases,
+  mediaCollectionAliases,
+  miniCollectionAliases,
+  socialCollectionAliases,
+  technologyCollectionAliases,
+  textEditCollectionAliases,
+  travelCollectionAliases,
+} from '@cds/core/icon';
 
 @Component({
   selector: 'clr-icon-selection-demo',
@@ -37,4 +63,31 @@ export class IconSelectionDemo {
     { name: 'Chart Shapes', shapes: Object.keys(ChartShapes) },
     { name: 'Text Edit Shapes', shapes: Object.keys(TextEditShapes) },
   ];
+
+  constructor() {
+    ClarityIcons.addIcons(
+      ...chartCollectionIcons,
+      ...commerceCollectionIcons,
+      ...coreCollectionIcons,
+      ...essentialCollectionIcons,
+      ...mediaCollectionIcons,
+      ...socialCollectionIcons,
+      ...technologyCollectionIcons,
+      ...textEditCollectionIcons,
+      ...travelCollectionIcons
+    );
+
+    ClarityIcons.addAliases(
+      ...chartCollectionAliases,
+      ...commerceCollectionAliases,
+      ...coreCollectionAliases,
+      ...essentialCollectionAliases,
+      ...mediaCollectionAliases,
+      ...miniCollectionAliases,
+      ...socialCollectionAliases,
+      ...technologyCollectionAliases,
+      ...textEditCollectionAliases,
+      ...travelCollectionAliases
+    );
+  }
 }


### PR DESCRIPTION
Fix epilepsies icon for Angular dev app and adding `vm-bug` to used icons.

This must solve some of the visual diff mismatches that we had before.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
