### PR TITLE
feat: test if content is scrollable before set tabindex for modal body

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -1494,8 +1494,9 @@ export declare class ClrModal implements OnChanges, OnDestroy {
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrModal, never>;
 }
 
-export declare class ClrModalBody implements OnDestroy {
+export declare class ClrModalBody implements AfterViewChecked, OnDestroy {
     constructor(ngZone: NgZone, renderer: Renderer2, host: ElementRef<HTMLElement>);
+    ngAfterViewChecked(): void;
     ngOnDestroy(): void;
     static ɵdir: i0.ɵɵDirectiveDeclaration<ClrModalBody, ".modal-body", never, {}, {}, never>;
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrModalBody, never>;

--- a/projects/angular/src/modal/modal-body.spec.ts
+++ b/projects/angular/src/modal/modal-body.spec.ts
@@ -50,17 +50,38 @@ describe('ClrModalBody Directive', () => {
 
     expect(spy.calls.count()).toEqual(0);
   });
+
+  it('remove tabindex from modal body when content has no scrollbar', () => {
+    fixture.componentInstance.testButton.nativeElement.click();
+    fixture.detectChanges();
+
+    expect(modalBodyEl.getAttribute('tabindex')).toBeNull();
+  });
 });
 
 @Component({
   template: `
     <div class="modal-body" #testElement>
-      <label #testLabel>test label</label>
+      <label #testLabel *ngIf="hasChildren">test label</label>
+      <button #testButton (click)="hasChildren = false" *ngIf="hasChildren">Remove Content</button>
     </div>
+    <style>
+      div.modal-body {
+        height: 50px;
+      }
+
+      label {
+        line-height: 100px;
+      }
+    </style>
   `,
 })
 class TestComponent {
   @ViewChild('testLabel') testLabel: ElementRef<HTMLElement>;
 
+  @ViewChild('testButton') testButton: ElementRef<HTMLElement>;
+
   @ViewChild('testElement') testElement: ElementRef<HTMLElement>;
+
+  hasChildren = true;
 }


### PR DESCRIPTION
Signed-off-by: KingMario <gcyyq@hotmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

tabindex is set for modal body for no condition.

Issue Number: N/A

## What is the new behavior?

test if content is scrollable before set tabindex for modal body

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
