### PR TITLE
fix(timeline): apply css sizing for each template icon and added step…

### DIFF
--- a/projects/angular/src/timeline/_timeline.clarity.scss
+++ b/projects/angular/src/timeline/_timeline.clarity.scss
@@ -93,6 +93,18 @@
   .clr-timeline-step-body {
     display: flex;
     flex-direction: column;
+    cds-icon,
+    clr-icon {
+      @include equilateral($clr-timeline-default-icon-size);
+      min-width: initial;
+      min-height: initial;
+      &[shape='circle'],
+      &[shape='dot-circle'],
+      &[shape='success-standard'],
+      &[shape='error-standard'] {
+        color: inherit;
+      }
+    }
   }
 
   .clr-timeline-step-title {

--- a/projects/angular/src/timeline/_variables.timeline.scss
+++ b/projects/angular/src/timeline/_variables.timeline.scss
@@ -18,6 +18,7 @@ $clr-timeline-error-step-color: $clr-color-danger-800 !default;
 
 // overall
 $clr-timeline-icon-size: $clr_baselineRem_1_5;
+$clr-timeline-default-icon-size: $clr_baselineRem_0_667;
 $clr-timeline-icon-inner-padding: $clr_baselineRem_2px;
 $clr-timeline-padding-width: $clr_baselineRem_0_5;
 $clr-timeline-line-thickness: $clr_baselineRem_2px;


### PR DESCRIPTION
…-body icon sizing

closes #5366

Signed-off-by: Miguel Amaya<mamaya@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Icons used in timeline-step-body inherit the same css size restrictions as the template icons. 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Template icons still have the css size restrictions, but step-body icons have their own css sizing.
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
