### PR TITLE
fix(website): fix caret sizing issue in website sidebar

### DIFF
--- a/apps/website/.vuepress/theme/components/Sidebar.vue
+++ b/apps/website/.vuepress/theme/components/Sidebar.vue
@@ -11,6 +11,8 @@
                   <cds-icon
                     class="nav-group-trigger-icon"
                     shape="angle"
+                    size="md"
+                    :cds-layout="states[index] ? 'm-t:md' : ''"
                     :direction="states[index] ? 'down' : 'right'"
                   ></cds-icon>
                 </button>


### PR DESCRIPTION
Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

The carets in the side bar of the website did not have a size, so they were showing up at 6px. This fixes that.

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

See above

## What is the new behavior?

<img width="451" alt="Screen Shot 2021-05-20 at 3 15 52 PM" src="https://user-images.githubusercontent.com/2728359/119043593-d2e25c00-b97e-11eb-86ba-22655c866a7c.png">

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
