### PR TITLE
fix: styles selectors fixes for datagrid and select

### DIFF
--- a/projects/angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/projects/angular/src/data/datagrid/_datagrid.clarity.scss
@@ -1791,7 +1791,8 @@
 
   // Small screens should only display the detail pane when opened, or optionally forced by a class
   .datagrid-detail-overlay {
-    &.datagrid-detail-open .datagrid-inner-wrapper {
+    // too specific query needed to avoid issues with nested datagrids
+    &.datagrid-detail-open > .datagrid-outer-wrapper > .datagrid-inner-wrapper {
       display: none;
     }
     .datagrid-detail-pane {
@@ -1800,7 +1801,8 @@
     }
   }
   @media screen and (max-width: map-get($clr-grid-breakpoints, sm)) {
-    .datagrid-detail-open .datagrid-inner-wrapper {
+    // too specific query needed to avoid issues with nested datagrids
+    .datagrid-detail-open > .datagrid-outer-wrapper > .datagrid-inner-wrapper {
       display: none;
     }
     .datagrid-detail-pane {

--- a/projects/angular/src/forms/styles/_select.clarity.scss
+++ b/projects/angular/src/forms/styles/_select.clarity.scss
@@ -75,7 +75,8 @@
     }
   }
 
-  .clr-error .clr-select-wrapper::after {
+  .clr-error .clr-select-wrapper::after,
+  .clr-success .clr-select-wrapper::after {
     right: $clr-forms-icon-size + $clr-forms-baseline;
   }
 

--- a/src/app/selects/selects.demo.html
+++ b/src/app/selects/selects.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -220,6 +220,21 @@
     <div class="clr-control-container clr-error">
       <div class="clr-select-wrapper">
         <select id="vertical-select-basic-error" placeholder="Enter value here" class="clr-select">
+          <option value="1">One</option>
+          <option value="2">Two</option>
+          <option value="3">Three</option>
+        </select>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+      </div>
+      <span class="clr-subtext">Helper Text</span>
+    </div>
+  </div>
+
+  <div class="clr-form-control">
+    <label for="vertical-select-basic-error" class="clr-control-label">Basic select, success</label>
+    <div class="clr-control-container clr-success">
+      <div class="clr-select-wrapper">
+        <select id="vertical-select-basic-success" placeholder="Enter value here" class="clr-select">
           <option value="1">One</option>
           <option value="2">Two</option>
           <option value="3">Three</option>


### PR DESCRIPTION
- datagrid fix allows properly nesting of datagrids inside other datagrids detail panes
- select fix fixes issue with caret overlapping success-state indicator
closes #4836, closes #6141

Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

- unable to nest datagrids inside other datagrid's detail panes. Nested grids disappear on SM media screen sizes.
- caret icon and success icon overlap in the select component

Issue Number: #4836, #6141

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
