### PR TITLE
fix: core button submit behavior

### DIFF
--- a/packages/core/src/button/button.stories.ts
+++ b/packages/core/src/button/button.stories.ts
@@ -44,13 +44,14 @@ export function form() {
       cds-layout="vertical gap:md"
       @submit="${(e: Event) => {
         e.preventDefault();
-        action('submit')(e);
+        console.log('submit');
       }}"
     >
       <div cds-layout="vertical gap:sm">
         <label for="name" cds-text="caption">Name</label>
         <input id="name" />
       </div>
+      <cds-button type="button" action="outline" @click=${() => console.log('click')}>cancel</cds-button>
       <cds-button type="submit">submit</cds-button>
     </form>
   `;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Base button would fire submit events incorrectly when set to type "button". The base button also incorrectly marked the active state for keydown and mousedown events. 

Issue Number: #6002 

## What is the new behavior?

Now the button will prevent submit events if type is set to button. Active state will only apply during mousedown and keydown events.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
