### PR TITLE
fix(core:control): prevent controls from overflowing control group

### DIFF
--- a/packages/core/src/forms/control.stories.ts
+++ b/packages/core/src/forms/control.stories.ts
@@ -113,6 +113,94 @@ export function genericContent() {
         </p>
         <cds-control-message>control message</cds-control-message>
       </cds-control>
+
+      <cds-control>
+        <label>long input</label>
+        <input
+          cds-control
+          value="A billion trillion another world rogue rich in heavy atoms worldlets cosmic ocean? The ash of stellar alchemy preserve and cherish that pale blue dot network of wormholes two ghostly white figures in coveralls and helmets are softly dancing a very small stage in a vast cosmic arena something incredible is waiting to be known. Permanence of the stars courage of our questions network of wormholes across the centuries bits of moving fluff a mote of dust suspended in a sunbeam. Tesseract hydrogen atoms circumnavigated dispassionate extraterrestrial observer the carbon in our apple pies vastness is bearable only through love. Prime number from which we spring muse about kindling the energy hidden in matter decipherment brain is the seed of intelligence? Hundreds of thousands from which we spring something incredible is waiting to be known of brilliant syntheses kindling the energy hidden in matter prime number. Hundreds of thousands made in the interiors of collapsing stars muse about the only home we've ever known a mote of dust suspended in a sunbeam from which we spring and billions upon billions upon billions upon billions upon billions upon billions upon billions."
+        />
+        <cds-control-message>control message</cds-control-message>
+      </cds-control>
+
+      <cds-control layout="vertical" status="success">
+        <label>long input with control badge</label>
+        <input
+          value="A billion trillion another world rogue rich in heavy atoms worldlets cosmic ocean? The ash of stellar alchemy preserve and cherish that pale blue dot network of wormholes two ghostly white figures in coveralls and helmets are softly dancing a very small stage in a vast cosmic arena something incredible is waiting to be known. Permanence of the stars courage of our questions network of wormholes across the centuries bits of moving fluff a mote of dust suspended in a sunbeam. Tesseract hydrogen atoms circumnavigated dispassionate extraterrestrial observer the carbon in our apple pies vastness is bearable only through love. Prime number from which we spring muse about kindling the energy hidden in matter decipherment brain is the seed of intelligence? Hundreds of thousands from which we spring something incredible is waiting to be known of brilliant syntheses kindling the energy hidden in matter prime number. Hundreds of thousands made in the interiors of collapsing stars muse about the only home we've ever known a mote of dust suspended in a sunbeam from which we spring and billions upon billions upon billions upon billions upon billions upon billions upon billions."
+        />
+        <cds-control-message status="success">success message</cds-control-message>
+      </cds-control>
+
+      <cds-control status="success">
+        <label>long input</label>
+        <p cds-control cds-text="body truncate" style="border: 1px solid black">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+          est laborum.
+        </p>
+        <cds-control-message status="success">control message</cds-control-message>
+      </cds-control>
+
+      <cds-control>
+        <label>long input</label>
+        <input
+          cds-control
+          value="A billion trillion another world rogue rich in heavy atoms worldlets cosmic ocean? The ash of stellar alchemy preserve and cherish that pale blue dot network of wormholes two ghostly white figures in coveralls and helmets are softly dancing a very small stage in a vast cosmic arena something incredible is waiting to be known. Permanence of the stars courage of our questions network of wormholes across the centuries bits of moving fluff a mote of dust suspended in a sunbeam. Tesseract hydrogen atoms circumnavigated dispassionate extraterrestrial observer the carbon in our apple pies vastness is bearable only through love. Prime number from which we spring muse about kindling the energy hidden in matter decipherment brain is the seed of intelligence? Hundreds of thousands from which we spring something incredible is waiting to be known of brilliant syntheses kindling the energy hidden in matter prime number. Hundreds of thousands made in the interiors of collapsing stars muse about the only home we've ever known a mote of dust suspended in a sunbeam from which we spring and billions upon billions upon billions upon billions upon billions upon billions upon billions."
+        />
+        <cds-control-message>control message</cds-control-message>
+      </cds-control>
+
+      <cds-control>
+        <label>long input</label>
+        <p cds-control cds-text="body truncate" style="border: 1px solid black">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+          est laborum.
+        </p>
+        <cds-control-message>control message</cds-control-message>
+      </cds-control>
+
+      <cds-control status="success">
+        <label>long input</label>
+        <p cds-control cds-text="body truncate" style="border: 1px solid black">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+          est laborum.
+        </p>
+        <cds-control-message status="success">control message</cds-control-message>
+      </cds-control>
+
+      <cds-control status="success">
+        <label>long input</label>
+        <p cds-control cds-text="body truncate" style="border: 1px solid black; margin-left: 0.3rem">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+          est laborum.
+        </p>
+        <cds-control-action
+          action="suffix"
+          readonly
+          aria-label="Icon indicating that the selected host status is stable"
+          title="Icon indicating that the selected host status is stable"
+        >
+          <cds-icon
+            shape="cloud"
+            badge="success"
+            role="img"
+            aria-label="Icon of host cloud with green badge"
+          ></cds-icon>
+        </cds-control-action>
+
+        <cds-control-message status="success">control message</cds-control-message>
+      </cds-control>
     </div>
   `;
 }

--- a/packages/core/src/forms/control/control.element.scss
+++ b/packages/core/src/forms/control/control.element.scss
@@ -31,6 +31,23 @@ $fallback-width: calc(#{$cds-global-layout-space-xxl} * 2);
 
 .input-container {
   line-height: 0;
+  max-width: 100%;
+
+  &.with-status-icon {
+    /*
+      the following is to allow space for the status icon in the layout
+      the sizing of the icon is hard-coded so there's no good way for me to
+      predict/decipher how it is sized. 
+      
+      - it's hard-coded so a clientRect is needlessly expensive.
+      - it's not sized by any design token so using one here would make it 
+        SEEM like it was cleverly done when actually there would be no connection
+        and any size-breakage would be harder to track down
+      
+      See: https://github.com/vmware/clarity/blob/66073e77391426b8d2a28d5b7485984eab7fc1b2/packages/core/src/forms/utils/index.ts#L48
+    */
+    max-width: calc(100% - 1.2rem);
+  }
 }
 
 :host([_disabled]) ::slotted([slot='input']) {
@@ -39,6 +56,10 @@ $fallback-width: calc(#{$cds-global-layout-space-xxl} * 2);
 
 :host([control-width='shrink']) {
   width: auto;
+}
+
+::slotted([cds-control]) {
+  width: 100%;
 }
 
 ::slotted(input) {

--- a/packages/core/src/forms/control/control.element.spec.ts
+++ b/packages/core/src/forms/control/control.element.spec.ts
@@ -383,3 +383,74 @@ describe('cds-control with non-input as control', () => {
     expect(control.hasAttribute('_disabled')).toBe(true, 'set aria-disabled is respected');
   });
 });
+
+describe('cds-control status icon sizing', () => {
+  let element: HTMLElement;
+  let control: CdsControl;
+  let controlWithSuccessStatus: CdsControl;
+  let controlWithErrorStatus: CdsControl;
+  let controlWithNeutralStatus: CdsControl;
+
+  beforeEach(async () => {
+    element = await createTestElement(html`
+      <cds-control class="a-control">
+        <label>control with no status</label>
+        <input placeholder="example" />
+        <cds-control-message>message text</cds-control-message>
+      </cds-control>
+
+      <cds-control class="a-control-with-neutral-status" status="neutral">
+        <label>control with neutral status</label>
+        <input placeholder="example" />
+        <cds-control-message status="neutral">message text</cds-control-message>
+      </cds-control>
+
+      <cds-control class="a-control-with-success-status" status="success">
+        <label>control without native input</label>
+        <input placeholder="example" />
+        <cds-control-message status="success">message text</cds-control-message>
+      </cds-control>
+
+      <cds-control class="a-control-with-error-status" status="success">
+        <label>control without native input</label>
+        <input placeholder="example" />
+        <cds-control-message status="success">message text</cds-control-message>
+      </cds-control>
+    `);
+
+    control = element.querySelector<CdsControl>('.a-control');
+    controlWithNeutralStatus = element.querySelector<CdsControl>('.a-control-with-neutral-status');
+    controlWithSuccessStatus = element.querySelector<CdsControl>('.a-control-with-success-status');
+    controlWithErrorStatus = element.querySelector<CdsControl>('.a-control-with-error-status');
+  });
+
+  afterEach(() => {
+    removeTestElement(element);
+  });
+
+  it('should apply .with-status-icon classname to controls with status', async () => {
+    await componentIsStable(control);
+
+    const containerWithNoStatus = control.shadowRoot.querySelector('.input-container');
+    const containerWithNeutralStatus = controlWithNeutralStatus.shadowRoot.querySelector('.input-container');
+    const containerWithSuccessStatus = controlWithSuccessStatus.shadowRoot.querySelector('.input-container');
+    const containerWithErrorStatus = controlWithErrorStatus.shadowRoot.querySelector('.input-container');
+
+    expect(containerWithNoStatus.classList.contains('with-status-icon')).toBe(
+      false,
+      'no status means no class gets added'
+    );
+    expect(containerWithNeutralStatus.classList.contains('with-status-icon')).toBe(
+      false,
+      'neutral status means no class gets added'
+    );
+    expect(containerWithSuccessStatus.classList.contains('with-status-icon')).toBe(
+      true,
+      'success status means class gets added'
+    );
+    expect(containerWithErrorStatus.classList.contains('with-status-icon')).toBe(
+      true,
+      'error status means class gets added'
+    );
+  });
+});

--- a/packages/core/src/forms/control/control.element.ts
+++ b/packages/core/src/forms/control/control.element.ts
@@ -175,6 +175,10 @@ export class CdsControl extends LitElement {
     return hasAriaLabelTypeAttr(this.inputControl);
   }
 
+  private get hasStatusIcon() {
+    return this.labelLayout !== ControlLabelLayout.inputGroup && (this.status === 'error' || this.status === 'success');
+  }
+
   render() {
     return html`
       ${this.labelLayout === ControlLabelLayout.hiddenLabel || this.labelLayout === ControlLabelLayout.inputGroup
@@ -198,13 +202,13 @@ export class CdsControl extends LitElement {
               cds-layout="horizontal align:top wrap:none ${this.controlWidth === 'shrink' || this.fixedControlWidth
                 ? 'align:shrink'
                 : 'align:horizontal-stretch'}"
-              class="input-container"
+              class="${this.hasStatusIcon ? 'input-container with-status-icon' : 'input-container'}"
             >
               ${this.inputTemplate} ${this.prefixTemplate}
               <slot name="input"></slot>
               ${this.suffixTemplate}
             </div>
-            ${this.labelLayout !== ControlLabelLayout.inputGroup ? getStatusIcon(this.status) : ''}
+            ${this.hasStatusIcon ? getStatusIcon(this.status) : ''}
           </div>
           ${this.messagesTemplate}
         </div>


### PR DESCRIPTION
Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

For a custom control or something like a select element with a super long selected option, the form control could push outside of the boundaries of the control group.

![image](https://user-images.githubusercontent.com/2728359/129219872-7db0fe4a-f8ae-4857-a71a-bf925db06b8d.png)

Issue Number: #6249

## What is the new behavior?

The input container for the control now has a max-width. I visually verified that none of the demos in our storybook are negatively affected by this change. 

The tricky part was we had to account for the status icon in the max width. See images below.

<img width="1044" alt="Screen Shot 2021-08-12 at 11 01 52 AM" src="https://user-images.githubusercontent.com/2728359/129220270-e4f07042-d70f-4e14-bd92-515e5f9b5922.png">

<img width="690" alt="Screen Shot 2021-08-12 at 10 34 55 AM" src="https://user-images.githubusercontent.com/2728359/129220112-4b386650-ee93-4ff0-9d1b-4b5231ede9c6.png">

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
