### PR TITLE
feat(modal): making the overflow on the modal content customizable

### DIFF
--- a/packages/core/src/modal/modal.element.scss
+++ b/packages/core/src/modal/modal.element.scss
@@ -8,6 +8,9 @@
   --background: #{$cds-alias-object-overlay-background};
   --box-shadow: #{$cds-alias-object-shadow-100};
   --width: calc(8 * #{$cds-global-space-13});
+  --content-overflow: hidden auto;
+  --max-height: 70vh;
+  --tablet-max-height: 55vh;
 }
 
 :host([size='sm']) {
@@ -45,19 +48,18 @@
 .modal-body {
   // This doesn't do much, but at least with several paragraphs in the content
   // it doesn't mess up the modal's proportions.
-  max-height: 70vh;
-  overflow-y: auto;
-  overflow-x: hidden;
+  max-height: var(--max-height);
+  overflow: var(--content-overflow);
 }
 
 @media screen and (max-width: $cds-global-layout-width-sm) and (orientation: landscape) {
   .modal-body {
-    max-height: 55vh;
+    max-height: var(--tablet-max-height);
   }
 }
 
 @media screen and (max-width: $cds-global-layout-width-xs) {
   .modal-body {
-    max-height: 55vh;
+    max-height: var(--tablet-max-height);
   }
 }

--- a/packages/core/src/modal/modal.element.ts
+++ b/packages/core/src/modal/modal.element.ts
@@ -54,6 +54,9 @@ import { styles } from './modal.element.css.js';
  * @cssprop --background
  * @cssprop --box-shadow
  * @cssprop --width
+ * @cssprop --content-overflow - set as { x, y }. take care when customizing because overflow settings can have unintended side effects.
+ * @cssprop --max-height - sets hard limit on height of modal
+ * @cssprop --tablet-max-height - sets hard limit on height of modal when on a tablet in landscape mode
  */
 @animate({
   hidden: {


### PR DESCRIPTION
Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

People who use core with third-party components introduce absolutely positioned dropdowns have a problem where a third-party component's drop-down is cut off by the modal content container.

## What is the new behavior?

This change allows users to customize the overflow of the modal's content area. Hopefully, they understand how that could be a bad thing too.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
