### PR TITLE
chore(core): upgrade custom-elements.json

### DIFF
--- a/apps/website/.vuepress/theme/global-components/DocWebComponentAPI.vue
+++ b/apps/website/.vuepress/theme/global-components/DocWebComponentAPI.vue
@@ -70,7 +70,7 @@
 </template>
 
 <script>
-import API from '@cds/core/custom-elements.json';
+import API from '@cds/core/custom-elements.legacy.json';
 
 export default {
   name: 'DocWebComponentAPI',

--- a/apps/website/data/clarity-web-components.js
+++ b/apps/website/data/clarity-web-components.js
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc.
+ * Copyright (c) 2016-2021 VMware, Inc.
  * All Rights ReserveThis software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import clarityWebComponents from '../dist/core/custom-elements.json';
+import clarityWebComponents from '../dist/core/custom-elements.legacy.json';
 
 export default {
   fetchApi(componentName) {

--- a/packages/core/npm.json
+++ b/packages/core/npm.json
@@ -5,6 +5,7 @@
   "author": "clarity",
   "description": "Clarity Design System Web Components",
   "homepage": "https://clarity.design",
+  "customElements": "custom-elements.json",
   "keywords": ["web component", "design system", "clarity", "ui"],
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,7 @@
     "build:update": "node ../../scripts/update-local-packages.js /packages/core/dist/core/package.json",
     "postinstall": "patch-package"
   },
+  "customElements": "dist/core/custom-elements.json",
   "sideEffects": [
     "src/**/*.register.js"
   ],
@@ -57,6 +58,7 @@
     "@types/resize-observer-browser": "^0.1.5"
   },
   "devDependencies": {
+    "@custom-elements-manifest/analyzer": "0.4.12",
     "@fullhuman/postcss-purgecss": "4.0.3",
     "@open-wc/dev-server-hmr": "0.1.2-next.0",
     "@rollup/plugin-alias": "3.1.2",

--- a/packages/core/rollup.utils.js
+++ b/packages/core/rollup.utils.js
@@ -29,7 +29,11 @@ export const packageCheck = dir => {
 export const webComponentAnalyer = outDir => {
   return execute({
     commands: [
-      `wca analyze ${resolve(outDir)} --silent --format=json --outFile ${resolve(outDir, 'custom-elements.json')}`,
+      `cd ${resolve(outDir)} && cem analyze --litelement --globs ./**/*.element.d.ts`, // https://github.com/open-wc/custom-elements-manifest/tree/master/packages/analyzer
+      `wca analyze ${resolve(outDir)} --silent --format=json --outFile ${resolve(
+        outDir,
+        'custom-elements.legacy.json'
+      )}`,
     ],
     hook: 'writeBundle',
   });

--- a/packages/core/src/breadcrumb/breadcrumb.stories.ts
+++ b/packages/core/src/breadcrumb/breadcrumb.stories.ts
@@ -7,12 +7,10 @@
 import '@cds/core/breadcrumb/register.js';
 import { getElementStorybookArgTypes, spreadProps, getElementStorybookArgs } from '@cds/core/internal';
 import { html } from 'lit';
-import customElements from '../../dist/core/custom-elements.json';
 
 export default {
   title: 'Stories/Breadcrumb',
   component: 'cds-breadcrumb',
-  argTypes: getElementStorybookArgTypes('cds-breadcrumb', customElements),
   parameters: {
     options: { showPanel: true },
     design: {

--- a/packages/core/src/card/card.stories.ts
+++ b/packages/core/src/card/card.stories.ts
@@ -9,7 +9,6 @@ import '@cds/core/divider/register.js';
 import '@cds/core/forms/register.js';
 import { getElementStorybookArgs, getElementStorybookArgTypes, spreadProps } from '@cds/core/internal';
 import { html } from 'lit';
-import customElements from '../../dist/core/custom-elements.json';
 import { ClarityIcons } from '@cds/core/icon/icon.service.js';
 import { shareIcon } from '@cds/core/icon/shapes/share.js';
 import { thumbsUpIcon } from '@cds/core/icon/shapes/thumbs-up.js';
@@ -21,7 +20,6 @@ const placeholder = 'Placeholder';
 export default {
   title: 'Stories/Card',
   component: 'cds-card',
-  argTypes: getElementStorybookArgTypes('cds-card', customElements),
   parameters: {
     options: { showPanel: true },
   },

--- a/scripts/core-ng-module-generator.js
+++ b/scripts/core-ng-module-generator.js
@@ -10,7 +10,7 @@ const fs = require('fs');
 const path = require('path');
 const Mustache = require('mustache');
 
-const SOURCE_PATH = path.join(__dirname, './../packages/core/dist/core/custom-elements.json');
+const SOURCE_PATH = path.join(__dirname, './../packages/core/dist/core/custom-elements.legacy.json');
 const TARGET_PATH = path.join(__dirname, './../packages/angular/projects/cds-angular/src/cds/components');
 const MUSTACHE_TEMPLTATE_PATH = path.join(__dirname, './../packages/angular/projects/cds-angular/src/cds/_stubs');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4151,7 +4151,7 @@
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
 "@cds/angular@./dist/angular":
-  version "5.4.0"
+  version "5.4.1"
   dependencies:
     jsdom "^16.5.3"
     tslib "^2.0.0"
@@ -4173,7 +4173,7 @@
     normalize.css "^8.0.1"
 
 "@clr/angular@./dist/clr-angular":
-  version "5.4.0"
+  version "5.4.1"
 
 "@clr/icons@./dist/clr-icons":
   version "0.0.0"
@@ -4378,6 +4378,20 @@
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
+
+"@custom-elements-manifest/analyzer@0.4.12":
+  version "0.4.12"
+  resolved "https://registry.yarnpkg.com/@custom-elements-manifest/analyzer/-/analyzer-0.4.12.tgz#55dd21bf00faa6cc33a1ba248de6b9fcb804ef6f"
+  integrity sha512-AvHMmiC5TpYBYmjdZ/5OKhsTQbJvb1A7jkTb3/DUuVZrRpvNuVz6/fhyQ0giF5VFwmPWgBdMdaA2qNDQlK0lIg==
+  dependencies:
+    "@web/config-loader" "^0.1.3"
+    chokidar "^3.5.2"
+    command-line-args "^5.1.1"
+    comment-parser "^1.1.5"
+    custom-elements-manifest "^1.0.0"
+    debounce "^1.2.1"
+    globby "^11.0.4"
+    typescript "^4.3.2"
 
 "@discoveryjs/json-ext@0.5.2":
   version "0.5.2"
@@ -9636,6 +9650,14 @@ anymatch@^3.0.3, anymatch@~3.1.1:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+anymatch@~3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
+  integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
+  dependencies:
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
+
 app-root-dir@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/app-root-dir/-/app-root-dir-1.0.2.tgz#38187ec2dea7577fff033ffcb12172692ff6e118"
@@ -11896,6 +11918,21 @@ chokidar@^3.4.1:
   optionalDependencies:
     fsevents "~2.1.2"
 
+chokidar@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
+  integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 chownr@^1.1.1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
@@ -12532,6 +12569,11 @@ commander@~2.9.0:
   integrity sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
   dependencies:
     graceful-readlink ">= 1.0.0"
+
+comment-parser@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.1.5.tgz#453627ef8f67dbcec44e79a9bd5baa37f0bce9b2"
+  integrity sha512-RePCE4leIhBlmrqiYTvaqEeGYg7qpSl4etaIabKtdOQVi+mSTIBBklGUwIr79GXYnl3LpMwmDw4KeR2stNc6FA==
 
 commitizen@^4.0.3, commitizen@^4.2.4:
   version "4.2.4"
@@ -14011,6 +14053,11 @@ custom-elements-hmr-polyfill@1.0.3:
   resolved "https://registry.yarnpkg.com/custom-elements-hmr-polyfill/-/custom-elements-hmr-polyfill-1.0.3.tgz#ee25e525020162a9d811c9108d4b398e1c624cad"
   integrity sha512-LG9AcR3MKLOjZmw3UNY1GWkA0NdWm/BMi8dLf+s59Kk0BJ77wssUbAIVXJIkCmoDuPkC4Y+nN8fff4QTtF4rOA==
 
+custom-elements-manifest@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/custom-elements-manifest/-/custom-elements-manifest-1.0.0.tgz#b35c2129076a1dc9f95d720c6f7b5b71a857274b"
+  integrity sha512-j59k0ExGCKA8T6Mzaq+7axc+KVHwpEphEERU7VZ99260npu/p/9kd+Db+I3cGKxHkM5y6q5gnlXn00mzRQkX2A==
+
 custom-event@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/custom-event/-/custom-event-1.0.1.tgz#5d02a46850adf1b4a317946a3928fccb5bfd0425"
@@ -14121,6 +14168,11 @@ debounce@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
   integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
+
+debounce@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
+  integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
@@ -17329,7 +17381,7 @@ fsevents@^2.1.2, fsevents@~2.1.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
 
-fsevents@~2.3.1:
+fsevents@~2.3.1, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -17708,7 +17760,7 @@ glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@^5.1.1, glob-parent@~5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob-parent@^5.1.2:
+glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -17952,6 +18004,18 @@ globby@^11.0.3:
   version "11.0.3"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.3.tgz#9b1f0cb523e171dd1ad8c7b2a9fb4b644b9593cb"
   integrity sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
+
+globby@^11.0.4:
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
+  integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
   dependencies:
     array-union "^2.1.0"
     dir-glob "^3.0.1"
@@ -28158,6 +28222,13 @@ readdirp@~3.5.0:
   dependencies:
     picomatch "^2.2.1"
 
+readdirp@~3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
+  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
+  dependencies:
+    picomatch "^2.2.1"
+
 readline2@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/readline2/-/readline2-1.0.1.tgz#41059608ffc154757b715d9989d199ffbf372e35"
@@ -32674,6 +32745,11 @@ typescript@^3.6.3:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+
+typescript@^4.3.2:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
 typescript@~4.0.2:
   version "4.0.5"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?
Upgrades the `custom-elements.json` metadata. This file provides metadata for editors and tools to understand what Custom Elements are available. This upgrades to the [custom elements schema standard](https://github.com/webcomponents/custom-elements-manifest). The old format now ouputs to `custom-elements.legacy.json` as this is still used for `@cds/angular` which can be updated to the new standard in a followup PR.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
