### PR TITLE
fix(angular:schematics): ng add for 12.0.0-next.0

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,5 +1,6 @@
 const scopes = [
   'angular',
+  'angular:schematics',
   'a11y',
   'accordion',
   'alert',

--- a/projects/schematics/src/add/index.spec.ts
+++ b/projects/schematics/src/add/index.spec.ts
@@ -7,6 +7,7 @@
 import { Tree, HostTree, SchematicsException } from '@angular-devkit/schematics';
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
 import { join } from 'path';
+import { getVersion } from '.';
 import { getFileContent } from '../utility/get-file-content';
 import { setupProject } from '../utility/setup-project';
 
@@ -57,6 +58,38 @@ describe('ng add @clr/angular', () => {
       const styles = configFile.projects[PROJECT_NAME].architect.build.options.styles;
 
       expect(styles.includes('node_modules/@clr/ui/clr-ui.min.css')).toBeTruthy();
+    });
+
+    it('should add return Clarity version as correct', async () => {
+      const correct = getVersion('^12.0.0', '12.0.0-next.0');
+
+      expect(correct).toEqual('12.0.0-next.0');
+    });
+
+    it('should throw a not support message', async () => {
+      try {
+        getVersion('^12.0.0', '13.0.0');
+      } catch (e) {
+        expect(e.message).toEqual(`Clarity 13 doesn't support Angular 12`);
+      }
+    });
+
+    it('should return Clarity version 5', async () => {
+      const correct = getVersion('^11.0.0', '12.0.0');
+
+      expect(correct).toEqual('^5.0.0');
+    });
+
+    it('should return Clarity version 4', async () => {
+      const correct = getVersion('^10.0.0', '12.0.0');
+
+      expect(correct).toEqual('^4.0.0');
+    });
+
+    it('should return Clarity version 3', async () => {
+      const correct = getVersion('^9.0.0', '12.0.0');
+
+      expect(correct).toEqual('^3.0.0');
     });
 
     it('should not add Clarity assets in the configuration file if they are already present', async () => {

--- a/projects/schematics/src/add/index.ts
+++ b/projects/schematics/src/add/index.ts
@@ -48,13 +48,35 @@ function setProjectSettings(options: NgAddOptions) {
 }
 
 // Checks if a version of Angular is compatible with current or next
-function getVersion(ngVersion: string, clrVersion: string): string {
+export function getVersion(ngVersion: string, clrVersion: string): string {
+  const majorNgVersion = Number.parseInt(ngVersion.split('.')[0].replace(/\D/g, ''));
+
+  if (majorNgVersion >= 12) {
+    return getVersionsAfterTwelve(ngVersion, clrVersion);
+  } else {
+    // Otherwise, just link to installed version for latest or next releases
+    return getVersionsBeforeTwelve(ngVersion, clrVersion);
+  }
+}
+
+function getVersionsAfterTwelve(ngVersion: string, clrVersion: string): string {
+  const majorNgVersion = Number.parseInt(ngVersion.split('.')[0].replace(/\D/g, ''));
+  const majorClrVersion = Number.parseInt(clrVersion.split('.')[0].replace(/\D/g, ''));
+
+  if (majorNgVersion === majorClrVersion) {
+    return clrVersion;
+  } else {
+    // Otherwise, just link to installed version for latest or next releases
+    throw new SchematicsException(`Clarity ${majorClrVersion} doesn't support Angular ${majorNgVersion}`);
+  }
+}
+
+function getVersionsBeforeTwelve(ngVersion: string, clrVersion: string): string {
   const diff = 6; // Number disparity between Angular and Clarity, this works as long as we stay in sync with versioning
   const majorNgVersion = Number.parseInt(ngVersion.split('.')[0].replace(/\D/g, ''));
   const majorClrVersion = Number.parseInt(clrVersion.split('.')[0].replace(/\D/g, ''));
 
   if (majorNgVersion - majorClrVersion < diff) {
-    // If Angular is less than 6 versions ahead, backtrack Clarity version
     return `^${majorNgVersion - diff}.0.0`;
   } else {
     // Otherwise, just link to installed version for latest or next releases


### PR DESCRIPTION
The issue was introduced when we decided to sync Clarity Angular version naming with Angular.
The schematic was executing logic of `{Angular version} - 6` that is no longer correct for the new change in version naming.

Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`ng add @clr/angular@12.0.0-next.0` installs version of `@clr/angular` that doesn't exist.

## What is the new behavior?

`ng add @clr/angular@12.0.0-next.0` installs the correct version of `@clr/angular`

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
