### PR TITLE
fix(angular): rework the cds-angular build to use the new custom-elements json format

### DIFF
--- a/packages/angular/projects/cds-angular/src/all.spec.ts
+++ b/packages/angular/projects/cds-angular/src/all.spec.ts
@@ -43,7 +43,6 @@ import {
   CdsSearchDirective,
   CdsSelectDirective,
   CdsTagDirective,
-  CdsTestDropdownDirective,
   CdsTextareaDirective,
   CdsTimeDirective,
   CdsToggleGroupDirective,
@@ -851,26 +850,6 @@ describe('CDS Tag', () => {
   });
 });
 
-describe('CDS Test Dropdown', () => {
-  let fixture: ComponentFixture<any>;
-  let instance: TestDropdownTestComponent;
-
-  beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [CdsModule],
-      declarations: [TestDropdownTestComponent],
-    });
-
-    fixture = TestBed.createComponent(TestDropdownTestComponent);
-    fixture.detectChanges();
-    instance = fixture.componentInstance;
-  });
-
-  it('cds-test-dropdown should be defined', () => {
-    expect(instance.vcCdsTestDropdownDirective).toBeDefined();
-  });
-});
-
 describe('CDS Textarea', () => {
   let fixture: ComponentFixture<any>;
   let instance: TextareaTestComponent;
@@ -1359,13 +1338,6 @@ class SelectTestComponent {
 })
 class TagTestComponent {
   @ViewChild(CdsTagDirective) vcCdsTagDirective: CdsTagDirective;
-}
-
-@Component({
-  template: ` <cds-test-dropdown></cds-test-dropdown> `,
-})
-class TestDropdownTestComponent {
-  @ViewChild(CdsTestDropdownDirective) vcCdsTestDropdownDirective: CdsTestDropdownDirective;
 }
 
 @Component({

--- a/packages/core/rollup.utils.js
+++ b/packages/core/rollup.utils.js
@@ -29,7 +29,7 @@ export const packageCheck = dir => {
 export const webComponentAnalyer = outDir => {
   return execute({
     commands: [
-      `cd ${resolve(outDir)} && cem analyze --litelement --globs ./**/*.element.d.ts`, // https://github.com/open-wc/custom-elements-manifest/tree/master/packages/analyzer
+      `cd ${resolve(outDir)} && cem analyze --litelement`, // https://github.com/open-wc/custom-elements-manifest/tree/master/packages/analyzer
       `wca analyze ${resolve(outDir)} --silent --format=json --outFile ${resolve(
         outDir,
         'custom-elements.legacy.json'

--- a/packages/core/src/forms/control-action/control-action.element.ts
+++ b/packages/core/src/forms/control-action/control-action.element.ts
@@ -30,7 +30,6 @@ import { LogService } from '@cds/core/internal';
  *
  * </cds-control-action>
  * ```
- * @internal
  * @element cds-control-action
  * @slot - For projecting text content or cds-icon
  */

--- a/packages/core/src/forms/control-inline/control-inline.element.ts
+++ b/packages/core/src/forms/control-inline/control-inline.element.ts
@@ -23,7 +23,7 @@ import { getStatusIcon } from '../utils/index.js';
  *   <input type="radio" />
  * </ds-internal-control-inline>
  * ```
- *
+ * @element cds-internal-control-inline
  * @slot - For projecting inline input and label
  */
 export class CdsInternalControlInline extends CdsControl {

--- a/packages/core/src/forms/control-label/control-label.element.ts
+++ b/packages/core/src/forms/control-label/control-label.element.ts
@@ -20,7 +20,7 @@ import styles from './control-label.element.scss';
  *   <label>...</label>
  * </cds-internal-control-label>
  * ```
- * @internal
+ *
  * @element cds-internal-control-label
  * @slot - For projecting label text
  * @cssprop --label-width


### PR DESCRIPTION
* Fix some of the jsdoc attributes inside some of the Core
components
* Refactor the Angular Cds Wrapper
* Updating the specs for Angular Cds Wrapper
* Start to use the `custom-elements.json`

### How to test it 

Make sure that everything is updated 

```bash
$ yarn 
$ yarn build:ci
```

After this finish, the new `cds/angular` must be generated as expected. After that, the autogenerated code could be compared against `@cds/angular` package 

```bash
$ mkdir tmp && cd tmp
$ npm init -y && npm install @cds/angular
$ cd node_modules/@cds/angular
```

### How it works

```bash
$ node ./scripts/core-ng-module-generator.js
```

It will go pick the `packages/core/dist/core/custom-elements.json` and use it to generate Angular Wrappers.

This new `custom-elements.json` is different in structure and content, also includes `private` and `protected` fields, additional files like `*.scss.js` files, and much more.



close #6080 