### PR TITLE
fix(website): add unique name attributes to examples

### DIFF
--- a/projects/website/src/app/documentation/demos/checkboxes/checkboxes.demo.html
+++ b/projects/website/src/app/documentation/demos/checkboxes/checkboxes.demo.html
@@ -53,11 +53,11 @@
 
     <clr-checkbox-container>
       <clr-checkbox-wrapper>
-        <input type="checkbox" clrCheckbox name="test2" value="option1" />
+        <input type="checkbox" clrCheckbox name="test2-1" value="option1" />
         <label>Option 1</label>
       </clr-checkbox-wrapper>
       <clr-checkbox-wrapper>
-        <input type="checkbox" clrCheckbox name="test2" value="option2" />
+        <input type="checkbox" clrCheckbox name="test2-2" value="option2" />
         <label>Option 2</label>
       </clr-checkbox-wrapper>
     </clr-checkbox-container>
@@ -87,11 +87,11 @@
     <clr-checkbox-container>
       <label>Full checkbox example</label>
       <clr-checkbox-wrapper>
-        <input type="checkbox" clrCheckbox name="test3" required value="option1" [(ngModel)]="exampleOne.one" />
+        <input type="checkbox" clrCheckbox name="test3-1" required value="option1" [(ngModel)]="exampleOne.one" />
         <label>Option 1</label>
       </clr-checkbox-wrapper>
       <clr-checkbox-wrapper>
-        <input type="checkbox" clrCheckbox name="test3" required value="option2" [(ngModel)]="exampleOne.two" />
+        <input type="checkbox" clrCheckbox name="test3-2" required value="option2" [(ngModel)]="exampleOne.two" />
         <label>Option 2</label>
       </clr-checkbox-wrapper>
       <clr-control-helper>Helper text</clr-control-helper>
@@ -114,11 +114,11 @@
     <clr-checkbox-container clrInline>
       <label>Inline checkbox example</label>
       <clr-checkbox-wrapper>
-        <input type="checkbox" clrCheckbox name="test4" required value="option1" [(ngModel)]="exampleTwo.one" />
+        <input type="checkbox" clrCheckbox name="test4-1" required value="option1" [(ngModel)]="exampleTwo.one" />
         <label>Option 1</label>
       </clr-checkbox-wrapper>
       <clr-checkbox-wrapper>
-        <input type="checkbox" clrCheckbox name="test4" required value="option2" [(ngModel)]="exampleTwo.two" />
+        <input type="checkbox" clrCheckbox name="test4-2" required value="option2" [(ngModel)]="exampleTwo.two" />
         <label>Option 2</label>
       </clr-checkbox-wrapper>
       <clr-control-helper>Helper text</clr-control-helper>
@@ -143,11 +143,11 @@
     <clr-checkbox-container>
       <label>Disabled checkbox example</label>
       <clr-checkbox-wrapper>
-        <input type="checkbox" clrCheckbox name="test5" value="option1" [(ngModel)]="exampleThree.one" disabled />
+        <input type="checkbox" clrCheckbox name="test5-1" value="option1" [(ngModel)]="exampleThree.one" disabled />
         <label>Option 1</label>
       </clr-checkbox-wrapper>
       <clr-checkbox-wrapper>
-        <input type="checkbox" clrCheckbox name="test5" value="option2" [(ngModel)]="exampleThree.two" disabled />
+        <input type="checkbox" clrCheckbox name="test5-2" value="option2" [(ngModel)]="exampleThree.two" disabled />
         <label>Option 2</label>
       </clr-checkbox-wrapper>
       <clr-control-helper>Helper text</clr-control-helper>
@@ -235,15 +235,15 @@
       <label class="clr-control-label">Full checkbox example</label>
       <div class="clr-control-container">
         <div class="clr-checkbox-wrapper">
-          <input type="checkbox" id="checkbox1" name="checkbox-full" value="option1" class="clr-checkbox" />
+          <input type="checkbox" id="checkbox1" name="checkbox-full-1" value="option1" class="clr-checkbox" />
           <label for="checkbox1" class="clr-control-label">option 1</label>
         </div>
         <div class="clr-checkbox-wrapper">
-          <input type="checkbox" id="checkbox2" name="checkbox-full" value="option2" class="clr-checkbox" />
+          <input type="checkbox" id="checkbox2" name="checkbox-full-2" value="option2" class="clr-checkbox" />
           <label for="checkbox2" class="clr-control-label">option 2</label>
         </div>
         <div class="clr-checkbox-wrapper">
-          <input type="checkbox" id="checkbox3" name="checkbox-full" value="option3" class="clr-checkbox" />
+          <input type="checkbox" id="checkbox3" name="checkbox-full-3" value="option3" class="clr-checkbox" />
           <label for="checkbox3" class="clr-control-label">option 3</label>
         </div>
         <div class="clr-subtext-wrapper">
@@ -273,15 +273,15 @@
       <label class="clr-control-label">Error checkbox</label>
       <div class="clr-control-container clr-error">
         <div class="clr-checkbox-wrapper">
-          <input type="checkbox" id="checkbox4" name="checkbox-error" value="option1" class="clr-checkbox" />
+          <input type="checkbox" id="checkbox4" name="checkbox-error-1" value="option1" class="clr-checkbox" />
           <label for="checkbox4" class="clr-control-label">option 1</label>
         </div>
         <div class="clr-checkbox-wrapper">
-          <input type="checkbox" id="checkbox5" name="checkbox-error" value="option2" class="clr-checkbox" />
+          <input type="checkbox" id="checkbox5" name="checkbox-error-2" value="option2" class="clr-checkbox" />
           <label for="checkbox5" class="clr-control-label">option 2</label>
         </div>
         <div class="clr-checkbox-wrapper">
-          <input type="checkbox" id="checkbox6" name="checkbox-error" value="option3" class="clr-checkbox" />
+          <input type="checkbox" id="checkbox6" name="checkbox-error-3" value="option3" class="clr-checkbox" />
           <label for="checkbox6" class="clr-control-label">option 3</label>
         </div>
         <div class="clr-subtext-wrapper">
@@ -315,15 +315,15 @@
       <label class="clr-control-label">Inline checkbox example</label>
       <div class="clr-control-container clr-control-inline">
         <div class="clr-checkbox-wrapper">
-          <input type="checkbox" id="checkbox7" name="checkbox-error" value="option1" class="clr-checkbox" />
+          <input type="checkbox" id="checkbox7" name="checkbox-error-1" value="option1" class="clr-checkbox" />
           <label for="checkbox7" class="clr-control-label">option 1</label>
         </div>
         <div class="clr-checkbox-wrapper">
-          <input type="checkbox" id="checkbox8" name="checkbox-error" value="option2" class="clr-checkbox" />
+          <input type="checkbox" id="checkbox8" name="checkbox-error-2" value="option2" class="clr-checkbox" />
           <label for="checkbox8" class="clr-control-label">option 2</label>
         </div>
         <div class="clr-checkbox-wrapper">
-          <input type="checkbox" id="checkbox9" name="checkbox-error" value="option3" class="clr-checkbox" />
+          <input type="checkbox" id="checkbox9" name="checkbox-error-3" value="option3" class="clr-checkbox" />
           <label for="checkbox9" class="clr-control-label">option 3</label>
         </div>
         <div class="clr-subtext-wrapper">
@@ -354,7 +354,7 @@
           <input
             type="checkbox"
             id="checkbox10"
-            name="checkbox-disabled"
+            name="checkbox-disabled-1"
             value="option1"
             class="clr-checkbox"
             disabled
@@ -365,7 +365,7 @@
           <input
             type="checkbox"
             id="checkbox11"
-            name="checkbox-disabled"
+            name="checkbox-disabled-2"
             value="option2"
             class="clr-checkbox"
             disabled
@@ -376,7 +376,7 @@
           <input
             type="checkbox"
             id="checkbox12"
-            name="checkbox-disabled"
+            name="checkbox-disabled-3"
             value="option3"
             class="clr-checkbox"
             disabled

--- a/projects/website/src/app/documentation/demos/checkboxes/ng/disabled.html
+++ b/projects/website/src/app/documentation/demos/checkboxes/ng/disabled.html
@@ -1,11 +1,11 @@
 <clr-checkbox-container>
   <label>Disabled checkbox example</label>
   <clr-checkbox-wrapper>
-    <input type="checkbox" clrCheckbox name="options" value="option1" [(ngModel)]="options.option1" disabled />
+    <input type="checkbox" clrCheckbox name="options1" value="option1" [(ngModel)]="options.option1" disabled />
     <label>Option 1</label>
   </clr-checkbox-wrapper>
   <clr-checkbox-wrapper>
-    <input type="checkbox" clrCheckbox name="options" value="option2" [(ngModel)]="options.option2" disabled />
+    <input type="checkbox" clrCheckbox name="options2" value="option2" [(ngModel)]="options.option2" disabled />
     <label>Option 2</label>
   </clr-checkbox-wrapper>
   <clr-control-helper>Helper text</clr-control-helper>

--- a/projects/website/src/app/documentation/demos/checkboxes/ng/helpers.html
+++ b/projects/website/src/app/documentation/demos/checkboxes/ng/helpers.html
@@ -1,11 +1,11 @@
 <clr-checkbox-container>
   <label>Full checkbox</label>
   <clr-checkbox-wrapper>
-    <input type="checkbox" clrCheckbox name="options" required value="option1" [(ngModel)]="options.option1" />
+    <input type="checkbox" clrCheckbox name="options1" required value="option1" [(ngModel)]="options.option1" />
     <label>Option 1</label>
   </clr-checkbox-wrapper>
   <clr-checkbox-wrapper>
-    <input type="checkbox" clrCheckbox name="options" required value="option2" [(ngModel)]="options.option2" />
+    <input type="checkbox" clrCheckbox name="options2" required value="option2" [(ngModel)]="options.option2" />
     <label>Option 2</label>
   </clr-checkbox-wrapper>
   <clr-control-helper>Helper text</clr-control-helper>

--- a/projects/website/src/app/documentation/demos/checkboxes/ng/inline.html
+++ b/projects/website/src/app/documentation/demos/checkboxes/ng/inline.html
@@ -1,11 +1,11 @@
 <clr-checkbox-container clrInline>
   <label>Inline checkbox example</label>
   <clr-checkbox-wrapper>
-    <input type="checkbox" clrCheckbox name="options" required value="option1" [(ngModel)]="options.option1" />
+    <input type="checkbox" clrCheckbox name="options1" required value="option1" [(ngModel)]="options.option1" />
     <label>Option 1</label>
   </clr-checkbox-wrapper>
   <clr-checkbox-wrapper>
-    <input type="checkbox" clrCheckbox name="options" required value="option2" [(ngModel)]="options.option2" />
+    <input type="checkbox" clrCheckbox name="options2" required value="option2" [(ngModel)]="options.option2" />
     <label>Option 2</label>
   </clr-checkbox-wrapper>
   <clr-control-helper>Helper text</clr-control-helper>

--- a/projects/website/src/app/documentation/demos/checkboxes/ng/label.html
+++ b/projects/website/src/app/documentation/demos/checkboxes/ng/label.html
@@ -1,10 +1,10 @@
 <clr-checkbox-container>
   <clr-checkbox-wrapper>
-    <input type="checkbox" clrCheckbox value="option1" name="options" />
+    <input type="checkbox" clrCheckbox value="option1" name="options1" />
     <label>Option 1</label>
   </clr-checkbox-wrapper>
   <clr-checkbox-wrapper>
-    <input type="checkbox" clrCheckbox value="option2" name="options" />
+    <input type="checkbox" clrCheckbox value="option2" name="options2" />
     <label>Option 2</label>
   </clr-checkbox-wrapper>
 </clr-checkbox-container>

--- a/projects/website/src/app/documentation/demos/checkboxes/ui/disabled.html
+++ b/projects/website/src/app/documentation/demos/checkboxes/ui/disabled.html
@@ -2,15 +2,15 @@
   <label class="clr-control-label">Disabled checkbox example</label>
   <div class="clr-control-container">
     <div class="clr-checkbox-wrapper">
-      <input type="checkbox" id="checkbox10" name="checkbox-disabled" value="option1" class="clr-checkbox" disabled />
+      <input type="checkbox" id="checkbox10" name="checkbox-disabled-1" value="option1" class="clr-checkbox" disabled />
       <label for="checkbox10" class="clr-control-label">option 1</label>
     </div>
     <div class="clr-checkbox-wrapper">
-      <input type="checkbox" id="checkbox11" name="checkbox-disabled" value="option2" class="clr-checkbox" disabled />
+      <input type="checkbox" id="checkbox11" name="checkbox-disabled-2" value="option2" class="clr-checkbox" disabled />
       <label for="checkbox11" class="clr-control-label">option 2</label>
     </div>
     <div class="clr-checkbox-wrapper">
-      <input type="checkbox" id="checkbox12" name="checkbox-disabled" value="option3" class="clr-checkbox" disabled />
+      <input type="checkbox" id="checkbox12" name="checkbox-disabled-3" value="option3" class="clr-checkbox" disabled />
       <label for="checkbox12" class="clr-control-label">option 3</label>
     </div>
     <div class="clr-subtext-wrapper">

--- a/projects/website/src/app/documentation/demos/checkboxes/ui/error.html
+++ b/projects/website/src/app/documentation/demos/checkboxes/ui/error.html
@@ -2,15 +2,15 @@
   <label class="clr-control-label">Basic checkbox</label>
   <div class="clr-control-container clr-error">
     <div class="clr-checkbox-wrapper">
-      <input type="checkbox" id="vertical-checkbox1" name="checkbox-error" value="option1" class="clr-checkbox" />
+      <input type="checkbox" id="vertical-checkbox1" name="checkbox-error-1" value="option1" class="clr-checkbox" />
       <label for="vertical-checkbox1" class="clr-control-label">option 1</label>
     </div>
     <div class="clr-checkbox-wrapper">
-      <input type="checkbox" id="vertical-checkbox2" name="checkbox-error" value="option2" class="clr-checkbox" />
+      <input type="checkbox" id="vertical-checkbox2" name="checkbox-error-2" value="option2" class="clr-checkbox" />
       <label for="vertical-checkbox2" class="clr-control-label">option 2</label>
     </div>
     <div class="clr-checkbox-wrapper">
-      <input type="checkbox" id="vertical-checkbox3" name="checkbox-error" value="option3" class="clr-checkbox" />
+      <input type="checkbox" id="vertical-checkbox3" name="checkbox-error-3" value="option3" class="clr-checkbox" />
       <label for="vertical-checkbox3" class="clr-control-label">option 3</label>
     </div>
     <div class="clr-subtext-wrapper">

--- a/projects/website/src/app/documentation/demos/checkboxes/ui/full.html
+++ b/projects/website/src/app/documentation/demos/checkboxes/ui/full.html
@@ -2,15 +2,15 @@
   <label class="clr-control-label">Full checkbox</label>
   <div class="clr-control-container">
     <div class="clr-checkbox-wrapper">
-      <input type="checkbox" id="vertical-checkbox1" name="checkbox-full" value="option1" class="clr-checkbox" />
+      <input type="checkbox" id="vertical-checkbox1" name="checkbox-full-1" value="option1" class="clr-checkbox" />
       <label for="vertical-checkbox1" class="clr-control-label">option 1</label>
     </div>
     <div class="clr-checkbox-wrapper">
-      <input type="checkbox" id="vertical-checkbox2" name="checkbox-full" value="option2" class="clr-checkbox" />
+      <input type="checkbox" id="vertical-checkbox2" name="checkbox-full-2" value="option2" class="clr-checkbox" />
       <label for="vertical-checkbox2" class="clr-control-label">option 2</label>
     </div>
     <div class="clr-checkbox-wrapper">
-      <input type="checkbox" id="vertical-checkbox3" name="checkbox-full" value="option3" class="clr-checkbox" />
+      <input type="checkbox" id="vertical-checkbox3" name="checkbox-full-3" value="option3" class="clr-checkbox" />
       <label for="vertical-checkbox3" class="clr-control-label">option 3</label>
     </div>
     <div class="clr-subtext-wrapper">

--- a/projects/website/src/app/documentation/demos/checkboxes/ui/inline.html
+++ b/projects/website/src/app/documentation/demos/checkboxes/ui/inline.html
@@ -2,15 +2,15 @@
   <label class="clr-control-label">Inline checkbox example</label>
   <div class="clr-control-container clr-control-inline">
     <div class="clr-checkbox-wrapper">
-      <input type="checkbox" id="vertical-checkbox1" name="checkbox-full" value="option1" class="clr-checkbox" />
+      <input type="checkbox" id="vertical-checkbox1" name="checkbox-inline-1" value="option1" class="clr-checkbox" />
       <label for="vertical-checkbox1" class="clr-control-label">option 1</label>
     </div>
     <div class="clr-checkbox-wrapper">
-      <input type="checkbox" id="vertical-checkbox2" name="checkbox-full" value="option2" class="clr-checkbox" />
+      <input type="checkbox" id="vertical-checkbox2" name="checkbox-inline-2" value="option2" class="clr-checkbox" />
       <label for="vertical-checkbox2" class="clr-control-label">option 2</label>
     </div>
     <div class="clr-checkbox-wrapper">
-      <input type="checkbox" id="vertical-checkbox3" name="checkbox-full" value="option3" class="clr-checkbox" />
+      <input type="checkbox" id="vertical-checkbox3" name="checkbox-inline-3" value="option3" class="clr-checkbox" />
       <label for="vertical-checkbox3" class="clr-control-label">option 3</label>
     </div>
     <div class="clr-subtext-wrapper">


### PR DESCRIPTION
the "same name" syntax breaks preselection
Signed-off-by: Ivan Donchev idonchev@vmware.com

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Same name attributes to example code.  Leading to pre-selection problems.

Issue Number: 6118

## What is the new behavior?

unique name attributes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
