### PR TITLE
fix(angular:form): align input placeholder color to core

### DIFF
--- a/projects/angular/src/color/_properties.color.scss
+++ b/projects/angular/src/color/_properties.color.scss
@@ -170,6 +170,11 @@
       --clr-color-on-success-800: #{$clr-color-on-success-800};
       --clr-color-on-success-900: #{$clr-color-on-success-900};
       --clr-color-on-success-1000: #{$clr-color-on-success-1000};
+
+      // placeholder text that aligns with core color
+      // Added as a fix for https://github.com/vmware/clarity/issues/6439
+      // Unifies only form input placeholder color and makes it accessible and align with core form placeholders.
+      --clr-global-color-construction-600: #{$clr-global-color-construction-600};
     }
   }
 }

--- a/projects/angular/src/forms/styles/_properties.forms.scss
+++ b/projects/angular/src/forms/styles/_properties.forms.scss
@@ -15,7 +15,7 @@
       --clr-forms-valid-color: var(--clr-color-success-700);
       --clr-forms-valid-text-color: var(--clr-color-success-900);
       --clr-forms-subtext-color: var(--clr-color-neutral-600);
-      --clr-forms-placeholder-color: var(--clr-color-neutral-600);
+      --clr-forms-placeholder-color: var(--clr-global-color-construction-600);
       --clr-forms-border-color: var(--clr-color-neutral-500);
       --clr-forms-focused-color: var(--clr-color-action-600);
 

--- a/projects/angular/src/forms/styles/_variables.forms.scss
+++ b/projects/angular/src/forms/styles/_variables.forms.scss
@@ -14,7 +14,7 @@ $clr-forms-invalid-color: $clr-color-danger-800 !default;
 $clr-forms-valid-color: $clr-color-success-700 !default;
 $clr-forms-valid-text-color: $clr-color-success-900 !default;
 $clr-forms-subtext-color: $clr-color-neutral-600 !default;
-$clr-forms-placeholder-color: $clr-color-neutral-600 !default;
+$clr-forms-placeholder-color: $clr-global-color-construction-600 !default;
 $clr-forms-border-color: $clr-color-neutral-500 !default;
 $clr-forms-focused-color: $clr-color-action-600 !default;
 $clr-forms-subtext-disabled-color: $clr-color-neutral-600 !default;

--- a/projects/angular/src/utils/_normalize.scss
+++ b/projects/angular/src/utils/_normalize.scss
@@ -424,11 +424,6 @@ textarea {
 // Correct the text style of placeholders in Chrome, Edge, and Safari.
 //
 
-::-webkit-input-placeholder {
-  color: inherit;
-  opacity: 0.54;
-}
-
 //
 // 1. Correct the inability to style clickable types in iOS and Safari.
 // 2. Change font properties to `inherit` in Safari.

--- a/projects/angular/src/utils/_overwrites.clarity.scss
+++ b/projects/angular/src/utils/_overwrites.clarity.scss
@@ -258,6 +258,10 @@ $clr-color-on-success-800: null; // #fff
 $clr-color-on-success-900: null; // #fff
 $clr-color-on-success-1000: null; // #fff
 
+// Added as a fix for https://github.com/vmware/clarity/issues/6439
+// Unifies only form input placeholder color and makes it accessible
+$clr-global-color-construction-600: null; // hsl(198, 14%, 36%)
+
 /*================================================================================*/
 /* DEPRECATED color variables below:       */
 /*================================================================================*/
@@ -449,7 +453,7 @@ $clr-forms-invalid-color: null; // $clr-color-danger-800
 $clr-forms-valid-color: null; // $clr-color-success-700
 $clr-forms-valid-text-color: null; // $clr-color-success-900
 $clr-forms-subtext-color: null; // $clr-color-neutral-600
-$clr-forms-placeholder-color: null; // $clr-color-neutral-600
+$clr-forms-placeholder-color: null; // $clr-global-color-construction-600
 $clr-forms-border-color: null; // $clr-color-neutral-500
 $clr-forms-focused-color: null; // $clr-color-action-600
 $clr-forms-subtext-disabled-color: null;

--- a/projects/angular/src/utils/variables/_variables.color.scss
+++ b/projects/angular/src/utils/variables/_variables.color.scss
@@ -244,3 +244,8 @@ $clr-red-dark-midtone: $clr-color-danger-800 !default;
 $clr-red-dark: $clr-color-danger-900 !default;
 $clr-red-darker: $clr-color-danger-1000 !default;
 $clr-red-darkest: $clr-color-danger-1000 !default;
+
+// placeholder text that aligns with core color
+// Added as a fix for https://github.com/vmware/clarity/issues/6439
+// Unifies only form input placeholder color and makes it accessible and align with core form placeholders.
+$clr-global-color-construction-600: hsl(198, 14%, 36%) !default;

--- a/projects/website/src/sitemap.xml
+++ b/projects/website/src/sitemap.xml
@@ -301,6 +301,10 @@
         <changefreq>daily</changefreq>
     </url>
     <url>
+        <loc>https://clarity.design/news/src/releases/12.x/12.0.7.html</loc>
+        <changefreq>daily</changefreq>
+    </url>
+    <url>
         <loc>https://clarity.design/news/src/releases/12.x/12.0.6.html</loc>
         <changefreq>daily</changefreq>
     </url>
@@ -330,6 +334,10 @@
     </url>
     <url>
         <loc>https://clarity.design/news/src/releases/12.x/12.0.0-next.0.html</loc>
+        <changefreq>daily</changefreq>
+    </url>
+    <url>
+        <loc>https://clarity.design/news/src/releases/5.x/5.5.2.html</loc>
         <changefreq>daily</changefreq>
     </url>
     <url>


### PR DESCRIPTION
Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?
Placeholder color of Angular form inputs does not have a high enough color contrast. This fixes that by aligning the color with placeholder color in forms. 

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Form input placeholder text does not have an accessible color contrast. 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #6439

## What is the new behavior?
form input placeholder text has an accessible color contrast. 
## Does this PR introduce a breaking change?

- [x] Yes*
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
*Applications that use visual regression testing may fail because of this change. 
