### PR TITLE
fix(core:accordion): header content to wrap in smaller screens

### DIFF
--- a/packages/core/src/accordion/accordion-header.element.ts
+++ b/packages/core/src/accordion/accordion-header.element.ts
@@ -51,7 +51,7 @@ export class CdsAccordionHeader extends LitElement {
   }
 
   render() {
-    return html`<div class="private-host" cds-layout="horizontal gap:md align:vertical-center">
+    return html`<div class="private-host" cds-layout="horizontal gap:md align:vertical-center wrap:none">
       <cds-icon class="accordion-angle" shape="angle" size="9" inner-offset="2"></cds-icon>
       <div cds-text="secondary" cds-layout="align:stretch"><slot></slot></div>
     </div>`;


### PR DESCRIPTION
Closes #6337

Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

See #6337

## What is the new behavior?

The content of the header wraps on smaller screens

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
