### PR TITLE
fix(core:datalist): double caret on hover and focus

### DIFF
--- a/packages/core/src/datalist/datalist.global.scss
+++ b/packages/core/src/datalist/datalist.global.scss
@@ -3,5 +3,6 @@
 // The full license information can be found in LICENSE in the root directory of this project.
 
 cds-datalist input::-webkit-calendar-picker-indicator {
-  display: none;
+  opacity: 0;
+  cursor: text;
 }


### PR DESCRIPTION
closes #6110

Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Double caret was visible on Chrome, when focused/hovered
![Screen Shot 2021-07-01 at 13 44 59](https://user-images.githubusercontent.com/1798828/124130511-86af2f00-da87-11eb-9e3b-4989d55bbf67.jpg)


Issue Number: #6110 

## What is the new behavior?

Using display:none seemed to be only working with the date-picker, not the datalist, although the css property is the same.
Changed to opacity:0 + cursor fix, which is not discarded unlike the display:none.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
