### PR TITLE
fix(core:button): not submitting forms on Enter key

### DIFF
--- a/packages/angular/projects/clr-angular/README.md
+++ b/packages/angular/projects/clr-angular/README.md
@@ -1,0 +1,1 @@
+The `clr-angular` project has been moved to the `angular` branch.

--- a/packages/core/src/forms/forms.stories.ts
+++ b/packages/core/src/forms/forms.stories.ts
@@ -2072,6 +2072,50 @@ export function responsiveCheckoutForm() {
     ></iframe>`;
 }
 
+export function submitOnEnter() {
+  let count = 0;
+  let typeVal = 'submit';
+
+  const onSubmit = {
+    handleEvent(e: any) {
+      e.preventDefault();
+      count++;
+      document.querySelector('div#submit-count').innerHTML = `Submit count: ${count}`;
+      return false;
+    },
+  };
+
+  const changeType = {
+    handleEvent() {
+      typeVal = typeVal === 'submit' ? 'button' : 'submit';
+      const button = document.querySelector('cds-button[name=test-button]');
+      button.setAttribute('type', typeVal);
+      document.querySelector('div#button-type').innerHTML = `type="${typeVal}"`;
+    },
+  };
+
+  return html`
+    <div cds-layout="vertical gap:md">
+      <form @submit="${onSubmit}">
+        <cds-form-group layout="horizontal-inline">
+          <cds-input>
+            <label>Form input 1</label>
+            <input placeholder="Press Enter to submit" />
+          </cds-input>
+          <cds-input>
+            <label>Form input 2</label>
+            <input placeholder="Press Enter to submit" />
+          </cds-input>
+          <cds-button type="${typeVal}" name="test-button" value="test-value">Submit</cds-button>
+        </cds-form-group>
+      </form>
+      <div id="submit-count">Submit count: ${count}</div>
+      <div><cds-button @click="${changeType}">Change type</cds-button></div>
+      <div id="button-type">type="${typeVal}"</div>
+    </div>
+  `;
+}
+
 /** @website */
 export function darkTheme() {
   return html`

--- a/packages/core/src/test/utils.ts
+++ b/packages/core/src/test/utils.ts
@@ -85,3 +85,13 @@ export function componentIsStable(component: any) {
       })
   );
 }
+
+// Full set of mouse events, generated on click
+export function emulatedClick(component: HTMLElement) {
+  const event1 = new MouseEvent('mousedown');
+  const event2 = new MouseEvent('mouseup');
+  const event3 = new MouseEvent('click');
+  component.dispatchEvent(event1);
+  component.dispatchEvent(event2);
+  component.dispatchEvent(event3);
+}


### PR DESCRIPTION
Close: #6263

Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Forms with button with type="submit" having more than 1 input field are not submitted on Enter.
A temporary native button is created dynamically only on Click.

Issue Number: #6263 

## What is the new behavior?

Forms are submitted on Enter if button type="submit" or not defined (default is "submit"). Not submitted on type="button".
If the form has submit type button, it will pre-create a native button with role="presentation".
Changing type dynamically changes button behavior.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
