### PR TITLE
feat(combobox): reduce change detection cycles

### DIFF
--- a/packages/angular/golden/clr-angular.d.ts
+++ b/packages/angular/golden/clr-angular.d.ts
@@ -326,7 +326,7 @@ export declare class ClrCombobox<T> extends WrappedFormControl<ClrComboboxContai
     smartPosition: ClrPopoverPosition;
     textbox: ElementRef;
     trigger: ElementRef;
-    constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef, optionSelectionService: OptionSelectionService<T>, commonStrings: ClrCommonStringsService, toggleService: ClrPopoverToggleService, positionService: ClrPopoverPositionService, controlStateService: IfControlStateService, containerService: ComboboxContainerService, platformId: any, ariaService: AriaService, focusHandler: ComboboxFocusHandler<T>, cdr: ChangeDetectorRef);
+    constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef, optionSelectionService: OptionSelectionService<T>, commonStrings: ClrCommonStringsService, toggleService: ClrPopoverToggleService, positionService: ClrPopoverPositionService, controlStateService: IfControlStateService, containerService: ComboboxContainerService, platformId: any, ariaService: AriaService, focusHandler: ComboboxFocusHandler<T>, cdr: ChangeDetectorRef, ngZone: NgZone);
     focusFirstActive(): void;
     focusInput(): void;
     getActiveDescendant(): string;
@@ -338,7 +338,6 @@ export declare class ClrCombobox<T> extends WrappedFormControl<ClrComboboxContai
     ngOnDestroy(): void;
     onBlur(): void;
     onFocus(): void;
-    onKeyUp(event: KeyboardEvent): void;
     registerOnChange(onChange: any): void;
     registerOnTouched(onTouched: any): void;
     setDisabledState(): void;


### PR DESCRIPTION
This PR reduces change detection cycles for the combobox by replacing
`HostListener` with `Renderer.listen` outside of the zone. We don't need to
run change detections when any keyboard button is pressed or when the multiselect
mode is off. Note that the `HostListener` wraps the actual listener under the hood
into the internal Angular function which runs `markDirty()` before running the actual
listener (the decorated class method).

Signed-off-by: Artur Androsovych <arthurandrosovich@gmail.com>

## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Feature

## Does this PR introduce a breaking change?

- [x] No