### PR TITLE
fix: support native aria property reflection

### DIFF
--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -29,7 +29,7 @@ const config = {
   baseDir: './src',
   outDir: './dist/core',
   entryPoints: {
-    modules: ['./src', './src/internal', './src/test'],
+    modules: ['./src', './src/internal', './src/polyfills', './src/test'],
     components: [
       './src/accordion',
       './src/alert',
@@ -83,6 +83,7 @@ const config = {
     explicitExports: [
       { input: './icon/shapes/*', output: './icon/shapes/*' },
       { input: './icon/icon.service.js', output: './icon/icon.service.js' },
+      { input: './polyfills/index.js', output: './polyfills/index.js' },
       { input: './tokens/tokens.js', output: './tokens/tokens.js' },
       { input: './tokens/tokens.d.ts', output: './tokens/tokens.d.ts' },
       { input: './tokens/tokens.json', output: './tokens/tokens.json' },
@@ -90,6 +91,7 @@ const config = {
       { input: './tokens/tokens.ios.swift', output: './tokens/tokens.ios.swift' },
       { input: './tokens/tokens.android.xml', output: './tokens/tokens.android.xml' },
     ],
+    explicitSideEffects: ['./polyfills/index.js', './polyfills/aria-reflect.js'],
   },
 };
 

--- a/packages/core/rollup.utils.js
+++ b/packages/core/rollup.utils.js
@@ -168,9 +168,10 @@ export const addComponentEntryPoints = (packageFile, config) => {
     ${[modules, explicitExports, components, styles].join(',')}
   }`);
 
-  const sideEffects = config.entryPoints.components.map(
-    name => `.${resolve(name).replace(resolve(config.baseDir), '')}/register.js`
-  );
+  const sideEffects = [
+    ...config.entryPoints.components.map(name => `.${resolve(name).replace(resolve(config.baseDir), '')}/register.js`),
+    ...config.entryPoints.explicitSideEffects,
+  ];
 
   return JSON.stringify({ ...JSON.parse(packageFile), sideEffects, exports }, null, 2);
 };

--- a/packages/core/src/alert/alert-group.element.ts
+++ b/packages/core/src/alert/alert-group.element.ts
@@ -71,12 +71,6 @@ export class CdsAlertGroup extends LitElement {
   type: AlertGroupTypes = 'default';
 
   /**
-   * Autosets the alert groups aria role to 'region'
-   */
-  @property({ type: String })
-  role = 'region';
-
-  /**
    * Sets the status of the alerts inside the alert group
    * @type {neutral | info | success | warning | danger | alt | loading}
    */
@@ -109,6 +103,11 @@ export class CdsAlertGroup extends LitElement {
         </div>
       </div>
     `;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.role = 'region';
   }
 
   firstUpdated(props: Map<string, any>) {

--- a/packages/core/src/alert/alert.performance.ts
+++ b/packages/core/src/alert/alert.performance.ts
@@ -16,7 +16,7 @@ describe('cds-badge performance', () => {
   `;
 
   it(`should bundle and treeshake alert`, async () => {
-    expect((await testBundleSize('@cds/core/alert/register.js')).kb).toBeLessThan(23);
+    expect((await testBundleSize('@cds/core/alert/register.js')).kb).toBeLessThan(23.5);
   });
 
   it(`should render 1 alert under 20ms`, async () => {

--- a/packages/core/src/badge/badge.performance.ts
+++ b/packages/core/src/badge/badge.performance.ts
@@ -11,7 +11,7 @@ describe('cds-badge performance', () => {
   const badge = html`<cds-badge></cds-badge>`;
 
   it(`should bundle and treeshake badge`, async () => {
-    expect((await testBundleSize('@cds/core/badge/register.js')).kb).toBeLessThan(12);
+    expect((await testBundleSize('@cds/core/badge/register.js')).kb).toBeLessThan(12.5);
   });
 
   it(`should render 1 badge under 20ms`, async () => {

--- a/packages/core/src/breadcrumb/breadcrumb.element.ts
+++ b/packages/core/src/breadcrumb/breadcrumb.element.ts
@@ -23,12 +23,11 @@ import styles from './breadcrumb.element.scss';
  * @cssprop --color
  */
 export class CdsBreadcrumb extends LitElement {
-  @state({ type: String, reflect: true, attribute: 'role' })
-  protected role = 'navigation';
-
   @state({ type: Array }) private navItems: Element[] = [];
 
   @querySlot('[slot="cds-separator"]') private customSeparator: HTMLElement;
+
+  role = 'navigation';
 
   render() {
     return html`
@@ -47,6 +46,7 @@ export class CdsBreadcrumb extends LitElement {
       <slot @slotchange=${this.assignSlots}></slot>
     `;
   }
+
   private get separator() {
     if (this.customSeparator) {
       const separatorClone = this.customSeparator.cloneNode(true) as Element;

--- a/packages/core/src/card/card.element.ts
+++ b/packages/core/src/card/card.element.ts
@@ -1,5 +1,5 @@
 import { css } from 'lit';
-import { property, globalStyle } from '@cds/core/internal';
+import { globalStyle } from '@cds/core/internal';
 import { CdsInternalPanel } from '@cds/core/internal-components/panel';
 import styles from './card.element.scss';
 
@@ -49,7 +49,7 @@ import styles from './card.element.scss';
  * @cssprop --cds-card-remove-margin
  */
 export class CdsCard extends CdsInternalPanel {
-  @property({ type: String, reflect: true }) role = 'region';
+  role = 'region';
 
   @globalStyle() globalStyles = css`
     [cds-card-remove-margin] {

--- a/packages/core/src/icon/icon.performance.ts
+++ b/packages/core/src/icon/icon.performance.ts
@@ -18,7 +18,7 @@ describe('cds-icon performance', () => {
       import '@cds/core/icon/register.js';
       ClarityIcons.addIcons(userIcon);
     `;
-    expect((await testBundleSize(bundle)).kb).toBeLessThan(14);
+    expect((await testBundleSize(bundle)).kb).toBeLessThan(14.5);
   });
 
   it(`should bundle all icons`, async () => {

--- a/packages/core/src/internal-components/overlay/overlay.element.ts
+++ b/packages/core/src/internal-components/overlay/overlay.element.ts
@@ -101,7 +101,8 @@ export class CdsInternalOverlay extends CdsBaseFocusTrap implements Animatable {
   // renderRoot needs delegatesFocus so that focus can cross the shadowDOM
   // inside an element with aria-modal set to true
   /** @private */
-  static get shadowRootOptions() {
+  static get shadowRootOptions(): any {
+    // any is used until TS 4.4.x adopted through other @cds/* libraries. Can be removed in 6.0
     return { ...super.shadowRootOptions, delegatesFocus: true };
   }
 

--- a/packages/core/src/internal/base/button.base.ts
+++ b/packages/core/src/internal/base/button.base.ts
@@ -24,15 +24,11 @@ export class CdsBaseButton extends LitElement {
 
   @property({ type: Boolean }) disabled = false;
 
-  @state({ type: String, attribute: 'aria-disabled', reflect: true }) ariaDisabled: 'true' | 'false' | null = 'false';
-
   @state({ type: Number, attribute: 'tabindex', reflect: true }) protected tabIndexAttr: number | null; // don't override native prop as it stops native focus behavior
 
   @state({ type: Boolean, reflect: true }) protected focused = false;
 
   @state({ type: Boolean, reflect: true }) protected active = false;
-
-  @state({ type: String, reflect: true, attribute: 'role' }) protected role: string | null = 'button';
 
   @state({ type: Boolean, reflect: true }) protected isAnchor = false;
 
@@ -56,6 +52,7 @@ export class CdsBaseButton extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     this.tabIndex = 0; // initialize immediately so button can be focused synchronously
+    this.role = 'button';
   }
 
   protected updated(props: Map<string, any>) {

--- a/packages/core/src/internal/index.ts
+++ b/packages/core/src/internal/index.ts
@@ -4,10 +4,10 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-/** @internal private module to Clarity Core */
-
+import '@cds/core/polyfills';
 import styles from './base/base.element.scss';
 
+/** @internal private module to Clarity Core */
 export const baseStyles = styles;
 export * from './base/button.base.js';
 export * from './base/focus-trap.base.js';

--- a/packages/core/src/internal/utils/exists.ts
+++ b/packages/core/src/internal/utils/exists.ts
@@ -14,7 +14,8 @@ export const existsIn = curryN(2, (pathToCheck: string[], obj: object): boolean 
   return typeof pathExists !== 'undefined';
 });
 
-export function elementExists(tagName: string, registry?: { get: (name: string) => {} }): boolean {
+export function elementExists(tagName: string, registry?: any): boolean {
+  // any should be CustomElementRegistry but waiting until TS 4.4.x adopted through other @cds/* libraries. Cane be updated in 6.0
   if (!registry) {
     registry = window && window.customElements;
   }

--- a/packages/core/src/modal/modal-content.element.ts
+++ b/packages/core/src/modal/modal-content.element.ts
@@ -35,7 +35,8 @@ export class CdsModalContent extends LitElement {
   // inside modal-content with a tabindex of -1. we need the tabindex so a
   // modal's content can scroll if it needs to.
   /** @private */
-  static get shadowRootOptions() {
+  static get shadowRootOptions(): any {
+    // any is used until TS 4.4.x adopted through other @cds/* libraries. Can be removed in 6.0
     return { ...super.shadowRootOptions, delegatesFocus: true };
   }
 

--- a/packages/core/src/navigation/navigation-item.element.ts
+++ b/packages/core/src/navigation/navigation-item.element.ts
@@ -50,9 +50,6 @@ export class CdsNavigationItem extends LitElement implements FocusableItem {
   @property({ type: Boolean, reflect: true })
   disabled = false;
 
-  @property({ type: String, reflect: true })
-  role = 'listitem';
-
   @state({ type: Boolean })
   expanded = false;
 
@@ -73,6 +70,8 @@ export class CdsNavigationItem extends LitElement implements FocusableItem {
 
   @querySlotAll('[cds-navigation-sr-text]')
   itemText: NodeListOf<HTMLSpanElement>;
+
+  role = 'listitem';
 
   connectedCallback() {
     super.connectedCallback();

--- a/packages/core/src/navigation/navigation.element.ts
+++ b/packages/core/src/navigation/navigation.element.ts
@@ -84,9 +84,6 @@ export class CdsNavigation extends LitElement implements Animatable {
   @property({ type: String })
   cdsMotion = 'on';
 
-  @property({ type: String })
-  role = 'list';
-
   @event()
   protected expandedChange: EventEmitter<boolean>;
 
@@ -101,12 +98,6 @@ export class CdsNavigation extends LitElement implements Animatable {
    */
   @state({ type: Boolean })
   protected groupItem = true;
-
-  /**
-   * Set and update the aria-active descended value onto the navigation.
-   */
-  @state({ type: String })
-  ariaActiveDescendant: any;
 
   /**
    *
@@ -182,6 +173,8 @@ export class CdsNavigation extends LitElement implements Animatable {
    */
   @querySlotAll('cds-navigation-group')
   protected navigationGroupRefs: NodeListOf<CdsNavigationGroup>;
+
+  role = 'list';
 
   private toggle() {
     this.expandedChange.emit(!this.expanded);
@@ -310,7 +303,7 @@ export class CdsNavigation extends LitElement implements Animatable {
       if (this.currentActiveItem?.tagName === 'CDS-NAVIGATION-ITEM' && !!groupParent) {
         const groupStartElement = groupParent?.querySelector('cds-navigation-start');
         removeFocus(this.currentActiveItem as FocusableElement);
-        this.ariaActiveDescendant = groupStartElement?.id;
+        this.ariaActiveDescendant = groupStartElement?.id ?? null;
         setFocus(groupStartElement as FocusableElement);
         return;
       }
@@ -389,7 +382,7 @@ export class CdsNavigation extends LitElement implements Animatable {
       ${this.startTemplate}
       <slot name="cds-navigation-substart"></slot>
       <nav class="navigation-body-wrapper">
-        <div aria-activedescendant="${this.ariaActiveDescendant}" tabindex="0" id="item-container">
+        <div .ariaActiveDescendant=${this.ariaActiveDescendant} tabindex="0" id="item-container">
           <div class="navigation-body" cds-layout="vertical wrap:none align:horizontal-stretch">
             <slot></slot>
           </div>

--- a/packages/core/src/password/password.element.ts
+++ b/packages/core/src/password/password.element.ts
@@ -51,13 +51,12 @@ export class CdsPassword extends CdsControl {
     ClarityIcons.addIcons(eyeIcon, eyeHideIcon);
   }
 
-  private get ariaLabel() {
-    return this.showPassword ? this.i18n.hideButtonAriaLabel : this.i18n.showButtonAriaLabel;
-  }
-
   protected get suffixDefaultTemplate() {
     return html`
-      <cds-control-action @click=${() => this.togglePasswordVisibility()} aria-label="${this.ariaLabel}">
+      <cds-control-action
+        @click=${() => this.togglePasswordVisibility()}
+        .ariaLabel=${this.showPassword ? this.i18n.hideButtonAriaLabel : this.i18n.showButtonAriaLabel}
+      >
         <cds-icon shape="${this.showPassword ? 'eye-hide' : 'eye'}"></cds-icon>
       </cds-control-action>
     `;

--- a/packages/core/src/polyfills/aria-reflect.ts
+++ b/packages/core/src/polyfills/aria-reflect.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+/*
+ * Shim for aria atribute reflection missing in Firefox
+ * https://wicg.github.io/aom/aria-reflection-explainer.html
+ * https://developer.mozilla.org/en-US/docs/Web/API/Element/ariaLabel
+ * Patching missing types as needed
+ */
+declare global {
+  interface Element {
+    // overide ARIAMixin interface in TS lib.dom.d.ts 4.4.4+ https://github.com/microsoft/TypeScript/issues/46456
+    role: string | null;
+    ariaActiveDescendant: string | null;
+    ariaControls: string | null;
+    ariaLabelledBy: string | null;
+    ariaDisabled: string | null;
+    ariaExpanded: string | null;
+    ariaSelected: string | null;
+    ariaAtomic: string | null;
+    ariaAutoComplete: string | null;
+    ariaBusy: string | null;
+    ariaChecked: string | null;
+    ariaColCount: string | null;
+    ariaColIndex: string | null;
+    ariaColSpan: string | null;
+    ariaCurrent: string | null;
+    ariaHasPopup: string | null;
+    ariaHidden: string | null;
+    ariaKeyShortcuts: string | null;
+    ariaLabel: string | null;
+    ariaLevel: string | null;
+    ariaLive: string | null;
+    ariaModal: string | null;
+    ariaMultiLine: string | null;
+    ariaMultiSelectable: string | null;
+    ariaOrientation: string | null;
+    ariaPlaceholder: string | null;
+    ariaPosInSet: string | null;
+    ariaPressed: string | null;
+    ariaReadOnly: string | null;
+    ariaRequired: string | null;
+    ariaRoleDescription: string | null;
+    ariaRowCount: string | null;
+    ariaRowIndex: string | null;
+    ariaRowSpan: string | null;
+    ariaSetSize: string | null;
+    ariaSort: string | null;
+    ariaValueMax: string | null;
+    ariaValueMin: string | null;
+    ariaValueNow: string | null;
+    ariaValueText: string | null;
+  }
+}
+
+let roleRegistered = false;
+let ariaRegistered = false;
+
+function isNode() {
+  return (globalThis as any)?.process?.env?.JEST_WORKER_ID !== undefined; // Jest and JSDom breaks on property reflection
+}
+
+// eslint-disable-next-line
+if (!roleRegistered && !Element.prototype.hasOwnProperty('role') && !isNode()) {
+  reflect(Element.prototype, 'role', 'role');
+  roleRegistered = true;
+}
+
+// https://www.w3.org/TR/wai-aria-1.0/states_and_properties
+// eslint-disable-next-line
+if (!ariaRegistered && !Element.prototype.hasOwnProperty('ariaLabel') && !isNode()) {
+  ariaRegistered = true;
+  [
+    'ActiveDescendant',
+    'Atomic',
+    'AutoComplete',
+    'Busy',
+    'Checked',
+    'ColCount',
+    'ColIndex',
+    'ColSpan',
+    'Controls',
+    'Current',
+    'DescribedBy',
+    'Details',
+    'Disabled',
+    'ErrorMessage',
+    'Expanded',
+    'FlowTo',
+    'HasPopup',
+    'Hidden',
+    'Invalid',
+    'KeyShortcuts',
+    'Label',
+    'LabelledBy',
+    'Level',
+    'Live',
+    'Modal',
+    'MultiLine',
+    'MultiSelectable',
+    'Orientation',
+    'Owns',
+    'Placeholder',
+    'PosInSet',
+    'Pressed',
+    'ReadOnly',
+    'Relevant',
+    'Required',
+    'RoleDescription',
+    'RowCount',
+    'RowIndex',
+    'RowSpan',
+    'Selected',
+    'SetSize',
+    'Sort',
+    'ValueMax',
+    'ValueMin',
+    'ValueNow',
+    'ValueText',
+  ].forEach(name => reflect(Element.prototype, `aria-${name.toLowerCase()}`, `aria${name}`));
+}
+
+export function reflect(element: HTMLElement | Element, attributeName: string, propertyName: string) {
+  Object.defineProperty(element, propertyName, {
+    configurable: true,
+    enumerable: true,
+    get: function () {
+      return this.hasAttribute(attributeName) ? this.getAttribute(attributeName) : null;
+    },
+    set: function (value) {
+      if (value !== null) {
+        this.setAttribute(attributeName, value);
+      } else {
+        this.removeAttribute(attributeName);
+      }
+    },
+  });
+}

--- a/packages/core/src/polyfills/index.ts
+++ b/packages/core/src/polyfills/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import './aria-reflect.js';

--- a/packages/core/src/tree-view/tree-item.element.ts
+++ b/packages/core/src/tree-view/tree-item.element.ts
@@ -8,14 +8,12 @@ import {
   Animatable,
   animate,
   AnimationTreeItemExpandName,
-  AriaBooleanAttributeValues,
   baseStyles,
   createId,
   event,
   EventEmitter,
   i18n,
   I18nService,
-  state,
   property,
   querySlot,
   querySlotAll,
@@ -63,23 +61,11 @@ import styles from './tree-item.element.scss';
 export class CdsTreeItem extends LitElement implements Animatable {
   @i18n() i18n = I18nService.keys.treeview;
 
-  @state({ type: String, reflect: true, attribute: 'role' })
-  role = 'treeitem';
-
   @property({ type: String })
   cdsMotion = 'on';
 
   @event()
   cdsMotionChange: EventEmitter<string>;
-
-  @state({ type: String, reflect: true, attribute: 'aria-disabled' })
-  ariaDisabled: AriaBooleanAttributeValues | undefined = 'false';
-
-  @state({ type: String, reflect: true, attribute: 'aria-expanded' })
-  ariaExpanded: AriaBooleanAttributeValues | undefined = 'false';
-
-  @state({ type: String, reflect: true, attribute: 'aria-selected' })
-  ariaSelected: AriaBooleanAttributeValues | undefined = 'false';
 
   @property({ type: Boolean, reflect: true, attribute: 'multi-select' })
   multiSelect = false;
@@ -118,6 +104,7 @@ export class CdsTreeItem extends LitElement implements Animatable {
   connectedCallback() {
     super.connectedCallback();
     this.tabIndex = -1;
+    this.role = 'treeitem';
     if (!this.id) {
       this.id = createId();
     }
@@ -133,13 +120,13 @@ export class CdsTreeItem extends LitElement implements Animatable {
     if (this.expandable) {
       this.ariaExpanded = this.expanded ? 'true' : 'false';
     } else {
-      this.ariaExpanded = undefined;
+      this.ariaExpanded = null;
     }
 
     if (this.multiSelect) {
       this.ariaSelected = this.selected ? 'true' : 'false';
     } else {
-      this.ariaSelected = undefined;
+      this.ariaSelected = null;
     }
 
     this.ariaDisabled = this.disabled ? 'true' : 'false';

--- a/packages/core/src/tree-view/tree.element.ts
+++ b/packages/core/src/tree-view/tree.element.ts
@@ -5,11 +5,9 @@
  */
 
 import {
-  AriaBooleanAttributeValues,
   arrayHead,
   arrayTail,
   baseStyles,
-  state,
   isVisible,
   nextInArray,
   onAnyKey,
@@ -44,17 +42,8 @@ import styles from './tree.element.scss';
  * @slot - Content slot for inside the tree
  */
 export class CdsTree extends LitElement {
-  @state({ type: String, reflect: true, attribute: 'role' })
-  role = 'tree';
-
   @property({ type: Boolean, attribute: 'multi-select' })
   multiSelect = false;
-
-  @state({ type: String, reflect: true, attribute: 'aria-activedescendant' })
-  ariaActiveDescendant: string;
-
-  @state({ type: String, reflect: true, attribute: 'aria-multiselectable' })
-  ariaMultiSelectable: AriaBooleanAttributeValues = 'false';
 
   @querySlot('cds-tree-item') private firstChildItem: CdsTreeItem;
 
@@ -63,6 +52,7 @@ export class CdsTree extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     this.tabIndex = 0;
+    this.role = 'tree';
     this.addEventListener('focus', this.initAriaActiveDescendant);
     this.addEventListener('click', this.clickHandler);
     this.addEventListener('keydown', this.keyboardNavigationHandler);

--- a/packages/core/web-dev-server.config.mjs
+++ b/packages/core/web-dev-server.config.mjs
@@ -47,6 +47,7 @@ export default /** @type {import('@web/dev-server').DevServerConfig} */ ({
             '@cds/core/tokens/tokens.json': '/dist/core/tokens/tokens.json',
 
             '@cds/core': '/dist/core/index.js',
+            '@cds/core/polyfills': '/dist/core/polyfills/index.js',
             '@cds/core/icon': '/dist/core/icon/index.js',
             '@cds/core/icon/register.js': '/dist/core/icon/register.js',
             '@cds/core/icon/icon.service.js': '/dist/core/icon/icon.service.js',

--- a/packages/core/web-test-runner.config.mjs
+++ b/packages/core/web-test-runner.config.mjs
@@ -26,6 +26,7 @@ export default /** @type {import("@web/test-runner").TestRunnerConfig} */ ({
       '**/node_modules/**',
       '**/test/**',
       '**/dist/core/**/index.js',
+      '**/dist/core/polyfills/*.js',
       '**/dist/core/**/register.js',
     ],
     report: true,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
The newer aria reflection AP enables elements to set an aria property and have it auto reflect to the attribute.

```javascript
const element = document.querySelector('div');
element.ariaDisabled = 'true'
```

```html
<div aria-disabled="true"></div>
```

This means we do not need the property decorators to handle the reflection on `aria*` properties and need to adjust the types to match TypeScript in the newer version 4.3.4+. To support the newer versions of TS we need to adjust and remove overrides on any native aria property type. We also need a shim for firefox as it does not fully support aria property reflection yet.
https://wicg.github.io/aom/caniuse.html
https://wicg.github.io/aom/aria-reflection-explainer.html

## What is the new behavior?
Components can now use the native aria properties and fallback to a shim for Firefox. This aligns and fixes the mismatched types with TypeScript. See https://github.com/microsoft/TypeScript/issues/46456 for more details

Unblocks part of the Angular 13 update https://github.com/vmware/clarity/pull/6455 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
