### PR TITLE
fix(angular:combobox): reduce change detection cycles

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -326,7 +326,7 @@ export declare class ClrCombobox<T> extends WrappedFormControl<ClrComboboxContai
     smartPosition: ClrPopoverPosition;
     textbox: ElementRef;
     trigger: ElementRef;
-    constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef, optionSelectionService: OptionSelectionService<T>, commonStrings: ClrCommonStringsService, toggleService: ClrPopoverToggleService, positionService: ClrPopoverPositionService, controlStateService: IfControlStateService, containerService: ComboboxContainerService, platformId: any, ariaService: AriaService, focusHandler: ComboboxFocusHandler<T>, cdr: ChangeDetectorRef);
+    constructor(vcr: ViewContainerRef, injector: Injector, control: NgControl, renderer: Renderer2, el: ElementRef, optionSelectionService: OptionSelectionService<T>, commonStrings: ClrCommonStringsService, toggleService: ClrPopoverToggleService, positionService: ClrPopoverPositionService, controlStateService: IfControlStateService, containerService: ComboboxContainerService, platformId: any, ariaService: AriaService, focusHandler: ComboboxFocusHandler<T>, cdr: ChangeDetectorRef, ngZone: NgZone);
     focusFirstActive(): void;
     focusInput(): void;
     getActiveDescendant(): string;
@@ -338,7 +338,6 @@ export declare class ClrCombobox<T> extends WrappedFormControl<ClrComboboxContai
     ngOnDestroy(): void;
     onBlur(): void;
     onFocus(): void;
-    onKeyUp(event: KeyboardEvent): void;
     registerOnChange(onChange: any): void;
     registerOnTouched(onTouched: any): void;
     setDisabledState(): void;

--- a/projects/angular/src/forms/combobox/combobox.spec.ts
+++ b/projects/angular/src/forms/combobox/combobox.spec.ts
@@ -3,11 +3,11 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { TestBed, ComponentFixture, tick, async, fakeAsync } from '@angular/core/testing';
+import { TestBed, ComponentFixture, tick, waitForAsync, fakeAsync } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { Component } from '@angular/core';
+import { ApplicationRef, Component } from '@angular/core';
 
 import { ClrCombobox } from './combobox';
 import { OptionSelectionService } from './providers/option-selection.service';
@@ -17,6 +17,7 @@ import { ClrPopoverContent } from '../../utils/popover/popover-content';
 import { ClrPopoverToggleService } from '../../utils/popover/providers/popover-toggle.service';
 import { ClrIconModule } from '../../icon/icon.module';
 import { ClrComboboxModule } from './combobox.module';
+import { BACKSPACE, UP_ARROW } from '../../utils/key-codes/key-codes';
 
 @Component({
   template: `
@@ -125,21 +126,27 @@ export default function (): void {
 
       // The forms framework has some inner asychronisity, which requires the async/whenStable
       // approach in the following tests
-      it('sets selection model based on selection binding', async(() => {
-        fixture.componentInstance.selection = 'test';
-        fixture.detectChanges();
-        fixture.whenStable().then(() => {
-          expect(selectionService.selectionModel.containsItem('test')).toBeTrue();
-        });
-      }));
+      it(
+        'sets selection model based on selection binding',
+        waitForAsync(() => {
+          fixture.componentInstance.selection = 'test';
+          fixture.detectChanges();
+          fixture.whenStable().then(() => {
+            expect(selectionService.selectionModel.containsItem('test')).toBeTrue();
+          });
+        })
+      );
 
-      it('clears selection model', async(() => {
-        fixture.componentInstance.selection = null;
-        fixture.detectChanges();
-        fixture.whenStable().then(() => {
-          expect(selectionService.selectionModel.isEmpty()).toBeTrue();
-        });
-      }));
+      it(
+        'clears selection model',
+        waitForAsync(() => {
+          fixture.componentInstance.selection = null;
+          fixture.detectChanges();
+          fixture.whenStable().then(() => {
+            expect(selectionService.selectionModel.isEmpty()).toBeTrue();
+          });
+        })
+      );
     });
 
     describe('Template API', function () {
@@ -222,6 +229,30 @@ export default function (): void {
           const button: HTMLButtonElement = clarityElement.querySelector('.clr-combobox-trigger');
           expect(button.disabled).toBeTruthy();
         }));
+    });
+
+    describe('Change detection', () => {
+      it('should not run change detection if the keydown event was not backspace', async () => {
+        fixture.componentInstance.multi = true;
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        fixture.componentInstance.selection = ['test'];
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const appRef = TestBed.inject(ApplicationRef);
+        const spy = spyOn(appRef, 'tick').and.callThrough();
+
+        clarityElement.dispatchEvent(new KeyboardEvent('keydown', { keyCode: UP_ARROW }));
+        clarityElement.dispatchEvent(new KeyboardEvent('keydown', { keyCode: UP_ARROW }));
+
+        expect(spy).toHaveBeenCalledTimes(0);
+
+        clarityElement.dispatchEvent(new KeyboardEvent('keydown', { keyCode: BACKSPACE }));
+
+        expect(spy).toHaveBeenCalledTimes(1);
+      });
     });
   });
 }

--- a/projects/angular/src/forms/combobox/combobox.ts
+++ b/projects/angular/src/forms/combobox/combobox.ts
@@ -9,7 +9,6 @@ import {
   Component,
   ContentChild,
   ElementRef,
-  HostListener,
   PLATFORM_ID,
   Renderer2,
   ViewChild,
@@ -23,6 +22,7 @@ import {
   AfterContentInit,
   Inject,
   ChangeDetectorRef,
+  NgZone,
 } from '@angular/core';
 import { Subscription, Observable } from 'rxjs';
 
@@ -87,6 +87,7 @@ export class ClrCombobox<T>
   @ContentChild(ClrOptionSelected) optionSelected: ClrOptionSelected<T>;
 
   private onChangeCallback: (model: T | T[]) => any;
+  private unlisten: VoidFunction;
 
   protected index = 1;
 
@@ -110,7 +111,8 @@ export class ClrCombobox<T>
     @Inject(PLATFORM_ID) private platformId: any,
     private ariaService: AriaService,
     private focusHandler: ComboboxFocusHandler<T>,
-    private cdr: ChangeDetectorRef
+    private cdr: ChangeDetectorRef,
+    private ngZone: NgZone
   ) {
     super(vcr, ClrComboboxContainer, injector, control, renderer, el);
     if (control) {
@@ -119,6 +121,7 @@ export class ClrCombobox<T>
     // default to SingleSelectComboboxModel, in case the optional input [ClrMulti] isn't used
     this.optionSelectionService.selectionModel = new SingleSelectComboboxModel<T>();
     this.updateControlValue();
+    this.setupKeyDownListener();
   }
 
   focusedPill: any;
@@ -243,19 +246,6 @@ export class ClrCombobox<T>
     return this.commonStrings.keys.comboboxSelection;
   }
 
-  @HostListener('keydown', ['$event'])
-  onKeyUp(event: KeyboardEvent) {
-    // if BACKSPACE in multiselect mode, delete the last pill if text is empty
-    if (event.keyCode === BACKSPACE && this.multiSelect && this._searchText.length === 0) {
-      const multiModel: T[] = this.optionSelectionService.selectionModel.model as T[];
-      if (multiModel && multiModel.length > 0) {
-        const lastItem: T = multiModel[multiModel.length - 1];
-        this.control.control.markAsTouched();
-        this.optionSelectionService.unselect(lastItem);
-      }
-    }
-  }
-
   @Output('clrInputChange') public clrInputChange: EventEmitter<string> = new EventEmitter<string>(false);
 
   @Output('clrOpenChange') public clrOpenChange: Observable<boolean> = this.toggleService.openChange;
@@ -312,6 +302,35 @@ export class ClrCombobox<T>
         })
       );
     }
+  }
+
+  private setupKeyDownListener(): void {
+    this.ngZone.runOutsideAngular(() => {
+      this.unlisten = this.renderer.listen(this.el.nativeElement, 'keydown', (event: KeyboardEvent) => {
+        // if BACKSPACE in multiselect mode, delete the last pill if text is empty
+        if (event.keyCode !== BACKSPACE || !this.multiSelect || this._searchText.length !== 0) {
+          return;
+        }
+
+        const multiModel = this.optionSelectionService.selectionModel.model as T[];
+
+        if (!multiModel || multiModel.length === 0) {
+          return;
+        }
+
+        // We'll run change detection only when the `Backspace` button has been pressed, and the multiselect mode is on.
+        this.ngZone.run(() => {
+          // Caretaker note: the `Zone.prototype.run` will only notify the `ApplicationRef` to run the `tick()`.
+          // Angular will run change detection but the component won't have the `ChecksEnabled` state (e.g. if it's
+          // inside some `OnPush` component).
+          // This is done to be backwards-compatible with `HostListener` since `HostListener` calls `markDirty()` internally.
+          this.cdr.markForCheck();
+          const lastItem: T = multiModel[multiModel.length - 1];
+          this.control.control.markAsTouched();
+          this.optionSelectionService.unselect(lastItem);
+        });
+      });
+    });
   }
 
   focusFirstActive() {
@@ -393,6 +412,7 @@ export class ClrCombobox<T>
   }
 
   ngOnDestroy() {
+    this.unlisten();
     this.subscriptions.forEach((sub: Subscription) => sub.unsubscribe());
   }
 }


### PR DESCRIPTION
This is an adoption of: https://github.com/vmware/clarity/pull/6058

This PR reduces change detection cycles for the combobox by replacing
`HostListener` with `Renderer.listen` outside of the zone. We don't need to
run change detections when any keyboard button is pressed or when the multiselect
mode is off. Note that the `HostListener` wraps the actual listener under the hood
into the internal Angular function which runs `markDirty()` before running the actual
listener (the decorated class method).

Signed-off-by: Artur Androsovych <arthurandrosovich@gmail.com>
Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Unoptimized change detectino cycles in combobox. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #6058 (og pr)

## What is the new behavior?
Fewer change detection cycles in combobox. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
