### PR TITLE
fix(core:control): allow aria-disabled to set control as disabled

### DIFF
--- a/packages/core/src/forms/control.stories.ts
+++ b/packages/core/src/forms/control.stories.ts
@@ -96,12 +96,23 @@ export function controlCompact() {
 
 export function genericContent() {
   return html`
-    <cds-control>
-      <label>label</label>
-      <p cds-text="body" cds-control cds-layout="m-t:sm">
-        Use the <code cds-text="code">cds-control</code> attribute to place generic content into a control layout.
-      </p>
-      <cds-control-message>control message</cds-control-message>
-    </cds-control>
+    <div cds-layout="vertical gap:lg">
+      <cds-control>
+        <label>label</label>
+        <p cds-text="body" cds-control cds-layout="m-t:sm">
+          Use the <code cds-text="code">cds-control</code> attribute to place generic content into a control layout.
+        </p>
+        <cds-control-message>control message</cds-control-message>
+      </cds-control>
+
+      <cds-control>
+        <label>label</label>
+        <p cds-text="body" cds-control cds-layout="m-t:sm" style="opacity: 0.3" aria-disabled="true">
+          Use the <code cds-text="code">aria-disabled</code> to render a non-form control inert. Note that applications
+          need to manage the styles of their own custom controls.
+        </p>
+        <cds-control-message>control message</cds-control-message>
+      </cds-control>
+    </div>
   `;
 }

--- a/packages/core/src/forms/control/control.element.spec.ts
+++ b/packages/core/src/forms/control/control.element.spec.ts
@@ -343,3 +343,43 @@ describe('cds-control with label control action', () => {
     expect(input.getAttribute('style')).toBeNull();
   });
 });
+
+describe('cds-control with non-input as control', () => {
+  let element: HTMLElement;
+  let control: CdsControl;
+  let para: HTMLElement;
+
+  beforeEach(async () => {
+    element = await createTestElement(html`
+      <cds-control>
+        <label>control without native input</label>
+        <p cds-text="body" cds-control aria-disabled="true">aria disabled</p>
+        <cds-control-message error="valueMissing">message text</cds-control-message>
+      </cds-control>
+    `);
+
+    control = element.querySelector<CdsControl>('cds-control');
+    para = control.querySelector<HTMLElement>('p[cds-control]');
+  });
+
+  afterEach(() => {
+    removeTestElement(element);
+  });
+
+  it('should apply disabled styles when non-input has aria-disabled', async () => {
+    await componentIsStable(control);
+    expect(control.hasAttribute('_disabled')).toBe(true, 'true aria-disabled is true');
+
+    para.setAttribute('aria-disabled', '');
+    await componentIsStable(control);
+    expect(control.hasAttribute('_disabled')).toBe(false, 'non-true aria-disabled is false');
+
+    para.removeAttribute('aria-disabled');
+    await componentIsStable(control);
+    expect(control.hasAttribute('_disabled')).toBe(false, 'no aria-disabled is false');
+
+    para.setAttribute('aria-disabled', 'true');
+    await componentIsStable(control);
+    expect(control.hasAttribute('_disabled')).toBe(true, 'set aria-disabled is respected');
+  });
+});

--- a/packages/core/src/forms/control/control.element.ts
+++ b/packages/core/src/forms/control/control.element.ts
@@ -323,6 +323,11 @@ export class CdsControl extends LitElement {
     this.inputControl.addEventListener('focusout', () => (this.focused = false));
     this.observers.push(
       getElementUpdates(this.inputControl, 'disabled', (value: any) => (this.disabled = value === '' ? true : value)),
+      getElementUpdates(
+        this.inputControl,
+        'aria-disabled',
+        (value: any) => (this.disabled = value === 'true' ? true : false)
+      ),
       getElementUpdates(this.inputControl, 'readonly', (value: any) => (this.readonly = value === '' ? true : value))
     );
   }


### PR DESCRIPTION
• for a custom control without an input, the control component needs to be aware of changes to the `aria-disabed` attr

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #6213

## What is the new behavior?

If you set `aria-disabled` on a custom control, the component's `_disabled` state is likewise set.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
