### PR TITLE
fix: adding 'beta' tags for core components that are in beta

### DIFF
--- a/packages/core/src/card/card.element.ts
+++ b/packages/core/src/card/card.element.ts
@@ -34,6 +34,7 @@ export const CdsCardTagName = 'cds-card';
   </cds-card>
  * ```
  *
+ * @beta
  * @element cds-card
  * @slot - For projecting card content
  * @cssprop --width

--- a/packages/core/src/pagination/pagination-button.element.ts
+++ b/packages/core/src/pagination/pagination-button.element.ts
@@ -39,6 +39,7 @@ export enum CdsPaginationButtonAction {
  * </cds-pagination>
  * ```
  *
+ * @beta
  * @element cds-pagination-button
  * @slot
  * @slot cds-icon

--- a/packages/core/src/pagination/pagination.element.ts
+++ b/packages/core/src/pagination/pagination.element.ts
@@ -27,6 +27,7 @@ import { styles } from './pagination.element.css.js';
  * </cds-pagination>
  * ```
  *
+ * @beta
  * @element cds-pagination
  * @slot
  * @slot cds-pagination-button


### PR DESCRIPTION
Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The recently added components that are still in `beta` are not tagged as such.

## What is the new behavior?

The pagination and card components are tagged as beta.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

