### PR TITLE
Prevent disabled buttons from being enabled with ClrLoadingState.default

### DIFF
--- a/packages/core/src/button/button.element.spec.ts
+++ b/packages/core/src/button/button.element.spec.ts
@@ -274,6 +274,14 @@ describe('button element', () => {
       expect(component.hasAttribute('disabled')).toEqual(true);
       expect(component.getAttribute('aria-disabled')).toEqual('true');
     });
+
+    it('should stay disabled when loadingState changes to default', async () => {
+      await componentIsStable(component);
+      component.disabled = true;
+      component.loadingState = ClrLoadingState.default;
+      await componentIsStable(component);
+      expect(component.disabled).toBeTruthy();
+    });
   });
 
   describe('Button link', () => {

--- a/packages/core/src/button/button.element.ts
+++ b/packages/core/src/button/button.element.ts
@@ -143,6 +143,9 @@ export class CdsButton extends CdsBaseButton {
   static styles = [baseStyles, baseButtonStyles, styles];
 
   private updateLoadingState() {
+    if (this.disabled) {
+      return;
+    }
     switch (this.loadingState) {
       case ClrLoadingState.loading:
         this.disableButton();


### PR DESCRIPTION
# Note
This pr adopts #5966 and refines the proposed solution. 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Wh3en loading state changes on a disabled button it can be enables if loadingState is default.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When disabled buttons change to default loadingState they will not be enabled. 

Issue Number: #5965

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
