### PR TITLE
fix(core:tag): horizontally center cds-tag content to support fixed width

### DIFF
--- a/packages/core/src/tag/tag.element.ts
+++ b/packages/core/src/tag/tag.element.ts
@@ -82,7 +82,7 @@ export class CdsTag extends CdsBaseButton {
         class="private-host"
         role="group"
         aria-labelledby="${this.groupLabelId}"
-        cds-layout="horizontal align:vertical-center"
+        cds-layout="horizontal align:center"
       >
         <slot name="tag-icon"></slot>
         <span id="${this.groupLabelId}" class="tag-content" cds-text="lhe"><slot></slot></span>


### PR DESCRIPTION
this change forces horizontal centering when a cds-tag is given a fixed width

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

if a fixed width is set on a `cds-tag`, all the content is aligned-left. this forces the content to be aligned center when fixed width.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Not Fixed Width

![Screen Shot 2021-07-02 at 8 41 21 AM](https://user-images.githubusercontent.com/2728359/124284566-bb1bfd00-db12-11eb-8e14-8a7f087ed393.png)

![Screen Shot 2021-07-02 at 8 41 39 AM](https://user-images.githubusercontent.com/2728359/124284619-c4a56500-db12-11eb-9a64-3bd1ead72927.png)

## Fixed Width
![Screen Shot 2021-07-02 at 8 47 28 AM](https://user-images.githubusercontent.com/2728359/124284735-d555db00-db12-11eb-83c6-1964b085b250.png)

![Screen Shot 2021-07-02 at 8 47 20 AM](https://user-images.githubusercontent.com/2728359/124284665-ca9b4600-db12-11eb-8094-c6ae8cbc7baf.png)

Note that this is accounting for an edge case from a specific internal team. There are some oddities here (like the close action being aligned center) but the specific ask does not want close actions inside of fixed-width tags, just text and (maybe) a badge.

Note also that the tag content wraps if the fixed width is not long enough.

I'll reiterate this is enabling an edge case. Most users will not be setting a fixed width on `cds-tags`. The utility of this edge case appears limited to tags in a datagrid column or other tabular or scannable UX.

Issue Number: N/A

## What is the new behavior?

See above.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
