### PR TITLE
feat(core:grid): dynamic i18n functionality

### DIFF
--- a/packages/core/src/alert/alert.performance.ts
+++ b/packages/core/src/alert/alert.performance.ts
@@ -16,7 +16,7 @@ describe('cds-badge performance', () => {
   `;
 
   it(`should bundle and treeshake alert`, async () => {
-    expect((await testBundleSize('@cds/core/alert/register.js')).kb).toBeLessThan(29.5);
+    expect((await testBundleSize('@cds/core/alert/register.js')).kb).toBeLessThan(29.7);
   });
 
   it(`should render 1 alert under 20ms`, async () => {

--- a/packages/core/src/grid/docs/async-data.stories.ts
+++ b/packages/core/src/grid/docs/async-data.stories.ts
@@ -1,6 +1,8 @@
 import { html, LitElement, PropertyValues } from 'lit';
+import { query } from 'lit/decorators/query.js';
 import { state, customElement } from '@cds/core/internal';
 import { DemoGrid, DemoService } from '@cds/core/demo';
+import { CdsGrid } from '@cds/core/grid';
 
 export default {
   title: 'Stories/Grid',
@@ -11,6 +13,8 @@ export function asyncData() {
   @customElement('demo-grid-async-data')
   class DemoGridAsyncData extends LitElement {
     @state() private grid: DemoGrid = { label: '', rowActions: [], columns: [], rows: [] } as unknown as DemoGrid;
+
+    @query('cds-grid') private gridElement: CdsGrid;
 
     render() {
       return html`
@@ -39,6 +43,7 @@ export function asyncData() {
     private async load() {
       this.grid = { label: '', rowActions: [], columns: [], rows: [] } as unknown as DemoGrid;
       this.grid = (await DemoService.asyncData).grid;
+      this.gridElement.requestUpdate(); // <- we need this so the i18n hydrates itself after load
     }
   }
 

--- a/packages/core/src/grid/docs/cell-editable.stories.ts
+++ b/packages/core/src/grid/docs/cell-editable.stories.ts
@@ -1,4 +1,4 @@
-import { css, html, LitElement } from 'lit';
+import { html, LitElement } from 'lit';
 import { queryAll } from 'lit/decorators.js';
 import { customElement, getInputValueType, state } from '@cds/core/internal';
 import { DemoGridCell, DemoService, exportElementsToCSV, parseCSV } from '@cds/core/demo';

--- a/packages/core/src/internal/controllers/aria-modal.controller.spec.ts
+++ b/packages/core/src/internal/controllers/aria-modal.controller.spec.ts
@@ -1,5 +1,5 @@
 import { html, LitElement } from 'lit';
-import { customElement, AriaModalController, ariaModal } from '@cds/core/internal';
+import { customElement, ariaModal } from '@cds/core/internal';
 import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
 
 @ariaModal<AriaModalControllerTestElement>()

--- a/packages/core/src/internal/controllers/inline-focus-trap.controller.spec.ts
+++ b/packages/core/src/internal/controllers/inline-focus-trap.controller.spec.ts
@@ -1,5 +1,5 @@
 import { html, LitElement } from 'lit';
-import { customElement, firstFocus, focusTrap, InlineFocusTrapController } from '@cds/core/internal';
+import { customElement, firstFocus, focusTrap } from '@cds/core/internal';
 import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
 
 @focusTrap<InlineFocusTrapControllerTestElement>()
@@ -20,7 +20,7 @@ class InlineFocusTrapControllerTestElement extends LitElement {
 describe('inline-focus-trap.controller', () => {
   let component: HTMLElement;
   let element: HTMLElement;
-  let root: any;
+  // let root: HTMLDocument | ShadowRoot;
   let shadowRoot: ShadowRoot;
 
   beforeEach(async () => {
@@ -36,7 +36,7 @@ describe('inline-focus-trap.controller', () => {
     component = element.querySelector<InlineFocusTrapControllerTestElement>(
       'inline-focus-trap-controller-test-element'
     );
-    root = component.getRootNode() as any;
+    // root = component.getRootNode() as any;
     shadowRoot = component.shadowRoot as any;
   });
 

--- a/packages/core/src/internal/decorators/i18n.spec.ts
+++ b/packages/core/src/internal/decorators/i18n.spec.ts
@@ -4,10 +4,17 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
+import {
+  customElement,
+  i18n,
+  getI18nValues,
+  getI18nUpdateStrategy,
+  I18nService,
+  I18nElement,
+  LogService,
+} from '@cds/core/internal';
 import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators/custom-element.js';
 import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
-import { i18n } from './i18n.js';
 
 const i18nValues = {
   open: 'Open my element',
@@ -21,6 +28,18 @@ class TestI18nElement extends LitElement {
 
   render() {
     return html`<slot></slot>`;
+  }
+}
+
+/** @element test-alert-18n-element */
+@customElement('test-alert-18n-element')
+class TestAlertI18nElement extends LitElement {
+  @i18n() i18n: Record<string, any> = I18nService.keys.alert;
+
+  greeting = 'hello';
+
+  render() {
+    return html`<p>ohai</p>`;
   }
 }
 
@@ -50,5 +69,124 @@ describe('i18n decorator', () => {
     component.setAttribute('cds-i18n', `{ "close": "ohai" }`);
     await componentIsStable(component);
     expect(component.i18n.close).toEqual('ohai', 'double set i18n');
+  });
+});
+
+describe('i18n overrides: ', () => {
+  let testElement: HTMLElement;
+  let component: TestAlertI18nElement;
+
+  beforeEach(async () => {
+    testElement = await createTestElement(html` <test-alert-18n-element></test-alert-18n-element> `);
+    component = testElement.querySelector<TestAlertI18nElement>('test-alert-18n-element');
+  });
+
+  afterEach(() => {
+    removeTestElement(testElement);
+  });
+
+  it('picks up alert i18n as expected', () => {
+    const testMe = component.i18n;
+    expect(testMe.closeButtonAriaLabel).toBe('Close');
+    expect(testMe.loading).toBe('Loading');
+    expect(testMe.success).toBe('Success');
+  });
+
+  it('overrides from cds-i18n attr as expected, even partially', async () => {
+    component.setAttribute('cds-i18n', '{ "closeButtonAriaLabel": "${greeting} world" }');
+    await componentIsStable(component);
+    const testMe = component.i18n;
+    expect(testMe.closeButtonAriaLabel).toBe('hello world');
+    expect(testMe.loading).toBe('Loading');
+    expect(testMe.success).toBe('Success');
+  });
+
+  it('overrides from i18n as expected, even partially', async () => {
+    component.i18n = { closeButtonAriaLabel: '${greeting} from the other side...' };
+    await componentIsStable(component);
+    const testMe = component.i18n;
+    expect(testMe.closeButtonAriaLabel).toBe('hello from the other side...');
+    expect(testMe.loading).toBe('Loading');
+    expect(testMe.success).toBe('Success');
+  });
+});
+
+describe('helpers', () => {
+  let testElement: HTMLElement;
+  let component: TestAlertI18nElement;
+  const closeText = 'bye yall';
+
+  beforeEach(async () => {
+    testElement = await createTestElement(html` <test-alert-18n-element></test-alert-18n-element> `);
+    component = testElement.querySelector<TestAlertI18nElement>('test-alert-18n-element');
+  });
+
+  afterEach(() => {
+    removeTestElement(testElement);
+  });
+
+  describe('getI18nValues()', () => {
+    it('should return values if not empty', () => {
+      const testMe = getI18nValues({ go: 'niners' }, (component as unknown) as I18nElement);
+      expect(testMe).toEqual({ go: 'niners' });
+    });
+
+    it('should try to lookup string attr if passed empty', async () => {
+      component.setAttribute('cds-i18n', '{ "greet": "ohai" }');
+      await componentIsStable(component);
+      const testMe = getI18nValues(void 0, (component as unknown) as I18nElement);
+      expect(testMe).toEqual({ greet: 'ohai' });
+    });
+
+    it('should return empty obj and warn if it cannot parse the attr value', async () => {
+      component.i18n = null;
+      await componentIsStable(component);
+      component.setAttribute('cds-i18n', '{ notAJson: "wat" }');
+      const testMe = getI18nValues(void 0, (component as unknown) as I18nElement);
+      expect(testMe).toEqual({});
+    });
+
+    it('should return empty obj and warn if passed empty and attr is empty too', async () => {
+      component.i18n = null;
+      await componentIsStable(component);
+      const testMe = getI18nValues(void 0, (component as unknown) as I18nElement);
+      expect(testMe).toEqual({});
+    });
+  });
+
+  describe('getI18nUpdateStrategy()', () => {
+    it('should tell us not to update if the new key is nil and old/new values are the same', () => {
+      const values = { closeButtonAriaLabel: closeText + '' };
+      const testEmpty = getI18nUpdateStrategy('', 'alert', { ...values }, { ...values });
+      const testNull = getI18nUpdateStrategy(null, 'alert', { ...values }, { ...values });
+      const testUndefined = getI18nUpdateStrategy(void 0, 'alert', { ...values }, { ...values });
+      const expected = { update: false };
+      expect(testEmpty).toEqual(expected);
+      expect(testNull).toEqual(expected);
+      expect(testUndefined).toEqual(expected);
+    });
+
+    it('should tell us not to update if sent a new key that is the same as the old key', () => {
+      const values = { closeButtonAriaLabel: closeText + '' };
+      const testMe = getI18nUpdateStrategy('alert', 'alert', { ...values }, I18nService.keys.alert);
+      expect(testMe.update).toBe(false);
+      expect(testMe.key).toBeUndefined();
+      expect(testMe.values).toEqual({});
+    });
+
+    it('should tell us to update values but not keys if old/new values do not match', () => {
+      const values = { closeButtonAriaLabel: closeText + '' };
+      const testMe = getI18nUpdateStrategy(null, 'alert', { ...values }, I18nService.keys.alert);
+
+      expect(testMe.update).toBe(true);
+      expect(testMe.key).toBeUndefined();
+      expect(testMe.values).toEqual({ ...values });
+    });
+
+    it('should handle bad input', () => {
+      const testMe = getI18nUpdateStrategy(void 0, 'alert', void 0, void 0);
+      const expected = { update: false };
+      expect(testMe).toEqual(expected);
+    });
   });
 });

--- a/packages/core/src/internal/services/i18n.service.spec.ts
+++ b/packages/core/src/internal/services/i18n.service.spec.ts
@@ -10,6 +10,10 @@ describe('I18nService', () => {
   const closeButtonAriaLabelText = 'close this alert';
   const customText = "custom text for a key that doesn't exist by default.";
 
+  beforeEach(() => {
+    I18nService.reset();
+  });
+
   it('should provide default values', () => {
     expect(I18nService.keys.dropdown).toEqual(componentStringsDefault.dropdown);
   });
@@ -24,10 +28,109 @@ describe('I18nService', () => {
 
   it('should allow adding new key and values', () => {
     I18nService.localize({
-      foo: { bar: customText },
+      custom: {
+        foo: { bar: customText },
+      },
     });
-    expect(I18nService.keys.foo).toBeDefined();
-    expect(I18nService.keys.foo.bar).toBeDefined();
-    expect(I18nService.keys.foo.bar).toEqual(customText);
+    expect(I18nService.keys.custom.foo).toBeDefined();
+    expect(I18nService.keys.custom.foo.bar).toBeDefined();
+    expect(I18nService.keys.custom.foo.bar).toEqual(customText);
+  });
+
+  describe('get()', () => {
+    it('should return key objects as expected', () => {
+      const testMe = I18nService.get('password');
+      expect(testMe.showButtonAriaLabel.toLowerCase()).toBe('show password');
+      expect(testMe.hideButtonAriaLabel.toLowerCase()).toBe('hide password');
+    });
+
+    it('should return customized key objects as expected', () => {
+      I18nService.localize({
+        password: {
+          showButtonAriaLabel: 'ohai',
+          hideButtonAriaLabel: 'stealthd',
+        },
+      });
+      const testMe = I18nService.get('password');
+      expect(testMe.showButtonAriaLabel.toLowerCase()).toBe('ohai');
+      expect(testMe.hideButtonAriaLabel.toLowerCase()).toBe('stealthd');
+
+      const sanityCheck = I18nService.get('alert');
+      expect(sanityCheck.success.toLowerCase()).toBe(
+        'success',
+        'retrieves unaltered top-level values from default i18n object'
+      );
+    });
+
+    it('should return an empty object if passed a nil key', () => {
+      const testMe = I18nService.get('bigfoot');
+      expect(testMe).toEqual({});
+    });
+  });
+
+  describe('reset()', () => {
+    it('resets all localizations and customizations on i18n', () => {
+      I18nService.localize({
+        actions: {
+          sort: 'ortsay',
+          expand: 'expandway',
+          close: 'oseclay',
+          resize: 'esizeray',
+          filter: 'ilterfay',
+        },
+        custom: {
+          bigfoot: 'igfootbay',
+        },
+      });
+
+      // verify i18n updated
+      expect(I18nService.get('custom').bigfoot).toBeDefined();
+      expect(I18nService.get('actions').sort).toBe('ortsay');
+
+      // now verify it clears out
+      I18nService.reset();
+
+      expect(I18nService.get('custom')).toEqual({});
+      expect(I18nService.get('actions').sort).toBe('Sort');
+    });
+  });
+
+  describe('hydrate()', () => {
+    it('returns i18n with hydrated tokens', () => {
+      I18nService.localize({
+        custom: {
+          truth: '${name} the Cat likes ${preferences.favoriteFood}',
+          alsoTruth: '${name} the Cat likes pets very much from ${preferences.favoritePerson}',
+        },
+      });
+
+      const pet = {
+        name: 'Jackie',
+        preferences: {
+          favoriteFood: 'treats',
+          favoritePerson: 'Jeremy',
+        },
+      };
+
+      const testMe = I18nService.hydrate(I18nService.get('custom'), pet);
+
+      expect(testMe.truth).toBe('Jackie the Cat likes treats');
+      expect(testMe.alsoTruth).toBe('Jackie the Cat likes pets very much from Jeremy');
+    });
+  });
+
+  describe('findKey()', () => {
+    it('finds key if object matches a keyed value', () => {
+      const findMe = I18nService.get('alert');
+      const testMe = I18nService.findKey(findMe);
+      expect(testMe).toBe('alert');
+    });
+
+    it('returns undefined if it cannot find a key to match the object it is passed', () => {
+      const passwdKeys = I18nService.get('password');
+      const butWaitTheresMore = { bahbahbahbah: 'bigfoot' };
+      const findMe = { ...passwdKeys, ...butWaitTheresMore };
+      expect(I18nService.findKey(findMe)).toBeUndefined();
+    });
   });
 });

--- a/packages/core/src/internal/utils/string.ts
+++ b/packages/core/src/internal/utils/string.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { isNilOrEmpty, isNumericString } from './identity.js';
+import { getFromObjectPath, isNilOrEmpty, isNumericString } from './identity.js';
 
 export function transformToString(delimiter: string, fns: any[], ...args: any[]): string {
   return fns
@@ -160,4 +160,13 @@ export function pluckValueFromStringUnit(val: string, unit: string) {
 
 export function pluckPixelValue(val: string): number {
   return !val ? 0 : pluckValueFromStringUnit(val.trim(), 'px');
+}
+
+export function interpolateNaively(template: string, dataObj: any, fallback?: string) {
+  const interpolatedString = template.replace(/\$\{.+?\}/g, match => {
+    const path = match.substr(2, match.length - 3).trim();
+    const value = getFromObjectPath(path, dataObj, fallback);
+    return value;
+  });
+  return interpolatedString;
 }


### PR DESCRIPTION
Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

This PR introduces a beta for "dynamic" i18n strings and fixes a couple of issues with the legacy i18n code that had crept in over the last couple of versions.

### Dynamic i18n

The way these work is you put in a template token in an i18n string. For example, creating an i18n value that says something like... `{ "pageOf": "Page ${currentPage} of ${totalPages}" }` would tell the i18n service to look at the component to pull values for `component.currentPage` and `component.totalPages`. This means the final output would render as `Page 2 of 49` if those values were `2` and `49` in the component instance when the component is rendered.

#### Do these update with the component?

Yes.

### Fixes

A couple of fixes were handled in this PR as well.

#### 1. Updating from the `cds-i18n` HTML attribute

Somehow this got broken. It now works.

#### 2. Properly gathering overrides with keys

This also used to work, afaik. But when I took this on, I discovered that trying to override, say, `{ "loading": "Busy" }` would hard set the i18n on a component to just the override and blow away all the rest of the keys. If your component's i18n keys were `{ success: "Success", error: "Error", loading: "Loading" }` then customizing the loading i18n string would kill success and error.

Previously there were no tests in the i18n decorator to guard against this breaking. I've added those as well.

### Points for Improvement/Future Work

The following areas are all areas that fell outside the scope of this effort (which was driven more by an a11y need).

1. Implementing dynamic aria labels in the progress circle. We held off a bit on dynamic updates on the progress circle aria-label until this was in. We can do that now.
2. Forcing i18n updates from the parent down. Presently, if I override an i18n string at the topmost level (say `cds-alert-group`), it only propagates if it is forced to (similar to how we've used `syncProps` in the past). This is a present issue with i18n that is resolved in some components but not all. More work to be done here.
3. Documentation. This is a beta easter egg right now. When we feel comfortable with it, it would be good to make it a first class citizen in our i18n docs.

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

See above.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

See above.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
