### PR TITLE
fix(website): update updating documentation page

### DIFF
--- a/apps/website/get-started/updating/README.md
+++ b/apps/website/get-started/updating/README.md
@@ -15,9 +15,3 @@ If you are using either the React or Angular packages, you should update them at
 npm install @cds/core@latest @cds/angular@latest # updates both Core and Angular
 npm install @cds/core@latest @cds/react@latest # updates both Core and React
 ```
-
-If there is a prerelease version available for testing, you can install it using the `next` tag on NPM. These versions are only available when we are actively working on a new major version, so only do this if you are willing to try beta software.
-
-```bash
-npm install @cds/core@next
-```

--- a/apps/website/get-started/updating/angular.md
+++ b/apps/website/get-started/updating/angular.md
@@ -9,10 +9,3 @@ In order to keep up with Clarity, you can use ng update to automatically update 
 ng update @angular/core @angular/cli
 ng update @clr/angular
 ```
-
-If you want to update to a prerelease version, you can do so by running:
-
-```bash
-ng update @angular/core@next @angular/cli@next
-ng update @clr/angular@next
-```


### PR DESCRIPTION
Updating the Update page for the website.

The `next` NPM tag is not used at the moment and only creates issues with people trying to upgrade.