### PR TITLE
fix(website): fix for broken sidenav height calc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}-${{ github.base_ref }}
+          key: ${{ runner.os }}-modules-v1-${{ hashFiles('**/yarn.lock') }}-${{ github.base_ref }}
       - run: yarn install
       - run: yarn build:ci
 

--- a/apps/website/.vuepress/theme/components/Sidebar.vue
+++ b/apps/website/.vuepress/theme/components/Sidebar.vue
@@ -126,6 +126,12 @@
 .nav-group-children {
   overflow-y: hidden;
   transition: height 0.2s ease-in-out;
+
+  // This fixes an unknown rendering issue with the expanded nav-group-children. The calculation in template is fine.
+  // This works for now.
+  &.is-expanded {
+    height: fit-content !important;
+  }
 }
 .nav-group-trigger-icon {
   padding-top: 10px;


### PR DESCRIPTION
Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
The website builds but an error in Sidebar.vue template breaks sidenav.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is inline height calculation in the template. Rather than keep the js. I just let it calculate height for everything, even beta components but force it to use `height: fit-content` for now. 

Issue Number: N/A

## What is the new behavior?
Website sidenav works. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
