### PR TITLE
build: ignore website deploy failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,9 @@ jobs:
       - uses: microsoft/playwright-github-action@v1
       - run: npm install
       - run: npm run build:ci
-      - run: npm run deploy:website
+      - name: Website Deploy
+        continue-on-error: true
+        run: npm run deploy:website
 
     env:
       CI: true


### PR DESCRIPTION
Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Type

What kind of change does this PR introduce?
Ignore netlify deploy failures. 

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Th
e build will fail if the deploy to netlify task fails (b/c of an auth timout or network error)
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
The build will ignore failures to deploy for the website.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
