### PR TITLE
feat(core:progress-circle): intelligently default aria label to i18n string

### DIFF
--- a/packages/core/src/internal/decorators/i18n.spec.ts
+++ b/packages/core/src/internal/decorators/i18n.spec.ts
@@ -48,5 +48,8 @@ describe('i18n decorator', () => {
     component.setAttribute('cds-i18n', `{ "close": "${closeText}" }`);
     await componentIsStable(component);
     expect(component.i18n.close).toEqual(closeText);
+    component.setAttribute('cds-i18n', `{ "close": "ohai" }`);
+    await componentIsStable(component);
+    expect(component.i18n.close).toEqual('ohai', 'double set i18n');
   });
 });

--- a/packages/core/src/internal/services/i18n.service.ts
+++ b/packages/core/src/internal/services/i18n.service.ts
@@ -35,6 +35,10 @@ export interface I18nStrings {
     showButtonAriaLabel: string;
     hideButtonAriaLabel: string;
   };
+  progress: {
+    loading: string;
+    looping: string;
+  };
   treeview: {
     loading: string;
   };
@@ -72,6 +76,10 @@ export const componentStringsDefault = {
   password: {
     showButtonAriaLabel: 'Show password',
     hideButtonAriaLabel: 'Hide password',
+  },
+  progress: {
+    loading: 'Loading',
+    looping: 'Loading',
   },
   treeview: {
     loading: 'Loading',

--- a/packages/core/src/internal/utils/identity.spec.ts
+++ b/packages/core/src/internal/utils/identity.spec.ts
@@ -47,6 +47,8 @@ describe('Functional Helper: ', () => {
       expect(isNilOrEmpty({ item: 1 })).toEqual(false);
       expect(isNilOrEmpty([1, 2])).toEqual(false);
       expect(isNilOrEmpty('ohai')).toEqual(false);
+      expect(isNilOrEmpty(0)).toEqual(false);
+      expect(isNilOrEmpty(-1)).toEqual(false);
       expect(isNilOrEmpty(true)).toEqual(false);
       expect(isNilOrEmpty(false)).toEqual(false);
     });

--- a/packages/core/src/progress-circle/progress-circle.element.spec.ts
+++ b/packages/core/src/progress-circle/progress-circle.element.spec.ts
@@ -155,4 +155,147 @@ describe('progress circle element – ', () => {
     });
   });
   // circle classname arcstroke/backstroke
+
+  describe('ariaLabel', () => {
+    it('should show indeterminate label if no label is set and there is no value', async () => {
+      await componentIsStable(componentUnset);
+      expect(componentUnset.getAttribute('aria-label')).toBe('Loading');
+    });
+    it('should show loading label and value if no label is set', async () => {
+      await componentIsStable(component);
+      expect(component.getAttribute('aria-label')).toBe('Loading 49%');
+      component.value = 80;
+      await componentIsStable(component);
+      expect(component.getAttribute('aria-label')).toBe('Loading 80%');
+    });
+    it('should not show default label if a custom label is set', async () => {
+      await componentIsStable(componentUnset);
+      expect(componentUnset.getAttribute('aria-label')).toBe('Loading');
+      componentUnset.setAttribute('aria-label', 'ohai');
+      await componentIsStable(componentUnset);
+      expect(componentUnset.getAttribute('aria-label')).toBe('ohai');
+
+      await componentIsStable(component);
+      component.setAttribute('aria-label', 'ohai');
+      await componentIsStable(component);
+      expect(component.getAttribute('aria-label')).toBe('ohai');
+      component.value = 88;
+      await componentIsStable(component);
+      expect(component.getAttribute('aria-label')).toBe('ohai');
+    });
+  });
+
+  describe('i18n', () => {
+    const newLoading = 'ohai';
+    const newLooping = 'kthxbye';
+
+    it('uses i18n strings by default', async () => {
+      await componentIsStable(component);
+      expect(component.getAttribute('aria-label').indexOf(component.i18n.loading) > -1).toBe(
+        true,
+        'has loading i18n string'
+      );
+      await componentIsStable(componentUnset);
+      expect(componentUnset.getAttribute('aria-label').indexOf(componentUnset.i18n.looping) > -1).toBe(
+        true,
+        'has looping i18n string'
+      );
+    });
+    it('updates looping i18n strings as expected', async () => {
+      await componentIsStable(componentUnset);
+      componentUnset.setAttribute('cds-i18n', `{ "loading": "${newLoading}", "looping": "${newLooping}" }`);
+      await componentIsStable(componentUnset);
+      expect(componentUnset.getAttribute('aria-label').indexOf(newLooping) > -1).toBe(true);
+    });
+    it('updates loading i18n strings as expected', async () => {
+      await componentIsStable(component);
+      component.setAttribute('cds-i18n', `{ "loading": "${newLoading}", "looping": "${newLooping}" }`);
+      await componentIsStable(component);
+      expect(component.getAttribute('aria-label').indexOf(newLoading) > -1).toBe(true);
+    });
+  });
+
+  describe('setAriaAttributes', () => {
+    it('should return expected for indeterminate progress', async () => {
+      await componentIsStable(componentUnset);
+      componentUnset.setAriaAttributes();
+      await componentIsStable(componentUnset);
+      expect(componentUnset.getAttribute('role')).toBe('img');
+      expect(componentUnset.hasAttribute('aria-valuemin')).toBe(false);
+      expect(componentUnset.hasAttribute('aria-valuemax')).toBe(false);
+      expect(componentUnset.hasAttribute('aria-valuenow')).toBe(false);
+      expect(componentUnset.getAttribute('aria-label')).toBe('Loading');
+
+      componentUnset.ariaLabel = 'howdy';
+      await componentIsStable(componentUnset);
+      expect(componentUnset.getAttribute('role')).toBe('img');
+      expect(componentUnset.hasAttribute('aria-valuemin')).toBe(false);
+      expect(componentUnset.hasAttribute('aria-valuemax')).toBe(false);
+      expect(componentUnset.hasAttribute('aria-valuenow')).toBe(false);
+      expect(componentUnset.getAttribute('aria-label')).toBe('howdy');
+    });
+    it('should return as expected for progress with value', async () => {
+      await componentIsStable(component);
+      component.setAriaAttributes();
+      await componentIsStable(component);
+      expect(component.getAttribute('role')).toBe('progressbar');
+      expect(component.getAttribute('aria-valuemin')).toBe('0');
+      expect(component.getAttribute('aria-valuemax')).toBe('100');
+      expect(component.getAttribute('aria-valuenow')).toBe('49');
+      expect(component.getAttribute('aria-label')).toBe('Loading 49%');
+
+      component.value = 0;
+      await componentIsStable(component);
+      expect(component.getAttribute('role')).toBe('progressbar');
+      expect(component.getAttribute('aria-valuemin')).toBe('0');
+      expect(component.getAttribute('aria-valuemax')).toBe('100');
+      expect(component.getAttribute('aria-valuenow')).toBe('0');
+      expect(component.getAttribute('aria-label')).toBe('Loading 0%');
+
+      component.ariaLabel = 'ohai';
+      component.value = 80;
+      await componentIsStable(component);
+      expect(component.getAttribute('role')).toBe('progressbar');
+      expect(component.getAttribute('aria-valuemin')).toBe('0');
+      expect(component.getAttribute('aria-valuemax')).toBe('100');
+      expect(component.getAttribute('aria-valuenow')).toBe('80');
+      expect(component.getAttribute('aria-label')).toBe('ohai');
+    });
+    it('should update as expected for indeterminate progress given a value', async () => {
+      await componentIsStable(componentUnset);
+      componentUnset.setAriaAttributes();
+      await componentIsStable(componentUnset);
+      expect(componentUnset.getAttribute('role')).toBe('img');
+      expect(componentUnset.hasAttribute('aria-valuemin')).toBe(false);
+      expect(componentUnset.hasAttribute('aria-valuemax')).toBe(false);
+      expect(componentUnset.hasAttribute('aria-valuenow')).toBe(false);
+      expect(componentUnset.getAttribute('aria-label')).toBe('Loading');
+
+      componentUnset.value = 66;
+      await componentIsStable(componentUnset);
+      expect(componentUnset.getAttribute('role')).toBe('progressbar');
+      expect(componentUnset.getAttribute('aria-valuemin')).toBe('0');
+      expect(componentUnset.getAttribute('aria-valuemax')).toBe('100');
+      expect(componentUnset.getAttribute('aria-valuenow')).toBe('66');
+      expect(componentUnset.getAttribute('aria-label')).toBe('Loading 66%');
+    });
+    it('should update as expected for progress with a value shifted to indeterminate', async () => {
+      await componentIsStable(component);
+      component.setAriaAttributes();
+      await componentIsStable(component);
+      expect(component.getAttribute('role')).toBe('progressbar');
+      expect(component.getAttribute('aria-valuemin')).toBe('0');
+      expect(component.getAttribute('aria-valuemax')).toBe('100');
+      expect(component.getAttribute('aria-valuenow')).toBe('49');
+      expect(component.getAttribute('aria-label')).toBe('Loading 49%');
+
+      component.value = null;
+      await componentIsStable(component);
+      expect(component.getAttribute('role')).toBe('img');
+      expect(component.hasAttribute('aria-valuemin')).toBe(false);
+      expect(component.hasAttribute('aria-valuemax')).toBe(false);
+      expect(component.hasAttribute('aria-valuenow')).toBe(false);
+      expect(component.getAttribute('aria-label')).toBe('Loading');
+    });
+  });
 });

--- a/packages/core/src/progress-circle/progress-circle.element.ts
+++ b/packages/core/src/progress-circle/progress-circle.element.ts
@@ -7,15 +7,24 @@
 import {
   baseStyles,
   hasStringPropertyChanged,
+  listenForAttributeChange,
   property,
   setAttributes,
   StatusTypes,
   updateEquilateralSizeStyles,
-  HTMLAttributeTuple,
+  I18nService,
+  i18n,
+  isNilOrEmpty,
 } from '@cds/core/internal';
 import { html, LitElement } from 'lit';
-import isNil from 'ramda/es/isNil.js';
+import isNil from 'ramda/es/isNil.js'; // TODO: REPLACE AFTER DROPDOWN MERGE TO PREVENT CIRCULAR DEPENDENCIES
 import styles from './progress-circle.element.scss';
+import {
+  getAriaLabelOrDefault,
+  getDefaultAriaLabel,
+  getProgressCircleAriaAttributes,
+  getProgressCircleRadius,
+} from './progress-circle.utils.js';
 
 /**
  * Circular progress indicators provide a method to track how close long-running tasks are to
@@ -70,15 +79,8 @@ export class CdsProgressCircle extends LitElement {
   line = 3;
 
   private get radius() {
-    // 36 is the default viewbox dimensions; half of 36 is 18
-    // we need to keep this so that circular-progress remains aligned with our icons
-    // we shouldn't change it unless we change the default viewbox of the icons!
-    const halfOfViewbox = 18;
-
-    // line offset takes the width/thickness of the progress circle into account
-    const lineOffset = Math.ceil(this.line / 2);
-
-    return halfOfViewbox - lineOffset;
+    // 36 is the default viewbox dimensions
+    return getProgressCircleRadius(this.line);
   }
 
   private get circumference() {
@@ -115,21 +117,60 @@ export class CdsProgressCircle extends LitElement {
     }
   }
 
-  private setAriaAttributes() {
+  private _ariaLabel: string | undefined | null;
+
+  /**
+   * The aria-label attribute is added here as a convenience. It is not set
+   * to a default value.
+   *
+   * If this attribute/property remains unset, it will default to an i18n string.
+   * This means that the aria-label can be customized using the aria-label
+   * attribute or by overriding the i18n value for the progress circle.
+   */
+  @property({ type: String })
+  get ariaLabel() {
+    return getAriaLabelOrDefault(this._ariaLabel as string, this.value, this.i18n.loading, this.i18n.looping);
+  }
+
+  /**
+   * Changes the svg glyph displayed in the icon component. Defaults to the 'unknown' icon if
+   * the specified icon cannot be found in the icon registry.
+   */
+  set ariaLabel(newAriaLabel: string) {
+    if (hasStringPropertyChanged(newAriaLabel, this._ariaLabel as string)) {
+      const oldVal = this._ariaLabel;
+      this._ariaLabel = newAriaLabel;
+      this.requestUpdate('ariaLabel', oldVal);
+    }
+  }
+
+  @i18n() i18n = I18nService.keys.progress;
+
+  // note: this aria attr logic could be reused when we introduce progress bars
+  // consider promoting this to a shared utility in internal in the future
+  /** @private */
+  setAriaAttributes(oldValueForAriaLabelCheck?: number) {
     const currentValue = this.value;
-    const ariaAttrsIfValue: HTMLAttributeTuple[] = [
-      ['role', 'progressbar'],
-      ['aria-valuemin', '0'],
-      ['aria-valuemax', '100'],
-      ['aria-valuenow', currentValue + ''],
-    ];
-    const ariaAttrsNoValue: HTMLAttributeTuple[] = [
-      ['role', 'img'],
-      ['aria-valuemin', false],
-      ['aria-valuemax', false],
-      ['aria-valuenow', false],
-    ];
-    const attrsToSet = isNil(currentValue) ? ariaAttrsNoValue : ariaAttrsIfValue;
+    const oldValIsNil = isNilOrEmpty(oldValueForAriaLabelCheck);
+    let ariaLabel: string;
+
+    if (oldValIsNil) {
+      if (!isNilOrEmpty(currentValue) && this.ariaLabel === this.i18n.looping) {
+        ariaLabel = getDefaultAriaLabel(currentValue, this.i18n.loading, this.i18n.looping);
+      } else {
+        ariaLabel = this.ariaLabel;
+      }
+    } else {
+      ariaLabel = getAriaLabelOrDefault(
+        this._ariaLabel as string,
+        currentValue,
+        this.i18n.loading,
+        this.i18n.looping,
+        oldValueForAriaLabelCheck
+      );
+    }
+
+    const attrsToSet = getProgressCircleAriaAttributes(currentValue, ariaLabel);
 
     setAttributes(this, ...attrsToSet);
   }
@@ -139,10 +180,39 @@ export class CdsProgressCircle extends LitElement {
     this.setAriaAttributes();
   }
 
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.observers.forEach(o => o.disconnect());
+  }
+
+  protected observers: MutationObserver[] = [];
+
+  firstUpdated(props: Map<string, any>) {
+    super.firstUpdated(props);
+    // FIXME: we need the mutation observer here because the i18n decorator property
+    // is not firing an update as expected. maybe if we move it to a reactive
+    // controller it will work with the lifecycle again?
+    this.observers.push(
+      listenForAttributeChange(this, 'cds-i18n', () => {
+        const oldAriaLabel = this.ariaLabel;
+        this.ariaLabel = '';
+        this.requestUpdate('ariaLabel', oldAriaLabel);
+      })
+    );
+  }
+
+  // note: this update logic could be reused when we introduce progress bars
+  // consider promoting this to a shared utility in internal in the future
   updated(props: Map<string, any>) {
     super.updated(props);
     if (props.has('value')) {
+      this.setAriaAttributes(props.get('value'));
+    } else if (props.has('ariaLabel')) {
       this.setAriaAttributes();
+    } else if (props.has('ariaLabelTemplate')) {
+      // if you update the template or i18n (edge case), you force reset of aria-label...
+      this._ariaLabel = null;
+      this.setAriaAttributes(this.value);
     }
   }
 

--- a/packages/core/src/progress-circle/progress-circle.utils.spec.ts
+++ b/packages/core/src/progress-circle/progress-circle.utils.spec.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import {
+  getAriaLabelFromTemplate,
+  getAriaLabelOrDefault,
+  getDefaultAriaLabel,
+  getProgressCircleAriaAttributes,
+  getProgressCircleRadius,
+} from './progress-circle.utils.js';
+
+describe('progress circle helpers – ', () => {
+  // beforeEach(async () => {});
+
+  // afterEach(() => {});
+
+  describe('getProgressCircleRadius:', () => {
+    it('should default to viewBox size of 36', () => {
+      expect(getProgressCircleRadius(3)).toBe(16);
+      expect(getProgressCircleRadius(8)).toBe(14);
+      expect(getProgressCircleRadius(1)).toBe(17);
+    });
+    it('should accept other viewBox sizes if needed', () => {
+      expect(getProgressCircleRadius(3, 24)).toBe(10);
+      expect(getProgressCircleRadius(8, 50)).toBe(21);
+      expect(getProgressCircleRadius(1, 20)).toBe(9);
+    });
+  });
+
+  describe('getAriaLabelFromTemplate:', () => {
+    it('should use current value if not passed a forced value', () => {
+      const currentValue = 88;
+      const i18nMock = 'ohai';
+      const expected = `${i18nMock} ${currentValue}%`;
+      const testUndefined = getAriaLabelFromTemplate(currentValue, i18nMock);
+      const testNull = getAriaLabelFromTemplate(currentValue, i18nMock, null);
+      const testBadArg = getAriaLabelFromTemplate(currentValue, i18nMock, ('' as unknown) as number);
+      expect(testUndefined.indexOf(currentValue + '')).not.toBe(-1, 'current val present in undefined case');
+      expect(testNull.indexOf(currentValue + '')).not.toBe(-1, 'current val present in null case');
+      expect(testBadArg.indexOf(currentValue + '')).not.toBe(-1, 'current val present in bad parameter case');
+      expect(testUndefined).toBe(expected);
+      expect(testNull).toBe(expected);
+      expect(testBadArg).toBe(expected);
+    });
+
+    it('should use forced value if passed one', () => {
+      const currentVal = 42;
+      expect(getAriaLabelFromTemplate(currentVal, 'low ding...', 80)).toBe('low ding... 80%');
+      expect(getAriaLabelFromTemplate(currentVal, 'flapjack', -1)).toBe('flapjack -1%');
+    });
+
+    it('should force value of zero', () => {
+      expect(getAriaLabelFromTemplate(16, 'autobotz roll out!', 0)).toBe('autobotz roll out! 0%');
+    });
+  });
+
+  describe('getDefaultAriaLabel:', () => {
+    const loopingMsg = 'spinning';
+
+    it('should return indeterminate (loading) template if value is nil', () => {
+      const valUndefined = getDefaultAriaLabel(void 0, '...', loopingMsg);
+      const valNull = getDefaultAriaLabel(null, '...', loopingMsg);
+      const valBadVal = getDefaultAriaLabel(('' as unknown) as number, '...', loopingMsg);
+      expect(valUndefined).toBe(loopingMsg, 'undefined checks out');
+      expect(valNull).toBe(loopingMsg, 'null checks out');
+      expect(valBadVal).toBe(loopingMsg, 'bad argument checks out');
+    });
+    it('should return loading template if value is passed', () => {
+      const goodVal = getDefaultAriaLabel(16, '...', loopingMsg);
+      const zeroVal = getDefaultAriaLabel(0, '...', loopingMsg);
+      const negativeVal = getDefaultAriaLabel(-1, '...', loopingMsg);
+      expect(goodVal).toBe('... 16%', 'good val checks out');
+      expect(zeroVal).toBe('... 0%', 'zero checks out');
+      expect(negativeVal).toBe('... -1%', 'negative val checks out');
+    });
+  });
+
+  describe('getAriaLabelOrDefault:', () => {
+    it('should return default if no existing aria-label', () => {
+      const nope = getAriaLabelOrDefault(void 0, 3000, 'I love you', 'spins!', 80);
+      expect(nope).toBe('I love you 3000%');
+    });
+    it('should return default if existing aria-label is just an old default aria-label', () => {
+      const testMe = getAriaLabelOrDefault('I love you 200%', 3000, 'I love you', 'spins!', 200);
+      expect(testMe).toBe('I love you 3000%');
+    });
+    it('should return existing aria-label if there is one and it is not an old default aria-label', () => {
+      const testMe = getAriaLabelOrDefault('ohai', 3000, 'I love you', 'spins!', 200);
+      expect(testMe).toBe('ohai');
+    });
+  });
+
+  describe('getProgressCircleAriaAttributes:', () => {
+    const ariaLbl = 'ohai';
+    const currentVal = 49;
+    const expectedLoopingAttrs = [
+      ['role', 'img'],
+      ['aria-valuemin', false],
+      ['aria-valuemax', false],
+      ['aria-valuenow', false],
+      ['aria-label', ariaLbl],
+    ];
+    const expectedLoadingAttrs = [
+      ['role', 'progressbar'],
+      ['aria-valuemin', '0'],
+      ['aria-valuemax', '100'],
+      ['aria-valuenow', currentVal + ''],
+      ['aria-label', ariaLbl],
+    ];
+
+    it('should return indeterminate/looping attrs if value is undefined', () => {
+      const testMe = getProgressCircleAriaAttributes(void 0, ariaLbl);
+      expect(testMe).toEqual(expectedLoopingAttrs as any);
+    });
+    it('should return indeterminate/looping attrs if value is null', () => {
+      const testMe = getProgressCircleAriaAttributes(null, ariaLbl);
+      expect(testMe).toEqual(expectedLoopingAttrs as any);
+    });
+    it('should return indeterminate/looping attrs if value is bad', () => {
+      const testMe = getProgressCircleAriaAttributes(('' as unknown) as number, ariaLbl);
+      expect(testMe).toEqual(expectedLoopingAttrs as any);
+    });
+    it('should return loading attrs if value is passed', () => {
+      const testMe = getProgressCircleAriaAttributes(currentVal, ariaLbl);
+      expect(testMe).toEqual(expectedLoadingAttrs as any);
+    });
+    it('should return loading attrs even if value is zero', () => {
+      const testMe = getProgressCircleAriaAttributes(0, ariaLbl);
+      expect(testMe).toEqual([
+        ['role', 'progressbar'],
+        ['aria-valuemin', '0'],
+        ['aria-valuemax', '100'],
+        ['aria-valuenow', 0 + ''],
+        ['aria-label', ariaLbl],
+      ] as any);
+    });
+    it('should return loading attrs even if value is negative', () => {
+      const testMe = getProgressCircleAriaAttributes(-10, ariaLbl);
+      expect(testMe).toEqual([
+        ['role', 'progressbar'],
+        ['aria-valuemin', '0'],
+        ['aria-valuemax', '100'],
+        ['aria-valuenow', -10 + ''],
+        ['aria-label', ariaLbl],
+      ] as any);
+    });
+  });
+});

--- a/packages/core/src/progress-circle/progress-circle.utils.ts
+++ b/packages/core/src/progress-circle/progress-circle.utils.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { HTMLAttributeTuple, isNilOrEmpty } from '@cds/core/internal';
+
+// note: these may be of more general use with progress bars in general; perhaps promote them at some point???
+
+// 36 is the default viewbox dimensions
+export function getProgressCircleRadius(lineThickness: number, viewboxDimension = 36) {
+  // we need to keep this so that circular-progress remains aligned with our icons
+  // we shouldn't change it unless we change the default viewbox of the icons!
+  const halfOfViewbox = viewboxDimension / 2;
+
+  // line offset takes the width/thickness of the progress circle into account
+  const lineOffset = Math.ceil(lineThickness / 2);
+
+  return halfOfViewbox - lineOffset;
+}
+
+// TODO: once the global i18n templating from the datagrid is merged in, pretty much all
+// of this code and a good chunk of code in progress-circle.element.ts can go away
+export function getAriaLabelFromTemplate(currentValue: number, loadingi18n: string, forceToValue?: number) {
+  const value = isNilOrEmpty(forceToValue) ? currentValue : forceToValue;
+  // this default will be overrideable once the datagrid enhancements to i18n are in
+  return `${loadingi18n} ${value}%`;
+}
+
+export function getDefaultAriaLabel(currentValue: number | undefined | null, loadingi18n: string, loopingMsg: string) {
+  if (isNilOrEmpty(currentValue)) {
+    return loopingMsg;
+  } else {
+    return getAriaLabelFromTemplate(currentValue as number, loadingi18n);
+  }
+}
+
+export function getAriaLabelOrDefault(
+  existingAriaLabel: string,
+  currentValue: number,
+  loadingi18n: string,
+  loopingMsg: string,
+  previousValue?: number
+) {
+  switch (true) {
+    case !existingAriaLabel:
+      return getDefaultAriaLabel(currentValue, loadingi18n, loopingMsg);
+    case previousValue && existingAriaLabel === getAriaLabelFromTemplate(currentValue, loadingi18n, previousValue):
+      return getDefaultAriaLabel(currentValue, loadingi18n, loopingMsg);
+    default:
+      return existingAriaLabel;
+  }
+}
+
+export function getProgressCircleAriaAttributes(
+  currentValue: number | undefined | null,
+  ariaLabel: string
+): HTMLAttributeTuple[] {
+  if (isNilOrEmpty(currentValue)) {
+    // no value so return aria attrs of the looping progress circle
+    return [
+      ['role', 'img'],
+      ['aria-valuemin', false],
+      ['aria-valuemax', false],
+      ['aria-valuenow', false],
+      ['aria-label', ariaLabel],
+    ];
+  } else {
+    // if the progress has a value, then we return as if we expect it to be incrementing
+    return [
+      ['role', 'progressbar'],
+      ['aria-valuemin', '0'],
+      ['aria-valuemax', '100'],
+      ['aria-valuenow', currentValue + ''],
+      ['aria-label', ariaLabel],
+    ];
+  }
+}


### PR DESCRIPTION
This PR adds the following functionality:

- progress circles now have a default aria label if end-users do not define one
- the default aria label leans on new i18n keys in the i18n service
- overriding the i18n keys is one path for customization for the progress circle's aria labels
- if a custom `aria-label` is given, the progress-circle will ignore the default

#### Built for the future

Most of the work here translates easily to the progress bar. I've made notes in a few places where I think code can become shared between the progress circle and progress bar.

#### Advanced override

As an advanced customization users can override the default aria label's loading message composition. The default label is set up like `$i18n $val%` where the `$i8n` token represents the string stored in the i18n `progress.loading` key and the `$val` token represents the value of the progress circle. By default, this is transformed to `Loading 48%` where the progress circle's value is `48`. 

Through the following customization `<cds-progress-circle aria-label-template="Now $i18n... $val of 100" ...>` the default loading aria label's message would read `Now Loading... 48 of 100` and stay in sync with the changing value.

This was introduced as a way for users to customize/localize the loading message.

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)*
- [ ] If applicable, have a visual design approval

* - These are largely advanced customization features. A number of power users will use them. Most will not.

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The complaint was that creating an aria label that stayed in sync with the changing value of the progress circle was too onerous. The request was for the component to just handle it on its own.

Issue Number: #6334 

## What is the new behavior?

An auto syncing default are you label has been introduced. But done in a way that custom audio labels still override the default. There are a couple of tricky edge cases in here. But if you stay away from mixing the customization victors, you should be fine.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
