### PR TITLE
chore(core): cleanup deprecated done api

### DIFF
--- a/packages/core/src/accordion/accordion-panel.element.spec.ts
+++ b/packages/core/src/accordion/accordion-panel.element.spec.ts
@@ -6,7 +6,13 @@
 import { html } from 'lit';
 import '@cds/core/accordion/register.js';
 import { CdsAccordionHeader, CdsAccordionPanel } from '@cds/core/accordion';
-import { componentIsStable, createTestElement, getComponentSlotContent, removeTestElement } from '@cds/core/test';
+import {
+  componentIsStable,
+  createTestElement,
+  getComponentSlotContent,
+  onceEvent,
+  removeTestElement,
+} from '@cds/core/test';
 
 describe('accordion-panel element', () => {
   let testElement: HTMLElement;
@@ -39,18 +45,12 @@ describe('accordion-panel element', () => {
     expect(slots['accordion-content'].includes(placeholderContent)).toBe(true);
   });
 
-  it('should emit an expandedChange event when header is clicked', async done => {
-    let value: any;
+  it('should emit an expandedChange event when header is clicked', async () => {
     await componentIsStable(component);
-    component.addEventListener<any>('expandedChange', (e: CustomEvent) => {
-      value = e.detail;
-      expect(value).toBe(true);
-      done();
-    });
-
+    const event = onceEvent(component, 'expandedChange');
     const button = component.shadowRoot.querySelector<HTMLButtonElement>('.accordion-header-button');
-    expect(button).toBeDefined();
     button.click();
+    expect((await event).detail).toBe(true);
   });
 
   it('should associate the aria-labelledby and aria-controls values correctly', async () => {

--- a/packages/core/src/alert/alert.element.spec.ts
+++ b/packages/core/src/alert/alert.element.spec.ts
@@ -10,7 +10,13 @@ import '@cds/core/icon/register.js';
 import { CdsAlert, getIconStatusTuple, iconShapeIsAlertStatusType } from '@cds/core/alert';
 import { CdsIcon } from '@cds/core/icon/icon.element.js';
 import { infoStandardIcon } from '@cds/core/icon/shapes/info-standard.js';
-import { componentIsStable, createTestElement, getComponentSlotContent, removeTestElement } from '@cds/core/test';
+import {
+  componentIsStable,
+  createTestElement,
+  getComponentSlotContent,
+  onceEvent,
+  removeTestElement,
+} from '@cds/core/test';
 import { CdsInternalCloseButton } from '@cds/core/internal-components/close-button';
 import { I18nService } from '@cds/core/internal';
 
@@ -294,23 +300,14 @@ describe('Alert element – ', () => {
       expect(getCloseButton().getAttribute('aria-label')).toBe(expectedLabel);
     });
 
-    it('should emit a closeChanged event when close button is clicked', async done => {
-      let value: any;
-      await componentIsStable(component);
-
+    it('should emit a closeChanged event when close button is clicked', async () => {
       component.type = 'default';
       component.closable = true;
       await componentIsStable(component);
 
-      component.addEventListener<any>('closeChange', (e: CustomEvent) => {
-        value = e.detail;
-        expect(value).toBe(true);
-        done();
-      });
-
-      const button = getCloseButton();
-      expect(button).toBeDefined();
-      button.click();
+      const event = onceEvent(component, 'closeChange');
+      getCloseButton().click();
+      expect((await event).detail).toBe(true);
     });
 
     it('sets 16 as the default icon size', async () => {

--- a/packages/core/src/button/button.element.spec.ts
+++ b/packages/core/src/button/button.element.spec.ts
@@ -14,10 +14,12 @@ import {
   getComponentSlotContent,
   removeTestElement,
   emulatedClick,
+  onceEvent,
 } from '@cds/core/test';
 
 describe('button element', () => {
   let testElement: HTMLElement;
+  let form: HTMLFormElement;
   let component: CdsButton;
   const placeholderText = 'Button Placeholder';
 
@@ -31,6 +33,8 @@ describe('button element', () => {
     `);
 
     component = testElement.querySelector<CdsButton>('cds-button');
+    form = testElement.querySelector('form');
+    form.addEventListener('submit', e => e.preventDefault());
   });
 
   afterEach(() => {
@@ -65,28 +69,19 @@ describe('button element', () => {
       expect(component.getAttribute('aria-disabled')).toBe('true');
     });
 
-    it('should work with form elements when clicked; defaults to type="submit"', async done => {
+    it('should work with form elements when clicked; defaults to type="submit"', async () => {
       await componentIsStable(component);
-      testElement.querySelector('form').addEventListener('submit', e => {
-        e.preventDefault();
-        expect(true).toBe(true);
-        done();
-      });
-
+      const event = onceEvent(form, 'submit');
       emulatedClick(component);
+      expect((await event) instanceof SubmitEvent).toBe(true);
     });
 
-    it('should work with form elements when clicked via keyboard; defaults to type="submit"', async done => {
+    it('should work with form elements when clicked via keyboard; defaults to type="submit"', async () => {
       await componentIsStable(component);
-      testElement.querySelector('form').addEventListener('submit', e => {
-        e.preventDefault();
-        expect(true).toBe(true);
-        done();
-      });
-
-      const event = new KeyboardEvent('keyup', { key: 'Enter' });
+      const event = onceEvent(form, 'submit');
       component.focus();
-      component.dispatchEvent(event);
+      component.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter' }));
+      expect((await event) instanceof SubmitEvent).toBe(true);
     });
 
     it('should not interact with form elements if type is button', async () => {
@@ -98,7 +93,7 @@ describe('button element', () => {
         },
       };
       spyOn(o, 'f');
-      testElement.querySelector('form').addEventListener('submit', o.f);
+      form.addEventListener('submit', o.f);
       component.click();
       const event = new KeyboardEvent('keyup', { key: 'Enter' });
       component.focus();
@@ -106,7 +101,7 @@ describe('button element', () => {
       expect(o.f).not.toHaveBeenCalled();
     });
 
-    it('should handle dynamic changes in button type', async done => {
+    it('should handle dynamic changes in button type', async () => {
       const o = {
         f: () => {
           // Do nothing
@@ -114,33 +109,23 @@ describe('button element', () => {
       };
       spyOn(o, 'f');
 
-      // submit case needs this setup to prevent actual form submission and change of locaiton
-      // which lead to errors in the tests
-      const p = (e: Event) => {
-        e.preventDefault();
-        expect(true).toBe(true);
-        done();
-      };
-
       // change from default (implicit "submit") to type="button"
       component.type = 'button';
       await componentIsStable(component);
-      testElement.querySelector('form').addEventListener('submit', o.f);
+      form.addEventListener('submit', o.f);
       emulatedClick(component);
       expect(o.f).not.toHaveBeenCalled();
 
       // change from type="button" to type="submit"
       component.type = 'submit';
       await componentIsStable(component);
-      testElement.querySelector('form').removeEventListener('submit', o.f);
-      testElement.querySelector('form').addEventListener('submit', p);
+      form.removeEventListener('submit', o.f);
       emulatedClick(component);
 
       // change from type="submit" to type="button"
       component.type = 'button';
       await componentIsStable(component);
-      testElement.querySelector('form').removeEventListener('submit', p);
-      testElement.querySelector('form').addEventListener('submit', o.f);
+      form.addEventListener('submit', o.f);
       emulatedClick(component);
       expect(o.f).not.toHaveBeenCalled();
     });
@@ -154,7 +139,7 @@ describe('button element', () => {
         },
       };
       spyOn(o, 'f');
-      testElement.querySelector('form').addEventListener('submit', o.f);
+      form.addEventListener('submit', o.f);
       expect(o.f).not.toHaveBeenCalled();
     });
 
@@ -167,7 +152,7 @@ describe('button element', () => {
         },
       };
       spyOn(o, 'f');
-      testElement.querySelector('form').addEventListener('submit', o.f);
+      form.addEventListener('submit', o.f);
       expect(o.f).not.toHaveBeenCalled();
     });
 

--- a/packages/core/src/internal/utils/dom.spec.ts
+++ b/packages/core/src/internal/utils/dom.spec.ts
@@ -367,17 +367,15 @@ describe('Functional Helper: ', () => {
   });
 
   describe('listenForAttributeChange', () => {
-    it('executes callback when observed attribute changes', async done => {
+    it('executes callback when observed attribute changes', async () => {
       const element = await createTestElement();
       expect(element.getAttribute('name')).toBe(null);
-
-      listenForAttributeChange(element, 'name', id => {
-        expect(id).toBe('hello world');
-        done();
-      });
+      const event = new Promise(resolve => listenForAttributeChange(element, 'name', id => resolve(id)));
 
       element.setAttribute('name', 'hello world');
       removeTestElement(element);
+
+      expect(await event).toBe('hello world');
     });
   });
 

--- a/packages/core/src/internal/utils/events.spec.ts
+++ b/packages/core/src/internal/utils/events.spec.ts
@@ -5,7 +5,7 @@
  */
 
 import { html } from 'lit';
-import { removeTestElement, createTestElement } from '@cds/core/test';
+import { removeTestElement, createTestElement, onceEvent } from '@cds/core/test';
 import { getElementUpdates } from './events.js';
 
 describe('getElementUpdates', () => {
@@ -29,31 +29,16 @@ describe('getElementUpdates', () => {
     expect(checked).toEqual(true);
   });
 
-  it('get notified of initial attr value', async done => {
+  it('get notified of initial attr value', async () => {
     input.setAttribute('indeterminate', '');
-
-    getElementUpdates(input, 'indeterminate', value => {
-      expect(value).toEqual('');
-      done();
-    });
+    const event = new Promise(resolve => getElementUpdates(input, 'indeterminate', v => resolve(v)));
+    expect(await event).toBe('');
   });
 
-  it('get notified of attr changes', async done => {
-    const values: any = [];
-    getElementUpdates(input, 'checked', value => {
-      values.push(value === '');
-
-      if (values.length === 2) {
-        // initial property value set
-        expect(values[0]).toEqual(false);
-
-        // attribute update set
-        expect(values[1]).toEqual(true);
-        done();
-      }
-    });
-
+  it('get notified of attr changes', async () => {
+    const event = new Promise(resolve => getElementUpdates(input, 'checked', v => resolve(v)));
     input.setAttribute('checked', '');
+    expect(await event).toBe(false);
   });
 
   it('should reset any React value trackers if input', () => {

--- a/packages/core/src/test/utils.ts
+++ b/packages/core/src/test/utils.ts
@@ -95,3 +95,10 @@ export function emulatedClick(component: HTMLElement) {
   component.dispatchEvent(event2);
   component.dispatchEvent(event3);
 }
+
+/** helpful for capturing a single event in a async test rather than Jasmine `done()` */
+export function onceEvent(element: HTMLElement, event: string) {
+  return new Promise<any>(resolve => {
+    element.addEventListener(event, e => resolve(e));
+  });
+}

--- a/packages/core/src/tree-view/tree-item.element.spec.ts
+++ b/packages/core/src/tree-view/tree-item.element.spec.ts
@@ -8,7 +8,7 @@ import { html } from 'lit';
 import '@cds/core/tree-view/register.js';
 import { CdsTreeItem } from '@cds/core/tree-view';
 import { CdsProgressCircle } from '@cds/core/progress-circle';
-import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
+import { componentIsStable, createTestElement, onceEvent, removeTestElement } from '@cds/core/test';
 
 describe('tree item element', () => {
   let testElement: HTMLElement;
@@ -75,35 +75,26 @@ describe('tree item element', () => {
     expect(component.getAttribute('aria-selected')).toBe('false');
   });
 
-  it('should emit an expandedChange event when expand/collapse icon is clicked', async done => {
-    let value: any;
+  it('should emit an expandedChange event when expand/collapse icon is clicked', async () => {
     await componentIsStable(component);
 
     component.expandable = true;
     await componentIsStable(component);
 
-    component.addEventListener<any>('expandedChange', (e: CustomEvent) => {
-      value = e.detail;
-      expect(value).toBe(true);
-      done();
-    });
-
+    const event = onceEvent(component, 'expandedChange');
     const itemCaret = component.shadowRoot.querySelector<HTMLElement>('[part="expand-collapse-icon"]');
     expect(itemCaret).toBeDefined();
     itemCaret.click();
+
+    expect((await event).detail).toBe(true);
   });
 
-  it('should emit a selectedChange event when an item is clicked', async done => {
-    let value: any;
+  it('should emit a selectedChange event when an item is clicked', async () => {
     await componentIsStable(component);
-    component.addEventListener<any>('selectedChange', (e: CustomEvent) => {
-      value = e.detail;
-      expect(value).toBe(true);
-      done();
-    });
-
+    const event = onceEvent(component, 'selectedChange');
     const item = component.shadowRoot.querySelector<HTMLElement>('.item-content');
     expect(item).toBeDefined();
     item.click();
+    expect((await event).detail).toBe(true);
   });
 });

--- a/packages/core/src/tree-view/tree-item.element.ts
+++ b/packages/core/src/tree-view/tree-item.element.ts
@@ -64,7 +64,7 @@ export class CdsTreeItem extends LitElement implements Animatable {
   @i18n() i18n = I18nService.keys.treeview;
 
   @state({ type: String, reflect: true, attribute: 'role' })
-  protected role = 'treeitem';
+  role = 'treeitem';
 
   @property({ type: String })
   cdsMotion = 'on';
@@ -73,13 +73,13 @@ export class CdsTreeItem extends LitElement implements Animatable {
   cdsMotionChange: EventEmitter<string>;
 
   @state({ type: String, reflect: true, attribute: 'aria-disabled' })
-  protected ariaDisabled: AriaBooleanAttributeValues | undefined = 'false';
+  ariaDisabled: AriaBooleanAttributeValues | undefined = 'false';
 
   @state({ type: String, reflect: true, attribute: 'aria-expanded' })
-  protected ariaExpanded: AriaBooleanAttributeValues | undefined = 'false';
+  ariaExpanded: AriaBooleanAttributeValues | undefined = 'false';
 
   @state({ type: String, reflect: true, attribute: 'aria-selected' })
-  protected ariaSelected: AriaBooleanAttributeValues | undefined = 'false';
+  ariaSelected: AriaBooleanAttributeValues | undefined = 'false';
 
   @property({ type: Boolean, reflect: true, attribute: 'multi-select' })
   multiSelect = false;

--- a/packages/core/src/tree-view/tree.element.spec.ts
+++ b/packages/core/src/tree-view/tree.element.spec.ts
@@ -7,7 +7,7 @@
 import { html } from 'lit';
 import '@cds/core/tree-view/register.js';
 import { CdsTree } from '@cds/core/tree-view';
-import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
+import { componentIsStable, createTestElement, onceEvent, removeTestElement } from '@cds/core/test';
 
 describe('tree element', () => {
   let testElement: HTMLElement;
@@ -152,20 +152,16 @@ describe('keyboard navigation', () => {
   });
 
   describe('arrow-left key - ', () => {
-    it('should emit expandedChange event if expanded', async done => {
-      let value: any;
+    it('should emit expandedChange event if expanded', async () => {
       await componentIsStable(component);
       const treeItemChildren = testElement.querySelectorAll('cds-tree-item');
       component.focus();
 
       await componentIsStable(component);
-      treeItemChildren[0].addEventListener<any>('expandedChange', (e: CustomEvent) => {
-        value = e.detail;
-        expect(value).toBe(false);
-        done();
-      });
+      const event = onceEvent(treeItemChildren[0], 'expandedChange');
 
       component.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }));
+      expect((await event).detail).toBe(false);
     });
 
     it('should move focus to parent if not expanded', async () => {
@@ -209,8 +205,7 @@ describe('keyboard navigation', () => {
   });
 
   describe('arrow-right key - ', () => {
-    it('should emit expandedChange event if not expanded', async done => {
-      let value: any;
+    it('should emit expandedChange event if not expanded', async () => {
       await componentIsStable(component);
       const treeItemChildren = testElement.querySelectorAll('cds-tree-item');
       component.focus();
@@ -219,13 +214,9 @@ describe('keyboard navigation', () => {
       treeItemChildren[1].focus();
       component.ariaActiveDescendant = treeItemChildren[1].id;
 
-      treeItemChildren[1].addEventListener<any>('expandedChange', (e: CustomEvent) => {
-        value = e.detail;
-        expect(value).toBe(true);
-        done();
-      });
-
+      const event = onceEvent(treeItemChildren[1], 'expandedChange');
       component.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowLeft', key: 'ArrowRight' }));
+      expect((await event).detail).toBe(true);
     });
 
     it('should move focus to first child node if expanded', async () => {
@@ -316,23 +307,18 @@ describe('keyboard navigation', () => {
   });
 
   describe('enter key - ', () => {
-    it('should emit expandedChange event if expandable', async done => {
-      let value: any;
+    it('should emit expandedChange event if expandable', async () => {
       await componentIsStable(component);
       const treeItemChildren = testElement.querySelectorAll('cds-tree-item');
       component.focus();
 
       await componentIsStable(component);
-      treeItemChildren[0].addEventListener<any>('expandedChange', (e: CustomEvent) => {
-        value = e.detail;
-        expect(value).toBe(false);
-        done();
-      });
-
+      const event = onceEvent(treeItemChildren[0], 'expandedChange');
       component.dispatchEvent(new KeyboardEvent('keydown', { code: 'Enter', key: 'Enter' }));
+      expect((await event).detail).toBe(false);
     });
 
-    it('should click on a link inside tree node', async done => {
+    it('should click on a link inside tree node', async () => {
       testElement = await createTestElement(html`
         <cds-tree>
           <cds-tree-item>
@@ -348,41 +334,30 @@ describe('keyboard navigation', () => {
       `);
       component = testElement.querySelector<CdsTree>('cds-tree');
       await componentIsStable(component);
-      const link = testElement.querySelector('#link1');
+      const link = testElement.querySelector<HTMLElement>('#link1');
       component.focus();
-
-      let clicked = false;
       await componentIsStable(component);
 
-      expect(link).toBeDefined();
-      link.addEventListener<any>('click', () => {
-        clicked = true;
-        expect(clicked).toBe(true);
-        done();
-      });
-
+      const event = onceEvent(link, 'click');
       component.dispatchEvent(new KeyboardEvent('keydown', { code: 'Enter', key: 'Enter' }));
+      expect(await event).toBeTruthy();
     });
   });
 
   describe('space key - ', () => {
-    it('should emit selectedChange event if selectable', async done => {
-      let value: any;
+    it('should emit selectedChange event if selectable', async () => {
       await componentIsStable(component);
       const treeItemChildren = testElement.querySelectorAll('cds-tree-item');
       component.focus();
 
       await componentIsStable(component);
-      treeItemChildren[0].addEventListener<any>('selectedChange', (e: CustomEvent) => {
-        value = e.detail;
-        expect(value).toBe(true);
-        done();
-      });
 
+      const event = onceEvent(treeItemChildren[0], 'selectedChange');
       component.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space', key: ' ' }));
+      expect((await event).detail).toBe(true);
     });
 
-    it('should click on a link inside tree node', async done => {
+    it('should click on a link inside tree node', async () => {
       testElement = await createTestElement(html`
         <cds-tree>
           <cds-tree-item>
@@ -398,20 +373,12 @@ describe('keyboard navigation', () => {
       `);
       component = testElement.querySelector<CdsTree>('cds-tree');
       await componentIsStable(component);
-      const link = testElement.querySelector('#link1');
+      const link = testElement.querySelector<HTMLElement>('#link1');
       component.focus();
-
-      let clicked = false;
       await componentIsStable(component);
-
-      expect(link).toBeDefined();
-      link.addEventListener<any>('click', () => {
-        clicked = true;
-        expect(clicked).toBe(true);
-        done();
-      });
-
+      const event = onceEvent(link, 'click');
       component.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space', key: ' ' }));
+      expect((await event).detail).toBe(0);
     });
   });
 });

--- a/packages/core/src/tree-view/tree.element.ts
+++ b/packages/core/src/tree-view/tree.element.ts
@@ -45,7 +45,7 @@ import styles from './tree.element.scss';
  */
 export class CdsTree extends LitElement {
   @state({ type: String, reflect: true, attribute: 'role' })
-  protected role = 'tree';
+  role = 'tree';
 
   @property({ type: Boolean, attribute: 'multi-select' })
   multiSelect = false;
@@ -54,7 +54,7 @@ export class CdsTree extends LitElement {
   ariaActiveDescendant: string;
 
   @state({ type: String, reflect: true, attribute: 'aria-multiselectable' })
-  protected ariaMultiSelectable: AriaBooleanAttributeValues = 'false';
+  ariaMultiSelectable: AriaBooleanAttributeValues = 'false';
 
   @querySlot('cds-tree-item') private firstChildItem: CdsTreeItem;
 

--- a/packages/core/web-test-runner.config.mjs
+++ b/packages/core/web-test-runner.config.mjs
@@ -45,7 +45,6 @@ export default /** @type {import("@web/test-runner").TestRunnerConfig} */ ({
   ],
   testRunnerHtml: (testRunnerImport, config) => `<html>
     <head>
-      <link href="./node_modules/modern-normalize/modern-normalize.css" rel="stylesheet" />
       <link href="./dist/core/global.min.css" rel="stylesheet" />
       <script>window.process = { env: { NODE_ENV: "development" } }</script>
       <script type="text/javascript" src="./node_modules/jasmine-core/lib/jasmine-core/jasmine.js"></script>


### PR DESCRIPTION
Signed-off-by: Cory Rylan <splintercode.cb@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?
This PR removes most but not all usages of Jasmine `done` inside async functions. Using both `done` and `async` in a test is deprecated and causes a lot of noise in the build output.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
