### PR TITLE
Warning danger buttons split

### DIFF
--- a/projects/angular/src/button/_buttons.clarity.scss
+++ b/projects/angular/src/button/_buttons.clarity.scss
@@ -306,11 +306,13 @@
   .btn-success .btn {
     @include populateButtonProperties(success);
   }
+  .btn.btn-warning,
+  .btn-warning .btn {
+    @include populateButtonProperties(warning);
+  }
 
   .btn.btn-danger,
-  .btn.btn-warning,
-  .btn-danger .btn,
-  .btn-warning .btn {
+  .btn-danger .btn {
     @include populateButtonProperties(danger);
   }
 
@@ -329,15 +331,17 @@
   .btn-outline-success .btn {
     @include populateButtonProperties(success-outline);
   }
+  .btn.btn-warning-outline,
+  .btn.btn-outline-warning,
+  .btn-warning-outline .btn,
+  .btn-outline-warning .btn {
+    @include populateButtonProperties(warning-outline);
+  }
 
   .btn.btn-danger-outline,
   .btn.btn-outline-danger,
-  .btn.btn-warning-outline,
-  .btn.btn-outline-warning,
   .btn-danger-outline .btn,
-  .btn-outline-danger .btn,
-  .btn-warning-outline .btn,
-  .btn-outline-warning .btn {
+  .btn-outline-danger .btn {
     @include populateButtonProperties(danger-outline);
   }
 
@@ -396,7 +400,10 @@
 
     &.disabled,
     &:disabled {
-      @include button-css-var(icon, color, disabled-color, $clr-use-custom-properties);
+      cds-icon,
+      clr-icon {
+        @include css-var(color, clr-btn-icon-disabled-color, $clr-color-neutral-400, $clr-use-custom-properties);
+      }
     }
   }
 
@@ -483,8 +490,11 @@
       @include btn-checked-styles(success);
     }
 
-    &.btn-danger,
     &.btn-warning {
+      @include btn-checked-styles(warning);
+    }
+
+    &.btn-danger {
       @include btn-checked-styles(danger);
     }
 
@@ -494,10 +504,13 @@
     }
 
     &.btn-danger-outline,
-    &.btn-outline-danger,
+    &.btn-outline-danger {
+      @include btn-checked-styles(outline-danger);
+    }
+
     &.btn-warning-outline,
     &.btn-outline-warning {
-      @include btn-checked-styles(outline-danger);
+      @include btn-checked-styles(outline-warning);
     }
 
     &.btn-link {
@@ -541,8 +554,11 @@
       @include btn-checked-styles(success, radio);
     }
 
-    &.btn-danger,
     &.btn-warning {
+      @include btn-checked-styles(warning, radio);
+    }
+
+    &.btn-danger {
       @include btn-checked-styles(danger, radio);
     }
 
@@ -551,10 +567,13 @@
       @include btn-checked-styles(success-outline, radio);
     }
 
-    &.btn-danger-outline,
-    &.btn-outline-danger,
     &.btn-warning-outline,
     &.btn-outline-warning {
+      @include btn-checked-styles(warning-outline, radio);
+    }
+
+    &.btn-danger-outline,
+    &.btn-outline-danger {
       @include btn-checked-styles(danger-outline, radio);
     }
 

--- a/projects/angular/src/button/_properties.buttons.scss
+++ b/projects/angular/src/button/_properties.buttons.scss
@@ -116,7 +116,7 @@
       --clr-btn-danger-box-shadow-color: var(--clr-color-danger-900);
       --clr-btn-danger-disabled-color: var(--clr-color-neutral-700);
       --clr-btn-danger-disabled-bg-color: var(--clr-color-neutral-400);
-      --clr-btn-danger-disabled-border-color: var(--clr-btn-danger-disabled-color);
+      --clr-btn-danger-disabled-border-color: var(--clr-color-neutral-400);
       --clr-btn-danger-checked-bg-color: var(--clr-color-danger-800);
       --clr-btn-danger-checked-color: var(--clr-btn-danger-color);
 
@@ -132,6 +132,32 @@
       --clr-btn-danger-outline-disabled-border-color: var(--clr-btn-danger-outline-disabled-color);
       --clr-btn-danger-outline-checked-bg-color: var(--clr-color-danger-800);
       --clr-btn-danger-outline-checked-color: var(--clr-color-neutral-0);
+
+      // Warning button colors
+      --clr-btn-warning-color: var(--clr-color-neutral-0);
+      --clr-btn-warning-bg-color: var(--clr-color-danger-700);
+      --clr-btn-warning-border-color: var(--clr-btn-danger-bg-color);
+      --clr-btn-warning-hover-bg-color: var(--clr-color-danger-800);
+      --clr-btn-warning-hover-color: var(--clr-btn-danger-color);
+      --clr-btn-warning-box-shadow-color: var(--clr-color-danger-900);
+      --clr-btn-warning-disabled-color: var(--clr-color-neutral-700);
+      --clr-btn-warning-disabled-bg-color: var(--clr-color-neutral-400);
+      --clr-btn-warning-disabled-border-color: var(--clr-color-neutral-400);
+      --clr-btn-warning-checked-bg-color: var(--clr-color-danger-800);
+      --clr-btn-warning-checked-color: var(--clr-btn-danger-color);
+
+      // Warning outline button colors
+      --clr-btn-warning-outline-color: var(--clr-color-danger-700);
+      --clr-btn-warning-outline-bg-color: var(--clr-btn-outline-bg-color);
+      --clr-btn-warning-outline-border-color: var(--clr-color-danger-800);
+      --clr-btn-warning-outline-hover-bg-color: var(--clr-color-danger-100);
+      --clr-btn-warning-outline-hover-color: var(--clr-color-danger-900);
+      --clr-btn-warning-outline-box-shadow-color: var(--clr-color-danger-200);
+      --clr-btn-warning-outline-disabled-color: var(--clr-color-neutral-700);
+      --clr-btn-warning-outline-disabled-bg-color: var(--clr-btn-danger-outline-bg-color);
+      --clr-btn-warning-outline-disabled-border-color: var(--clr-btn-danger-outline-disabled-color);
+      --clr-btn-warning-outline-checked-bg-color: var(--clr-color-danger-800);
+      --clr-btn-warning-outline-checked-color: var(--clr-color-neutral-0);
 
       // Link button colors
       --clr-btn-link-color: var(--clr-color-action-600);

--- a/src/app/buttons/button-states.html
+++ b/src/app/buttons/button-states.html
@@ -1,14 +1,29 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
 
-<h4>Info, Success and Danger Outline Buttons</h4>
+<h4>Info, Success, Warning and Danger Outline Buttons</h4>
 <button class="btn btn-info-outline">Info</button>
-<button type="submit" class="btn btn-success-outline">Success</button>
+<button class="btn btn-success-outline">Success</button>
+<button class="btn btn-warning-outline">Warning</button>
 <button class="btn btn-danger-outline">Danger</button>
 
-<h4>Success and Danger Solid Buttons</h4>
-<button type="submit" class="btn btn-success">Success</button>
+<h4>Info, Success, Warning and Danger Outline Disabled Buttons</h4>
+<button disabled class="btn btn-info-outline">Info</button>
+<button disabled class="btn btn-success-outline">Success</button>
+<button disabled class="btn btn-warning-outline">Warning</button>
+<button disabled class="btn btn-danger-outline">Danger</button>
+
+<h4>Primary, Success, Warning and Danger Buttons</h4>
+<button class="btn btn-primary">Primary</button>
+<button class="btn btn-success">Success</button>
+<button class="btn btn-warning">Warning</button>
 <button class="btn btn-danger">Danger</button>
+
+<h4>Primary, Success, Warning and Danger Disabled Buttons</h4>
+<button disabled class="btn btn-primary">Disabled Info</button>
+<button disabled class="btn btn-success">Disabled Success</button>
+<button disabled class="btn btn-warning">Disabled Warning</button>
+<button disabled class="btn btn-danger">Disabled Danger</button>

--- a/src/app/buttons/real-button.html
+++ b/src/app/buttons/real-button.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -9,7 +9,7 @@
 <button type="submit" class="btn btn-success">Success</button>
 <button type="submit" class="btn btn-warning">Warning</button>
 <button type="submit" class="btn btn-danger">Danger</button>
-<button type="submit" class="btn btn-danger" disabled>Disabled</button>
+<button type="submit" class="btn" disabled>Disabled</button>
 
 <h4>Outline Buttons</h4>
 <button type="submit" class="btn btn-outline">Regular</button>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

This PR splits the shared style of danger and warning buttons. They look exactly the same in clr/ui. This change doesn't introduce any visual changes. But by splitting the styles, we would allow them each to have their own independent styles.

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
