### PR TITLE
feat(card): add react card component

### DIFF
--- a/packages/react/App.tsx
+++ b/packages/react/App.tsx
@@ -28,6 +28,7 @@ import { CdsTextarea } from './dist/react/textarea/index.js';
 import { CdsToggle, CdsToggleGroup } from './dist/react/toggle/index.js';
 import { ClarityIcons, userIcon, timesIcon } from '@cds/core/icon';
 import { CdsDivider } from './dist/react/divider/index.js';
+import { CdsCard } from './dist/react/card/index.js';
 
 ClarityIcons.addIcons(userIcon, timesIcon);
 
@@ -302,6 +303,32 @@ export default class App extends React.Component<{}, AppState> {
         <CdsBadge color="blue">15</CdsBadge>
         <CdsBadge color="orange">2</CdsBadge>
         <CdsBadge color="light-blue">3</CdsBadge>
+
+        <h2>Card</h2>
+        <div cds-layout="vertical gap:lg">
+          <CdsCard> Placeholder </CdsCard>
+
+          <CdsCard>
+            <div cds-layout="vertical gap:md">
+              <div cds-text="section" cds-layout="p-y:sm">
+                Card Title
+              </div>
+
+              <CdsDivider cds-card-remove-margin></CdsDivider>
+
+              <div cds-text="body" cds-layout="p-y:md">
+                Lorem ipsum dolor sit amet consectetur adipisicing elit. Nostrum eum id alias aliquid, natus veritatis
+                aperiam repudiandae rem porro non, accusamus officia culpa maiores! Quis possimus ea hic laborum dicta!
+              </div>
+
+              <CdsDivider cds-card-remove-margin></CdsDivider>
+
+              <div cds-layout="horizontal gap:sm p-y:sm align:vertical-center">
+                <CdsButton action="flat-inline">View</CdsButton>
+              </div>
+            </div>
+          </CdsCard>
+        </div>
 
         <h2>Forms</h2>
         <div cds-layout="vertical gap:lg">

--- a/packages/react/src/card/__snapshots__/index.test.tsx.snap
+++ b/packages/react/src/card/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CdsCard snapshot 1`] = `
+<div>
+  <CdsCard>
+    <cds-card(CustomElement)
+      __forwardedRef={null}
+    >
+      <cds-card
+        __forwardedRef={null}
+      >
+        Placeholder
+      </cds-card>
+    </cds-card(CustomElement)>
+  </CdsCard>
+</div>
+`;

--- a/packages/react/src/card/entrypoint.tsconfig.json
+++ b/packages/react/src/card/entrypoint.tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.lib.json",
+  "compilerOptions": {
+    "composite": true
+  },
+  "references": [{ "path": "../converter/entrypoint.tsconfig.json" }]
+}

--- a/packages/react/src/card/index.test.tsx
+++ b/packages/react/src/card/index.test.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { mount, shallow } from 'enzyme';
+import { CdsCard } from './index';
+
+describe('CdsCard', () => {
+  it('renders', () => {
+    const wrapper = shallow(
+      <div>
+        <CdsCard>Placeholder</CdsCard>
+      </div>
+    );
+    const renderedComponent = wrapper.find('CdsCard');
+    expect(renderedComponent.at(0).html()).toMatch(/Placeholder/);
+  });
+
+  it('snapshot', () => {
+    const wrapper = mount(
+      <div>
+        <CdsCard>Placeholder</CdsCard>
+      </div>
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/packages/react/src/card/index.tsx
+++ b/packages/react/src/card/index.tsx
@@ -1,0 +1,5 @@
+import { CdsCard as Card } from '@cds/core/card';
+import '@cds/core/card/register';
+import { createComponent } from '../converter/react-wrapper.js';
+
+export const CdsCard = createComponent('cds-card', Card);

--- a/packages/react/src/card/package.json
+++ b/packages/react/src/card/package.json
@@ -1,0 +1,4 @@
+{
+    "sideEffects": true,
+    "name": "@cds/react/card"
+  }


### PR DESCRIPTION
Adding a React version of the `cds-card`

Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

No React `cds-card` component available

## What is the new behavior?

`cds-card` is now availabe in React with `CdsCard`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
