### PR TITLE
build: ignore website deploy failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,9 @@ jobs:
       - uses: microsoft/playwright-github-action@v1
       - run: npm install
       - run: npm run build:ci
-      - run: npm run deploy:website
+      - name: Website Deploy
+        continue-on-error: true
+        run: npm run deploy:website
 
     env:
       CI: true


### PR DESCRIPTION
Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Type

What kind of change does this PR introduce?
Adds an ignore flag for the netlify deploy step that will allow PRs to pass even if netlify cli auth times out. . 

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Netlify will intermittently fail when deploying a preview and the build will fail.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
The build will not fail if netlify fails to deploy. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No