### PR TITLE
chore(core): add hslToRgb utility function to exports

### DIFF
--- a/packages/core/src/internal/index.ts
+++ b/packages/core/src/internal/index.ts
@@ -11,6 +11,7 @@ import styles from './base/base.element.scss';
 export const baseStyles = styles;
 export * from './base/button.base.js';
 export * from './base/focus-trap.base.js';
+export * from './utils/color.js';
 export * from './utils/css.js';
 export * from './utils/dom.js';
 export * from './utils/register.js';

--- a/packages/core/src/internal/utils/color.ts
+++ b/packages/core/src/internal/utils/color.ts
@@ -1,0 +1,27 @@
+export function hslToRgb(h: number, s: number, l: number) {
+  s = s / 100;
+  l = l / 100;
+  const a = s * Math.min(l, 1 - l);
+  const f = (n: any, k = (n + h / 30) % 12) => l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
+  return [Math.round(f(0) * 255), Math.round(f(8) * 255), Math.round(f(4) * 255)];
+}
+
+export function rgbToHex(red: number, green: number, blue: number) {
+  let r = red.toString(16);
+  let g = green.toString(16);
+  let b = blue.toString(16);
+
+  if (r.length === 1) {
+    r = '0' + r;
+  }
+
+  if (g.length === 1) {
+    g = '0' + g;
+  }
+
+  if (b.length === 1) {
+    b = '0' + b;
+  }
+
+  return `#${r}${g}${b}`;
+}

--- a/packages/core/src/styles/tokens/tokens.stories.ts
+++ b/packages/core/src/styles/tokens/tokens.stories.ts
@@ -11,6 +11,7 @@ import { homeIcon } from '@cds/core/icon/shapes/home.js';
 import { plusIcon } from '@cds/core/icon/shapes/plus.js';
 import { trashIcon } from '@cds/core/icon/shapes/trash.js';
 import { downloadIcon } from '@cds/core/icon/shapes/download.js';
+import { hslToRgb, rgbToHex } from '@cds/core/internal';
 
 import '@cds/core/navigation/register.js';
 
@@ -171,34 +172,6 @@ function createToken(token: Token, globals: any, currentTheme: any) {
 
 function tokenToCssProp(name: string) {
   return `--cds-${name.replace(/([A-Z]|\d+)/g, '-$1').toLocaleLowerCase()}`;
-}
-
-function hslToRgb(h: number, s: number, l: number) {
-  s = s / 100;
-  l = l / 100;
-  const a = s * Math.min(l, 1 - l);
-  const f = (n: any, k = (n + h / 30) % 12) => l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
-  return [Math.round(f(0) * 255), Math.round(f(8) * 255), Math.round(f(4) * 255)];
-}
-
-function rgbToHex(red: number, green: number, blue: number) {
-  let r = red.toString(16);
-  let g = green.toString(16);
-  let b = blue.toString(16);
-
-  if (r.length === 1) {
-    r = '0' + r;
-  }
-
-  if (g.length === 1) {
-    g = '0' + g;
-  }
-
-  if (b.length === 1) {
-    b = '0' + b;
-  }
-
-  return `#${r}${g}${b}`;
 }
 
 function isAnimationToken(token: Token) {


### PR DESCRIPTION
Signed-off-by: Ashley Ryan <asryan@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [x] Other... Please describe:

## What is the current behavior?

`hslToRgb` is a utility function in tokens.story.ts, but not exported for use by consuming developers

## What is the new behavior?

`hslToRgb` (and `rgbToHex`) is now exported from internal utilities

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This came out of this slack thread, here: https://cloudhealth.slack.com/archives/C0JF8D2LB/p1629810760303500
