### PR TITLE
fix(react): move react to peer dependency to allow React 17

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,12 +23,12 @@
     "url": "https://github.com/vmware/clarity.git"
   },
   "dependencies": {
-    "@lit-labs/react": "^1.0.1",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "@lit-labs/react": "^1.0.1"
   },
   "peerDependencies": {
-    "@cds/core": "./dist/core"
+    "@cds/core": "./dist/core",
+    "react":">= 16.13.1",
+    "react-dom": ">= 16.13.1"
   },
   "devDependencies": {
     "@cds/core": "./dist/core",
@@ -57,6 +57,8 @@
     "parcel": "^2.0.0-beta.1",
     "prettier": "2.0.5",
     "pretty-quick": "1.11.0",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
     "replace": "1.1.0",
     "ts-jest": "^26.1.0",
     "typescript": "^4.4.2"


### PR DESCRIPTION
Fix #6464

Signed-off-by: Ashley Ryan <asryan@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue #6464 

@cds/react has react 16 as a dependency which can cause two version of react if apps are using v17.

## What is the new behavior?

react is now a peer dependency 

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

I think moving a dependency to a peerDependency is technically a breaking change, but there's no way an app would use @cds/react without already having react/react-dom.

## Other information

There's probably a lot more to test with this, I was hoping this could be a jumping off point for discussion
