### PR TITLE
fix: accordion and stepper issue with clrAccordionPanelOpenChange event

### DIFF
--- a/packages/angular/projects/clr-angular/src/accordion/accordion-panel.spec.ts
+++ b/packages/angular/projects/clr-angular/src/accordion/accordion-panel.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -20,7 +20,11 @@ import { IfExpandService } from '../utils/conditional/if-expanded.service';
 @Component({
   template: `
     <clr-accordion>
-      <clr-accordion-panel [(clrAccordionPanelOpen)]="open" [clrAccordionPanelDisabled]="disabled">
+      <clr-accordion-panel
+        [(clrAccordionPanelOpen)]="open"
+        [clrAccordionPanelDisabled]="disabled"
+        (clrAccordionPanelOpenChange)="change($event)"
+      >
         <clr-accordion-title>title</clr-accordion-title>
         <clr-accordion-description *ngIf="showDescription">description</clr-accordion-description>
         <clr-accordion-content>panel</clr-accordion-content>
@@ -32,6 +36,26 @@ class TestComponent {
   open = false;
   disabled = false;
   showDescription = false;
+  change = state => {
+    return state;
+  };
+}
+
+@Component({
+  template: `
+    <clr-accordion>
+      <clr-accordion-panel (clrAccordionPanelOpenChange)="change($event)">
+        <clr-accordion-title>title</clr-accordion-title>
+        <clr-accordion-description>description</clr-accordion-description>
+        <clr-accordion-content>panel</clr-accordion-content>
+      </clr-accordion-panel>
+    </clr-accordion>
+  `,
+})
+class TestNoBindingComponent {
+  change = state => {
+    return state;
+  };
 }
 
 describe('ClrAccordionPanel', () => {
@@ -83,7 +107,7 @@ describe('ClrAccordionPanel', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        declarations: [TestComponent],
+        declarations: [TestComponent, TestNoBindingComponent],
         providers: [UNIQUE_ID_PROVIDER],
         imports: [ClrAccordionModule, ReactiveFormsModule, NoopAnimationsModule],
       });
@@ -111,6 +135,48 @@ describe('ClrAccordionPanel', () => {
       testComponent.disabled = true;
       fixture.detectChanges();
       expect(fixture.componentInstance.disabled).toBe(true);
+    });
+
+    describe('Output (clrAccordionPanelOpenChange)', () => {
+      /**
+       * Test that (clrAccordionPanelOpenChange) will be called with the correct state of the panel even
+       * when there is no [clrAccordionPanelOpen] binding.
+       */
+      it('emit value for [clrAccordionPanelOpen] without binding it', () => {
+        const fixture: ComponentFixture<TestNoBindingComponent> = TestBed.createComponent(TestNoBindingComponent);
+        const component = fixture.componentInstance;
+        const accordionPanel = fixture.debugElement.query(By.directive(ClrAccordionPanel)).componentInstance;
+        spyOn(component, 'change');
+
+        // First render
+        fixture.detectChanges();
+
+        accordionPanel.togglePanel();
+        expect(component.change).toHaveBeenCalledWith(true);
+
+        // Toggle it again
+        accordionPanel.togglePanel();
+        expect(component.change).toHaveBeenCalledWith(false);
+      });
+
+      /**
+       * Same test as above but with binding to the [clrAccordionPanelOpen]
+       */
+      it('emit value for [clrAccordionPanelOpen] when there is a binding to it', () => {
+        const component = fixture.componentInstance;
+        const accordionPanel = fixture.debugElement.query(By.directive(ClrAccordionPanel)).componentInstance;
+        spyOn(component, 'change');
+
+        // First render
+        fixture.detectChanges();
+
+        accordionPanel.togglePanel();
+        expect(component.change).toHaveBeenCalledWith(true);
+
+        // Toggle it again
+        accordionPanel.togglePanel();
+        expect(component.change).toHaveBeenCalledWith(false);
+      });
     });
   });
 

--- a/packages/angular/projects/clr-angular/src/accordion/accordion-panel.ts
+++ b/packages/angular/projects/clr-angular/src/accordion/accordion-panel.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -104,6 +104,16 @@ export class ClrAccordionPanel implements OnInit, OnChanges {
   private emitPanelChange(panel: AccordionPanelModel) {
     if (panel.open !== this.panelOpen) {
       this.panelOpenChange.emit(panel.open);
+      /**
+       * @Note: this line below is needed because we don't want to use another value to track
+       * for changes of the panel. Because we use BehaviorSubject this emit event is trigger on
+       * init (that is not needed - there is no change of the original value) - in some cases this
+       * lead to duplicate events.
+       *
+       * To prevent this we try to emit only when the value is changed and keep the value in sync
+       * even that is used only into the Initial Lifecycle (ngOnInit).
+       */
+      this.panelOpen = panel.open;
     }
 
     if (panel.open) {

--- a/packages/angular/projects/dev/src/app/accordion/accordion.demo.html
+++ b/packages/angular/projects/dev/src/app/accordion/accordion.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -9,7 +9,7 @@
 <h2>Angular - simple accordion</h2>
 
 <clr-accordion>
-  <clr-accordion-panel>
+  <clr-accordion-panel (clrAccordionPanelOpenChange)="change($event)">
     <clr-accordion-title>Step 1</clr-accordion-title>
     <clr-accordion-content>Content 1</clr-accordion-content>
   </clr-accordion-panel>

--- a/packages/angular/projects/dev/src/app/accordion/accordion.demo.ts
+++ b/packages/angular/projects/dev/src/app/accordion/accordion.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -13,4 +13,8 @@ import { Component } from '@angular/core';
 export class AccordionDemo {
   stepOpen = true;
   disableThirdPanel = true;
+
+  change(event) {
+    console.log('Accordion Changed', event);
+  }
 }


### PR DESCRIPTION
Fixing issue #5957 with not firing both states of the clrAccordionPanelOpenChange (true and false)

Also closing #5981 - could not reproduce it - probably fixed in previous versions (tested with latest v5)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5981 & #5957 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

closes #5957 
closes #5981 
