### PR TITLE
fix(button-group): adds style for clr-dropdown corner radius in button-group

### DIFF
--- a/projects/angular/src/button/button-group/_button-group.clarity.scss
+++ b/projects/angular/src/button/button-group/_button-group.clarity.scss
@@ -14,6 +14,20 @@
     display: inline-flex;
     margin-right: $clr_baselineRem_0_5;
 
+    clr-dropdown {
+      .dropdown-toggle {
+        @include square-off-btngroup-btns(left);
+        @include square-off-btngroup-btns(right);
+      }
+
+      &:last-child {
+        .dropdown-toggle {
+          border-top-right-radius: $clr-btn-border-radius;
+          border-bottom-right-radius: $clr-btn-border-radius;
+        }
+      }
+    }
+
     .btn {
       margin: 0;
       vertical-align: top;


### PR DESCRIPTION
closes #6166

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?
This fixes an issue with clr-dropdown radius when inside a button group. 

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
clr-dropdown buttons do not have the right styles when inside a button-group

**Before:**
![Screen Shot 2021-07-26 at 2 01 04 PM](https://user-images.githubusercontent.com/433692/127058557-3455d7cc-8eea-46a6-90e5-333afd17ed05.png)
![Screen Shot 2021-07-26 at 2 00 59 PM](https://user-images.githubusercontent.com/433692/127058559-0a8ce2c9-4fd0-46e8-9032-b66920d8d8c3.png)

**After:**
![Screen Shot 2021-07-26 at 1 53 48 PM](https://user-images.githubusercontent.com/433692/127058395-e38e0850-2fab-4c50-9aca-f15f25a5cb83.png)
![Screen Shot 2021-07-26 at 1 53 42 PM](https://user-images.githubusercontent.com/433692/127058399-719d6960-2d7a-447d-a38b-a4f139b05aa5.png)

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
