### PR TITLE
fix(core:controls): enable aria-labelledby

### DIFF
--- a/packages/core/src/forms/control-inline/control-inline.element.spec.ts
+++ b/packages/core/src/forms/control-inline/control-inline.element.spec.ts
@@ -11,7 +11,9 @@ import '@cds/core/forms/register.js';
 
 let element: HTMLElement;
 let control: CdsInternalControlInline;
+let controlInGroup: CdsInternalControlInline;
 let input: HTMLInputElement;
+let inputInControlGroup: HTMLInputElement;
 
 describe('cds-internal-control-inline', () => {
   beforeEach(async () => {
@@ -20,10 +22,20 @@ describe('cds-internal-control-inline', () => {
         <label>control</label>
         <input type="checkbox" />
       </cds-internal-control-inline>
+
+      <cds-internal-control-group>
+        <cds-internal-control-inline>
+          <label>control</label>
+          <input type="checkbox" />
+        </cds-internal-control-inline>
+      </cds-internal-control-group>
     `);
 
-    control = element.querySelector<CdsInternalControlInline>('cds-internal-control-inline');
+    control = element.querySelectorAll<CdsInternalControlInline>('cds-internal-control-inline')[0];
+    controlInGroup = element.querySelectorAll<CdsInternalControlInline>('cds-internal-control-inline')[1];
+
     input = element.querySelector<HTMLInputElement>('input');
+    inputInControlGroup = element.querySelector<HTMLInputElement>('cds-internal-control-group input');
   });
 
   afterEach(() => {
@@ -69,5 +81,17 @@ describe('cds-internal-control-inline', () => {
     expect(control.shadowRoot.querySelector('.private-host').getAttribute('cds-layout').includes('horizontal')).toBe(
       true
     );
+  });
+
+  it('should only bubble events if control is not managed by a control group', async () => {
+    await componentIsStable(control);
+
+    let eventCount = 0;
+    element.addEventListener('checkedChange', () => eventCount++);
+    inputInControlGroup.click();
+    input.click();
+
+    await componentIsStable(control);
+    expect(eventCount).toBe(1);
   });
 });

--- a/packages/core/src/forms/control-inline/control-inline.element.ts
+++ b/packages/core/src/forms/control-inline/control-inline.element.ts
@@ -11,7 +11,7 @@ import { CdsControl } from '../control/control.element.js';
 import { getStatusIcon } from '../utils/index.js';
 
 /**
- * Internal Control Inline
+ * Internal Control Inline (boolean types)
  *
  * ```typescript
  * import '@cds/core/forms/register.js';
@@ -59,7 +59,7 @@ export class CdsInternalControlInline extends CdsControl {
             ? 'order:reverse'
             : ''}"
         >
-          <div class="input" @click=${() => this.inputControl.click()}></div>
+          <div class="input" @click=${this.selectInput}></div>
           <cds-internal-control-label
             action="secondary"
             .disabled="${this.disabled}"
@@ -105,7 +105,12 @@ export class CdsInternalControlInline extends CdsControl {
 
     if (props.has('checked') && props.get('checked') !== this.checked && this.checked) {
       this.indeterminate = false;
-      this.checkedChange.emit(this.checked);
+      this.checkedChange.emit(this.checked, { bubbles: !this.isControlGroup }); // if not a group then bubble to notify the other associated controls
     }
+  }
+
+  private selectInput(e: any) {
+    this.inputControl.click();
+    e.preventDefault(); // prevent any events from the input div, only the native input
   }
 }

--- a/packages/core/src/forms/control/control.element.spec.ts
+++ b/packages/core/src/forms/control/control.element.spec.ts
@@ -287,3 +287,28 @@ describe('cds-control with aria-label', () => {
     expect(control.labelLayout).toBe(ControlLabelLayout.ariaLabel);
   });
 });
+
+describe('cds-control with aria-labelledby', () => {
+  let element: HTMLElement;
+  let control: CdsControl;
+
+  beforeEach(async () => {
+    element = await createTestElement(html`
+      <cds-control layout="compact">
+        <input type="text" aria-labelledby="label" />
+      </cds-control>
+      <p id="label">input label</p>
+    `);
+
+    control = element.querySelector<CdsControl>('cds-control');
+  });
+
+  afterEach(() => {
+    removeTestElement(element);
+  });
+
+  it('should not enable hidden label', async () => {
+    await componentIsStable(control);
+    expect(control.labelLayout).toBe(ControlLabelLayout.ariaLabel);
+  });
+});

--- a/packages/core/src/forms/control/control.element.ts
+++ b/packages/core/src/forms/control/control.element.ts
@@ -22,6 +22,7 @@ import {
   syncProps,
   pxToRem,
   getElementUpdates,
+  hasAriaLabelTypeAttr,
 } from '@cds/core/internal';
 import { ClarityIcons } from '@cds/core/icon/icon.service.js';
 import { exclamationCircleIcon } from '@cds/core/icon/shapes/exclamation-circle.js';
@@ -140,7 +141,7 @@ export class CdsControl extends LitElement {
     requiredMessage: 'To meet a11y standards either a <label> or input[aria-label] should be provided.',
     assign: 'label',
     exemptOn: _this => {
-      return _this.inputControl?.hasAttribute('aria-label');
+      return _this.hasAriaLabelTypeAttr;
     },
   })
   protected label: HTMLLabelElement;
@@ -168,6 +169,10 @@ export class CdsControl extends LitElement {
 
   static get styles() {
     return [baseStyles, styles];
+  }
+
+  private get hasAriaLabelTypeAttr() {
+    return hasAriaLabelTypeAttr(this.inputControl);
   }
 
   render() {
@@ -356,7 +361,7 @@ export class CdsControl extends LitElement {
       this.labelLayout = ControlLabelLayout.hiddenLabel;
     }
 
-    if (this.inputControl.hasAttribute('aria-label')) {
+    if (this.hasAriaLabelTypeAttr) {
       this.labelLayout = ControlLabelLayout.ariaLabel;
     }
   }

--- a/packages/core/src/internal/utils/a11y.spec.ts
+++ b/packages/core/src/internal/utils/a11y.spec.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { describeElementByElements } from './a11y.js';
+import { describeElementByElements, hasAriaLabelTypeAttr } from './a11y.js';
 import { createTestElement } from '@cds/core/test';
 
 describe('a11y utilities', () => {
@@ -14,5 +14,19 @@ describe('a11y utilities', () => {
     describeElementByElements(element, descriptions);
 
     expect(element.getAttribute('aria-describedby').trim()).toBe(`${descriptions[0].id} ${descriptions[1].id}`);
+  });
+
+  it('hasAriaLabelTypeAttr', async () => {
+    const element = await createTestElement();
+    expect(hasAriaLabelTypeAttr(element)).toBe(false);
+
+    element.setAttribute('aria-label', 'hello');
+    expect(hasAriaLabelTypeAttr(element)).toBe(true);
+
+    element.removeAttribute('aria-label');
+    expect(hasAriaLabelTypeAttr(element)).toBe(false);
+
+    element.setAttribute('aria-labelledby', 'hello');
+    expect(hasAriaLabelTypeAttr(element)).toBe(true);
   });
 });

--- a/packages/core/src/internal/utils/a11y.ts
+++ b/packages/core/src/internal/utils/a11y.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -12,4 +12,8 @@ export function describeElementByElements(element: HTMLElement, messages: HTMLEl
     'aria-describedby',
     messages.length ? messages.map(m => (m.id = createId())).join(' ') : false,
   ]);
+}
+
+export function hasAriaLabelTypeAttr(element: HTMLElement) {
+  return element.hasAttribute('aria-label') || element.hasAttribute('aria-labelledby');
 }

--- a/packages/core/src/radio/radio.element.spec.ts
+++ b/packages/core/src/radio/radio.element.spec.ts
@@ -9,7 +9,7 @@ import { createTestElement, removeTestElement, componentIsStable } from '@cds/co
 import { CdsRadio } from '@cds/core/radio';
 import '@cds/core/radio/register.js';
 
-describe('cds-radio', () => {
+describe('cds-radio-group', () => {
   let component: CdsRadio;
   let componentTwo: CdsRadio;
   let element: HTMLElement;
@@ -58,6 +58,47 @@ describe('cds-radio', () => {
     await componentIsStable(component);
     component.inputControl.click();
     await componentIsStable(component);
+
+    expect(component.hasAttribute('_checked')).toBe(true);
+    expect(componentTwo.hasAttribute('_checked')).toBe(false);
+  });
+});
+
+describe('cds-radio', () => {
+  let component: CdsRadio;
+  let componentTwo: CdsRadio;
+  let element: HTMLElement;
+
+  beforeEach(async () => {
+    element = await createTestElement(html`
+      <cds-radio>
+        <label>radio 2</label>
+        <input type="radio" value="1" name="radio-group" />
+      </cds-radio>
+      <cds-radio>
+        <label>radio 2</label>
+        <input type="radio" value="2" name="radio-group" checked />
+      </cds-radio>
+    `);
+
+    component = element.querySelector<CdsRadio>('cds-radio');
+    componentTwo = element.querySelectorAll<CdsRadio>('cds-radio')[1];
+  });
+
+  afterEach(() => {
+    removeTestElement(element);
+  });
+
+  it('should mark checked radio when outside of a cds-radio-group', async () => {
+    await componentIsStable(component);
+
+    expect(component.hasAttribute('_checked')).toBe(false);
+    expect(componentTwo.hasAttribute('_checked')).toBe(true);
+    await componentIsStable(component);
+    component.inputControl.click();
+
+    await componentIsStable(component);
+    await componentIsStable(componentTwo);
 
     expect(component.hasAttribute('_checked')).toBe(true);
     expect(componentTwo.hasAttribute('_checked')).toBe(false);

--- a/packages/core/src/radio/radio.element.ts
+++ b/packages/core/src/radio/radio.element.ts
@@ -32,4 +32,31 @@ export class CdsRadio extends CdsInternalControlInline {
   static get styles() {
     return [...super.styles, styles];
   }
+
+  firstUpdated(props: Map<string, any>) {
+    super.firstUpdated(props);
+
+    if (!this.isControlGroup) {
+      this.associateNonGroupRadios();
+    }
+  }
+
+  /**
+   * Native radio inputs have no concept of an un-checked event. This means for
+   * our radios to update/rerender we need to listen for the other radios in the
+   * group when the are checked. If the Radio is within a cds-control-group or
+   * cds-radio-group then the group handles this. Radios can be used outside of
+   * groups in cases of using aria-labelledby like a selectable grid row/cell.
+   */
+  private associateNonGroupRadios() {
+    const root = this.getRootNode() as HTMLElement;
+    root.addEventListener('checkedChange', (e: any) => {
+      if (e.target.tagName === 'CDS-RADIO' && e.target.inputControl.name === this.inputControl.name) {
+        root
+          .querySelectorAll<CdsRadio>(`cds-radio input[type=radio][name=${this.inputControl.name}]`)
+          .forEach(c => (c.checked = false));
+        e.target.inputControl.checked = true;
+      }
+    });
+  }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Form controls support aria-label but fail when using aria-labelledby. This is needed for certain complex UI patterns like selectable grid rows

Issue Number: N/A

## What is the new behavior?
- enable controls to be labeled with aria-labelledby
- enable radio style to associate when not within a parent control-group

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
