### PR TITLE
fix: use variable for table header color

### DIFF
--- a/projects/angular/src/data/_properties.tables.scss
+++ b/projects/angular/src/data/_properties.tables.scss
@@ -30,7 +30,7 @@
       --clr-table-font-color: var(--clr-color-neutral-700);
 
       // Table header styles
-      --clr-thead-color: #{$clr-p6-color};
+      --clr-thead-color: #{$clr-thead-color};
     }
   }
 }

--- a/projects/angular/src/utils/_theme.dark.clarity.scss
+++ b/projects/angular/src/utils/_theme.dark.clarity.scss
@@ -691,6 +691,8 @@ $clr-stack-view-stack-block-caret-color: hsl(0, 0%, 60%);
   * - ../data/_tables.clarity.scss
   * - ../data/datagrid/_datagrid.clarity.scss
   */
+
+$clr-thead-color: hsl(210, 17%, 93%);
 $clr-thead-bgcolor: hsl(201, 30%, 15%);
 $clr-table-bgcolor: hsl(198, 28%, 18%);
 $clr-table-font-color: hsl(203, 16%, 72%);


### PR DESCRIPTION
Signed-off-by: stsogoo <stsogoo@vmware.com>

In this PR, we are using the correct color variable for `--clr-thead-color`, which is `$clr-thead-color`. Also, `$clr-thead-color` is added to `_theme.dark.clarity.scss` so that users could set it to their desired value.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/vmware/clarity/issues/6276

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
