### PR TITLE
fix(core:typography): correct font weight tokens

### DIFF
--- a/packages/core/build/tokens.ts
+++ b/packages/core/build/tokens.ts
@@ -320,13 +320,13 @@ const typography = {
     500: token(color.black), // content
   },
   fontWeight: {
-    // Clarity City is limited to 400-500, tokens provide hooks for customization
-    light: token('200'),
+    // Clarity City is limited to a minimum weight of 300 and max weight of 600, tokens provide hooks for customization
+    light: token('300'),
     regular: token('400'),
     medium: token('500'),
-    semibold: token('500'),
-    bold: token('500'),
-    extrabold: token('500'),
+    semibold: token('600'),
+    bold: token('600'),
+    extrabold: token('600'),
   },
   fontSize: {
     0: token(10),

--- a/packages/core/src/styles/typography/typography.stories.ts
+++ b/packages/core/src/styles/typography/typography.stories.ts
@@ -70,7 +70,7 @@ export function code() {
 export function weights() {
   return html`
     <cds-demo cds-layout="vertical gap:lg">
-      <p cds-text="body light">The <em>200</em> quick brown foxes <em>lightly</em> jump over the lazy dog. (light)</p>
+      <p cds-text="body light">The <em>300</em> quick brown foxes <em>lightly</em> jump over the lazy dog. (light)</p>
       <p cds-text="body regular">
         The <em>400</em> quick brown foxes <em>regularly</em> jump over the lazy dog. (regular)
       </p>
@@ -78,7 +78,7 @@ export function weights() {
         The <em>500</em> quick brown foxes <em>mediumly</em> jump over the lazy dog. (medium)
       </p>
       <p cds-text="body semibold">
-        The <em>500</em> quick brown foxes <em>semi-boldly</em> jump over the lazy dog. (semibold)
+        The <em>600</em> quick brown foxes <em>semi-boldly</em> jump over the lazy dog. (semibold)
       </p>
       <p cds-text="body bold">The <em>600</em> quick brown foxes <em>boldly</em> jump over the lazy dog. (bold)</p>
       <p cds-text="body extrabold">


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?
- Semi-bold and up weights were incorrectly set to 500 and are now set to the correct 600
- The light font weight token value was incorrectly set to 200. The font loads light at the correct 300 since the browser will default to the next available font. So no visual change for light token just a more accurate value to the CSS.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
