### PR TITLE
fix(a11y): fix color contrasts and styles for buttons and form elements

### DIFF
--- a/projects/angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/projects/angular/src/data/datagrid/_datagrid.clarity.scss
@@ -697,7 +697,7 @@
 
         cds-icon,
         clr-icon {
-          @include css-var(color, clr-color-neutral-500, $clr-color-neutral-500, $clr-use-custom-properties);
+          @include css-var(color, clr-color-neutral-600, $clr-color-neutral-600, $clr-use-custom-properties);
         }
 
         &:hover {
@@ -1190,7 +1190,7 @@
         padding-right: 0;
         cds-icon,
         clr-icon {
-          @include css-var(color, clr-color-neutral-500, $clr-color-neutral-500, $clr-use-custom-properties);
+          @include css-var(color, clr-color-neutral-600, $clr-color-neutral-600, $clr-use-custom-properties);
         }
 
         &:hover {
@@ -1237,11 +1237,6 @@
             min-width: $clr_baselineRem_0_75;
             margin: 0;
             padding: 0;
-            @include css-var(color, clr-color-neutral-500, $clr-color-neutral-500, $clr-use-custom-properties);
-
-            &:hover {
-              @include css-var(color, clr-color-action-600, $clr-color-action-600, $clr-use-custom-properties);
-            }
           }
         }
 

--- a/projects/angular/src/forms/styles/_radio.clarity.scss
+++ b/projects/angular/src/forms/styles/_radio.clarity.scss
@@ -52,24 +52,12 @@
 
     //Outline color for unchecked radios
     input[type='radio']:focus + label::before {
-      outline: 0;
-      @include css-var(
-        box-shadow,
-        clr-forms-radio-focused-shadow,
-        $clr-forms-radio-focused-shadow,
-        $clr-use-custom-properties
-      );
+      @include include-outline-style-form-fields();
     }
 
     //Outline color for checked radios
     input[type='radio']:focus:checked + label::before {
-      outline: 0;
-      // IE/OldEdge
-      box-shadow: $clr-forms-radio-selected-shadow, $clr-forms-radio-focused-shadow;
-      @if $clr-use-custom-properties == true {
-        box-shadow: var(--clr-forms-radio-selected-shadow, $clr-forms-radio-selected-shadow),
-          var(--clr-forms-radio-focused-shadow, $clr-forms-radio-focused-shadow);
-      }
+      @include include-outline-style-form-fields();
     }
 
     input[type='radio']:disabled + label::before {

--- a/projects/angular/src/forms/styles/_select.clarity.scss
+++ b/projects/angular/src/forms/styles/_select.clarity.scss
@@ -11,7 +11,12 @@
     select {
       @include custom-inputs($clr_baselineRem_1);
       @include form-fields-appearance();
-      @include input-border-bottom-animation();
+      &:not([multiple]) {
+        @include input-border-bottom-animation();
+      }
+      &[multiple]:focus {
+        @include include-slim-outline-style-form-fields();
+      }
       position: relative;
       padding: 0 ($clr-forms-select-caret-size + $clr-forms-baseline * 2) 0 $clr-forms-baseline;
       cursor: pointer;
@@ -130,20 +135,7 @@
 
   .clr-error select[multiple] {
     @include css-var(border-color, clr-forms-invalid-color, $clr-forms-invalid-color, $clr-use-custom-properties);
-
-    &:focus {
-      outline: 0;
-      // TODO: this is a mess and will need to be fixed. we shouldn't be using lighten() like this
-      $focus-shadow-color: lighten($clr-forms-invalid-color, 30%);
-      $sass-box-shadow: 0 $clr_baselineRem_1px $clr_baselineRem_3px $focus-shadow-color;
-      $cssvar-box-shadow: 0 $clr_baselineRem_1px $clr_baselineRem_3px
-        var(--clr-forms-select-multiple-error-focus-color, $focus-shadow-color);
-
-      box-shadow: $sass-box-shadow;
-      box-shadow: $cssvar-box-shadow;
-    }
   }
-
   .clr-form-control-disabled .clr-select {
     &.disabled {
       @include disabled-form-fields();

--- a/projects/angular/src/forms/styles/_textarea.clarity.scss
+++ b/projects/angular/src/forms/styles/_textarea.clarity.scss
@@ -36,13 +36,7 @@
     font-size: $clr-forms-field-font-size;
 
     &:focus {
-      $focused-outline: 0 0 $clr_baselineRem_2px $clr_baselineRem_2px $clr-outline-color;
-      outline: 0;
-      // Old IE/Edge
-      box-shadow: $focused-outline;
-      @if $clr-use-custom-properties == true {
-        box-shadow: var(--clr-forms-textarea-focused-outline, #{$focused-outline});
-      }
+      @include include-slim-outline-style-form-fields();
     }
 
     &:disabled {
@@ -52,16 +46,6 @@
 
   .clr-error .clr-textarea {
     @include css-var(border-color, clr-forms-invalid-color, $clr-forms-invalid-color, $clr-use-custom-properties);
-
-    &:focus {
-      $error-outline: 0 0 $clr_baselineRem_2px $clr_baselineRem_2px lighten($clr-forms-invalid-color, 30%);
-      outline: 0;
-      // Old IE/Edge
-      box-shadow: $error-outline;
-      @if $clr-use-custom-properties == true {
-        box-shadow: var(--clr-forms-textarea-invalid-focused-outline, #{$error-outline});
-      }
-    }
   }
 
   .clr-control-container textarea {

--- a/projects/angular/src/layout/tabs/_properties.tabs.scss
+++ b/projects/angular/src/layout/tabs/_properties.tabs.scss
@@ -11,7 +11,7 @@
       --clr-nav-active-bg-color: var(--clr-global-selection-color);
       --clr-nav-hover-bg-color: var(--clr-sidenav-link-hover-color);
 
-      --clr-nav-link-color: var(--clr-color-neutral-600);
+      --clr-nav-link-color: var(--clr-color-neutral-700);
       --clr-nav-link-active-color: var(--clr-color-neutral-1000);
 
       --clr-nav-link-font-weight: var(--clr-p1-font-weight);

--- a/projects/angular/src/layout/tabs/_variables.tabs.scss
+++ b/projects/angular/src/layout/tabs/_variables.tabs.scss
@@ -6,7 +6,7 @@
 $clr-nav-box-shadow-color: $clr-color-neutral-400 !default;
 $clr-nav-active-box-shadow-color: $clr-color-action-600 !default;
 
-$clr-nav-link-color: $clr-color-neutral-600 !default;
+$clr-nav-link-color: $clr-color-neutral-700 !default;
 $clr-nav-link-active-color: $clr-color-neutral-1000 !default;
 
 $clr-nav-link-font-size: $clr-p1-font-size !default;

--- a/projects/angular/src/utils/_mixins.scss
+++ b/projects/angular/src/utils/_mixins.scss
@@ -24,13 +24,15 @@ $clr-outline-color-inverse: hsla(0, 0%, 100%, 0.09) !default;
 $clr-outline-blur: $clr_baselineRem_2px;
 $clr-outline-spread: $clr_baselineRem_2px;
 
-@mixin include-outline-style-form-fields(
-  $outline-color: $clr-outline-color,
-  $outline-blur: $clr-outline-blur,
-  $outline-spread: $clr-outline-spread
-) {
-  outline: 0;
-  box-shadow: 0 0 $outline-blur $outline-spread $outline-color;
+@mixin include-outline-style-form-fields() {
+  outline: Highlight solid $clr_baselineRem_2px;
+  outline: -webkit-focus-ring-color solid $clr_baselineRem_2px;
+  outline-offset: $clr_baselineRem_1px;
+}
+
+@mixin include-slim-outline-style-form-fields() {
+  outline: Highlight auto $clr_baselineRem_2px;
+  outline: -webkit-focus-ring-color auto $clr_baselineRem_2px;
 }
 
 @mixin include-outline-style-links() {

--- a/projects/angular/src/utils/_reboot.clarity.scss
+++ b/projects/angular/src/utils/_reboot.clarity.scss
@@ -317,8 +317,16 @@
   //
   // Credit: https://github.com/suitcss/base/
   button:focus {
-    outline: 1px dotted;
-    outline: 5px auto -webkit-focus-ring-color;
+    outline: 2px solid -webkit-focus-ring-color;
+    outline-offset: 1px;
+  }
+
+  button:-moz-focusring,
+  [type='button']:-moz-focusring,
+  [type='reset']:-moz-focusring,
+  [type='submit']:-moz-focusring {
+    outline: 2px solid Highlight;
+    outline-offset: 1px;
   }
 
   input,


### PR DESCRIPTION
Box-shadow changed to outline.
Color changed to default browser color for outlines.

Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

We have multiple A11Y issues about color contrast of the outlines of buttons and form elements.

Issue Number: N/A

## What is the new behavior?

Outlines made same as in Clarity Core.

**Button groups:**
before 
![before-buttongroup](https://user-images.githubusercontent.com/1798828/134686907-94135e8d-6a23-4adf-8a63-6a8397489ef7.jpg)
after
![after-buttongroup](https://user-images.githubusercontent.com/1798828/134686882-70b6283f-a81e-419d-aacc-9a4802e0b37f.jpg)

**Buttons**
before
![before-buttons-flat](https://user-images.githubusercontent.com/1798828/134686900-87983d4e-a488-4d92-83e3-0f25bf26f5f4.jpg)
![before-buttons-outline](https://user-images.githubusercontent.com/1798828/134686902-131e57f4-e431-4507-8676-1b5d96c21fc9.jpg)
![before-buttons-solid](https://user-images.githubusercontent.com/1798828/134686904-8428251b-14f2-4aa3-a341-cf844366720a.jpg)
after
![after-buttons-flat](https://user-images.githubusercontent.com/1798828/134686874-6d67bdf2-7c5f-4318-9e0c-e6f5be542b68.jpg)
![after-buttons-outline](https://user-images.githubusercontent.com/1798828/134686877-4dae5f7a-6332-43d3-9b91-83ac044d5f6e.jpg)
![after-buttons-solid](https://user-images.githubusercontent.com/1798828/134686879-7ae201f5-29c4-492a-8a7a-27eb0395bf70.jpg)

**Checkboxes**
before
![before-checkbox-selected](https://user-images.githubusercontent.com/1798828/134686894-5bb0121d-2819-4b37-a7b0-2ba4d31a240f.jpg)
![before-checkbos](https://user-images.githubusercontent.com/1798828/134686896-c896d4ee-b3a2-4093-ace3-763aa4a9ea55.jpg)
after
![after-checkbox-selected](https://user-images.githubusercontent.com/1798828/134686870-38a7e860-2416-43d4-96f5-28fe65ed7b2d.jpg)
![after-checkbox](https://user-images.githubusercontent.com/1798828/134686872-a9fc2754-513e-4e3a-8aad-09bcedb68b0d.jpg)

**Close button**
before
![before-close-button](https://user-images.githubusercontent.com/1798828/134686892-33befbf3-a56a-41a2-8b55-bd5e67f47173.jpg)
after
![after-close-button](https://user-images.githubusercontent.com/1798828/134686868-8b4e5a63-6b1a-4fee-9f62-328def29a60c.jpg)


**Radios**
before
![before-radios-selected](https://user-images.githubusercontent.com/1798828/134686888-c546dc0f-173d-4ab2-bafc-798aac104975.jpg)
![before-radios](https://user-images.githubusercontent.com/1798828/134686891-78b0ae02-1f58-4368-81b2-196403964325.jpg)
after
![after-radios-selected](https://user-images.githubusercontent.com/1798828/134686866-a1ffd3c8-76d1-435b-b735-ce30b16af966.jpg)
![after-radios](https://user-images.githubusercontent.com/1798828/134686867-578d80b8-4439-4998-8a42-f9c4a555e3f3.jpg)

**Select multiple**
before
![before-multiselect-error](https://user-images.githubusercontent.com/1798828/134686884-fec1038d-3d57-47e7-907e-ad5f5ecf1c5f.jpg)
![before-multiselect](https://user-images.githubusercontent.com/1798828/134686886-3a91a5c1-8f07-4da1-ae28-767beae49b22.jpg)
after
![after-multiselect-error](https://user-images.githubusercontent.com/1798828/134686863-64ec84c0-b267-4fd9-a988-31228edf2812.jpg)
![after-multiselect](https://user-images.githubusercontent.com/1798828/134686865-57736746-4cfa-4130-ad38-ff0646cdd9a1.jpg)

**Toggles**
before
![before-toggles](https://user-images.githubusercontent.com/1798828/134686883-dcd0fa68-8b76-485d-9aa4-ef598d3905b0.jpg)
after
![after-toggles](https://user-images.githubusercontent.com/1798828/134686862-6ed0b7a4-f8c0-402a-9eee-72670c50e3fb.jpg)

**Textareas**
before
![before-textarea-error](https://user-images.githubusercontent.com/1798828/134686856-b1a98ff0-855f-4d64-bdcc-76eda3623d78.jpg)
![before-textarea](https://user-images.githubusercontent.com/1798828/134686859-e3373245-d512-470e-b064-a9e8a074ef96.jpg)
after
![after-textarea-error](https://user-images.githubusercontent.com/1798828/134686851-d4623b43-39f1-4a28-b656-0e6cbc424aef.jpg)
![after-textarea](https://user-images.githubusercontent.com/1798828/134686854-0ed81d85-6634-4776-aa14-b029c96cf17c.jpg)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
