### PR TITLE
fix(input): add top padding to cds-input elements

### DIFF
--- a/packages/core/src/input/input.element.scss
+++ b/packages/core/src/input/input.element.scss
@@ -14,6 +14,7 @@
   --border-radius: 0;
   --outline: none;
   --padding: 0 #{$cds-global-space-4};
+  --padding: #{$cds-global-space-2} #{$cds-global-space-4} 0 #{$cds-global-space-4}; // 2px top for line height alignment with label: https://github.com/vmware/clarity/issues/6044
   --font-size: #{$cds-global-typography-font-size-3};
   --color: #{$cds-global-typography-color-500};
   --line-height: #{$cds-global-space-9};


### PR DESCRIPTION
This seems to fix an alignment issue with form control labels and form inputs.
closes #6044

Before and after screen shots:
![Screen Shot 2021-06-11 at 1 35 52 PM](https://user-images.githubusercontent.com/433692/121745966-f9953d80-cab9-11eb-9710-a92ab3a9cd61.png)


Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?
This remove line height from control label elements. 

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
The `control label text` and `control input text` is mis-aligned.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #6044

## What is the new behavior?
Control label text aligns with control input text. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
