### PR TITLE
a11y(core:navigation): fixes keyboard activation for items

### DIFF
--- a/packages/core/src/navigation/navigation.element.spec.ts
+++ b/packages/core/src/navigation/navigation.element.spec.ts
@@ -120,11 +120,21 @@ describe('cds-navigation', () => {
       element.dispatchEvent(ee);
     }
 
+    // function enterEvent(element: any) {
+    //   const ee = new KeyboardEvent('keydown', {
+    //     code: 'Enter',
+    //     key: 'Enter',
+    //   });
+    //   element.dispatchEvent(ee);
+    // }
+
     beforeEach(async () => {
       element = await createTestElement(html`
-        <cds-navigation cds-motion="off">
+        <cds-navigation cds-motion="off" id="testNav">
           <cds-navigation-start id="rootStart">Root start</cds-navigation-start>
-          <cds-navigation-item>Root item</cds-navigation-item>
+          <cds-navigation-item>
+            Root Item
+          </cds-navigation-item>
           <cds-navigation-group>
             <cds-navigation-start id="groupStart">
               <cds-icon shape="home" size="md"></cds-icon>
@@ -134,10 +144,9 @@ describe('cds-navigation', () => {
           </cds-navigation-group>
         </cds-navigation>
       `);
-      component = element.querySelector<CdsNavigation>('cds-navigation');
+      component = element.querySelector<CdsNavigation>('cds-navigation#testNav');
       group = component.querySelector<CdsNavigationGroup>('cds-navigation-group');
       groupStart = component.querySelector<CdsNavigationStart>('cds-navigation-start#groupStart');
-      ``;
       rootStart = component.querySelector<CdsNavigationStart>('cds-navigation-start#rootStart');
     });
 
@@ -278,6 +287,23 @@ describe('cds-navigation', () => {
       initFocus(component);
       group.expandedChange.emit(true);
       expect(component.currentActiveItem.hasFocus).toBeTruthy();
+    });
+
+    xit('respond to space key and fire click events for cds-navigation-item anchor tags', async () => {
+      // TODO address same as test below.
+    });
+
+    xit('respond to enter key and fire click events for cds-navigation-item anchor tags', async () => {
+      // TODO: why is this code and the addEventListener pattern not firing events in the same order as a real browser?
+      // Try with Spy on the link.click() fn
+      // await componentIsStable(component);
+      // const link: HTMLAnchorElement = component.querySelector<HTMLAnchorElement>('#rootItem');
+      // const clickSpy = spyOn(link, 'click');
+      // initFocus(component);
+      // arrowDownEvent(component)
+      // enterEvent(component);
+      // await componentIsStable(component);
+      // expect(clickSpy).toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/navigation/navigation.element.ts
+++ b/packages/core/src/navigation/navigation.element.ts
@@ -241,23 +241,24 @@ export class CdsNavigation extends LitElement implements Animatable {
     onKey('arrow-right', event, () => {
       const groupParent = this.currentActiveItem?.closest('cds-navigation-group');
 
-      if (groupParent && !groupParent.expanded) {
-        groupParent.expandedChange.emit(!groupParent.expanded);
+      if (!groupParent && this.currentActiveItem?.tagName === 'CDS-NAVIGATION-START' && !this.expanded) {
+        this.toggle();
         return;
       }
 
-      if (!groupParent) {
-        this.toggle();
+      if (groupParent && !groupParent.expanded) {
+        groupParent.expandedChange.emit(!groupParent.expanded);
         return;
       }
     });
 
     onKey('arrow-left', event, () => {
       const groupParent = this.currentActiveItem?.closest('cds-navigation-group');
-      if (!groupParent) {
+      if (!groupParent && this.currentActiveItem?.tagName === 'CDS-NAVIGATION-START' && this.expanded) {
         this.toggle();
         return;
       }
+
       if (this.currentActiveItem?.tagName === 'CDS-NAVIGATION-ITEM' && !!groupParent) {
         const groupStartElement = groupParent?.querySelector('cds-navigation-start');
         removeFocus(this.currentActiveItem as FocusableElement);
@@ -287,6 +288,20 @@ export class CdsNavigation extends LitElement implements Animatable {
         const end = focusableElements[focusableElements.length - 1];
         this.ariaActiveDescendant = end.id;
         setFocus(end);
+      }
+    });
+
+    onKey('enter', event, () => {
+      // focusElement is either an Anchor or a button and we want to click it here
+      if (this.currentActiveItem?.focusElement) {
+        this.currentActiveItem?.focusElement.click();
+      }
+    });
+
+    onKey('space', event, () => {
+      // focusElement is either an Anchor or a button and we want to click it here
+      if (this.currentActiveItem?.focusElement) {
+        this.currentActiveItem?.focusElement.click();
       }
     });
   }
@@ -336,7 +351,8 @@ export class CdsNavigation extends LitElement implements Animatable {
     }
   }
 
-  firstUpdated() {
+  firstUpdated(props: PropertyValues) {
+    super.firstUpdated(props);
     // set all visible navigation elements to tabindex = -1
     this.allNavigationElements.forEach(item => {
       setAttributes(item, ['tabindex', '-1']);
@@ -382,7 +398,6 @@ export class CdsNavigation extends LitElement implements Animatable {
       <div class="navigation-body-wrapper" role="list" cds-layout="p-y:xxs">
         <div class="navigation-body" role="presentation" cds-layout="vertical wrap:none align:horizontal-stretch">
           <slot></slot>
-          <!-- make naviagtion body default slot-->
         </div>
       </div>
       ${this.endTemplate}

--- a/packages/core/src/navigation/utils/index.ts
+++ b/packages/core/src/navigation/utils/index.ts
@@ -32,9 +32,11 @@ export function getToggleIconDirection(element: CdsNavigationStart): Directions 
 
 export function manageScreenReaderElements(element: HTMLElement, expandedRoot: boolean): void {
   const span = element.querySelector('span');
-  setOrRemoveAttribute(span, ['cds-layout', 'display:screen-reader-only'], () => {
-    return !expandedRoot;
-  });
+  if (span) {
+    setOrRemoveAttribute(span, ['cds-layout', 'display:screen-reader-only'], () => {
+      return !expandedRoot;
+    });
+  }
 }
 
 export function removeFocus(element: FocusableElement) {


### PR DESCRIPTION
Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features) *
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

* I've run into an issue where the testing environment isn't triggering the events in the correct lifecycle order. The artificial test event happens before `initAriaActiveDescendant`. This method is wired up in connectedCallback. Debugging the behavior in demo app works as expected, debugging the test does not. I spent over ½ a day trying to find out why. Submitting as is for now with the tests ignored and commented for my future self.  

## PR Type

What kind of change does this PR introduce?
Adds enter and space key handling for cds-navigation. Fixes a bug with arrow-left and arrow-right handlers. 

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
navigation item links and start buttons do not respond to enter or space keys. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Navigation item links and start buttons respond to enter and space keys. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
