### PR TITLE
fix(angular:timeline): apply css sizing only to template cds-icon

### DIFF
--- a/packages/angular/projects/clr-angular/src/timeline/_timeline.clarity.scss
+++ b/packages/angular/projects/clr-angular/src/timeline/_timeline.clarity.scss
@@ -17,8 +17,7 @@
     min-width: $clr-timeline-step-min-width;
     margin-left: $clr-timeline-gutter-width;
 
-    cds-icon,
-    clr-icon {
+    cds-icon:not([size]) {
       @include min-equilateral($clr-timeline-icon-size);
     }
 


### PR DESCRIPTION
…ments

closes #5366

Signed-off-by: Miguel Amaya <mamaya@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?
This adds more specificity for the timeline icon css.
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
When users project icons into the timeline component our css sets the size.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Users can project icons into the timeline component and can set any size that is valid.
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
