### PR TITLE
fix(input): adds specificity to datagrid style

### DIFF
--- a/packages/angular/projects/clr-angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/_datagrid.clarity.scss
@@ -1346,12 +1346,12 @@
         }
       }
     }
-  }
 
-  .clr-form-control-disabled {
-    display: flex;
-    align-items: center;
-    height: 100%;
+    .clr-form-control-disabled {
+      display: flex;
+      align-items: center;
+      height: 100%;
+    }
   }
 
   .clr-form-control-disabled .datagrid-footer-select.clr-checkbox-wrapper input[type='checkbox']:checked + label {


### PR DESCRIPTION
In the pr fix #5818 I added style to clr-input-container for the element inside datagrid footers.
I put it in the wrong level and it was bleeding globally and affecting all clr-input-container's. This change
moves the override styles into the .datagrid-footer.

closes #5982

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?
This fixes a regression introduced by #5818. It changes the specificity for styles applied to disabled clr-input-container element inside datagrid-footer. 

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
All `clr-input-container` elements are getting `align-items: center` applied.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5982

## What is the new behavior?
Only `clr-input-container` elements inside the `.datagrid-footer` element will get the align-items: center style applied. 
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
