### PR TITLE
fix(a11y): add role and label to built-in datagrid filters

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -379,6 +379,7 @@ export interface ClrCommonStrings {
     currentPage: string;
     danger: string;
     datagridFilterAriaLabel?: string;
+    datagridFilterDialogAriaLabel?: string;
     dategridExpandableBeginningOf?: string;
     dategridExpandableEndOf?: string;
     dategridExpandableRowContent?: string;

--- a/projects/angular/src/data/datagrid/datagrid-filter.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-filter.spec.ts
@@ -167,6 +167,17 @@ export default function (): void {
         expect(toggle.getAttribute('aria-label')).toBe(commonStrings.keys.datagridFilterAriaLabel);
       });
 
+      it('has role and label on the filter dialog', function () {
+        const commonStrings: ClrCommonStringsService =
+          context.fixture.debugElement.injector.get(ClrCommonStringsService);
+        const openBtn: HTMLButtonElement = context.clarityElement.querySelector('.clr-smart-open-close');
+        openBtn.click();
+        context.detectChanges();
+        const popoverContent = document.querySelector('.clr-popover-content');
+        expect(popoverContent.getAttribute('role')).toBe('dialog');
+        expect(popoverContent.getAttribute('aria-label')).toBe(commonStrings.keys.datagridFilterDialogAriaLabel);
+      });
+
       it('projects content into the dropdown', function () {
         const openBtn: HTMLButtonElement = context.clarityElement.querySelector('.clr-smart-open-close');
         const prePopoverContent = document.querySelector('.clr-popover-content');

--- a/projects/angular/src/data/datagrid/datagrid-filter.ts
+++ b/projects/angular/src/data/datagrid/datagrid-filter.ts
@@ -63,6 +63,8 @@ import { isPlatformBrowser } from '@angular/common';
       [id]="popoverId"
       clrFocusTrap
       *clrPopoverContent="open; at: smartPosition; outsideClickToClose: true; scrollToClose: true"
+      role="dialog"
+      [attr.aria-label]="commonStrings.keys.datagridFilterDialogAriaLabel"
     >
       <div class="datagrid-filter-close-wrapper">
         <button type="button" class="close" clrPopoverCloseButton>

--- a/projects/angular/src/utils/i18n/common-strings.default.ts
+++ b/projects/angular/src/utils/i18n/common-strings.default.ts
@@ -49,7 +49,8 @@ export const commonStringsDefault: ClrCommonStrings = {
   singleSelectionAriaLabel: 'Single selection header',
   singleActionableAriaLabel: 'Single actionable header',
   detailExpandableAriaLabel: 'Toggle more row content',
-  datagridFilterAriaLabel: 'Toggle column filter',
+  datagridFilterAriaLabel: 'Filter dialog',
+  datagridFilterDialogAriaLabel: 'Toggle column filter',
   columnSeparatorAriaLabel: 'Column resize handle',
   columnSeparatorDescription: 'Not necessary to use this button',
   // Alert

--- a/projects/angular/src/utils/i18n/common-strings.interface.ts
+++ b/projects/angular/src/utils/i18n/common-strings.interface.ts
@@ -133,6 +133,10 @@ export interface ClrCommonStrings {
    */
   datagridFilterAriaLabel?: string;
   /**
+   * Datagrid filter dialog
+   */
+  datagridFilterDialogAriaLabel?: string;
+  /**
    * Datagrid column handler string
    */
   columnSeparatorAriaLabel?: string;


### PR DESCRIPTION
Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

No role or label for the built-in filters

Issue Number: N/A

## What is the new behavior?

role="dialog" 
aria-label="Filter dialog"

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
