### PR TITLE
build: make sure to use always npm for angular branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "clarity",
   "version": "5.4.1",
+  "engines": {
+    "yarn": "please-use-npm",
+    "npm": ">= 6.14.0"
+  },
   "scripts": {
     "start": "ng serve dev",
     "website:news": "node projects/website/generate-news",
@@ -42,7 +46,7 @@
     "build:icons:zip": "node ./scripts/clr-icons-svg.js",
     "build:icons": "npm-run-all build:icons:css build:icons:optimize build:icons:webpack build:icons:zip build:icons:package",
     "schematics:clean": "rm -rf projects/schematics/src/**/*.{js,js.map}",
-    "schematics:test": "yarn run schematics:build:test && jasmine projects/schematics/**/*.spec.js",
+    "schematics:test": "npm run schematics:build:test && jasmine projects/schematics/**/*.spec.js",
     "schematics:build:clr": "tsc -p projects/schematics/tsconfig.json",
     "schematics:build:test": "tsc -p projects/schematics/tsconfig.test.json",
     "schematics:copy:clr": "cpy --parents --cwd='projects/schematics/src' '**/*.json' ../../../dist/clr-angular/schematics",
@@ -52,10 +56,10 @@
     "build:sync-versions": "node ./scripts/sync-versions.js",
     "build:release": "npm-run-all clean:build format lint test build:angular schematics:build build:ui build:icons build:sync-versions golden:fix golden:test",
     "build:ci": "npm-run-all build:release build:website build:dev",
-    "publish": "yarn publish dist/clr-angular; yarn publish dist/clr-ui; yarn publish dist/clr-icons;",
-    "publish:rc": "yarn publish dist/clr-angular --tag rc; yarn publish dist/clr-ui --tag rc; yarn publish dist/clr-icons --tag rc;",
-    "publish:next": "yarn publish dist/clr-angular --tag next; yarn publish dist/clr-ui --tag next; yarn publish dist/clr-icons --tag next;",
-    "publish:local": "yarn publish dist/clr-icons --registry http://localhost:4873 --tag local; yarn publish dist/clr-ui --registry http://localhost:4873 --tag local; yarn publish dist/clr-angular --registry http://localhost:4873 --tag local;"
+    "publish": "npm publish dist/clr-angular; npm publish dist/clr-ui; npm publish dist/clr-icons;",
+    "publish:rc": "npm publish dist/clr-angular --tag rc; npm publish dist/clr-ui --tag rc; npm publish dist/clr-icons --tag rc;",
+    "publish:next": "npm publish dist/clr-angular --tag next; npm publish dist/clr-ui --tag next; npm publish dist/clr-icons --tag next;",
+    "publish:local": "npm publish dist/clr-icons --registry http://localhost:4873 --tag local; npm publish dist/clr-ui --registry http://localhost:4873 --tag local; npm publish dist/clr-angular --registry http://localhost:4873 --tag local;"
   },
   "private": true,
   "dependencies": {
@@ -143,7 +147,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn format:fix && yarn license:fix",
+      "pre-commit": "npm run format:fix && npm run license:fix",
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   }

--- a/projects/schematics/README.md
+++ b/projects/schematics/README.md
@@ -95,18 +95,18 @@ This will ensure that this project runs through your local registry before going
 
 You can test the schematic on a new project without the Angular CLI by using the schematics CLI directly. This is a bit easier as it doesn't require publishing to a local registry.
 
-Start by running `yarn build` to build the whole project. Then `cd dist/clr-angular` and run `npm link`. This will link this build directory to global node modules for schematics to leverage.
+Start by running `npm run build` to build the whole project. Then `cd dist/clr-angular` and run `npm link`. This will link this build directory to global node modules for schematics to leverage.
 
-Now, as you make changes run `yarn schematics:build` to build just the schematics.
+Now, as you make changes run `npm run schematics:build` to build just the schematics.
 
 Finally, in your new CLI project you can run `schematics @clr/angular:ng-add` to execute the schematic.
 
 ##### How to test package with npm registry
 
-During local development you can run the build `yarn build` from the repo root, and then `yarn publish:local` to publish it locally. It will assume you have a local npm registry running, and that you've incremented the version number. Otherwise you may have to clear out the local registry to publish again.
+During local development you can run the build `npm run build` from the repo root, and then `npm run publish:local` to publish it locally. It will assume you have a local npm registry running, and that you've incremented the version number. Otherwise you may have to clear out the local registry to publish again.
 
 ```bash
-rm -rf ~/.config/verdaccio/storage/@clr && yarn build:libs && yarn publish:local
+rm -rf ~/.config/verdaccio/storage/@clr && npm run build:libs && npm run publish:local
 ```
 
 Finally run `ng add @clr/angular` or `ng add @cds/angular` to have it install using your local registry.
@@ -146,7 +146,7 @@ You'll also want to ensure that when you build the project that you're increment
 
 ##### How to test package with npm registry
 
-During local development you can build and publish to the local registry `yarn publish:local`. It will assume you have a local npm registry running, and that you've incremented the version number. Otherwise you may have to clear out the local registry to publish again.
+During local development you can build and publish to the local registry `npm run publish:local`. It will assume you have a local npm registry running, and that you've incremented the version number. Otherwise you may have to clear out the local registry to publish again.
 
 ```bash
 rm -rf ~/.config/verdaccio/storage/@clr && yarn publish:local


### PR DESCRIPTION
Make sure to use only NPM inside the angular branch and not have task that depend on other package manager