### PR TITLE
fix(website): this change fixes two issues with the website

### DIFF
--- a/apps/website/.vuepress/theme/global-components/ComponentsOverview.vue
+++ b/apps/website/.vuepress/theme/global-components/ComponentsOverview.vue
@@ -8,11 +8,18 @@
       :isNew="component.isNew"
     >
       <template>
-        <img cds-layout="fill" :src="component.name | adjustToSvgUrl" :alt="component.title + ' visual example'" />
+        <img class="overview-image" :src="component.name | adjustToSvgUrl" :alt="component.title + ' visual example'" />
       </template>
     </ItemOverview>
   </section>
 </template>
+
+<style lang="scss">
+.overview-image {
+  max-width: 50%;
+  height: auto;
+}
+</style>
 
 <script>
 export default {

--- a/apps/website/.vuepress/theme/global-components/ItemOverview.vue
+++ b/apps/website/.vuepress/theme/global-components/ItemOverview.vue
@@ -7,7 +7,7 @@
           <span role="status" v-if="isNew" class="badge badge-info">new</span>
         </div>
       </h2>
-      <div cds-layout="align:center p:md">
+      <div cds-layout="vertical align:center p:md">
         <slot></slot>
       </div>
       <slot name="footer"></slot>


### PR DESCRIPTION
1. Set a max-width for the  overview images
2. Add a filter for Sidnav.vue that returns an array of only non beta
   navigation items.

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?
1. This limits the component overview image width to 50% of its container.
2. This fixes the beta filtering done for navigation. 

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Website navigation is broken wit fit-content on the child navigation containers (clicking doesn't work as expected), core component overview page is missing and some images on angular component overview page are the full width of their container. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Navigation works, core overview page is in navigation and overview images {angular|core} have a max-width applied to them. 
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
