### PR TITLE
fix(a11y): do not overwrite aria-label on signpost trigger

### DIFF
--- a/projects/angular/src/popover/signpost/signpost-trigger.spec.ts
+++ b/projects/angular/src/popover/signpost/signpost-trigger.spec.ts
@@ -66,6 +66,13 @@ export default function (): void {
       expect(trigger.getAttribute('aria-label')).toEqual('Signpost Toggle');
     });
 
+    it('preserves explicitly set label', () => {
+      const testLabel = 'Test label';
+      fixture.debugElement.componentInstance.label = testLabel;
+      fixture.detectChanges();
+      expect(trigger.getAttribute('aria-label')).toEqual(testLabel);
+    });
+
     it('reflects the correct aria-expanded state', () => {
       expect(trigger.getAttribute('aria-expanded')).toBeFalsy();
       trigger.click();
@@ -85,10 +92,13 @@ export default function (): void {
       type="button"
       class="signpost-action btn btn-small btn-link"
       [ngClass]="{ active: open }"
+      [attr.aria-label]="label"
       clrSignpostTrigger
     >
       <cds-icon shape="info-circle"></cds-icon>
     </button>
   `,
 })
-class TestTrigger {}
+class TestTrigger {
+  label = null;
+}

--- a/projects/angular/src/popover/signpost/signpost-trigger.ts
+++ b/projects/angular/src/popover/signpost/signpost-trigger.ts
@@ -15,7 +15,6 @@ import { SignpostIdService } from './providers/signpost-id.service';
   selector: '[clrSignpostTrigger]',
   host: {
     class: 'signpost-trigger',
-    '[attr.aria-label]': 'commonStrings.keys.signpostToggle',
     '[attr.aria-expanded]': 'ariaExpanded',
     '[attr.aria-controls]': 'ariaControl',
     '[class.active]': 'isOpen',
@@ -68,6 +67,13 @@ export class ClrSignpostTrigger implements OnDestroy {
       }),
       this.signpostIdService.id.subscribe(idChange => (this.ariaControl = idChange))
     );
+    this.addDefaultAriaLabel(this.el.nativeElement);
+  }
+
+  private addDefaultAriaLabel(el: HTMLElement) {
+    if (!el.hasAttribute('aria-label')) {
+      el.setAttribute('aria-label', this.commonStrings.keys.signpostToggle);
+    }
   }
 
   private focusOnClose() {


### PR DESCRIPTION
Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

aria-label provided by user is overwritten with default value

Issue Number: N/A

## What is the new behavior?

aria-label provided by user is preserved. Default value is added only if no aria-label was supplied by user

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
