### PR TITLE
fix(core:control): avoid applying padding style to generic controls

### DIFF
--- a/packages/core/src/forms/control/control.element.spec.ts
+++ b/packages/core/src/forms/control/control.element.spec.ts
@@ -10,6 +10,7 @@ import { listenForAttributeChange } from '@cds/core/internal';
 import { CdsIcon } from '@cds/core/icon/icon.element.js';
 import { CdsControl, ControlLabelLayout, CdsControlMessage } from '@cds/core/forms';
 import '@cds/core/forms/register.js';
+import '@cds/core/icon/register.js';
 
 describe('cds-control', () => {
   let element: HTMLElement;
@@ -310,5 +311,35 @@ describe('cds-control with aria-labelledby', () => {
   it('should not enable hidden label', async () => {
     await componentIsStable(control);
     expect(control.labelLayout).toBe(ControlLabelLayout.ariaLabel);
+  });
+});
+
+describe('cds-control with label control action', () => {
+  let element: HTMLElement;
+  let control: CdsControl;
+  let input: HTMLElement;
+
+  beforeEach(async () => {
+    element = await createTestElement(html`
+      <cds-control>
+        <label>with label control action</label>
+        <cds-control-action action="label" aria-label="get more details">
+          <cds-icon shape="unknown"></cds-icon>
+        </cds-control-action>
+        <input placeholder="example" />
+      </cds-control>
+    `);
+
+    control = element.querySelector<CdsControl>('cds-control');
+    input = control.querySelector<HTMLElement>('input');
+  });
+
+  afterEach(() => {
+    removeTestElement(element);
+  });
+
+  it('should not apply padding inline styles to generic control', async () => {
+    await componentIsStable(control);
+    expect(input.getAttribute('style')).toBeNull();
   });
 });

--- a/packages/core/src/forms/control/control.element.ts
+++ b/packages/core/src/forms/control/control.element.ts
@@ -224,6 +224,10 @@ export class CdsControl extends LitElement {
     return null;
   }
 
+  private get isGenericControl() {
+    return this.tagName.toLowerCase() === 'cds-control';
+  }
+
   private get hasControlActions() {
     return this.controlActions.length > 0 || this.prefixDefaultTemplate || this.suffixDefaultTemplate;
   }
@@ -331,7 +335,7 @@ export class CdsControl extends LitElement {
 
   private async setActionOffsetPadding() {
     await childrenUpdateComplete(this.controlActions);
-    if (this.supportsPrefixSuffixActions && this.hasControlActions) {
+    if (!this.isGenericControl && this.supportsPrefixSuffixActions && this.hasControlActions) {
       const start = pxToRem(this.prefixAction.getBoundingClientRect().width + 6);
       const end = pxToRem(this.suffixAction.getBoundingClientRect().width + 6);
       this.inputControl.style.setProperty('padding-left', this.isRTL ? end : start, 'important');

--- a/packages/core/src/input/input.element.spec.ts
+++ b/packages/core/src/input/input.element.spec.ts
@@ -7,6 +7,7 @@
 import { html } from 'lit';
 import { CdsInput } from '@cds/core/input';
 import '@cds/core/input/register.js';
+import '@cds/core/icon/register.js';
 import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test';
 
 describe('cds-input', () => {
@@ -31,5 +32,38 @@ describe('cds-input', () => {
   it('should create component', async () => {
     await componentIsStable(component);
     expect(component).toBeTruthy();
+  });
+});
+
+describe('cds-input with label control action', () => {
+  let component: CdsInput;
+  let element: HTMLElement;
+  let input: HTMLElement;
+
+  beforeEach(async () => {
+    element = await createTestElement(html`
+      <cds-input>
+        <label>with label control action</label>
+        <cds-control-action action="label" aria-label="get more details">
+          <cds-icon shape="unknown"></cds-icon>
+        </cds-control-action>
+        <input placeholder="example" />
+      </cds-input>
+    `);
+
+    component = element.querySelector<CdsInput>('cds-input');
+    input = component.querySelector<HTMLElement>('input');
+  });
+
+  afterEach(() => {
+    removeTestElement(element);
+  });
+
+  it('should have inline padding styles when a cds-* form control and a control action is used with the label', async () => {
+    await componentIsStable(component);
+    const styleAttr = input.getAttribute('style');
+    expect(styleAttr).not.toBeNull();
+    expect(styleAttr.includes('padding-left')).toBe(true);
+    expect(styleAttr.includes('padding-right')).toBe(true);
   });
 });


### PR DESCRIPTION
cds-control was applying padding to non-clarity inputs when a control action was present

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

If a control action is present, `cds-control` applies custom padding to the left and right of any input inside it. This causes a problem when the generic control is used for third party widgets.

Issue Number: #6212 

## What is the new behavior?

The custom padding is now only applied in core components. It is not added inside of a generic `cds-control`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<img width="988" alt="Screen Shot 2021-08-05 at 11 35 17 AM" src="https://user-images.githubusercontent.com/2728359/128410595-c9f78428-cd3d-451b-9538-d377b7377735.png">
