### PR TITLE
fix(website): navbar card item apperience under angular-components section

### DIFF
--- a/apps/adoption/src/app/app-routing.module.ts
+++ b/apps/adoption/src/app/app-routing.module.ts
@@ -15,6 +15,7 @@ import { IconsPage } from './pages/icons.page';
 import { AccordionPage } from './pages/accordion.page';
 import { CheckboxPage } from './pages/checkbox.page';
 import { AdoptionToolingPage } from './pages/adoption-tooling.page';
+import { CardPage } from './pages/card.page';
 
 const routes: Routes = [
   { path: '', redirectTo: '/getting-started', pathMatch: 'full' },
@@ -22,6 +23,7 @@ const routes: Routes = [
   { path: 'accordion', component: AccordionPage },
   { path: 'alert', component: AlertPage },
   { path: 'badge', component: BadgePage },
+  { path: 'card', component: CardPage },
   { path: 'checkbox', component: CheckboxPage },
   { path: 'icons', component: IconsPage },
   { path: 'label', component: LabelPage },

--- a/apps/adoption/src/app/app.component.html
+++ b/apps/adoption/src/app/app.component.html
@@ -34,6 +34,7 @@
         <clr-vertical-nav-group-children>
           <a routerLink="/accordion" routerLinkActive="active" clrVerticalNavLink>Accordion</a>
           <a routerLink="/alert" routerLinkActive="active" clrVerticalNavLink>Alert</a>
+          <a routerLink="/card" routerLinkActive="active" clrVerticalNavLink>Card</a>
           <a routerLink="/checkbox" routerLinkActive="active" clrVerticalNavLink>Checkbox</a>
           <a routerLink="/icons" routerLinkActive="active" clrVerticalNavLink>Icons</a>
           <a routerLink="/label" routerLinkActive="active" clrVerticalNavLink>Labels</a>

--- a/apps/adoption/src/app/app.module.ts
+++ b/apps/adoption/src/app/app.module.ts
@@ -26,6 +26,7 @@ import { IconsPage } from './pages/icons.page';
 import { AccordionPage } from './pages/accordion.page';
 import { CheckboxPage } from './pages/checkbox.page';
 import { AdoptionToolingPage } from './pages/adoption-tooling.page';
+import { CardPage } from './pages/card.page';
 
 @NgModule({
   declarations: [
@@ -35,6 +36,7 @@ import { AdoptionToolingPage } from './pages/adoption-tooling.page';
     GettingStartedPage,
     AccordionPage,
     AlertPage,
+    CardPage,
     BadgePage,
     CheckboxPage,
     IconsPage,

--- a/apps/adoption/src/app/migrations/card/card.1.angular.txt
+++ b/apps/adoption/src/app/migrations/card/card.1.angular.txt
@@ -1,0 +1,28 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  template: `
+    <div class="card">
+      <div class="card-header">
+        <h3>Card title</h3>
+      </div>
+      <div class="card-block">
+        <p>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Aut adipisci distinctio error, totam tempore iusto,
+          quaerat nisi quam dicta, sapiente ratione rem mollitia laudantium at magni quas in ullam. Adipisci?
+        </p>
+      </div>
+    </div>
+  `,
+  styles: [
+    `
+      :host {
+        display: flex;
+        margin: 1rem;
+        justify-content: center;
+      }
+    `,
+  ],
+})
+export class AppComponent {}

--- a/apps/adoption/src/app/migrations/card/card.1.core.txt
+++ b/apps/adoption/src/app/migrations/card/card.1.core.txt
@@ -1,0 +1,31 @@
+import { Component } from '@angular/core';
+
+import '@cds/core/card/register.js';
+
+@Component({
+  selector: 'app-root',
+  template: `
+    <cds-card aria-labelledby="cardWithLayout">
+      <div cds-layout="vertical gap:md">
+        <h2 id="cardWithLayout" cds-text="section" cds-layout="p-y:sm">Card Title</h2>
+
+        <cds-divider cds-card-remove-margin></cds-divider>
+
+        <div cds-text="body light" cds-layout="p-y:lg">
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Aut adipisci distinctio error, totam tempore iusto,
+          quaerat nisi quam dicta, sapiente ratione rem mollitia laudantium at magni quas in ullam. Adipisci?
+        </div>
+      </div>
+    </cds-card>
+  `,
+  styles: [
+    `
+      :host {
+        display: flex;
+        margin: 1rem;
+        justify-content: center;
+      }
+    `,
+  ],
+})
+export class AppComponent {}

--- a/apps/adoption/src/app/migrations/card/card.2.angular.txt
+++ b/apps/adoption/src/app/migrations/card/card.2.angular.txt
@@ -1,0 +1,34 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  template: `
+    <div class="card">
+      <div class="card-header">
+        Header
+      </div>
+      <div class="card-block">
+        <div class="card-media-block">
+          <img src="..." class="card-media-image" />
+          <div class="card-media-description">
+            <span class="card-media-title">
+              Project A
+            </span>
+            <span class="card-media-text">
+              Owner: John Doe
+            </span>
+          </div>
+        </div>
+        <div class="card-text">
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sunt excepturi labore explicabo temporibus, enim
+          voluptate saepe corrupti illum earum eveniet ab veniam vel nisi fugit accusantium perferendis quas facilis
+          quod.
+        </div>
+      </div>
+      <div class="card-footer">
+        <button class="btn btn-sm btn-link">Action</button>
+      </div>
+    </div>
+  `,
+})
+export class AppComponent {}

--- a/apps/adoption/src/app/migrations/card/card.2.core.txt
+++ b/apps/adoption/src/app/migrations/card/card.2.core.txt
@@ -1,0 +1,51 @@
+import { Component } from '@angular/core';
+
+import '@cds/core/alert/register.js';
+
+@Component({
+  selector: 'app-root',
+  template: `
+    <cds-card>
+      <div cds-layout="vertical gap:md">
+        <h2 id="containerOfCards1" cds-text="section" cds-layout="horizontal align:vertical-center">
+          Header
+        </h2>
+
+        <cds-divider cds-card-remove-margin></cds-divider>
+
+        <div cds-text="body light" cds-layout="p-y:lg">
+          <div cds-layout="horizontal gap:md p-b:md">
+            <img width="60" src="..." />
+            <div cds-layout="vertical gap:md">
+              <span>
+                Project A
+              </span>
+              <span>
+                Owner: John Doe
+              </span>
+            </div>
+          </div>
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sunt excepturi labore explicabo temporibus, enim
+          voluptate saepe corrupti illum earum eveniet ab veniam vel nisi fugit accusantium perferendis quas facilis
+          quod.
+        </div>
+
+        <cds-divider cds-card-remove-margin></cds-divider>
+
+        <div cds-layout="horizontal gap:sm p-y:sm align:vertical-center">
+          <cds-button action="flat-inline"> Action </cds-button>
+        </div>
+      </div>
+    </cds-card>
+  `,
+  styles: [
+    `
+      :host {
+        display: flex;
+        margin: 1rem;
+        justify-content: center;
+      }
+    `,
+  ],
+})
+export class AppComponent {}

--- a/apps/adoption/src/app/pages/adoption-tooling.page.ts
+++ b/apps/adoption/src/app/pages/adoption-tooling.page.ts
@@ -17,6 +17,7 @@ const eslintRules: Record<string, { name: string; errorLevel: string; fixer: boo
   'no-clr-alert': { name: 'Alert', errorLevel: 'warn', fixer: false },
   'no-clr-badge': { name: 'Badge', errorLevel: 'warn', fixer: true },
   'no-clr-button': { name: 'Button', errorLevel: 'warn', fixer: false },
+  'no-clr-card': { name: 'Card', errorLevel: 'warn', fixer: false },
   'no-clr-checkbox': { name: 'Checkbox', errorLevel: 'warn', fixer: false },
   'no-clr-datalist': { name: 'Datalist', errorLevel: 'warn', fixer: false },
   'no-clr-form': { name: 'Form', errorLevel: 'warn', fixer: false },

--- a/apps/adoption/src/app/pages/alert.page.ts
+++ b/apps/adoption/src/app/pages/alert.page.ts
@@ -11,6 +11,9 @@ import { DemoTabData } from '../components/demo.component';
   selector: 'app-alert',
   template: `
     <h1>Alerts</h1>
+
+    <eslint-intro-block rule="clarity-alert"> Any additional information goes here </eslint-intro-block>
+
     <p>
       Angular alerts could be replaced with
       <a href="https://clarity.design/core-components/alert/" target="_blank">Core alerts</a>. There some examples below

--- a/apps/adoption/src/app/pages/card.page.ts
+++ b/apps/adoption/src/app/pages/card.page.ts
@@ -1,0 +1,55 @@
+import { Component } from '@angular/core';
+import { DemoTabData } from '../components/demo.component';
+
+@Component({
+  selector: 'app-card',
+  template: `
+    <h1>Card</h1>
+
+    <demo [tabs]="demo1">
+      <h2>Basic</h2>
+    </demo>
+    <demo [tabs]="demo2">
+      <h2>Card media block</h2>
+    </demo>
+  `,
+})
+export class CardPage {
+  demo1: DemoTabData[] = [
+    {
+      name: 'Angular',
+      files: {
+        'src/app/app.component.ts': 'card/card.1.angular.txt',
+      },
+      language: 'ts',
+      template: 'angular',
+    },
+    {
+      name: 'Core',
+      files: {
+        'src/app/app.component.ts': 'card/card.1.core.txt',
+      },
+      language: 'ts',
+      template: 'core',
+    },
+  ];
+
+  demo2: DemoTabData[] = [
+    {
+      name: 'Angular',
+      files: {
+        'src/app/app.component.ts': 'card/card.2.angular.txt',
+      },
+      language: 'ts',
+      template: 'angular',
+    },
+    {
+      name: 'Core',
+      files: {
+        'src/app/app.component.ts': 'card/card.2.core.txt',
+      },
+      language: 'ts',
+      template: 'core',
+    },
+  ];
+}


### PR DESCRIPTION
The change we introduced with PR #6052 and was intended to hide the card navbar item under
core-components section but we missed the change was also
hiding the card navbar item under
angular-components section as well.

Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [] Documentation content changes
- [x] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

![image](https://user-images.githubusercontent.com/15037947/122370256-98f97b00-cf67-11eb-8d04-1c47641fe792.png)

## What is the new behavior?

![image](https://user-images.githubusercontent.com/15037947/122382289-715be000-cf72-11eb-95f3-418334352c04.png)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

