### PR TITLE
fix(button): disabled button should remain disabled after loadingState changes to default

### DIFF
--- a/apps/core-create-react-app/src/App.tsx
+++ b/apps/core-create-react-app/src/App.tsx
@@ -13,6 +13,7 @@ ClarityIcons.addIcons(userIcon);
 interface AppProps {}
 interface AppState {
   show: boolean;
+  loadingState: "default" | "success" | "loading" | "error" | undefined;
 }
 
 export default class App extends Component<AppProps, AppState> {
@@ -20,7 +21,15 @@ export default class App extends Component<AppProps, AppState> {
     super(props);
     this.state = {
       show: false,
+      loadingState: 'loading'
     };
+
+    setTimeout(() => {
+      this.setState({
+        ...this.state,
+        loadingState: 'default'
+      });
+     }, 1000);
   }
 
   render() {
@@ -47,6 +56,9 @@ export default class App extends Component<AppProps, AppState> {
           <CdsButton status="danger">danger</CdsButton>
           <CdsButton status="danger" disabled>
             disabled
+          </CdsButton>
+          <CdsButton loadingState={this.state.loadingState} disabled>
+            disabled with loadingState
           </CdsButton>
         </section>
         <section cds-layout="horizontal gap:sm">

--- a/packages/core/src/button/button.element.ts
+++ b/packages/core/src/button/button.element.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { baseStyles, CdsBaseButton, getElementWidth, property, spanWrapper } from '@cds/core/internal';
+import { baseStyles, CdsBaseButton, property, spanWrapper } from '@cds/core/internal';
 import { ClarityIcons } from '@cds/core/icon/icon.service.js';
 import { errorStandardIcon } from '@cds/core/icon/shapes/error-standard.js';
 import { checkIcon } from '@cds/core/icon/shapes/check.js';
@@ -155,12 +155,12 @@ export class CdsButton extends CdsBaseButton {
         this.disableButton();
         return;
       default:
-        this.enableButton();
+        this.disabled ? this.disableButton() : this.enableButton();
     }
   }
 
   private disableButton() {
-    this.style.width = getElementWidth(this);
+    this.style.removeProperty('width');
     this.disabled = true;
   }
 


### PR DESCRIPTION
Close: #5965

Signed-off-by: Derek Wang <guanghui-wang@foxmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

https://github.com/vmware/clarity/issues/5965

Issue Number: #5965

## What is the new behavior?

Disabled button remains disabled regardless of loadingState

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

