### PR TITLE
fix(core:button): disabled/loading state

### DIFF
--- a/packages/core/src/button/base-button.element.scss
+++ b/packages/core/src/button/base-button.element.scss
@@ -33,7 +33,6 @@
   cursor: pointer;
   font-size: var(--font-size);
   height: 100%;
-  justify-content: center;
   line-height: 1em;
   min-width: var(--min-width);
   overflow: visible;
@@ -52,21 +51,10 @@
     @include center-content('block');
     height: 100%;
   }
+}
 
-  .button-status-icon {
-    cds-icon {
-      @include min-equilateral(#{$cds-global-space-8});
-      fill: var(--color);
-    }
-
-    cds-icon[shape='error-standard'] {
-      --color: #{$cds-alias-status-danger};
-    }
-
-    .button-spinner {
-      --ring-color: #{$cds-global-color-construction-400};
-    }
-  }
+cds-progress-circle {
+  --ring-color: #{$cds-global-color-construction-400};
 }
 
 :host(:active) .private-host,

--- a/packages/core/src/button/icon-button.element.ts
+++ b/packages/core/src/button/icon-button.element.ts
@@ -5,10 +5,9 @@
  */
 
 import { baseStyles, property } from '@cds/core/internal';
-import { html } from 'lit';
 import baseButtonStyles from './base-button.element.scss';
 import styles from './icon-button.element.scss';
-import { CdsButton, ClrLoadingState, iconCheck, iconSpinner } from './button.element.js';
+import { CdsButton } from './button.element.js';
 
 /**
  * Icon buttons give applications a compact alternative to communicate action and direct user intent.
@@ -43,16 +42,6 @@ export class CdsIconButton extends CdsButton {
    */
   @property({ type: String, required: 'warning' })
   ariaLabel: string;
-
-  render() {
-    return html`
-      <div class="private-host">
-        ${this.loadingState === ClrLoadingState.loading ? iconSpinner(this.size) : ''}
-        ${this.loadingState === ClrLoadingState.success ? iconCheck : ''}
-        ${this.loadingState === ClrLoadingState.default ? html`<slot></slot>` : ''}
-      </div>
-    `;
-  }
 
   static styles = [baseStyles, baseButtonStyles, styles];
 }

--- a/packages/core/src/button/register.ts
+++ b/packages/core/src/button/register.ts
@@ -10,6 +10,11 @@ import { registerElementSafely } from '@cds/core/internal';
 import { CdsButton } from './button.element.js';
 import { CdsIconButton } from './icon-button.element.js';
 import { CdsInlineButton } from './inline-button.element.js';
+import { ClarityIcons } from '@cds/core/icon/icon.service.js';
+import { errorStandardIcon } from '@cds/core/icon/shapes/error-standard.js';
+import { checkIcon } from '@cds/core/icon/shapes/check.js';
+
+ClarityIcons.addIcons(errorStandardIcon, checkIcon);
 
 registerElementSafely('cds-button', CdsButton);
 registerElementSafely('cds-icon-button', CdsIconButton);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
If a button was disabled prior to the loading state change it would attempt to revert to inital disabled state once loading was back to default. However the logic was not quite right and would break the loading state in subsequent updates.

Issue Number: https://github.com/vmware/clarity/issues/6129

## What is the new behavior?
Now the loading state will disable the button when not default and when switch back to default set the disabled property the original value properly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
