### PR TITLE
fix: move @type jsdoc tag to help documentation generation

### DIFF
--- a/packages/core/src/alert/alert-group.element.ts
+++ b/packages/core/src/alert/alert-group.element.ts
@@ -57,15 +57,15 @@ import styles from './alert-group.element.scss';
  */
 export class CdsAlertGroup extends LitElement {
   /**
-   * @type {default | sm}
    * Sets the overall height and width of the alerts inside the alert group
+   * @type {default | sm}
    */
   @property({ type: String })
   size: AlertSizes = 'default';
 
   /**
-   * @type {default | banner | light}
    * Passed down into the alerts inside the alert-group
+   * @type {default | banner | light}
    */
   @property({ type: String })
   type: AlertGroupTypes = 'default';
@@ -77,8 +77,8 @@ export class CdsAlertGroup extends LitElement {
   role = 'region';
 
   /**
-   * @type {neutral | info | success | warning | danger | alt | loading}
    * Sets the status of the alerts inside the alert group
+   * @type {neutral | info | success | warning | danger | alt | loading}
    */
   @property({ type: String })
   status: AlertStatusTypes = 'neutral';

--- a/packages/core/src/alert/alert.element.ts
+++ b/packages/core/src/alert/alert.element.ts
@@ -136,8 +136,8 @@ export class CdsAlert extends LitElement {
   @event() private closeChange: EventEmitter<boolean>;
 
   /**
-   * @type {default | sm}
    * Sets the overall height and width of the alert and icon based on value
+   * @type {default | sm}
    */
   @property({ type: String })
   size: AlertSizes = 'default';
@@ -162,8 +162,8 @@ export class CdsAlert extends LitElement {
   closable = false;
 
   /**
-   * @type {neutral | info | success | warning | danger | alt | loading}
    * Sets the color of the alert from a predefined list of statuses
+   * @type {neutral | info | success | warning | danger | alt | loading}
    */
   @property({ type: String })
   status: AlertStatusTypes = 'neutral';

--- a/packages/core/src/badge/badge.element.ts
+++ b/packages/core/src/badge/badge.element.ts
@@ -40,8 +40,8 @@ export class CdsBadge extends LitElement {
   color: 'default' | 'gray' | 'purple' | 'blue' | 'orange' | 'light-blue' | null = null;
 
   /**
-   * @type {neutral | info | success | warning | danger}
    * Sets the color of the badge
+   * @type {neutral | info | success | warning | danger}
    */
   @property({ type: String })
   status: StatusTypes = 'neutral';

--- a/packages/core/src/button/button.element.ts
+++ b/packages/core/src/button/button.element.ts
@@ -72,8 +72,8 @@ export class CdsButton extends CdsBaseButton {
   block = false;
 
   /**
-   * @type {default | loading | success | error}
    * Changes the button content based on the value passed.
+   * @type {default | loading | success | error}
    *
    * - `default`: shows the content of the button
    * - `loading`: disables the button and shows a spinner inside the button

--- a/packages/core/src/forms/control-group/control-group.element.ts
+++ b/packages/core/src/forms/control-group/control-group.element.ts
@@ -62,8 +62,8 @@ import {
  */
 export class CdsInternalControlGroup extends LitElement {
   /**
-   * @type {neutral | error | success}
    * Set the status of control group validation
+   * @type {neutral | error | success}
    */
   @property({ type: String }) status: ControlStatus = 'neutral';
 
@@ -77,8 +77,8 @@ export class CdsInternalControlGroup extends LitElement {
   @property({ type: Boolean }) disabled = false;
 
   /**
-   * @type {stretch | shrink}
    * Adjust the control from the default full width or the browser default width
+   * @type {stretch | shrink}
    */
   @property({ type: String }) controlWidth: ControlWidth = defaultControlWidth;
 

--- a/packages/core/src/forms/control-message/control-message.element.ts
+++ b/packages/core/src/forms/control-message/control-message.element.ts
@@ -35,8 +35,8 @@ import { ValidityStateKey } from '../utils/validate.js';
  */
 export class CdsControlMessage extends LitElement {
   /**
-   * @type {neutral | error | success}
    * Set the status of form control message validation
+   * @type {neutral | error | success}
    */
   @property({ type: String }) status: ControlStatus = 'neutral';
 

--- a/packages/core/src/forms/control/control.element.ts
+++ b/packages/core/src/forms/control/control.element.ts
@@ -66,14 +66,14 @@ export const enum ControlLabelLayout {
  */
 export class CdsControl extends LitElement {
   /**
-   * @type {neutral | error | success}
    * Set the status of form control validation
+   * @type {neutral | error | success}
    */
   @property({ type: String }) status: ControlStatus = 'neutral';
 
   /**
-   * @type {stretch | shrink}
    * Adjust the control from the default full width or the browser default width
+   * @type {stretch | shrink}
    */
   @property({ type: String }) controlWidth: ControlWidth = defaultControlWidth;
 
@@ -90,8 +90,8 @@ export class CdsControl extends LitElement {
   @property({ type: Boolean }) responsive = true;
 
   /**
-   * @type {vertical | horizontal | compact}
    * Set to adjust the default control layout. When `responsive` is true this will be the largest size to scale to.
+   * @type {vertical | horizontal | compact}
    */
   @property({ type: String })
   get layout(): ControlLayout {

--- a/packages/core/src/forms/form-group/form-group.element.ts
+++ b/packages/core/src/forms/form-group/form-group.element.ts
@@ -49,15 +49,15 @@ import styles from './form-group.element.scss';
  */
 export class CdsFormGroup extends LitElement {
   /**
-   * @type {horizontal | horizontal-inline | vertical | vertical-inline | compact}
    * Set to adjust the default control layout for all controls within form group.
    * When `responsive` is true this will be the largest size to scale to.
+   * @type {horizontal | horizontal-inline | vertical | vertical-inline | compact}
    */
   @property({ type: String }) layout: FormLayout = defaultFormLayout;
 
   /**
-   * @type {stretch | shrink}
    * Adjust the control from the default full width or the browser default width
+   * @type {stretch | shrink}
    */
   @property({ type: String }) controlWidth: ControlWidth; // no default given so child controls are not overridden unless explicity set by parent form group
 

--- a/packages/core/src/icon/icon.element.ts
+++ b/packages/core/src/icon/icon.element.ts
@@ -74,8 +74,8 @@ export class CdsIcon extends LitElement {
   }
 
   /**
-   * @type {string | xs | sm | md | lg | xl | xxl}
    * Apply numerical width-height or a t-shirt-sized CSS classname
+   * @type {string | xs | sm | md | lg | xl | xxl}
    */
   @property({ type: String })
   set size(val: string) {
@@ -88,16 +88,16 @@ export class CdsIcon extends LitElement {
   }
 
   /**
-   * @type {up | down | left | right}
    * Takes a directional value that rotates the icon 90° with the
    * top of the icon pointing in the specified direction.
+   * @type {up | down | left | right}
    */
   @property({ type: String })
   direction: Directions;
 
   /**
-   * @type {horizontal | vertical}
    * Takes an orientation value that reverses the orientation of the icon vertically or horizontally'
+   * @type {horizontal | vertical}
    */
   @property({ type: String })
   flip: Orientations;
@@ -109,8 +109,8 @@ export class CdsIcon extends LitElement {
   solid = false;
 
   /**
-   * @type {info | success | warning | danger}
    * Changes color of icon fills and outlines
+   * @type {info | success | warning | danger}
    */
   @property({ type: String })
   status: StatusTypes;
@@ -123,7 +123,6 @@ export class CdsIcon extends LitElement {
   inverse = false;
 
   /**
-   * @type {info | success | warning | danger | inherit | warning-triangle | inherit-triangle}
    * Sets the color of the icon decoration that appears in the top-right corner
    * of the glyph. The icon decoration is derived from the following predefined types.
    *
@@ -141,6 +140,7 @@ export class CdsIcon extends LitElement {
    * By default, the badge displays a 'danger' dot (a red-colored dot).
    *
    * Setting the badge to 'false' or removing the attribute will remove the default icon badge.
+   * @type {info | success | warning | danger | inherit | warning-triangle | inherit-triangle}
    */
   @property({ type: String })
   badge: StatusTypes | 'inherit' | 'warning-triangle' | 'inherit-triangle' | true | false;

--- a/packages/core/src/progress-circle/progress-circle.element.ts
+++ b/packages/core/src/progress-circle/progress-circle.element.ts
@@ -39,8 +39,8 @@ export class CdsProgressCircle extends LitElement {
   private _size: string;
 
   /**
-   * @type {neutral | info | success | warning | danger}
    * Sets the color of the badge
+   * @type {neutral | info | success | warning | danger}
    */
   @property({ type: String })
   status: StatusTypes = 'neutral';
@@ -102,8 +102,8 @@ export class CdsProgressCircle extends LitElement {
   }
 
   /**
-   * @type {string | sm | md | lg | xl | xxl}
    * Apply numerical width-height or a t-shirt-sized CSS classname
+   * @type {string | sm | md | lg | xl | xxl}
    */
   @property({ type: String })
   set size(val: string) {

--- a/packages/core/src/tag/tag.element.ts
+++ b/packages/core/src/tag/tag.element.ts
@@ -33,8 +33,8 @@ import styles from './tag.element.scss';
  */
 export class CdsTag extends CdsBaseButton {
   /**
-   * @type {neutral | info | success | warning | danger}
    * Sets the color of the tag (and badge if present) from the following predefined list of statuses:
+   * @type {neutral | info | success | warning | danger}
    */
   @property({ type: String })
   status: StatusTypes = 'neutral';


### PR DESCRIPTION
Move the @type below the description block so our tooling could pick it up and use it as part of the Website Documentation and add it into the custom-elements definition for a given field.

