### PR TITLE
fix: split alert types style splits

### DIFF
--- a/projects/angular/src/emphasis/alert/_alert.clarity.scss
+++ b/projects/angular/src/emphasis/alert/_alert.clarity.scss
@@ -125,6 +125,8 @@
 @include exports('alert.clarity') {
   $alertIconWidth: $clr_baselineRem_1 + $clr_baselineRem_1px;
 
+  $alertTypes: info, warning, danger, success;
+
   .alert-icon {
     $alert-icon-dim: $clr_baselineRem_1;
     @include equilateral($alert-icon-dim);
@@ -503,6 +505,18 @@
 
   .alerts-pager {
     @include css-var(color, clr-app-alert-pager-text-color, $clr-color-neutral-0, $clr-use-custom-properties);
+
+    @each $alertType in $alertTypes {
+      .alert-#{$alertType} & {
+        @include css-var(
+          color,
+          clr-app-alert-#{$alertType}-pager-font-color,
+          $clr-color-neutral-0,
+          $clr-use-custom-properties
+        );
+      }
+    }
+
     font-size: $clr-alert-font-size;
     letter-spacing: $clr-alert-letter-spacing;
     float: left;
@@ -519,6 +533,17 @@
     cds-icon,
     clr-icon {
       @include css-var(color, clr-app-alert-pager-text-color, $clr-color-neutral-0, $clr-use-custom-properties);
+
+      @each $alertType in $alertTypes {
+        .alert-#{$alertType} & {
+          @include css-var(
+            color,
+            clr-app-alert-#{$alertType}-pager-font-color,
+            $clr-color-neutral-0,
+            $clr-use-custom-properties
+          );
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Signed-off-by: stsogoo <stsogoo@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

This PR splits the shared alert property into multiple properties that correspond to info, danger, warning, and success. By doing this, users could apply different styles to each alert type individually. This change won't introduce any visual changes. 

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
