### PR TITLE
feat(datagrid): reduce change detection cycles for `clr-dg-detail`

### DIFF
--- a/packages/angular/golden/clr-angular.d.ts
+++ b/packages/angular/golden/clr-angular.d.ts
@@ -621,12 +621,12 @@ export interface ClrDatagridComparatorInterface<T> {
     compare(a: T, b: T): number;
 }
 
-export declare class ClrDatagridDetail {
+export declare class ClrDatagridDetail implements OnDestroy {
     commonStrings: ClrCommonStringsService;
     detailService: DetailService;
     header: ClrDatagridDetailHeader;
-    constructor(detailService: DetailService, commonStrings: ClrCommonStringsService);
-    closeCheck(): void;
+    constructor(detailService: DetailService, commonStrings: ClrCommonStringsService, ngZone: NgZone, renderer: Renderer2);
+    ngOnDestroy(): void;
 }
 
 export declare class ClrDatagridDetailBody {

--- a/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-detail.ts
+++ b/packages/angular/projects/clr-angular/src/data/datagrid/datagrid-detail.ts
@@ -1,12 +1,13 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { Component, ContentChild, HostListener } from '@angular/core';
+import { Component, ContentChild, NgZone, OnDestroy, Renderer2 } from '@angular/core';
 import { DetailService } from './providers/detail.service';
 import { ClrCommonStringsService } from '../../utils/i18n/common-strings.service';
 import { ClrDatagridDetailHeader } from './datagrid-detail-header';
+import { ESC } from '../../utils/key-codes/key-codes';
 
 @Component({
   selector: 'clr-dg-detail',
@@ -31,13 +32,34 @@ import { ClrDatagridDetailHeader } from './datagrid-detail-header';
     </div>
   `,
 })
-export class ClrDatagridDetail {
+export class ClrDatagridDetail implements OnDestroy {
   @ContentChild(ClrDatagridDetailHeader) public header: ClrDatagridDetailHeader;
 
-  constructor(public detailService: DetailService, public commonStrings: ClrCommonStringsService) {}
+  private unlisten: VoidFunction;
 
-  @HostListener('document:keyup.esc')
-  closeCheck(): void {
-    this.detailService.close();
+  constructor(
+    public detailService: DetailService,
+    public commonStrings: ClrCommonStringsService,
+    ngZone: NgZone,
+    renderer: Renderer2
+  ) {
+    ngZone.runOutsideAngular(() => {
+      this.unlisten = renderer.listen('document', 'keyup', (event: KeyboardEvent) => {
+        // We could've actually used `render.listener('document', 'keyup.esc')`, and that would definitely work.
+        // Unfortunately, Angular delegates the event handling to the `KeyEventsPlugin` when it meets the `.` (dot)
+        // in the event name. The `KeyEventsPlugin` calls `ngZone.runGuarded`, which triggers change detection anyway
+        // (no matter if we added event listeners in the root zone).
+        // In that case, the change detection will be run only when the user clicks the `esc` button.
+        if (event.keyCode === ESC) {
+          ngZone.run(() => {
+            this.detailService.close();
+          });
+        }
+      });
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.unlisten();
   }
 }


### PR DESCRIPTION
This PR reduces change detection cycles for the `clr-dg-detail` by replacing
`HostListener` with `Renderer.listen` outside of the zone. We don't need to run
change detections when any keyboard button is pressed. Note that the `HostListener`
wraps the actual listener under the hood into the internal Angular function which runs
`markDirty()` before running the actual listener (the decorated class method).

Signed-off-by: Artur Androsovych <arthurandrosovich@gmail.com>

## PR Type

- [x] Feature

## Does this PR introduce a breaking change?

- [x] No