### PR TITLE
feat(datagrid): reduce change detection cycles for the `clrOutsideClick`

### DIFF
--- a/packages/angular/projects/clr-angular/src/utils/outside-click/outside-click.spec.ts
+++ b/packages/angular/projects/clr-angular/src/utils/outside-click/outside-click.spec.ts
@@ -1,52 +1,69 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { Component } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
+import { ApplicationRef, Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { OutsideClick } from './outside-click';
 
-describe('Loading directive', function () {
-  beforeEach(function () {
+describe('Outside click', () => {
+  let fixture: ComponentFixture<FullTest>;
+  let testComponent: FullTest;
+
+  let host: HTMLElement, button: HTMLElement, outside: HTMLElement;
+
+  beforeEach(() => {
     TestBed.configureTestingModule({ declarations: [OutsideClick, FullTest] });
-    this.fixture = TestBed.createComponent(FullTest);
-    this.fixture.detectChanges();
-    this.testComponent = this.fixture.componentInstance;
-    this.host = this.fixture.debugElement.query(By.css('.host')).nativeElement;
-    this.button = this.fixture.debugElement.query(By.css('button')).nativeElement;
-    this.outside = this.fixture.debugElement.query(By.css('.outside')).nativeElement;
+    fixture = TestBed.createComponent(FullTest);
+    fixture.detectChanges();
+    testComponent = fixture.componentInstance;
+    host = fixture.debugElement.query(By.css('.host')).nativeElement;
+    button = fixture.debugElement.query(By.css('button')).nativeElement;
+    outside = fixture.debugElement.query(By.css('.outside')).nativeElement;
   });
 
-  afterEach(function () {
-    this.fixture.destroy();
+  it('emits clicks outside of the host', () => {
+    expect(testComponent.nbClicks).toBe(0);
+    outside.click();
+    expect(testComponent.nbClicks).toBe(1);
+    outside.click();
+    expect(testComponent.nbClicks).toBe(2);
   });
 
-  it('emits clicks outside of the host', function () {
-    expect(this.testComponent.nbClicks).toBe(0);
-    this.outside.click();
-    expect(this.testComponent.nbClicks).toBe(1);
-    this.outside.click();
-    expect(this.testComponent.nbClicks).toBe(2);
+  it('ignores clicks inside of the host', () => {
+    expect(testComponent.nbClicks).toBe(0);
+    host.click();
+    expect(testComponent.nbClicks).toBe(0);
+    button.click();
+    expect(testComponent.nbClicks).toBe(0);
   });
 
-  it('ignores clicks inside of the host', function () {
-    expect(this.testComponent.nbClicks).toBe(0);
-    this.host.click();
-    expect(this.testComponent.nbClicks).toBe(0);
-    this.button.click();
-    expect(this.testComponent.nbClicks).toBe(0);
+  it('offers a strict input to only ignore clicks that happen exactly on the host', () => {
+    testComponent.strict = true;
+    fixture.detectChanges();
+    expect(testComponent.nbClicks).toBe(0);
+    host.click();
+    expect(testComponent.nbClicks).toBe(0);
+    button.click();
+    expect(testComponent.nbClicks).toBe(1);
   });
 
-  it('offers a strict input to only ignore clicks that happen exactly on the host', function () {
-    this.testComponent.strict = true;
-    this.fixture.detectChanges();
-    expect(this.testComponent.nbClicks).toBe(0);
-    this.host.click();
-    expect(this.testComponent.nbClicks).toBe(0);
-    this.button.click();
-    expect(this.testComponent.nbClicks).toBe(1);
+  it('should not run change detection if the click event happened on the host element', () => {
+    const appRef = TestBed.inject(ApplicationRef);
+    const spy = spyOn(appRef, 'tick').and.callThrough();
+
+    host.click();
+    host.click();
+    host.click();
+
+    expect(spy.calls.count()).toEqual(0);
+
+    outside.click();
+
+    expect(spy.calls.count()).toEqual(1);
+    expect(testComponent.nbClicks).toEqual(1);
   });
 });
 

--- a/packages/angular/projects/clr-angular/src/utils/outside-click/outside-click.ts
+++ b/packages/angular/projects/clr-angular/src/utils/outside-click/outside-click.ts
@@ -1,29 +1,41 @@
 /*
- * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { Directive, ElementRef, EventEmitter, HostListener, Input, Output } from '@angular/core';
+import { Directive, ElementRef, EventEmitter, Input, NgZone, OnDestroy, Output, Renderer2 } from '@angular/core';
 
 @Directive({ selector: '[clrOutsideClick]' })
-export class OutsideClick {
-  constructor(private el: ElementRef) {}
-
+export class OutsideClick implements OnDestroy {
   @Input('clrStrict') strict = false;
 
   @Output('clrOutsideClick') outsideClick = new EventEmitter<any>(false);
 
-  @HostListener('document:click', ['$event'])
-  documentClick(event: MouseEvent) {
-    const target = event.target; // Get the element in the DOM on which the mouse was clicked
-    const host = this.el.nativeElement; // Get the current actionMenu native HTML element
+  private documentClickListener: VoidFunction;
 
-    if (target === host) {
-      return;
-    }
-    if (!this.strict && host.contains(target)) {
-      return;
-    }
-    this.outsideClick.emit(event);
+  constructor(host: ElementRef<HTMLElement>, renderer: Renderer2, ngZone: NgZone) {
+    ngZone.runOutsideAngular(() => {
+      this.documentClickListener = renderer.listen('document', 'click', (event: MouseEvent) => {
+        // Compare the element in the DOM on which the mouse was clicked
+        // with the current actionMenu native HTML element.
+        if (host.nativeElement === event.target) {
+          return;
+        }
+
+        if (!this.strict && host.nativeElement.contains(event.target as HTMLElement)) {
+          return;
+        }
+
+        // We'll run change detection only if the click event actually happened outside of
+        // the host element.
+        ngZone.run(() => {
+          this.outsideClick.emit(event);
+        });
+      });
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.documentClickListener();
   }
 }


### PR DESCRIPTION
# NOTE
This pr is an adoption of https://github.com/vmware/clarity/pull/5673. 

## Commit Notes

This PR reduces change detection cycles for the `clrOutsideClick` by replacing
`HostListener` with `Renderer.listen` outside of the zone. Basically, it will not
run change detection when the click event happened on the host element, since the
listener will just `return`, it will run `ApplicationRef.tick()` only if the click
event happens outside of the host element. Note that the `HostListener` wraps the
actual listener under the hood into the internal Angular function which runs
`markDirty()` before running the actual listener (the decorated class method).

Signed-off-by: Artur Androsovych <arthurandrosovich@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
