### PR TITLE
fix(angular:form): update error object in clrIfError context

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -2,6 +2,7 @@ const scopes = [
   'a11y',
   'accordion',
   'alert',
+  'angular:form',
   'badge',
   'build',
   'button',

--- a/projects/angular/src/forms/common/if-control-state/if-error.spec.ts
+++ b/projects/angular/src/forms/common/if-control-state/if-error.spec.ts
@@ -128,6 +128,18 @@ export default function (): void {
         expect(fixture.nativeElement.innerHTML).toContain(`${maxLengthMessage}-5-6`);
       });
 
+      it('updates the error message with values from error object in context', () => {
+        const control = new FormControl('abcdef', [Validators.maxLength(5)]);
+        ngControlService.setControl(control);
+        ifControlStateService.triggerStatusChange();
+        fixture.detectChanges();
+        expect(fixture.nativeElement.innerHTML).toContain(`${maxLengthMessage}-5-6`);
+
+        control.setValue('abcdefg');
+        fixture.detectChanges();
+        expect(fixture.nativeElement.innerHTML).toContain(`${maxLengthMessage}-5-7`);
+      });
+
       it('should show error only when they are required', () => {
         const control = new FormControl(undefined, [
           Validators.required,

--- a/projects/angular/src/forms/common/if-control-state/if-error.ts
+++ b/projects/angular/src/forms/common/if-control-state/if-error.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { Directive, Input, Optional, TemplateRef, ViewContainerRef } from '@angular/core';
+import { Directive, EmbeddedViewRef, Input, Optional, TemplateRef, ViewContainerRef } from '@angular/core';
 import { NgControlService } from '../providers/ng-control.service';
 import { IfControlStateService, CONTROL_STATE } from './if-control-state.service';
 import { AbstractIfState } from './abstract-if-state';
@@ -11,6 +11,8 @@ import { AbstractIfState } from './abstract-if-state';
 @Directive({ selector: '[clrIfError]' })
 export class ClrIfError extends AbstractIfState {
   @Input('clrIfError') error: string;
+
+  private embeddedViewRef: EmbeddedViewRef<any>;
 
   constructor(
     @Optional() ifControlStateService: IfControlStateService,
@@ -40,10 +42,17 @@ export class ClrIfError extends AbstractIfState {
     if (!this.container) {
       return;
     }
-    if (invalid && this.displayedContent === false) {
-      this.container.createEmbeddedView(this.template, { error: this.control.getError(this.error) });
-      this.displayedContent = true;
-    } else if (!invalid) {
+    if (invalid) {
+      if (this.displayedContent === false) {
+        this.embeddedViewRef = this.container.createEmbeddedView(this.template, {
+          error: this.control.getError(this.error),
+        });
+        this.displayedContent = true;
+      } else if (this.embeddedViewRef && this.embeddedViewRef.context) {
+        // if view is already rendered, update the error object to keep it in sync
+        this.embeddedViewRef.context.error = this.control.getError(this.error);
+      }
+    } else {
       this.container.clear();
       this.displayedContent = false;
     }


### PR DESCRIPTION
- updates the error object if view is already rendered

Signed-off-by: gerinjacob <gerinjacob@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Once the view is rendered, error object not getting updated in the context. This leads to error object to be out of sync.

Issue Number: N/A

## What is the new behavior?

If the view is already rendered, update the context with new error object.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
