### PR TITLE
feat(button): core flat-inline action

### DIFF
--- a/packages/core/src/button/base-button.element.scss
+++ b/packages/core/src/button/base-button.element.scss
@@ -168,11 +168,17 @@
   --border-color: var(--color);
 }
 
-:host([action='flat']) {
+:host([action*='flat']) {
   --background: #{$cds-alias-object-opacity-0};
   --border-color: #{$cds-alias-object-opacity-0};
   --color: #{$cds-alias-status-info};
   --box-shadow-color: #{$cds-alias-object-opacity-0};
+}
+
+:host([action='flat-inline']) {
+  --height: auto;
+  --padding: 0;
+  --min-width: auto;
 }
 
 :host([size='sm']) {
@@ -212,7 +218,7 @@
   --color: #{$cds-alias-status-disabled};
 }
 
-:host([disabled][action='flat']) {
+:host([disabled][action*='flat']) {
   --border-color: #{$cds-alias-object-opacity-0};
   --background: #{$cds-alias-object-opacity-0};
   --color: #{$cds-alias-status-disabled};

--- a/packages/core/src/button/button.element.scss
+++ b/packages/core/src/button/button.element.scss
@@ -23,7 +23,7 @@
   --letter-spacing: 0.073em;
 }
 
-:host([action='flat']) ::slotted(cds-badge),
+:host([action*='flat']) ::slotted(cds-badge),
 :host([action='outline']) ::slotted(cds-badge) {
   --border-color: #{$cds-alias-status-info};
   --background: #{$cds-alias-status-info};
@@ -54,7 +54,7 @@
   --color: #{$cds-global-typography-color-100};
 }
 
-:host(:not([action='outline']):not([action='flat'])) ::slotted(cds-badge) {
+:host(:not([action='outline']):not([action*='flat'])) ::slotted(cds-badge) {
   --background: #{$cds-alias-object-opacity-0};
   --border-color: #{$cds-global-typography-color-100};
   --color: #{$cds-global-typography-color-100};
@@ -65,7 +65,7 @@
   --color: #{$cds-global-color-construction-900};
 }
 
-:host([action='flat'][disabled]) ::slotted(cds-badge) {
+:host([action*='flat'][disabled]) ::slotted(cds-badge) {
   --background: #{$cds-alias-object-opacity-0};
   --border-color: #{$cds-alias-status-neutral};
   --color: #{$cds-alias-status-neutral};
@@ -86,7 +86,7 @@
 
 :host([disabled][status='inverse']),
 :host([disabled][action='outline']),
-:host([disabled][action='flat']) {
+:host([disabled][action*='flat']) {
   ::slotted(cds-badge) {
     --border-color: #{$cds-alias-status-disabled} !important;
     --color: #{$cds-alias-status-disabled} !important;

--- a/packages/core/src/button/button.element.ts
+++ b/packages/core/src/button/button.element.ts
@@ -70,7 +70,7 @@ export class CdsButton extends CdsBaseButton {
    * - `flat`: buttons are used as tertiary buttons. Can also be used inline because they are different from content in style and recognizable as buttons alongside content.
    */
   @property({ type: String })
-  action: 'solid' | 'outline' | 'flat' = 'solid';
+  action: 'solid' | 'outline' | 'flat' | 'flat-inline' = 'solid';
 
   /**
    * Sets the color of the button to match the following string statuses

--- a/packages/core/src/button/button.stories.ts
+++ b/packages/core/src/button/button.stories.ts
@@ -63,6 +63,7 @@ export function actions() {
       <cds-button>solid</cds-button>
       <cds-button action="outline">outline</cds-button>
       <cds-button action="flat">flat</cds-button>
+      <cds-button action="flat-inline">flat-inline</cds-button>
     </div>
   `;
 }
@@ -73,6 +74,7 @@ export function disabled() {
       <cds-button disabled>solid</cds-button>
       <cds-button disabled action="outline">outline</cds-button>
       <cds-button disabled action="flat">flat</cds-button>
+      <cds-button disabled action="flat-inline">flat-inline</cds-button>
     </div>
   `;
 }
@@ -153,6 +155,9 @@ export function iconWithTextAndBadge() {
         <cds-button size="sm" action="flat"
           ><cds-icon shape="user"></cds-icon> click <cds-badge color="blue">10</cds-badge></cds-button
         >
+        <cds-button size="sm" action="flat-inline"
+          ><cds-icon shape="user"></cds-icon> click <cds-badge color="blue">10</cds-badge></cds-button
+        >
       </div>
     </div>
   `;
@@ -166,6 +171,7 @@ export function textAndBadge() {
         <cds-button>Click Me <cds-badge>10</cds-badge></cds-button>
         <cds-button action="outline">Click Me <cds-badge>10</cds-badge></cds-button>
         <cds-button action="flat">Click Me <cds-badge>10</cds-badge></cds-button>
+        <cds-button action="flat-inline">Click Me <cds-badge>10</cds-badge></cds-button>
       </div>
       <div cds-layout="horizontal gap:sm">
         <cds-button status="danger">Click Me <cds-badge>10</cds-badge></cds-button>
@@ -190,6 +196,7 @@ export function textAndBadge() {
         <cds-button size="sm">Click Me <cds-badge>10</cds-badge></cds-button>
         <cds-button size="sm" action="outline">Click Me <cds-badge>10</cds-badge></cds-button>
         <cds-button size="sm" action="flat">Click Me <cds-badge>10</cds-badge></cds-button>
+        <cds-button size="sm" action="flat-inline">Click Me <cds-badge>10</cds-badge></cds-button>
       </div>
     </div>
   `;
@@ -309,6 +316,9 @@ export function darkTheme() {
           ><cds-icon shape="user"></cds-icon>disabled<cds-badge>10</cds-badge></cds-button
         >
         <cds-button action="flat"><cds-icon shape="user"></cds-icon>flat<cds-badge>10</cds-badge></cds-button>
+        <cds-button action="flat-inline"
+          ><cds-icon shape="user"></cds-icon>flat-inline<cds-badge>10</cds-badge></cds-button
+        >
       </div>
     </div>
   `;


### PR DESCRIPTION
Closes #5775

We also needed a way to have a button with no padding on the right and left this one is giving us just what we need.

Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5775 

## What is the new behavior?

Having a flat button with no padding on left and right

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
