### PR TITLE
fix(button): changed border on disabled danger button group

### DIFF
--- a/projects/angular/src/button/_buttons.clarity.scss
+++ b/projects/angular/src/button/_buttons.clarity.scss
@@ -405,6 +405,9 @@
     &.btn-danger .dropdown-toggle {
       @include populateButtonProperties(primary);
     }
+    &.btn-danger :disabled {
+      @include css-var(border-color, --clr-color-neutral-400, $clr-color-neutral-400, $clr-use-custom-properties);
+    }
 
     &.btn-link .dropdown-toggle {
       @include populateButtonProperties(link);


### PR DESCRIPTION
closes #4003 

Signed-off-by: Miguel Amaya<mamaya@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?
This is a fix for: The border color of disabled danger buttons produces an inconsistent look of disabled button groups
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
When user uses button group and has a disabled danger button the border is bold/differs from the other buttons.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4003

## What is the new behavior?
The disabled danger button in a group has the same border as the other buttons
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
