### PR TITLE
fix(combobox): unable to select option "0"

### DIFF
--- a/projects/angular/src/forms/combobox/option-items.directive.spec.ts
+++ b/projects/angular/src/forms/combobox/option-items.directive.spec.ts
@@ -21,7 +21,7 @@ import { ClrPopoverToggleService } from '../../utils/popover/providers/popover-t
 })
 class FullTest {
   @ViewChild(ClrOptionItems) optionItems: ClrOptionItems<number>;
-  numbers = [1, 2, 3, 4, 5];
+  numbers = [0, 1, 2, 3];
   trackBy: (index: number, item: number) => any;
 }
 
@@ -34,7 +34,7 @@ class FullTest {
 })
 class TrackByIndexTest {
   @ViewChild(ClrOptionItems) optionItems: ClrOptionItems<number>;
-  numbers = [1, 2, 3, 4, 5];
+  numbers = [0, 1, 2, 3];
   trackBy = (index: number) => index;
 }
 
@@ -47,7 +47,7 @@ class TrackByIndexTest {
 })
 class ObjectDataTest {
   @ViewChild(ClrOptionItems) optionItems: ClrOptionItems<number>;
-  numbers = [{ a: 1 }, { a: 2 }, { a: 3 }];
+  numbers = [{ a: 0 }, { a: 1 }, { a: 2 }, { a: 3 }];
   trackBy = (index: number) => index;
 }
 
@@ -80,7 +80,7 @@ export default function (): void {
 
       it('can handle changes', function () {
         const initialContent = this.fixture.elementRef.nativeElement.textContent;
-        expect(initialContent.trim()).toEqual('12345');
+        expect(initialContent.trim()).toEqual('0123');
         this.testComponent.numbers.push(6);
         this.fixture.detectChanges();
         const updatedContent = this.fixture.elementRef.nativeElement.textContent;
@@ -95,8 +95,8 @@ export default function (): void {
            Based on the above, I prefer to avoid complicating the iterator, unless we have a real scenario for it.
         */
         // Deprecated check:
-        // expect(updatedContent.trim()).toEqual('123456');
-        expect(updatedContent.trim()).toEqual('12345');
+        // expect(updatedContent.trim()).toEqual('01236');
+        expect(updatedContent.trim()).toEqual('0123');
       });
 
       it('handles a null input for the array of items', function () {
@@ -112,7 +112,7 @@ export default function (): void {
       });
 
       it('can filter out items based on the option service currentInput field', function () {
-        expect(this.clarityDirective.iterableProxy._ngForOf).toEqual([1, 2, 3, 4, 5]);
+        expect(this.clarityDirective.iterableProxy._ngForOf).toEqual([0, 1, 2, 3]);
         const optionService: OptionSelectionService<any> = TestBed.get(OptionSelectionService);
         this.testComponent.numbers.push(12);
         optionService.currentInput = '1';
@@ -155,13 +155,13 @@ export default function (): void {
         this.fixture.nativeElement.querySelectorAll('li:first-child').forEach(li => (li.style.color = 'red'));
         const firstItem = this.fixture.nativeElement.querySelector('li');
         expect(firstItem.style.color).toBe('red');
-        expect(firstItem.textContent.trim()).toBe('1');
+        expect(firstItem.textContent.trim()).toBe('0');
 
         // First mutation
         this.testComponent.numbers.unshift(42);
         this.fixture.detectChanges();
         const unshiftedItem = this.fixture.nativeElement.querySelector('li');
-        expect(this.clarityDirective._rawItems).toEqual([42, 1, 2, 3, 4, 5]);
+        expect(this.clarityDirective._rawItems).toEqual([42, 0, 1, 2, 3]);
         expect(unshiftedItem.style.color).toBe('red');
 
         // Resetting
@@ -190,7 +190,7 @@ export default function (): void {
 
       it('generates content', function () {
         const initialContent = this.fixture.elementRef.nativeElement.textContent;
-        expect(initialContent.trim()).toEqual('123');
+        expect(initialContent.trim()).toEqual('0123');
       });
 
       it('sets display field', function () {

--- a/projects/angular/src/forms/combobox/option-items.directive.ts
+++ b/projects/angular/src/forms/combobox/option-items.directive.ts
@@ -81,7 +81,9 @@ export class ClrOptionItems<T> implements DoCheck, OnDestroy {
           return item.toString().toLowerCase().indexOf(this.filter.toString().toLowerCase()) > -1;
         }
         const objValues = Object.values(item).filter(value => {
-          return value ? value.toString().toLowerCase().indexOf(this.filter.toString().toLowerCase()) > -1 : false;
+          return value !== null && value !== undefined
+            ? value.toString().toLowerCase().indexOf(this.filter.toString().toLowerCase()) > -1
+            : false;
         });
         return objValues.length > 0;
       });

--- a/projects/angular/src/forms/combobox/providers/option-selection.service.ts
+++ b/projects/angular/src/forms/combobox/providers/option-selection.service.ts
@@ -21,7 +21,7 @@ export class OptionSelectionService<T> {
   }
   set currentInput(input) {
     // clear value in single selection model when input is empty
-    if (!input && !this.multiselectable) {
+    if (input === '' && !this.multiselectable) {
       this.setSelectionValue(null);
     }
     this._currentInput = input;
@@ -39,7 +39,7 @@ export class OptionSelectionService<T> {
   }
 
   select(item: T) {
-    if (!item || this.selectionModel.containsItem(item)) {
+    if (item === null || item === undefined || this.selectionModel.containsItem(item)) {
       return;
     }
     this.selectionModel.select(item);
@@ -47,7 +47,7 @@ export class OptionSelectionService<T> {
   }
 
   toggle(item: T) {
-    if (!item) {
+    if (item === null || item === undefined) {
       return;
     }
     if (this.selectionModel.containsItem(item)) {
@@ -59,7 +59,7 @@ export class OptionSelectionService<T> {
   }
 
   unselect(item: T) {
-    if (!item || !this.selectionModel.containsItem(item)) {
+    if (item === null || item === undefined || !this.selectionModel.containsItem(item)) {
       return;
     }
     this.selectionModel.unselect(item);


### PR DESCRIPTION
closes #6117

Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Unable to select options that contain exactly "0"

Issue Number: #6117

## What is the new behavior?

Can select "0" options

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
