### PR TITLE
fix(website): using frontmatter to hide navigation in sidebar

### DIFF
--- a/apps/website/.vuepress/sidebar.js
+++ b/apps/website/.vuepress/sidebar.js
@@ -41,7 +41,6 @@ function getChildren(dir) {
       // Remove anything prefixed with _
       .filter(basename => !basename.startsWith('_'))
       // Remove/hide card component from sidebar navigation
-      .filter(basename => basename !== 'card')
       .map(basename => {
         if (fs.statSync(path.join(base, basename)).isDirectory()) {
           return {

--- a/apps/website/core-components/accordion/README.md
+++ b/apps/website/core-components/accordion/README.md
@@ -1,6 +1,7 @@
 ---
 title: Overview
 toc: true
+beta: true
 ---
 
 <DocPreviewWarning/>

--- a/apps/website/core-components/card/README.md
+++ b/apps/website/core-components/card/README.md
@@ -1,6 +1,7 @@
 ---
 title: Overview
 toc: true
+beta: true
 ---
 
 ::: component-summary

--- a/apps/website/core-components/divider/README.md
+++ b/apps/website/core-components/divider/README.md
@@ -1,6 +1,7 @@
 ---
 title: Overview
 toc: true
+beta: true
 ---
 
 ::: component-summary

--- a/apps/website/core-components/file/README.md
+++ b/apps/website/core-components/file/README.md
@@ -1,6 +1,7 @@
 ---
 title: Overview
 toc: true
+beta: true
 ---
 
 ::: component-summary

--- a/apps/website/core-components/progress-circle/README.md
+++ b/apps/website/core-components/progress-circle/README.md
@@ -1,6 +1,7 @@
 ---
 title: Overview
 toc: true
+beta: true
 ---
 
 <DocPreviewWarning/>

--- a/apps/website/core-components/search/README.md
+++ b/apps/website/core-components/search/README.md
@@ -1,6 +1,7 @@
 ---
 title: Overview
 toc: true
+beta: true
 ---
 
 ::: component-summary

--- a/apps/website/core-components/time/README.md
+++ b/apps/website/core-components/time/README.md
@@ -1,6 +1,7 @@
 ---
 title: Overview
 toc: true
+beta: true
 ---
 
 ::: component-summary


### PR DESCRIPTION
Fixing the missing card navigation item in `angular-components` section on the sidebar

Adding the logic to hide items in sidebar by using the frontmatter

Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
