### PR TITLE
fix(core): icon button icon clicks when button is inert

### DIFF
--- a/packages/core/src/internal/base/base.element.scss
+++ b/packages/core/src/internal/base/base.element.scss
@@ -43,6 +43,7 @@ slot {
 
   ::slotted(*) {
     cursor: not-allowed !important;
+    pointer-events: none;
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

This change prevents an inert icon button from emitting a click event when the icon inside it is the target of a click event.

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Presently a user can click on the icon of an inner icon button and it click event will be emitted.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #6221

## What is the new behavior?

The click event is prevented. I had trouble writing a unit test for this, however. It seems test runner does not like programmatic events. I verified the fix manually.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
