### PR TITLE
fix(pagination): add missing React counterpart for Clarity Core pagination

### DIFF
--- a/packages/core/src/pagination/pagination-button.element.spec.ts
+++ b/packages/core/src/pagination/pagination-button.element.spec.ts
@@ -6,7 +6,7 @@
 
 import '@cds/core/icon/register.js';
 import { LogService } from '@cds/core/internal';
-import { CdsPaginationButton, CdsPaginationButtonAction } from '@cds/core/pagination';
+import { CdsPaginationButton } from '@cds/core/pagination';
 import '@cds/core/pagination/register.js';
 import { componentIsStable, createTestElement, getComponentSlotContent, removeTestElement } from '@cds/core/test';
 import { html } from 'lit';
@@ -15,7 +15,7 @@ describe('Pagination Buttons', () => {
   let paginationButtonElement: HTMLElement;
   let paginationButtonComponent: CdsPaginationButton;
 
-  const createDefaultPaginationButton = async (action: CdsPaginationButtonAction) => {
+  const createDefaultPaginationButton = async (action: CdsPaginationButton['action']) => {
     paginationButtonElement = await createTestElement(
       html`<cds-pagination-button action="${action}"></cds-pagination-button>`
     );
@@ -27,7 +27,7 @@ describe('Pagination Buttons', () => {
   });
 
   it('should use proper icon for when action attribute is first', async () => {
-    await createDefaultPaginationButton(CdsPaginationButtonAction.First);
+    await createDefaultPaginationButton('first');
     await componentIsStable(paginationButtonComponent);
     const defaultIcon = paginationButtonComponent.shadowRoot.querySelector('cds-icon');
     expect(defaultIcon.getAttribute('shape')).toBe('step-forward-2');
@@ -35,7 +35,7 @@ describe('Pagination Buttons', () => {
   });
 
   it('should use proper icon for when action attribute is last', async () => {
-    await createDefaultPaginationButton(CdsPaginationButtonAction.Last);
+    await createDefaultPaginationButton('last');
     await componentIsStable(paginationButtonComponent);
     const defaultIcon = paginationButtonComponent.shadowRoot.querySelector('cds-icon');
     expect(defaultIcon.getAttribute('shape')).toBe('step-forward-2');
@@ -43,7 +43,7 @@ describe('Pagination Buttons', () => {
   });
 
   it('should use proper icon for when action attribute is prev', async () => {
-    await createDefaultPaginationButton(CdsPaginationButtonAction.Previous);
+    await createDefaultPaginationButton('prev');
     await componentIsStable(paginationButtonComponent);
     const defaultIcon = paginationButtonComponent.shadowRoot.querySelector('cds-icon');
     expect(defaultIcon.getAttribute('shape')).toBe('angle');
@@ -51,7 +51,7 @@ describe('Pagination Buttons', () => {
   });
 
   it('should use proper icon for when action attribute is next', async () => {
-    await createDefaultPaginationButton(CdsPaginationButtonAction.Next);
+    await createDefaultPaginationButton('next');
     await componentIsStable(paginationButtonComponent);
     const defaultIcon = paginationButtonComponent.shadowRoot.querySelector('cds-icon');
     expect(defaultIcon.getAttribute('shape')).toBe('angle');

--- a/packages/core/src/pagination/pagination-button.element.ts
+++ b/packages/core/src/pagination/pagination-button.element.ts
@@ -16,13 +16,6 @@ import { html } from 'lit';
 import { query } from 'lit/decorators/query.js';
 import styles from './pagination-button.element.scss';
 
-export enum CdsPaginationButtonAction {
-  First = 'first',
-  Previous = 'prev',
-  Next = 'next',
-  Last = 'last',
-}
-
 /**
  * Web component pagination button to be used inside pagination.
  *
@@ -56,10 +49,10 @@ export enum CdsPaginationButtonAction {
 
 export class CdsPaginationButton extends CdsBaseButton {
   /**
-   * @type {first | prev | next | last}
    * Sets the action from a predefined list of actions
    */
-  @property({ type: String, reflect: true }) action: CdsPaginationButtonAction;
+  @property({ type: String })
+  action: 'first' | 'prev' | 'next' | 'last';
 
   connectedCallback() {
     super.connectedCallback();
@@ -78,18 +71,10 @@ export class CdsPaginationButton extends CdsBaseButton {
     return html`
       <div class="private-host" cds-layout="horizontal align:center ${this.customContent ? 'p-x:sm' : ''}">
         <slot name="cds-icon-slot">
-          ${this.action === CdsPaginationButtonAction.Next
-            ? html`<cds-icon shape="angle" direction="right"></cds-icon>`
-            : ''}
-          ${this.action === CdsPaginationButtonAction.Last
-            ? html`<cds-icon shape="step-forward-2" direction="up"></cds-icon>`
-            : ''}
-          ${this.action === CdsPaginationButtonAction.Previous
-            ? html`<cds-icon shape="angle" direction="left"></cds-icon>`
-            : ''}
-          ${this.action === CdsPaginationButtonAction.First
-            ? html`<cds-icon shape="step-forward-2" direction="down"></cds-icon>`
-            : ''}
+          ${this.action === 'next' ? html`<cds-icon shape="angle" direction="right"></cds-icon>` : ''}
+          ${this.action === 'last' ? html`<cds-icon shape="step-forward-2" direction="up"></cds-icon>` : ''}
+          ${this.action === 'prev' ? html`<cds-icon shape="angle" direction="left"></cds-icon>` : ''}
+          ${this.action === 'first' ? html`<cds-icon shape="step-forward-2" direction="down"></cds-icon>` : ''}
         </slot>
         <slot></slot>
       </div>

--- a/packages/react/src/pagination/__snapshots__/index.test.tsx.snap
+++ b/packages/react/src/pagination/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CdsPagination snapshot 1`] = `
+<CdsPagination
+  aria-label="pagination"
+>
+  <cds-pagination(CustomElement)
+    __forwardedRef={null}
+    aria-label="pagination"
+  >
+    <cds-pagination
+      __forwardedRef={null}
+      aria-label="pagination"
+    >
+      <CdsPaginationButton
+        action="prev"
+        aria-label="go to first"
+        disabled={true}
+      >
+        <cds-pagination-button(CustomElement)
+          __forwardedRef={null}
+          action="prev"
+          aria-label="go to first"
+          disabled={true}
+        >
+          <cds-pagination-button
+            __forwardedRef={null}
+            aria-label="go to first"
+          />
+        </cds-pagination-button(CustomElement)>
+      </CdsPaginationButton>
+      <CdsPaginationButton
+        action="next"
+        aria-label="go to next"
+      >
+        <cds-pagination-button(CustomElement)
+          __forwardedRef={null}
+          action="next"
+          aria-label="go to next"
+        >
+          <cds-pagination-button
+            __forwardedRef={null}
+            aria-label="go to next"
+          />
+        </cds-pagination-button(CustomElement)>
+      </CdsPaginationButton>
+    </cds-pagination>
+  </cds-pagination(CustomElement)>
+</CdsPagination>
+`;

--- a/packages/react/src/pagination/entrypoint.tsconfig.json
+++ b/packages/react/src/pagination/entrypoint.tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.lib.json",
+  "compilerOptions": {
+    "composite": true
+  },
+  "references": [{ "path": "../converter/entrypoint.tsconfig.json" }]
+}

--- a/packages/react/src/pagination/index.test.tsx
+++ b/packages/react/src/pagination/index.test.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { mount, shallow } from 'enzyme';
+import { CdsPagination, CdsPaginationButton } from './index';
+
+describe('CdsPagination', () => {
+  it('renders', () => {
+    const wrapper = shallow(
+      <CdsPagination aria-label="pagination">
+        <CdsPaginationButton aria-label="go to first" action="first" disabled></CdsPaginationButton>
+        <CdsPaginationButton aria-label="go to previous" action="prev" disabled></CdsPaginationButton>
+        <span aria-label="current page">1 / 3</span>
+        <CdsPaginationButton aria-label="go to next" action="next"></CdsPaginationButton>
+        <CdsPaginationButton aria-label="go to last" action="last"></CdsPaginationButton>
+      </CdsPagination>
+    );
+    const renderedComponent = wrapper.find('CdsPagination');
+    expect(renderedComponent.at(0)).toBeDefined();
+    expect(renderedComponent.at(1)).toBeDefined();
+    expect(renderedComponent.at(2)).toBeDefined();
+  });
+
+  it('snapshot', () => {
+    const wrapper = mount(
+      <CdsPagination aria-label="pagination">
+        <CdsPaginationButton aria-label="go to first" action="prev" disabled></CdsPaginationButton>
+        <CdsPaginationButton aria-label="go to next" action="next"></CdsPaginationButton>
+      </CdsPagination>
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/packages/react/src/pagination/index.tsx
+++ b/packages/react/src/pagination/index.tsx
@@ -1,0 +1,6 @@
+import { CdsPagination as Pagination, CdsPaginationButton as PaginationButton } from '@cds/core/pagination';
+import '@cds/core/pagination/register';
+import { createComponent } from '../converter/react-wrapper.js';
+
+export const CdsPagination = createComponent('cds-pagination', Pagination);
+export const CdsPaginationButton = createComponent('cds-pagination-button', PaginationButton);

--- a/packages/react/src/pagination/package.json
+++ b/packages/react/src/pagination/package.json
@@ -1,0 +1,4 @@
+{
+    "sideEffects": true,
+    "name": "@cds/react/pagination"
+  }

--- a/packages/react/tsconfig.project.json
+++ b/packages/react/tsconfig.project.json
@@ -14,6 +14,7 @@
     { "path": "./src/forms/entrypoint.tsconfig.json" },
     { "path": "./src/icon/entrypoint.tsconfig.json" },
     { "path": "./src/modal/entrypoint.tsconfig.json" },
+    { "path": "./src/pagination/entrypoint.tsconfig.json" },
     { "path": "./src/password/entrypoint.tsconfig.json" },
     { "path": "./src/progress-circle/entrypoint.tsconfig.json" },
     { "path": "./src/radio/entrypoint.tsconfig.json" },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- N/A Docs have been added / updated (for bug fixes / features)
- N/A If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

https://unpkg.com/browse/@cds/core@5.4.0/pagination/ is a thing but `CdsPagination` is missing from https://unpkg.com/browse/@cds/react@5.4.0/

Follow-up of https://github.com/vmware/clarity/pull/5706

## What is the new behavior?

`CdsPagination` should be importable from `@cds/react/pagination`.

## Does this PR introduce a breaking change?

- [x] Yes - I removed `CdsPaginationButtonAction` because the following was impossible: `<CdsPaginationButton action="first" />`. With the `enum`, one _has_ to use `<CdsPaginationButton action={CdsPaginationButtonAction.First} />`, the string equivalent does not pass the type checker. I reused the pattern from the `cds-button`'s `action` instead.
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This is my first contribution to `@cds/react` so hopefully I didn't forget anything, let me know if so 🙏 