### PR TITLE
fix: remove no-longer valid url redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,82 +5,8 @@
   publish = ""
   environment = { CI = "true" }
 
-# Legacy Website Redirects
-
-# getting started
+# With this, the app has full control over the routing logic
 [[redirects]]
-  from = "/documentation/get-started"
-  to = "/get-started/"
-  status = 301
-
-# news -> releases
-[[redirects]]
-  from = "/news/*"
-  to = "/releases/"
-  status = 301
-
-# community -> (re-direct to homepage)
-[[redirects]]
-  from = "/community"
-  to = "/"
-  status = 301
-
-# Icons
-[[redirects]]
-  from = "/icons"
-  to = "/foundation/icons/"
-  status = 301
-
-# foundation pages
-[[redirects]]
-  from = "/documentation/accessibility"
-  to = "/"
-  status = 301
-
-[[redirects]]
-  from = "/documentation/app-layout"
-  to = "/foundation/app-layout/"
-  status = 301
-
-[[redirects]]
-  from = "/documentation/color"
-  to = "/foundation/color/"
-  status = 301
-
-[[redirects]]
-  from = "/documentation/internationalization"
-  to = "/foundation/internationalization/"
-  status = 301
-
-[[redirects]]
-  from = "/documentation/navigation"
-  to = "/foundation/navigation/"
-  status = 301
-
-[[redirects]]
-  from = "/documentation/themes"
-  to = "/foundation/themes/"
-  status = 301
-
-[[redirects]]
-  from = "/documentation/typography"
-  to = "/foundation/typography/"
-  status = 301
-
-# Redirects for all images to CDN
-[[redirects]]
-  from = "/images/*"
-  to = "https://dt7zex2d2lk4u.cloudfront.net/images/:splat"
+  from = "/*"
+  to = "/index.html"
   status = 200
-
-# Support CORS on JSON files
-[[headers]]
-  for = "/*.json"
-    [headers.values]
-    Access-Control-Allow-Origin = "*"
-
-# Handle 404s in our app, SPA redirect config
-[[redirects]]
-from = "/*"
-to = "/404/"
-status = 404


### PR DESCRIPTION
Signed-off-by: stsogoo <stsogoo@vmware.com>

- Removed invalid redirects in `netlify.tom`
- Ensured that the angular app (website) has control over routing instead of netlify. Without these change, users won't be able to access the component pages directly. For example: https://angular.clarity.design/documentation/alerts.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
