### PR TITLE
feat: add description list element styling

### DIFF
--- a/packages/core/src/list/list.scss
+++ b/packages/core/src/list/list.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -88,5 +88,17 @@ ul[cds-layout~='horizontal'],
 ol[cds-layout~='horizontal'] {
   li {
     list-style-position: inside;
+  }
+}
+
+dl[cds-list] {
+  margin: 0;
+
+  dt {
+    font-weight: bold;
+  }
+
+  dd {
+    margin-left: 0;
   }
 }

--- a/packages/core/src/list/list.stories.mdx
+++ b/packages/core/src/list/list.stories.mdx
@@ -4,9 +4,9 @@ import { Meta, Story, Preview } from '@web/storybook-prebuilt/addon-docs/blocks.
 
 # Lists
 
-Lists in Clarity Core come in three varieties – ordered, unordered, and
-unstyled. Any "compact" style variations for list display is now handled through
-Clarity Core layouts.
+Lists in Clarity Core come in four varieties – ordered, unordered,
+unstyled, and description lists. Any "compact" style variations for
+list display is now handled through Clarity Core layouts.
 
 ## Installation
 
@@ -54,4 +54,16 @@ To use the list styles import the global CSS.
 
 <Preview>
   <Story id="stories-list--dark-theme" />
+</Preview>
+
+## Description List - dl/dd/dt
+
+<Preview>
+  <Story id="stories-list--description-list" />
+</Preview>
+
+## Description List Custom Spacing
+
+<Preview>
+  <Story id="stories-list--custom-space-description-list" />
 </Preview>

--- a/packages/core/src/list/list.stories.ts
+++ b/packages/core/src/list/list.stories.ts
@@ -489,3 +489,27 @@ export function darkTheme() {
     </div>
   `;
 }
+
+/** @website */
+export function descriptionList() {
+  return html`<dl cds-list>
+    <dt>Name</dt>
+    <dd>Description</dd>
+    <dt>Name</dt>
+    <dd>Description</dd>
+  </dl>`;
+}
+
+/** @website */
+export function customSpaceDescriptionList() {
+  return html`<dl cds-list cds-layout="vertical gap:md">
+    <div>
+      <dt>Name</dt>
+      <dd>Description</dd>
+    </div>
+    <div>
+      <dt>Name</dt>
+      <dd>Description</dd>
+    </div>
+  </dl>`;
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

## What is the new behavior?

Adds support for `cds-list` on a dl element, as well as layout styling with dl/dd/dt

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This is still in draft, but I wanted to get some early feedback. 

A couple of open questions:
- Should this be part of the existing `list` files/css?
- If it should remain separate, should it use a different attribute than `cds-list`?

Screenshot:

![image](https://user-images.githubusercontent.com/9469374/122248236-f2917500-ce95-11eb-97dd-1767000ac5eb.png)
