### PR TITLE
fix(core:control-group): vertical label expand

### DIFF
--- a/packages/core/src/forms/control-group/control-group.element.scss
+++ b/packages/core/src/forms/control-group/control-group.element.scss
@@ -37,3 +37,7 @@ cds-control-action.status {
     padding-top: $cds-global-space-3;
   }
 }
+
+:host([layout*='vertical']) cds-internal-control-label {
+  --label-width: 100%;
+}

--- a/packages/core/src/forms/control-inline/control-inline.element.spec.ts
+++ b/packages/core/src/forms/control-inline/control-inline.element.spec.ts
@@ -11,7 +11,6 @@ import '@cds/core/forms/register.js';
 
 let element: HTMLElement;
 let control: CdsInternalControlInline;
-let controlInGroup: CdsInternalControlInline;
 let input: HTMLInputElement;
 let inputInControlGroup: HTMLInputElement;
 
@@ -32,7 +31,6 @@ describe('cds-internal-control-inline', () => {
     `);
 
     control = element.querySelectorAll<CdsInternalControlInline>('cds-internal-control-inline')[0];
-    controlInGroup = element.querySelectorAll<CdsInternalControlInline>('cds-internal-control-inline')[1];
 
     input = element.querySelector<HTMLInputElement>('input');
     inputInControlGroup = element.querySelector<HTMLInputElement>('cds-internal-control-group input');

--- a/packages/core/src/forms/forms.stories.ts
+++ b/packages/core/src/forms/forms.stories.ts
@@ -1860,7 +1860,7 @@ export function longText() {
           <cds-control-message>control message</cds-control-message>
         </cds-radio-group>
 
-        <cds-radio-group layout="compact">
+        <cds-radio-group layout="vertical">
           <label
             >Compact Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
             et dolore magna aliqua. Ut enim ad minim veniam</label
@@ -2121,7 +2121,7 @@ export function checkoutForm() {
           </cds-input>
         </div>
       </cds-form-group>
-      <cds-button cds-layout="m-t:lg">continue to checkout</cds-button>
+      <cds-button>continue to checkout</cds-button>
     </div>
   `;
 }
@@ -2132,12 +2132,11 @@ export function responsiveCheckoutForm() {
         width: 100%;
         max-width: 820px;
         min-width: 440px;
-        height: 1400px;
+        height: 1000px;
       }
     </style>
     <iframe
-      src="./iframe.html?id=stories-forms--checkout-form%26viewMode=story"
-      scrolling="no"
+      src="./iframe.html?id=stories-forms--checkout-form&amp;viewMode=story"
       frameborder="0"
       resizable="true"
       id="complex-form-demo"

--- a/packages/core/src/navigation/navigation.element.spec.ts
+++ b/packages/core/src/navigation/navigation.element.spec.ts
@@ -6,7 +6,7 @@
 
 import { html } from 'lit';
 import { createTestElement, removeTestElement, componentIsStable } from '@cds/core/test';
-import { CdsNavigation, CdsNavigationGroup, CdsNavigationItem, CdsNavigationStart } from './index.js';
+import { CdsNavigation, CdsNavigationItem, CdsNavigationStart } from './index.js';
 import '@cds/core/navigation/register.js';
 import Spy = jasmine.Spy;
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Control groups such as radio and checkbox groups prevented the group label from expanding to the full container width when the group layout was vertical.

Issue Number: 
closes #6361 

## What is the new behavior?
Control groups now allow the label to span the full container width when the group layout is a vertical type option. Similar to standard controls [seen here](https://github.com/vmware/clarity/blob/0b5b5605e99359a73bc84c3503a7611b235b3764/packages/core/src/forms/control/control.element.scss#L28). Also fixed a broken link for one of the form demos.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
