### PR TITLE
fix(form): input lines are now proper contrast

### DIFF
--- a/packages/core/build/tokens.ts
+++ b/packages/core/build/tokens.ts
@@ -471,6 +471,7 @@ const aliases = {
       300: token('hsla(0, 0%, 0%, 0.6)'),
     },
     interaction: {
+      borderColor: token(color.construction[500]),
       background: {
         value: token(color.white),
         hover: token(color.blue[50]),

--- a/packages/core/src/checkbox/checkbox.element.scss
+++ b/packages/core/src/checkbox/checkbox.element.scss
@@ -9,7 +9,7 @@
   --check-color: #{$cds-global-typography-color-100};
   --background: #{$cds-alias-object-opacity-0};
   --border-radius: #{$cds-alias-object-border-radius-100};
-  --border: #{$cds-alias-object-border-width-100} solid #{$cds-alias-object-border-color};
+  --border: #{$cds-alias-object-border-width-100} solid #{$cds-alias-object-interaction-border-color};
 }
 
 .input {

--- a/packages/core/src/input/input.element.scss
+++ b/packages/core/src/input/input.element.scss
@@ -8,7 +8,7 @@
   --background-size: 0% 100%;
   --background-color: #{$cds-alias-object-opacity-0};
   --background: linear-gradient(180deg, var(--background-color) 95%, var(--border-color) 0) no-repeat;
-  --border-color: #{$cds-alias-object-border-color};
+  --border-color: #{$cds-alias-object-interaction-border-color};
   --border: 0;
   --border-bottom: #{$cds-alias-object-border-width-100} solid var(--border-color);
   --border-radius: 0;

--- a/packages/core/src/radio/radio.element.scss
+++ b/packages/core/src/radio/radio.element.scss
@@ -7,7 +7,7 @@
 :host {
   --width: #{$cds-global-space-7};
   --height: #{$cds-global-space-7};
-  --border: #{$cds-alias-object-border-width-100} solid #{$cds-alias-object-border-color};
+  --border: #{$cds-alias-object-border-width-100} solid #{$cds-alias-object-interaction-border-color};
   --fill-box-shadow: none;
 }
 

--- a/packages/core/src/textarea/textarea.element.scss
+++ b/packages/core/src/textarea/textarea.element.scss
@@ -6,7 +6,7 @@
 
 :host {
   --background: #{$cds-alias-object-container-background};
-  --border: #{$cds-alias-object-border-width-100} solid #{$cds-alias-object-border-color};
+  --border: #{$cds-alias-object-border-width-100} solid #{$cds-alias-object-interaction-border-color};
   --padding: #{$cds-global-space-5} #{$cds-global-space-6};
   --font-size: #{$cds-global-typography-font-size-3};
   --color: #{$cds-global-typography-color-500};


### PR DESCRIPTION
The default input underline was not 3:1 ratio for accessibility, so this will darken it for proper contrast.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
