### PR TITLE
feat(core:icon): support non-equilateral icon sizing

### DIFF
--- a/packages/core/src/icon/icon.element.scss
+++ b/packages/core/src/icon/icon.element.scss
@@ -15,6 +15,7 @@
   --color: currentColor;
   display: inline-block;
   @include equilateral(#{$cds-global-space-7});
+  @include min-equilateral(#{$cds-global-space-7});
   margin: 0;
   vertical-align: middle;
   fill: var(--color);
@@ -28,33 +29,49 @@ svg {
 }
 
 // sizing
-:host([size='xs']) {
+:host([size*='xs']) {
   @include equilateral(#{$cds-global-space-5});
+  @include min-equilateral(#{$cds-global-space-5});
 }
 
-:host([size='sm']) {
+:host([size*='sm']) {
   // weirdly, the default... 16px
   @include equilateral(#{$cds-global-space-7});
+  @include min-equilateral(#{$cds-global-space-7});
 }
 
-:host([size='md']) {
+:host([size*='md']) {
   // 24px
   @include equilateral(#{$cds-global-space-9});
+  @include min-equilateral(#{$cds-global-space-9});
 }
 
-:host([size='lg']) {
+:host([size*='lg']) {
   // 36px
   @include equilateral(#{$cds-global-space-11});
+  @include min-equilateral(#{$cds-global-space-11});
 }
 
-:host([size='xl']) {
+// note: the selectors for `xl` and `xxl` work as expected due to the order in
+// which they are listed here. this is fine and expected for CSS. just know
+// that if their order is switched around, they will break.
+// likewise if we add an `xxs` it will have to go AFTER `xs`!
+:host([size*='xl']) {
   // 48px
   @include equilateral(#{$cds-global-space-12});
+  @include min-equilateral(#{$cds-global-space-12});
 }
 
-:host([size='xxl']) {
+:host([size*='xxl']) {
   // 64px
   @include equilateral(calc(#{$cds-global-space-13} - #{$cds-global-space-5}));
+  @include min-equilateral(calc(#{$cds-global-space-13} - #{$cds-global-space-5}));
+}
+
+:host([size*='fit']) {
+  height: auto;
+  width: auto;
+  contain: layout;
 }
 
 // colors

--- a/packages/core/src/icon/icon.stories.ts
+++ b/packages/core/src/icon/icon.stories.ts
@@ -5,6 +5,7 @@
  */
 
 import '@cds/core/icon/register.js';
+import '@cds/core/button/register.js';
 import { ClarityIcons } from '@cds/core/icon/icon.service.js';
 import { imageIcon } from '@cds/core/icon/shapes/image.js';
 import { userIcon } from '@cds/core/icon/shapes/user.js';
@@ -12,25 +13,7 @@ import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators/custom-element.js';
 import { state } from 'lit/decorators/state.js';
 import { homeIcon } from '@cds/core/icon/shapes/home.js';
-// import { boolean, select, text } from '@storybook/addon-knobs';
-// import { classMap } from 'lit/directives/class-map.js';
-// import customElements from '../../dist/core/custom-elements.json';
-
-// import {
-//   loadChartIconSet,
-//   loadCommerceIconSet,
-//   loadCoreIconSet,
-//   loadEssentialIconSet,
-//   loadMediaIconSet,
-//   loadMiniIconSet,
-//   loadSocialIconSet,
-//   loadTechnologyIconSet,
-//   loadTextEditIconSet,
-//   loadTravelIconSet,
-// } from '@cds/core/icon';
-import { spreadProps, getElementStorybookArgs } from '@cds/core/internal';
-// import { ifDefined } from 'lit/directives/if-defined.js';
-// import { IconShapeTuple } from './interfaces/icon.interfaces.js';
+import { baseStyles, spreadProps, getElementStorybookArgs } from '@cds/core/internal';
 
 // here for testing
 ClarityIcons.addIcons(userIcon, imageIcon, homeIcon);
@@ -89,150 +72,6 @@ all.element = AllIcons; // get around unused class
 export function all() {
   return html`<demo-all-icons></demo-all-icons>`;
 }
-
-// export function all() {
-// import('@cds/core/icon').then(module => {
-//   module.loadChartIconSet();
-//   module.loadCommerceIconSet();
-//   module.loadCoreIconSet();
-//   module.loadEssentialIconSet();
-//   module.loadMediaIconSet();
-//   module.loadMiniIconSet();
-//   module.loadSocialIconSet();
-//   module.loadTechnologyIconSet();
-//   module.loadTextEditIconSet();
-//   module.loadTravelIconSet();
-// });
-//   const search = text('search', '', propertiesGroup);
-//   const size = select(
-//     'size',
-//     { xs: 'xs', 'sm (default)': 'sm', md: 'md', lg: 'lg', xl: 'xl', xxl: 'xxl' },
-//     'lg',
-//     propertiesGroup
-//   );
-//   const dir = select(
-//     'direction',
-//     { 'up (default)': undefined, down: 'down', left: 'left', right: 'right' },
-//     undefined,
-//     propertiesGroup
-//   );
-//   const fl = select(
-//     'flip',
-//     { 'none (default)': undefined, vertical: 'vertical', horizontal: 'horizontal' },
-//     undefined,
-//     propertiesGroup
-//   );
-//   const badge = select(
-//     'badge',
-//     {
-//       'none (default)': '',
-//       info: 'info',
-//       success: 'success',
-//       warning: 'warning',
-//       danger: 'danger',
-//       inherit: 'inherit',
-//       'warning-triangle': 'warning-triangle',
-//       'inherit-triangle': 'inherit-triangle',
-//     },
-//     '',
-//     propertiesGroup
-//   );
-//   const iconStatus = select(
-//     'status',
-//     { 'none (default)': '', info: 'info', success: 'success', warning: 'warning', danger: 'danger' },
-//     '',
-//     propertiesGroup
-//   );
-//   const inverse = boolean('inverse', false, propertiesGroup);
-//   const solid = boolean('solid', false, propertiesGroup);
-
-//   function createIconIndices(icons: IconShapeTuple[], aliases: [string, string[]][]): string[] {
-//     const iconsMap = icons.map(iconTuple => iconTuple[0]);
-//     const aliasMap = aliases.map(aliasTuple => aliasTuple[1]).reduce((acc, val) => acc.concat(val), []);
-//     return iconsMap.concat(aliasMap).sort();
-//   }
-
-//   const iconIndex: { [key: string]: string[] } = {
-//     Chart: createIconIndices(chartCollectionIcons, chartCollectionAliases),
-//     Commerce: createIconIndices(commerceCollectionIcons, commerceCollectionAliases),
-//     Core: createIconIndices(coreCollectionIcons, coreCollectionAliases),
-//     Essential: createIconIndices(essentialCollectionIcons, essentialCollectionAliases),
-//     Media: createIconIndices(mediaCollectionIcons, mediaCollectionAliases),
-//     Mini: createIconIndices(miniCollectionIcons, miniCollectionAliases),
-//     Social: createIconIndices(socialCollectionIcons, socialCollectionAliases),
-//     Technology: createIconIndices(technologyCollectionIcons, technologyCollectionAliases),
-//     'Text-Edit': createIconIndices(textEditCollectionIcons, textEditCollectionAliases),
-//     Travel: createIconIndices(travelCollectionIcons, travelCollectionAliases),
-//   };
-
-//   const iconSets = Object.keys(iconIndex);
-
-//   return html`
-//     <style>
-//       .dc-icon-set {
-//         max-width: 60rem;
-//       }
-
-//       .dc-icon-boxes {
-//         padding: 1.2rem 0.4rem 0;
-//         background: #f4f4f4;
-//         display: grid;
-//         grid-gap: 16px;
-//         grid-template-columns: repeat(12, 1fr);
-//       }
-
-//       .dc-icon-boxes.inverse {
-//         background: #565656;
-//       }
-
-//       .dc-icon-boxes.inverse .dc-icon-name {
-//         color: #fff;
-//       }
-
-//       .dc-icon-box {
-//         text-align: center;
-//         grid-column: span 2 / span 2;
-//       }
-
-//       .dc-icon-box p {
-//         margin: 0;
-//         padding: 0.2rem 0 1.2rem;
-//       }
-//     </style>
-//     ${iconSets.map(
-//       k => html`
-//         <section class="dc-icon-set">
-//           <h2>${k}</h2>
-
-//           <div class="dc-icon-boxes ${classMap({ inverse: inverse })}">
-//             ${iconIndex[k].map(
-//               i => html`
-//                 <div class="dc-icon-box" .hidden=${!i.includes(search)}>
-//                   <cds-icon
-//                     aria-label="This is an example of an icon using the ${i} shape"
-//                     badge=${badge}
-//                     status=${iconStatus}
-//                     ?solid=${solid}
-//                     size=${size}
-//                     shape=${i}
-//                     direction=${ifDefined(dir)}
-//                     ?inverse=${inverse}
-//                     flip=${ifDefined(fl)}
-//                   >
-//                   </cds-icon>
-//                   <span cds-layout="display:screen-reader-only"
-//                     >${'The shape needed to display this icon is ' + i}</span
-//                   >
-//                   <p class="dc-icon-name" aria-hidden="true">${i}</p>
-//                 </div>
-//               `
-//             )}
-//           </div>
-//         </section>
-//       `
-//     )}
-//   `;
-// }
 
 export function API(args: any) {
   return html`
@@ -542,7 +381,7 @@ export function customStyles() {
     <div class="custom-icon-colors a">
       <cds-icon
         shape="user"
-        badge="default"
+        badge="neutral"
         class="icon-a"
         aria-label="This is an example of how an icon can be visually customized."
       ></cds-icon>
@@ -558,7 +397,7 @@ export function customStyles() {
     <div class="custom-icon-colors c">
       <cds-icon
         shape="user"
-        badge="default"
+        badge="neutral"
         class="icon-c"
         aria-label="This is a third example of how an icon can be visually customized."
       ></cds-icon>
@@ -655,4 +494,70 @@ export function lazyLoading() {
       ClarityIcons.addIcons([shapeName, mySvg]);
     }
   }
+}
+
+const testNonequilateralIcon =
+  '<svg style="background: yellow" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 96 124"><defs><linearGradient id="illus_grad" x1="-1907.36" x2="-1863.1" y1="63.08" y2="112.71" gradientTransform="matrix(-1 0 0 1 -1840.95 0)" gradientUnits="userSpaceOnUse"><stop offset=".15" stop-color="#0091da" stop-opacity=".6"/><stop offset=".54" stop-color="#0091da" stop-opacity=".32"/><stop offset="1" stop-color="#0091da" stop-opacity="0"/></linearGradient><linearGradient id="illus_grad-2" x1="-1923.8" x2="-1892.27" y1="71.55" y2="106.92" xlink:href="#illus_grad"/><style>.path-size{fill:none}.vmw-color-blue-67,.vmw-color-blue-87{opacity:.5}.vmw-color-blue-87{fill:url(#illus_grad)}.vmw-color-blue-67{fill:url(#illus_grad-2)}.vmw-color-blue{fill:#0091da}</style></defs><path id="Layer_6" d="M0 0h96v124H0z" class="path-size" data-name="Layer 6"/><g id="Layer_4" data-name="Layer 4"><path d="M16.04 94.86h44.03V50.84L16.04 94.86z" class="vmw-color-blue-87"/><path d="M46.97 94.2h31.37V62.83L46.97 94.2z" class="vmw-color-blue-67"/></g><g id="Layer_2" data-name="Layer 2"><path d="M89.91 95.91H5.46a1 1 0 110-2h84.45a1 1 0 010 2zM57.38 40H38.62a1 1 0 010-2h18.76a1 1 0 010 2zM48.1 80.67A4.72 4.72 0 1152.82 76a4.72 4.72 0 01-4.72 4.67zm0-7.44A2.72 2.72 0 1050.82 76a2.72 2.72 0 00-2.72-2.77zM76.92 47H67v2h9.92a1 1 0 000-2zM19.08 48H29v2h-9.92a1 1 0 010-2z" class="vmw-color-blue"/><path d="M64 96a1 1 0 01-1-1V31a1 1 0 00-1-1H34a1 1 0 00-1 1v64a1 1 0 01-2 0V31a3 3 0 013-3h28a3 3 0 013 3v64a1 1 0 01-1 1zM83 95h-2V41a1 1 0 00-1-1H67v-2h13a3 3 0 013 3zM15 95h-2V41a3 3 0 013-3h13v2H16a1 1 0 00-1 1z" class="vmw-color-blue"/></g></svg>';
+const testNonequilateralIconName = 'test-nonequilateral';
+
+ClarityIcons.addIcons([testNonequilateralIconName, testNonequilateralIcon]);
+
+// rotate and resize!
+
+@customElement('demo-non-equilateral')
+class NonEquilateralIcon extends LitElement {
+  static get styles() {
+    return [baseStyles];
+  }
+
+  @state() sizeToFit = false;
+
+  toggleFitSizing() {
+    this.sizeToFit = !this.sizeToFit;
+  }
+
+  render() {
+    return html`
+      <div cds-layout="vertical gap:lg">
+        <div cds-layout="horizontal gap:lg">
+          <cds-icon
+            size=${this.sizeToFit ? 'xl fit' : 'xl'}
+            shape=${testNonequilateralIconName}
+            aria-label="This is an example of an icon that is taller than it is wide."
+            style="border: 1px solid red"
+          ></cds-icon>
+          <cds-icon
+            size=${this.sizeToFit ? 'xl fit' : 'xl'}
+            shape=${testNonequilateralIconName}
+            direction="right"
+            aria-label="This is an example of an icon that is taller than it is wide rotated to the right."
+            style="border: 1px solid red"
+          ></cds-icon>
+          <cds-icon
+            size=${this.sizeToFit ? 'xl fit' : 'xl'}
+            shape=${testNonequilateralIconName}
+            direction="down"
+            aria-label="This is an example of an icon that is taller than it is wide flipped upside down."
+            style="border: 1px solid red"
+          ></cds-icon>
+          <cds-icon
+            size=${this.sizeToFit ? 'xl fit' : 'xl'}
+            shape=${testNonequilateralIconName}
+            direction="left"
+            aria-label="This is an example of an icon that is taller than it is wide rotated to the left."
+            style="border: 1px solid red"
+          ></cds-icon>
+        </div>
+        <div>
+          <cds-button type="button" @click=${this.toggleFitSizing}>Size to Image</cds-button>
+        </div>
+      </div>
+    `;
+  }
+}
+
+nonequilateral.element = NonEquilateralIcon; // get around unused class
+
+export function nonequilateral() {
+  return html`<demo-non-equilateral></demo-non-equilateral>`;
 }

--- a/packages/core/src/internal/utils/css.spec.ts
+++ b/packages/core/src/internal/utils/css.spec.ts
@@ -12,6 +12,7 @@ import {
   pxToRem,
   removeClassnames,
   removeClassnamesUnless,
+  unsetElementStyles,
   updateElementStyles,
   isCssPropertyName,
   getCssPropertyValue,
@@ -91,6 +92,32 @@ describe('Css utility functions - ', () => {
       expect(testMe.style.backgroundColor).toBe('yellow');
       expect(testMe.style.width).toBe('100%');
       expect(testMe.style.fontSize).toBe('28px');
+    });
+  });
+
+  describe('pxToRem: ', () => {
+    it('should return a px to rem calc from the base font size token', () => {
+      expect(pxToRem(10)).toBe('calc((10 / var(--cds-global-base)) * 1rem)');
+    });
+  });
+
+  describe('unsetElementStyles: ', () => {
+    it('should unset element styles as expected', () => {
+      updateElementStyles(
+        testDiv,
+        ['backgroundColor', 'fuchsia'],
+        ['width', '500px'],
+        ['height', '200px'],
+        ['color', 'orange']
+      );
+
+      const testMe = unsetElementStyles(testDiv, 'background-color', 'width', 'margin', 'color');
+
+      expect(testMe.style.backgroundColor).toBe('');
+      expect(testMe.style.width).toBe('');
+      expect(testMe.style.color).toBe('');
+      expect(testMe.style.margin).toBe('');
+      expect(testMe.style.height).toBe('200px');
     });
   });
 

--- a/packages/core/src/internal/utils/css.ts
+++ b/packages/core/src/internal/utils/css.ts
@@ -40,6 +40,13 @@ export function updateElementStyles(el: HTMLElement, ...styleTuples: [string, st
   return el;
 }
 
+export function unsetElementStyles(el: HTMLElement, ...styleProperties: string[]): HTMLElement {
+  styleProperties.forEach(prop => {
+    (el.style as { [key: string]: any })[prop] = '';
+  });
+  return el;
+}
+
 export function pxToRem(pxValue: number) {
   return `calc((${pxValue} / var(--cds-global-base)) * 1rem)`;
 }

--- a/packages/core/src/internal/utils/events.spec.ts
+++ b/packages/core/src/internal/utils/events.spec.ts
@@ -5,7 +5,7 @@
  */
 
 import { html } from 'lit';
-import { removeTestElement, createTestElement, onceEvent } from '@cds/core/test';
+import { removeTestElement, createTestElement } from '@cds/core/test';
 import { getElementUpdates } from './events.js';
 
 describe('getElementUpdates', () => {

--- a/packages/core/src/internal/utils/string.spec.ts
+++ b/packages/core/src/internal/utils/string.spec.ts
@@ -21,6 +21,7 @@ import {
   removePrefix,
   removeSuffix,
   removePrefixOrSuffix,
+  replaceWord,
 } from './string.js';
 
 describe('Functional Helper: ', () => {
@@ -232,6 +233,34 @@ describe('Functional Helper: ', () => {
       expect(removePrefixOrSuffix('yep_ohai', 'yep_', '')).toBe('yep_ohai');
       expect(removePrefixOrSuffix('yep_ohai', 'yep_', null)).toBe('yep_ohai');
       expect(removePrefixOrSuffix('yep_ohai', 'yep_', 'sufix')).toBe('yep_ohai');
+    });
+  });
+
+  describe('replaceWord()', () => {
+    it('defaults to removing words', () => {
+      expect(replaceWord('dog seahawk cat', 'seahawk')).toBe('dog cat');
+    });
+
+    it('removes more than one instance of a word', () => {
+      expect(replaceWord('seahawk dog horse seahawk cat seahawk seahawk mouse', 'seahawk')).toBe('dog horse cat mouse');
+    });
+
+    it('handles empty strings', () => {
+      expect(replaceWord('', 'ohai')).toBe('');
+    });
+
+    it('does not mess with string if word is not in it', () => {
+      expect(replaceWord('dog horse cat seahawk mouse', 'niner')).toBe('dog horse cat seahawk mouse');
+    });
+
+    it('can also do a replace', () => {
+      expect(replaceWord('dog horse cat seahawk mouse', 'seahawk', 'niner')).toBe('dog horse cat niner mouse');
+    });
+
+    it('can replace multiple instances of a word', () => {
+      expect(replaceWord('seahawk dog horse seahawk cat seahawk seahawk mouse', 'seahawk', 'niner')).toBe(
+        'niner dog horse niner cat niner niner mouse'
+      );
     });
   });
 });

--- a/packages/core/src/internal/utils/string.ts
+++ b/packages/core/src/internal/utils/string.ts
@@ -121,3 +121,12 @@ export function removePrefix(str: string, prefix: string): string {
 export function removeSuffix(str: string, suffix: string): string {
   return removePrefixOrSuffix(str, suffix, 'suffix');
 }
+
+export function replaceWord(str: string, wordToReplace: string, replaceWith = '') {
+  const words = str.split(' ');
+  const returnWords =
+    replaceWith === ''
+      ? words.filter(w => w !== wordToReplace)
+      : words.map(w => (w === wordToReplace ? replaceWith : w));
+  return returnWords.length > 0 ? returnWords.join(' ') : '';
+}


### PR DESCRIPTION
Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

This was a lot trickier than I thought it would be. The CSS identified in the github issue was not the culprit. The challenge was the `contain` CSS style.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #6295

## What is the new behavior?

The icon now accepts `fit` as part of its value. Putting this in the size attribute what force the icon to take the size the icon inside of it. Note that the icon will still scale up and down with sizing. It will just allow for the SVG inside of it to push out the host's boundary.

```
<cds-icon shape="my-custom-icon" size="xl fit"></cds-icon>
```

This had to be added as a new feature because there was no way we could extend the current icon with its performance-focused CSS contain style to make it re-size to the internal image. This was the easiest way to maintain our current icon features and support the edge case of a non-equilateral icon added to the registry.

An example is provided under the storybook icon stories.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
