### PR TITLE
fix(core): lint/logging

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,10 @@
  */
 
 // we export any non component code such as utilities at the root '@clr/core'
-export { I18nService, componentStringsDefault } from '@cds/core/internal';
+export { I18nService } from '@cds/core/internal';
+
+// we don't re-export componentStringsDefault from @cds/internal to prevent rollup complaining about a unsed import being rexported
+export { componentStringsDefault } from './internal/services/i18n.service.js';
 
 // type global attribute utilities
 declare global {

--- a/packages/core/src/internal-components/popup/popup.element.ts
+++ b/packages/core/src/internal-components/popup/popup.element.ts
@@ -23,6 +23,7 @@ import {
   reverseAnimation,
   setAttributes,
   setPopupPosition,
+  state,
 } from '@cds/core/internal';
 import { html } from 'lit';
 import { query } from 'lit/decorators/query.js';
@@ -102,7 +103,7 @@ export class CdsInternalPopup extends CdsInternalStaticOverlay implements Animat
    * positioning logic may override your changes.
    */
   /** @private */
-  @property({ type: Boolean, reflect: true })
+  @state({ type: Boolean, reflect: true, attribute: 'responsive' })
   responsive = false;
 
   @event()

--- a/packages/core/src/internal/motion/utils.spec.ts
+++ b/packages/core/src/internal/motion/utils.spec.ts
@@ -109,7 +109,7 @@ describe('Animation Helpers: ', () => {
   ];
 
   describe('runPropertyAnimations()', () => {
-    it('logs a warning if the element it is passed is not animatable', async done => {
+    it('logs a warning if the element it is passed is not animatable', async () => {
       const testElement = await createTestElement(html`<div>ohai</div>`);
       spyOn(LogService, 'warn');
       expect(testElement).toBeDefined();
@@ -117,10 +117,9 @@ describe('Animation Helpers: ', () => {
       expect(LogService.warn).toHaveBeenCalled();
       expect(didRun).toBe(false);
       removeTestElement(testElement);
-      done();
     });
 
-    it('bails if the host element does not have the property (weird edge case)', async done => {
+    it('bails if the host element does not have the property (weird edge case)', async () => {
       const testElement = await createTestElement(html`<div>ohai</div>`);
       const propMap: Map<string, any> = new Map();
       propMap.set('jabberwocky', 'wat');
@@ -128,10 +127,9 @@ describe('Animation Helpers: ', () => {
       const didRun = await runPropertyAnimations(propMap, (testElement as unknown) as AnimatableElement);
       expect(didRun).toBe(false);
       removeTestElement(testElement);
-      done();
     });
 
-    it('bails if the host element property and the new propval have not changed (another weird edge case)', async done => {
+    it('bails if the host element property and the new propval have not changed (another weird edge case)', async () => {
       const testElement = await createTestElement(html`<test-animate-utils-element>ohai</test-animate-utils-element>`);
       const component = testElement.querySelector<TestAnimateUtilsElement & AnimatableElement>(
         'test-animate-utils-element'
@@ -144,10 +142,9 @@ describe('Animation Helpers: ', () => {
       const didRun = await runPropertyAnimations(propMap, component);
       expect(didRun).toBe(false);
       removeTestElement(testElement);
-      done();
     });
 
-    it('bails if there is no animation associated with the property value', async done => {
+    it('bails if there is no animation associated with the property value', async () => {
       const testElement = await createTestElement(html`<div class="hayy">ohai</div>`);
       const component = testElement.querySelector('.hayy');
       const propMap: Map<string, any> = new Map();
@@ -156,10 +153,9 @@ describe('Animation Helpers: ', () => {
       const didRun = await runPropertyAnimations(propMap, (component as unknown) as AnimatableElement);
       expect(didRun).toBe(false);
       removeTestElement(testElement);
-      done();
     });
 
-    it('runs if there is an animation associated with the property value', async done => {
+    it('runs if there is an animation associated with the property value', async () => {
       const testElement = await createTestElement(html`<test-animate-utils-element>ohai</test-animate-utils-element>`);
       const component = testElement.querySelector<TestAnimateUtilsElement>('test-animate-utils-element');
       ClarityMotion.add('something', [{ animation: [{ opacity: 0 }, { opacity: 1 }] }]);
@@ -170,10 +166,9 @@ describe('Animation Helpers: ', () => {
       const didRun = await runPropertyAnimations(propMap, (component as unknown) as AnimatableElement);
       expect(didRun).toBe(true);
       removeTestElement(testElement);
-      done();
     });
 
-    it('does NOT run if there is an animation label associated with the property value but no animation in ClarityMotion', async done => {
+    it('does NOT run if there is an animation label associated with the property value but no animation in ClarityMotion', async () => {
       const testElement = await createTestElement(html`<test-animate-utils-element>ohai</test-animate-utils-element>`);
       const component = testElement.querySelector<TestAnimateUtilsElement>('test-animate-utils-element');
       component.everythingIsFine = false;
@@ -183,7 +178,6 @@ describe('Animation Helpers: ', () => {
       const didRun = await runPropertyAnimations(propMap, (component as unknown) as AnimatableElement);
       expect(didRun).toBe(false);
       removeTestElement(testElement);
-      done();
     });
   });
 

--- a/packages/core/src/internal/utils/focus-trap.ts
+++ b/packages/core/src/internal/utils/focus-trap.ts
@@ -51,7 +51,7 @@ export function refocusIfOutsideFocusTrapElement(
     const focusableChildren = queryAllFocusable(focusTrapElement);
     const orderedFocusableChildrenAsArray = reorderCloseButtonSlot(Array.from(focusableChildren));
 
-    if (isReboundEl !== null && orderedFocusableChildrenAsArray !== []) {
+    if (isReboundEl !== null) {
       if (isReboundEl === 'top') {
         elementToRefocus = arrayTail(orderedFocusableChildrenAsArray) as HTMLElement;
       } else if (isReboundEl === 'bottom') {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?
This fixes the last linting/warning errors in the Core codebase for both the build and tests. There should be no warnings/logs in the console now.

- remove last of the deprecated jasmine done use/warnings 
- update private property to use `@state` to remove private api warning
- fix statement warning caught by TS/ESBuild compiler (boolean check guaranteed will always be true)
- fix the unused public export warning from rollup

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
