### PR TITLE
fix(angular): fix icons in labels in button-groups

### DIFF
--- a/projects/angular/src/button/_buttons.clarity.scss
+++ b/projects/angular/src/button/_buttons.clarity.scss
@@ -133,7 +133,10 @@
 
 @mixin btn-checked-styles($button-type: default, $type: checkbox) {
   // add semantic prop: group-checked-font-color
-  input[type='#{$type}']:checked + label {
+  input[type='#{$type}']:checked + label,
+  // override icon colors on inverted backgrounds
+  input[type='#{$type}']:checked + label > clr-icon,
+  input[type='#{$type}']:checked + label > cds-icon {
     background-color: getSassButtonColor($button-type, checked-bg-color);
     color: getSassButtonColor($button-type, checked-color);
   }

--- a/src/app/button-group/static/checkbox/button-group-checkboxes.html
+++ b/src/app/button-group/static/checkbox/button-group-checkboxes.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -9,7 +9,10 @@
   <div class="btn-group">
     <div class="checkbox btn">
       <input type="checkbox" id="btn-check-1" />
-      <label for="btn-check-1">Apples</label>
+      <label for="btn-check-1">
+        <cds-icon shape="cog" size="20"></cds-icon>
+        Apples
+      </label>
     </div>
     <div class="checkbox btn">
       <input type="checkbox" id="btn-check-2" />
@@ -32,7 +35,10 @@
   <div class="btn-group">
     <div class="checkbox btn">
       <input type="checkbox" id="btn-check-5" checked />
-      <label for="btn-check-5">checkbox 1</label>
+      <label for="btn-check-5">
+        <cds-icon shape="cog" size="20"></cds-icon>
+        checkbox 1
+      </label>
     </div>
     <div class="checkbox btn">
       <input type="checkbox" id="btn-check-6" />

--- a/src/app/button-group/static/radio/button-group-radios.html
+++ b/src/app/button-group/static/radio/button-group-radios.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -13,7 +13,10 @@
     </div>
     <div class="radio btn">
       <input type="radio" name="btn-group-radios" id="btn-radio-2" />
-      <label for="btn-radio-2">Radio 2</label>
+      <label for="btn-radio-2">
+        <cds-icon shape="cog" size="20"></cds-icon>
+        Radio 2
+      </label>
     </div>
     <div class="radio btn">
       <input type="radio" name="btn-group-radios" id="btn-radio-3" />
@@ -36,7 +39,10 @@
     </div>
     <div class="radio btn">
       <input type="radio" name="btn-group-radios" id="btn-radio-6" checked />
-      <label for="btn-radio-6">Radio 2</label>
+      <label for="btn-radio-6">
+        <cds-icon shape="cog" size="20"></cds-icon>
+        Radio 2
+      </label>
     </div>
     <div class="radio btn">
       <input type="radio" name="btn-group-radios" id="btn-radio-7" />


### PR DESCRIPTION
Radios and checkboxes had wrong color when selected. This fix adds more-specific override,
which will fix the problem coming from a previous less specific override.
closes: #6219

Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Color of the icon inside button-group checkbox or radio button is same as background when selected
Issue Number: #6219

## What is the new behavior?

Color is different than background
![Screen Shot 2021-08-12 at 14 10 35](https://user-images.githubusercontent.com/1798828/129191737-8e72aa80-4d59-4214-8b4c-2012a5295c9f.jpg)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
