### PR TITLE
fix: core dynamic rem calc

### DIFF
--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -120,11 +120,11 @@ export const globalTypes = {
   baseFont: {
     name: 'Base Font',
     description: 'Base Font for Document',
-    defaultValue: '125%',
+    defaultValue: '20',
     toolbar: {
       items: [
-        { value: '125%', title: 'Base 20px (Default)' },
-        { value: '100%', title: 'Base 16px' },
+        { value: '20', title: 'Base 20px (Default)' },
+        { value: '16', title: 'Base 16px' },
       ],
     },
   },
@@ -134,7 +134,7 @@ const themeDecorator = (story, { globals }) => {
   const themes = `${globals.theme ? globals.theme : ''} ${globals.motion ? globals.motion : ''}`;
   document.body.setAttribute('cds-theme', `${themes}`);
   window.parent.document.body.setAttribute('cds-theme', `${themes}`);
-  document.documentElement.setAttribute('cds-base-font', `${globals.baseFont === '100%' ? '16' : ''}`);
+  document.documentElement.style.setProperty('--cds-global-base', globals.baseFont);
 
   window.localStorage.setItem('cds-theme', themes);
 

--- a/packages/core/build/token-utils.ts
+++ b/packages/core/build/token-utils.ts
@@ -11,6 +11,7 @@ export interface CdsTheme {
     color: Tokens;
     typography: Tokens;
     animation: Tokens;
+    base: Token;
   };
   aliases: Tokens;
 }
@@ -37,7 +38,7 @@ export class Token {
     return this._value instanceof Token ? this._value : null;
   }
 
-  constructor(value: Token | number | string | HSL, public config: { absolute?: boolean } = {}) {
+  constructor(value: Token | number | string | HSL, public config: { static?: boolean } = {}) {
     this._value = value;
   }
 

--- a/packages/core/build/tokens.ts
+++ b/packages/core/build/tokens.ts
@@ -17,14 +17,14 @@ const layout = {
     xxl: token(96),
   },
   grid: {
-    cols: token(12, { absolute: true }),
+    cols: token(12, { static: true }),
   },
   width: {
-    xs: token(576),
-    sm: token(768),
-    md: token(992),
-    lg: token(1200),
-    xl: token(1440),
+    xs: token('576px', { static: true }),
+    sm: token('768px', { static: true }),
+    md: token('992px', { static: true }),
+    lg: token('1200px', { static: true }),
+    xl: token('1440px', { static: true }),
   },
 };
 
@@ -340,8 +340,8 @@ const typography = {
     8: token(32),
     9: token(40),
   },
-  baseFontSize: token('125%'),
-  baseFontSizePx: token(20),
+  baseFontSize: token('125%'), // deprecated for removal in 6.0
+  baseFontSizePx: token(20), // deprecated for removal in 6.0
   fontFamily: token("'Clarity City', 'Avenir Next', sans-serif"),
   headerFontFamily: token("'Clarity City', 'Avenir Next', sans-serif"),
   topGapHeight: token('0.1475em'), // line-height eraser
@@ -359,61 +359,61 @@ const typography = {
   },
   body: {
     fontSize: token(14),
-    lineHeight: token('1.42857em'),
+    lineHeight: token('1.42857em', { static: true }), // static for line height eraser calcs
     letterSpacing: token('-0.014286em'),
     fontWeight: token('400'),
   },
   display: {
     fontSize: token(40),
-    lineHeight: token('1.1em'),
+    lineHeight: token('1.1em', { static: true }),
     letterSpacing: token('-0.0125em'),
     fontWeight: token('400'),
   },
   heading: {
     fontSize: token(32),
-    lineHeight: token('1.125em'),
+    lineHeight: token('1.125em', { static: true }),
     letterSpacing: token('-0.0125em'),
     fontWeight: token('400'),
   },
   title: {
     fontSize: token(24),
-    lineHeight: token('1.16667em'),
+    lineHeight: token('1.16667em', { static: true }),
     letterSpacing: token('-0.008333em'),
     fontWeight: token('400'),
   },
   section: {
     fontSize: token(20),
-    lineHeight: token('1.2em'),
+    lineHeight: token('1.2em', { static: true }),
     letterSpacing: token('-0.01em'),
     fontWeight: token('400'),
   },
   subsection: {
     fontSize: token(16),
-    lineHeight: token('1.25em'),
+    lineHeight: token('1.25em', { static: true }),
     letterSpacing: token('-0.0125em'),
     fontWeight: token('400'),
   },
   message: {
     fontSize: token(16),
-    lineHeight: token('1.25em'),
+    lineHeight: token('1.25em', { static: true }),
     letterSpacing: token('-0.0125em'),
     fontWeight: token(400),
   },
   secondary: {
     fontSize: token(13),
-    lineHeight: token('1.23077em'),
+    lineHeight: token('1.23077em', { static: true }),
     letterSpacing: token('-0.007692em'),
     fontWeight: token('400'),
   },
   caption: {
     fontSize: token(11),
-    lineHeight: token('1.454545em'),
+    lineHeight: token('1.454545em', { static: true }),
     letterSpacing: token('0.018182em'),
     fontWeight: token('400'),
   },
   smallcaption: {
     fontSize: token(10),
-    lineHeight: token('1.2em'),
+    lineHeight: token('1.2em', { static: true }),
     letterSpacing: token('0.05em'),
     fontWeight: token('500'),
   },
@@ -539,6 +539,6 @@ const aliases = {
 };
 
 export const baseTheme: CdsTheme = {
-  global: { layout, space, color, typography, animation },
+  global: { layout, space, color, typography, animation, base: token(20, { static: true }) },
   aliases,
 };

--- a/packages/core/src/checkbox/checkbox.element.scss
+++ b/packages/core/src/checkbox/checkbox.element.scss
@@ -44,7 +44,7 @@
   border-bottom-color: var(--check-color);
   border-right-color: var(--check-color);
   border-top-color: var(--check-color);
-  transform: translateY($cds-global-space-3-static) rotate(-45deg);
+  transform: translateY($cds-global-space-3) rotate(-45deg);
 }
 
 :host([_indeterminate]) {

--- a/packages/core/src/forms/form-group/form-group.element.spec.ts
+++ b/packages/core/src/forms/form-group/form-group.element.spec.ts
@@ -109,7 +109,7 @@ describe('cds-form-group', () => {
     await componentIsStable(formGroup); // firstUpdated
 
     expect(controls[0].querySelector('label').getBoundingClientRect().width).toBe(200);
-    expect(getCssPropertyValue('--internal-label-min-width', formGroup)).toBe('10rem');
+    expect(getCssPropertyValue('--internal-label-min-width', formGroup)).toBe('calc((200 /  20) * 1rem)'); // --cds-global-base is used in place of "20" but computed properties return the result of css custom properties
   });
 
   it('should sync layouts when a control overflows', async () => {

--- a/packages/core/src/icon/icon.element.spec.ts
+++ b/packages/core/src/icon/icon.element.spec.ts
@@ -122,8 +122,8 @@ describe('icon element', () => {
       expect(component.style.height).toBe('');
       component.setAttribute('size', '43');
       await componentIsStable(component);
-      expect(component.style.width).toBe('2.15rem');
-      expect(component.style.height).toBe('2.15rem');
+      expect(component.style.width).toBe('calc((43 / var(--cds-global-base)) * 1rem)');
+      expect(component.style.height).toBe('calc((43 / var(--cds-global-base)) * 1rem)');
     });
     it('should remove the size attribute if set to undefined', async () => {
       await componentIsStable(component);

--- a/packages/core/src/icon/utils/icon.classnames.spec.ts
+++ b/packages/core/src/icon/utils/icon.classnames.spec.ts
@@ -62,15 +62,15 @@ describe('Icon classname helpers: ', () => {
     it('should remove classnames and update size styles if passed a numeric string', async () => {
       updateIconSizeStyle(component, '15');
       await componentIsStable(component);
-      expect(component.style.width).toEqual('0.75rem');
-      expect(component.style.height).toEqual('0.75rem');
+      expect(component.style.width).toEqual('calc((15 / var(--cds-global-base)) * 1rem)');
+      expect(component.style.height).toEqual('calc((15 / var(--cds-global-base)) * 1rem)');
     });
     it('should remove size styles and add classname if passed a t-shirt size', async () => {
       await componentIsStable(component);
       component.size = '30';
       await componentIsStable(component);
-      expect(component.style.height).toEqual('1.5rem');
-      expect(component.style.width).toEqual('1.5rem');
+      expect(component.style.height).toEqual('calc((30 / var(--cds-global-base)) * 1rem)');
+      expect(component.style.width).toEqual('calc((30 / var(--cds-global-base)) * 1rem)');
       updateIconSizeStyle(component, 'xl');
       await componentIsStable(component);
       expect(component.style.width).toEqual('');
@@ -95,8 +95,8 @@ describe('Icon classname helpers: ', () => {
       expect(component.style.height).toEqual('');
       updateIconSizeStyle(component, '48');
       await componentIsStable(component);
-      expect(component.style.width).toEqual('2.4rem');
-      expect(component.style.height).toEqual('2.4rem');
+      expect(component.style.width).toEqual('calc((48 / var(--cds-global-base)) * 1rem)');
+      expect(component.style.height).toEqual('calc((48 / var(--cds-global-base)) * 1rem)');
       updateIconSizeStyle(component, void 0);
       await componentIsStable(component);
       expect(component.style.width).toEqual('');
@@ -112,8 +112,8 @@ describe('Icon classname helpers: ', () => {
       expect(component.style.height).toEqual('');
       updateIconSizeStyle(component, '48');
       await componentIsStable(component);
-      expect(component.style.width).toEqual('2.4rem');
-      expect(component.style.height).toEqual('2.4rem');
+      expect(component.style.width).toEqual('calc((48 / var(--cds-global-base)) * 1rem)');
+      expect(component.style.height).toEqual('calc((48 / var(--cds-global-base)) * 1rem)');
       updateIconSizeStyle(component, '');
       await componentIsStable(component);
       expect(component.style.width).toEqual('');
@@ -127,12 +127,12 @@ describe('Icon classname helpers: ', () => {
       await componentIsStable(component);
       updateIconSizeStyle(component, '24');
       await componentIsStable(component);
-      expect(component.style.width).toEqual('1.2rem');
-      expect(component.style.height).toEqual('1.2rem');
+      expect(component.style.width).toEqual('calc((24 / var(--cds-global-base)) * 1rem)');
+      expect(component.style.height).toEqual('calc((24 / var(--cds-global-base)) * 1rem)');
       updateIconSizeStyle(component, '4d9rs');
       await componentIsStable(component);
-      expect(component.style.width).toEqual('1.2rem');
-      expect(component.style.height).toEqual('1.2rem');
+      expect(component.style.width).toEqual('calc((24 / var(--cds-global-base)) * 1rem)');
+      expect(component.style.height).toEqual('calc((24 / var(--cds-global-base)) * 1rem)');
     });
   });
 });

--- a/packages/core/src/internal/utils/css.spec.ts
+++ b/packages/core/src/internal/utils/css.spec.ts
@@ -95,14 +95,8 @@ describe('Css utility functions - ', () => {
   });
 
   describe('pxToRem: ', () => {
-    it('should convert px to rem values from base font size token', () => {
-      expect(pxToRem(10)).toBe('0.5rem');
-    });
-
-    it('should cache the rem calculation to the HTML cds-font-size attr', () => {
-      document.documentElement.setAttribute('cds-base-font', null);
-      expect(pxToRem(20)).toBe('1rem');
-      expect(document.documentElement.getAttribute('cds-base-font')).toBe('20');
+    it('should return a px to rem calc from the base font size token', () => {
+      expect(pxToRem(10)).toBe('calc((10 / var(--cds-global-base)) * 1rem)');
     });
   });
 

--- a/packages/core/src/internal/utils/css.ts
+++ b/packages/core/src/internal/utils/css.ts
@@ -41,17 +41,7 @@ export function updateElementStyles(el: HTMLElement, ...styleTuples: [string, st
 }
 
 export function pxToRem(pxValue: number) {
-  let base = parseInt(document.documentElement.getAttribute('cds-base-font') as string);
-
-  if (!base) {
-    const prop = window
-      .getComputedStyle(document.body, null)
-      .getPropertyValue('--cds-global-typography-base-font-size');
-    base = (16 * parseInt(prop !== '' ? prop : '100%')) / 100;
-    document.documentElement.setAttribute('cds-base-font', `${base}`);
-  }
-
-  return `${pxValue / base}rem`;
+  return `calc((${pxValue} / var(--cds-global-base)) * 1rem)`;
 }
 
 export function getCssPropertyValue(

--- a/packages/core/src/internal/utils/size.spec.ts
+++ b/packages/core/src/internal/utils/size.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -71,8 +71,8 @@ describe('Functional Helper: ', () => {
 
     it('updates equilateral styles if passed a numeric string', () => {
       updateEquilateralSizeStyles(testDiv, '100');
-      expect(testDiv.style.width).toBe('5rem');
-      expect(testDiv.style.height).toBe('5rem');
+      expect(testDiv.style.width).toBe('calc((100 / var(--cds-global-base)) * 1rem)');
+      expect(testDiv.style.height).toBe('calc((100 / var(--cds-global-base)) * 1rem)');
     });
 
     it('does nothing if passed a non-numeric string that is not a t-shirt size', () => {

--- a/packages/core/src/styles/layout/_optimize.scss
+++ b/packages/core/src/styles/layout/_optimize.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -7,22 +7,22 @@
 
 :root,
 :host {
-  --cxxs: var(--cds-global-layout-space-xxs, #{$cds-global-layout-space-xxs-static});
-  --cxs: var(--cds-global-layout-space-xs, #{$cds-global-layout-space-xs-static});
-  --csm: var(--cds-global-layout-space-sm, #{$cds-global-layout-space-sm-static});
-  --cmd: var(--cds-global-layout-space-md, #{$cds-global-layout-space-md-static});
-  --clg: var(--cds-global-layout-space-lg, #{$cds-global-layout-space-lg-static});
-  --cxl: var(--cds-global-layout-space-xl, #{$cds-global-layout-space-xl-static});
-  --cxxl: var(--cds-global-layout-space-xxl, #{$cds-global-layout-space-xxl-static});
+  --δ1: #{$cds-global-layout-space-xxs};
+  --δ2: #{$cds-global-layout-space-xs};
+  --δ3: #{$cds-global-layout-space-sm};
+  --δ4: #{$cds-global-layout-space-md};
+  --δ5: #{$cds-global-layout-space-lg};
+  --δ6: #{$cds-global-layout-space-xl};
+  --δ7: #{$cds-global-layout-space-xxl};
 }
 
-$cds-global-layout-space-xxs: var(--cxxs);
-$cds-global-layout-space-xs: var(--cxs);
-$cds-global-layout-space-sm: var(--csm);
-$cds-global-layout-space-md: var(--cmd);
-$cds-global-layout-space-lg: var(--clg);
-$cds-global-layout-space-xl: var(--cxl);
-$cds-global-layout-space-xxl: var(--cxxl);
+$cds-global-layout-space-xxs: var(--δ1);
+$cds-global-layout-space-xs: var(--δ2);
+$cds-global-layout-space-sm: var(--δ3);
+$cds-global-layout-space-md: var(--δ4);
+$cds-global-layout-space-lg: var(--δ5);
+$cds-global-layout-space-xl: var(--δ6);
+$cds-global-layout-space-xxl: var(--δ7);
 
 // selectors one location to make it easier to test for shorthand optimizations
 // this is also helpful for tools like AMP that require data-* prefix on all attrs

--- a/packages/core/src/styles/module.reset.scss
+++ b/packages/core/src/styles/module.reset.scss
@@ -5,7 +5,7 @@
 @import '../../dist/core/tokens/tokens';
 
 html {
-  font-size: $cds-global-typography-base-font-size;
+  font-size: calc((#{$cds-global-base} / 16) * 100%); // convert any base value to a scaled percentage
   box-sizing: border-box !important;
 }
 
@@ -13,6 +13,10 @@ html {
 *:before,
 *:after {
   box-sizing: inherit !important;
+}
+
+[cds-base-font='16'] {
+  --cds-global-base: 16;
 }
 
 [cds-theme] {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
The current spacing tokens in Core rely on a base 20 font size. This was done as a calculation during the token build step. When converting a px value to rem the browser had to re-compute the base rem size which is very expensive in the pxToRem function. Also due to the rem calculation happening at build time the base font was not easily changed dynamically in the browser. This is a problem when dynamically switching themes.

Issue Number: N/A

## What is the new behavior?
This PR updates the tokens to use a CSS calc the create a rem based on a base font variable. This allows the base font to be any value not just 20 or 16. Our components will automatically scale appropriately and scale with the browser font size settings. 

Before:
```css
:root {
  --cds-global-layout-space-xxs: 0.10rem;
  --cds-global-layout-space-xs: 0.20rem;
  --cds-global-layout-space-sm: 0.30rem;
  --cds-global-layout-space-md: 0.60rem;
  --cds-global-layout-space-lg: 1.20rem;
  --cds-global-layout-space-xl: 2.40rem;
  --cds-global-layout-space-xxl: 4.80rem;
}
```

After:
```css
:root {
  --cds-global-layout-space-xxs: calc((2 / var(--cds-global-base, 20)) * 1rem);
  --cds-global-layout-space-xs: calc((4 / var(--cds-global-base, 20)) * 1rem);
  --cds-global-layout-space-sm: calc((6 / var(--cds-global-base, 20)) * 1rem);
  --cds-global-layout-space-md: calc((12 / var(--cds-global-base, 20)) * 1rem);
  --cds-global-layout-space-lg: calc((24 / var(--cds-global-base, 20)) * 1rem);
  --cds-global-layout-space-xl: calc((48 / var(--cds-global-base, 20)) * 1rem);
  --cds-global-layout-space-xxl: calc((96 / var(--cds-global-base, 20)) * 1rem);
}

/* base 16 font simply set the base var */
:root {
  --cds-global-base: 16;
}
```

This change also improves the performance of the `pxToRem` function. The function no longer needs to call
`window.getComputedStyle(document.body, null).getPropertyValue('--cds-global-typography-base-font-size')` which is a expensive CSS recalc and causes performance issues for components that iterate often (icons, grid rows, nodes).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
