### PR TITLE
fix(core:typography): fix override issues with accordion header and content

### DIFF
--- a/packages/core/src/accordion/accordion-content.element.scss
+++ b/packages/core/src/accordion/accordion-content.element.scss
@@ -8,8 +8,8 @@
 :host {
   --color: #{$cds-global-typography-color-400};
   --font-size: #{$cds-global-typography-font-size-3};
-  --font-weight: #{$cds-global-typography-body-font-weight};
-  --background: #{$cds-alias-object-interaction-background};
+  --font-weight: inherit;
+  --background: inherit;
   width: 100%;
   contain: inherit;
 }

--- a/packages/core/src/accordion/accordion-header.element.scss
+++ b/packages/core/src/accordion/accordion-header.element.scss
@@ -7,8 +7,8 @@
 
 :host {
   --color: #{$cds-global-typography-color-400};
-  --font-size: #{$cds-global-typography-font-size-3};
-  --font-weight: #{$cds-global-typography-font-weight-semibold};
+  --font-size: #{$cds-global-typography-secondary-font-size};
+  --font-weight: #{$cds-global-typography-secondary-font-weight};
   --background: #{$cds-alias-object-app-background};
   --icon-color: var(--color);
   --icon-transform: rotate(90deg);
@@ -22,12 +22,9 @@
   padding: #{$cds-global-space-6};
   cursor: inherit;
   border: 0;
-
-  span {
-    color: var(--color);
-    font-size: var(--font-size);
-    font-weight: var(--font-weight);
-  }
+  font-size: var(--font-size);
+  font-weight: var(--font-weight);
+  color: var(--color);
 }
 
 :host([_nfg]) {

--- a/packages/core/src/accordion/accordion-header.element.ts
+++ b/packages/core/src/accordion/accordion-header.element.ts
@@ -53,7 +53,7 @@ export class CdsAccordionHeader extends LitElement {
   render() {
     return html`<div class="private-host" cds-layout="horizontal gap:md align:vertical-center wrap:none">
       <cds-icon class="accordion-angle" shape="angle" size="9" inner-offset="2"></cds-icon>
-      <div cds-text="secondary" cds-layout="align:stretch"><slot></slot></div>
+      <div cds-layout="align:stretch"><slot></slot></div>
     </div>`;
   }
 


### PR DESCRIPTION
Content projected into accordion-header was being hard coded to 'secondary'.
The API provided to override it was not being applied. This change removes the specificity
to span content as the template no longer has a span. It defaults the exposed font custom
properties to 'secondary' font-weight and font-size.

Content projected into accordion-content now inherits typography from the global scope.

closes #5915, closes #6347

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
CdsAccordion consumers cannot override typography styles for projected content inside cds-accordion-header elements. And, cds-accordion-content does not inherit the global typography scope for projected content. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5915, #6347

## What is the new behavior?
cds-accodion-content elements will inherit the global typography and still offer API for consumers to override as needed. cds-accordion-header will default typography styles to 'secondary' but still offer consumers API to override as needed. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
