### PR TITLE
fix: styles selectors fixes for datagrid and select (backport)

### DIFF
--- a/src/clr-angular/data/datagrid/_datagrid.clarity.scss
+++ b/src/clr-angular/data/datagrid/_datagrid.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -1739,7 +1739,8 @@
 
   // Small screens should only display the detail pane when opened, or optionally forced by a class
   .datagrid-detail-overlay {
-    &.datagrid-detail-open .datagrid-inner-wrapper {
+    // too specific query needed to avoid issues with nested datagrids
+    &.datagrid-detail-open > .datagrid-outer-wrapper > .datagrid-inner-wrapper {
       display: none;
     }
     .datagrid-detail-pane {
@@ -1748,7 +1749,8 @@
     }
   }
   @media screen and (max-width: map-get($clr-grid-breakpoints, sm)) {
-    .datagrid-detail-open .datagrid-inner-wrapper {
+    // too specific query needed to avoid issues with nested datagrids
+    .datagrid-detail-open > .datagrid-outer-wrapper > .datagrid-inner-wrapper {
       display: none;
     }
     .datagrid-detail-pane {

--- a/src/clr-angular/forms/styles/_select.clarity.scss
+++ b/src/clr-angular/forms/styles/_select.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -75,7 +75,8 @@
     }
   }
 
-  .clr-error .clr-select-wrapper::after {
+  .clr-error .clr-select-wrapper::after,
+  .clr-success .clr-select-wrapper::after {
     right: $clr-forms-icon-size + $clr-forms-baseline;
   }
 

--- a/src/dev/src/app/selects/selects.demo.html
+++ b/src/dev/src/app/selects/selects.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -226,6 +226,22 @@
     <div class="clr-control-container clr-error">
       <div class="clr-select-wrapper">
         <select id="vertical-select-basic-error" placeholder="Enter value here" class="clr-select">
+          <option value="1">One</option>
+          <option value="2">Two</option>
+          <option value="3">Three</option>
+        </select>
+        <clr-icon class="clr-validate-icon" shape="exclamation-circle"></clr-icon>
+      </div>
+      <span class="clr-subtext">Helper Text</span>
+    </div>
+  </div>
+
+  
+  <div class="clr-form-control">
+    <label for="vertical-select-basic-error" class="clr-control-label">Basic select, success</label>
+    <div class="clr-control-container clr-success">
+      <div class="clr-select-wrapper">
+        <select id="vertical-select-basic-success" placeholder="Enter value here" class="clr-select">
           <option value="1">One</option>
           <option value="2">Two</option>
           <option value="3">Three</option>


### PR DESCRIPTION
- datagrid fix allows properly nesting of datagrids inside other datagrids detail panes
- select fix fixes issue with caret overlapping success-state indicator
Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

