### PR TITLE
fix(commitlint): adding another delimiter for scopes

### DIFF
--- a/scripts/commitlint/angularScopes.js
+++ b/scripts/commitlint/angularScopes.js
@@ -1,4 +1,7 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+const { delimiter } = require('./common');
 
 const components = [
   'accordion',
@@ -51,6 +54,6 @@ const components = [
 module.exports = {
   components,
   getScopes: () => {
-    return components.map(c => `angular/${c}`).concat(['angular']);
+    return components.map(c => `angular${delimiter}${c}`).concat(['angular']);
   },
 };

--- a/scripts/commitlint/common.js
+++ b/scripts/commitlint/common.js
@@ -36,5 +36,6 @@ const findScopes = (path, predicate, topLevel) => {
 };
 
 module.exports = {
+  delimiter: ':',
   findScopes,
 };

--- a/scripts/commitlint/coreScopes.js
+++ b/scripts/commitlint/coreScopes.js
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 const { readdirSync } = require('fs');
-const { findScopes } = require('./common');
+const { findScopes, delimiter } = require('./common');
 
 const isScopeDirectory = directory => {
   const dir = readdirSync(directory, { withFileTypes: true });
@@ -19,10 +19,10 @@ module.exports = {
   getScopes: coreProjectPath => {
     const elements = findScopes(`${coreProjectPath}/src`, isScopeDirectory);
 
-    const core = elements.map(x => `core/${x}`);
-    const react = elements.map(x => `react/${x}`);
+    const core = elements.map(x => `core${delimiter}${x}`);
+    const react = elements.map(x => `react${delimiter}${x}`);
 
-    const design = findScopes(`${coreProjectPath}/src/styles`, () => true).map(x => `core/${x}`);
+    const design = findScopes(`${coreProjectPath}/src/styles`, () => true).map(x => `core${delimiter}${x}`);
 
     return new Set([...core, ...react, ...design, 'core', 'react']);
   },

--- a/scripts/commitlint/customScopes.js
+++ b/scripts/commitlint/customScopes.js
@@ -1,6 +1,9 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
+
 const { readFileSync } = require('fs');
 const { resolve } = require('path');
+const { delimiter } = require('./common');
 
 const getJsonData = path => {
   const json = readFileSync(path, 'utf8');
@@ -16,7 +19,7 @@ const generateCommitLintScopes = projects => {
   let _scopes = [];
 
   Object.entries(projects).forEach(([project, scopes]) => {
-    const projectScopes = scopes.map(scope => `${project}/${scope}`);
+    const projectScopes = scopes.map(scope => `${project}${delimiter}${scope}`);
     _scopes = _scopes.concat([project, ...projectScopes]);
   });
 

--- a/scripts/commitlint/websiteScopes.js
+++ b/scripts/commitlint/websiteScopes.js
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 const { readdirSync } = require('fs');
-const { findScopes } = require('./common');
+const { findScopes, delimiter } = require('./common');
 
 const isScopeDirectory = directory => {
   const dir = readdirSync(directory, { withFileTypes: true });
@@ -19,7 +19,7 @@ module.exports = {
   getScopes: websiteProjectPath => {
     const projectName = 'website';
     const websiteScopes = findScopes(websiteProjectPath, isScopeDirectory)
-      .map(x => `${projectName}/${x}`)
+      .map(x => `${projectName}${delimiter}${x}`)
       .concat([projectName]);
     return new Set(websiteScopes);
   },


### PR DESCRIPTION
When doing the research we missed that commitlint has
some multi-scope predefined delimiters and what we
are currently using is in conflict with commitlint expectations.

There is a PR in commitlint repo to fix these scenarios by letting
people provide a custom delimiters for scopes but
the owner is not actively working on that.

@bbogdanov will try to join and push that PR to get
in for their next release and unblock us to get back
to what we wanted in the first place.

https://github.com/conventional-changelog/commitlint/pull/2407

Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [x] Other... Please describe: Commitlint

## What is the current behavior?

Commit message like `fix(website/card)` won't be available because of the leading `/` at the moment.

## What is the new behavior?

The commit message above will be available as `fix(website:card)`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
