### PR TITLE
fix(schematics): modern-normalize import instead of normalize @cds/angular

### DIFF
--- a/packages/schematics/src/cds-add/index.spec.ts
+++ b/packages/schematics/src/cds-add/index.spec.ts
@@ -115,7 +115,7 @@ describe('ng add @cds/angular', () => {
 
       const styles = configFile.projects[PROJECT_NAME].architect.build.options.styles;
 
-      expect(styles.includes('node_modules/normalize.css/normalize.css')).toBeTruthy();
+      expect(styles.includes('node_modules/modern-normalize.css/modern-normalize.css')).toBeTruthy();
       expect(styles.includes('node_modules/@cds/core/global.min.css')).toBeTruthy();
       expect(styles.includes('node_modules/@cds/core/styles/module.shims.min.css')).toBeTruthy();
       expect(styles.includes('node_modules/@cds/city/css/bundles/default.min.css')).toBeTruthy();

--- a/packages/schematics/src/cds-add/index.ts
+++ b/packages/schematics/src/cds-add/index.ts
@@ -80,7 +80,7 @@ function addAssetsToConfigFile(host: Tree, context: SchematicContext): void {
     const target = json.projects[project].targets || json.projects[project].architect;
     const pathPrefix = json.apps ? '../' : '';
     const assets = [
-      'node_modules/normalize.css/normalize.css',
+      'node_modules/modern-normalize.css/modern-normalize.css',
       'node_modules/@cds/core/global.min.css',
       'node_modules/@cds/core/styles/module.shims.min.css',
       'node_modules/@cds/city/css/bundles/default.min.css',


### PR DESCRIPTION
Closes #6482

Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

In `angular.json` the previous version of `normalize` css was added.

Issue Number: #6482

## What is the new behavior?

As we updated to use `modern-normalize` the schematics now adds the path to the new package.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
