### PR TITLE
fix(button): unsubscribe from `ButtonInGroupService.changes`

### DIFF
--- a/packages/angular/golden/clr-angular.d.ts
+++ b/packages/angular/golden/clr-angular.d.ts
@@ -227,7 +227,7 @@ export declare class ClrButton implements LoadingListener {
     ngAfterViewInit(): void;
 }
 
-export declare class ClrButtonGroup {
+export declare class ClrButtonGroup implements OnDestroy {
     buttonGroupNewService: ButtonInGroupService;
     buttons: QueryList<ClrButton>;
     commonStrings: ClrCommonStringsService;
@@ -242,6 +242,7 @@ export declare class ClrButtonGroup {
     getMoveIndex(buttonToMove: ClrButton): number;
     initializeButtons(): void;
     ngAfterContentInit(): void;
+    ngOnDestroy(): void;
     rearrangeButton(button: ClrButton): void;
 }
 

--- a/packages/angular/projects/clr-angular/src/button/button-group/button-group.ts
+++ b/packages/angular/projects/clr-angular/src/button/button-group/button-group.ts
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, Inject, ContentChildren, Input, QueryList } from '@angular/core';
+import { Component, Inject, ContentChildren, Input, QueryList, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
 
 import { ButtonInGroupService } from '../providers/button-in-group.service';
 import { ClrCommonStringsService } from '../../utils/i18n/common-strings.service';
@@ -29,8 +30,10 @@ import { ClrButton } from './button';
   ],
   host: { '[class.btn-group]': 'true' },
 })
-export class ClrButtonGroup {
+export class ClrButtonGroup implements OnDestroy {
   @ContentChildren(ClrButton) buttons: QueryList<ClrButton>;
+
+  private subscription = Subscription.EMPTY;
 
   constructor(
     public buttonGroupNewService: ButtonInGroupService,
@@ -55,10 +58,14 @@ export class ClrButtonGroup {
    */
   ngAfterContentInit() {
     this.initializeButtons();
-    this.buttonGroupNewService.changes.subscribe(button => this.rearrangeButton(button));
+    this.subscription = this.buttonGroupNewService.changes.subscribe(button => this.rearrangeButton(button));
     this.buttons.changes.subscribe(() => {
       this.initializeButtons();
     });
+  }
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
   }
 
   /**


### PR DESCRIPTION
This PR adds unsubscription from the `ButtonInGroupService.changes` inside the `crl-button-group`
component, since its `next` callback captures `this` and prevents the component from being GC'd.

Signed-off-by: Artur Androsovych <arthurandrosovich@gmail.com>

## PR Type

- [x] Bugfix

## What is the current behavior?

You may see there's no distance from the GC root but component is still not getting GC'd:

![image](https://user-images.githubusercontent.com/7337691/121744952-56214880-cb0c-11eb-8f75-89a0cd1e7f42.png)

## Does this PR introduce a breaking change?

- [x] No