### PR TITLE
fix(core:select): support select size attr

### DIFF
--- a/packages/core/src/input/input.element.scss
+++ b/packages/core/src/input/input.element.scss
@@ -24,7 +24,8 @@
   width: 100%;
 }
 
-::slotted([slot='input']:not([multiple])) {
+// size/multiple are native select APIs
+::slotted([slot='input']:not([multiple]):not([size])) {
   text-transform: var(--text-transform) !important;
   border: var(--border) !important;
   outline: var(--outline) !important;

--- a/packages/core/src/select/register.ts
+++ b/packages/core/src/select/register.ts
@@ -1,14 +1,17 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { registerElementSafely } from '@cds/core/internal';
 import { CdsSelect } from './select.element.js';
+import { ClarityIcons } from '@cds/core/icon/icon.service.js';
+import { angleIcon } from '@cds/core/icon/shapes/angle.js';
 import '@cds/core/forms/register.js';
 import '@cds/core/icon/register.js';
 
+ClarityIcons.addIcons(angleIcon);
 registerElementSafely('cds-select', CdsSelect);
 
 declare global {

--- a/packages/core/src/select/select.element.scss
+++ b/packages/core/src/select/select.element.scss
@@ -4,6 +4,7 @@
 
 @import './../styles/tokens/generated/index';
 
+:host([_size]),
 :host([_multiple]) {
   --border: #{$cds-alias-object-border-width-100} solid #{$cds-alias-object-border-color} !important;
   --border-bottom: 0;
@@ -17,6 +18,7 @@
   cursor: pointer;
 }
 
+::slotted([slot='input'][size]),
 ::slotted([slot='input'][multiple]) {
   width: 100% !important;
   border-radius: #{$cds-alias-object-border-radius-100} !important;

--- a/packages/core/src/select/select.element.spec.ts
+++ b/packages/core/src/select/select.element.spec.ts
@@ -46,4 +46,13 @@ describe('cds-select', () => {
     await componentIsStable(component);
     expect(component.hasAttribute('_multiple')).toBe(true);
   });
+
+  it('should sync host size attr', async () => {
+    await componentIsStable(component);
+    expect(component.hasAttribute('_size')).toBe(false);
+
+    component.inputControl.setAttribute('size', '');
+    await componentIsStable(component);
+    expect(component.hasAttribute('_size')).toBe(true);
+  });
 });

--- a/packages/core/src/select/select.element.ts
+++ b/packages/core/src/select/select.element.ts
@@ -8,8 +8,6 @@ import { html } from 'lit';
 import { globalStyle, state, listenForAttributeChange } from '@cds/core/internal';
 import { CdsControl } from '@cds/core/forms';
 import { inputStyles } from '@cds/core/input';
-import { ClarityIcons } from '@cds/core/icon/icon.service.js';
-import { angleIcon } from '@cds/core/icon/shapes/angle.js';
 import globalStyles from './select.global.scss';
 import styles from './select.element.scss';
 
@@ -57,14 +55,14 @@ export class CdsSelect extends CdsControl {
 
   @state({ type: Boolean, reflect: true }) protected multiple = false;
 
-  constructor() {
-    super();
-    ClarityIcons.addIcons(angleIcon);
-  }
+  @state({ type: Boolean, reflect: true }) protected size = false;
 
   firstUpdated(props: Map<string, any>) {
     super.firstUpdated(props);
     this.multiple = this.inputControl.hasAttribute('multiple');
     this.observers.push(listenForAttributeChange(this.inputControl, 'multiple', val => (this.multiple = val !== null)));
+
+    this.size = this.inputControl.hasAttribute('size');
+    this.observers.push(listenForAttributeChange(this.inputControl, 'size', val => (this.size = val !== null)));
   }
 }

--- a/packages/core/src/select/select.stories.mdx
+++ b/packages/core/src/select/select.stories.mdx
@@ -55,6 +55,12 @@ import '@cds/core/select/register.js';
   <Story id="stories-select--multiple" />
 </Preview>
 
+## Size
+
+<Preview>
+  <Story id="stories-select--size" />
+</Preview>
+
 ## Dark Theme
 
 <Preview>

--- a/packages/core/src/select/select.stories.ts
+++ b/packages/core/src/select/select.stories.ts
@@ -208,6 +208,24 @@ export function multiple() {
 }
 
 /** @website */
+export function size() {
+  return html`
+    <cds-select>
+      <label>label</label>
+      <select size="5">
+        <option>Option One</option>
+        <option>Option Two</option>
+        <option>Option Three</option>
+        <option>Option Four</option>
+        <option>Option Five</option>
+        <option>Option Six</option>
+      </select>
+      <cds-control-message>message text</cds-control-message>
+    </cds-select>
+  `;
+}
+
+/** @website */
 export function darkTheme() {
   return html`
     <cds-form-group layout="horizontal" cds-theme="dark">


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
The cds-select is missing the `size` attr selector when supporting multi/size native APIs

Issue Number:
closes https://github.com/vmware/clarity/issues/6375 

## What is the new behavior?
Select will now respect native select `size`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
