### PR TITLE
chore: disable some stories from loading in the website

### DIFF
--- a/packages/core/src/accordion/accordion.stories.ts
+++ b/packages/core/src/accordion/accordion.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -208,7 +208,6 @@ export const interactive = () => {
   `;
 };
 
-/** @website */
 export function darkTheme() {
   return html`
     <div cds-theme="dark">
@@ -236,7 +235,6 @@ export function darkTheme() {
   `;
 }
 
-/** @website */
 export function customStyles() {
   return html`
     <style>

--- a/packages/core/src/alert/alert-group.stories.ts
+++ b/packages/core/src/alert/alert-group.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -691,7 +691,6 @@ export function compactAlertGroup() {
   `;
 }
 
-/** @website */
 export function darkTheme() {
   return html`
     <div cds-layout="vertical gap:lg" cds-theme="dark">
@@ -816,7 +815,6 @@ export function darkTheme() {
   `;
 }
 
-/** @website */
 export function customStyles() {
   return html`
     <style>

--- a/packages/core/src/alert/alert.stories.ts
+++ b/packages/core/src/alert/alert.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -35,7 +35,6 @@ export function API(args: any) {
   `;
 }
 
-/** @website */
 export function actions() {
   return html`
     <div cds-layout="vertical gap:sm">
@@ -122,7 +121,6 @@ export function compact() {
   `;
 }
 
-/** @website */
 export function darkTheme() {
   return html`
     <div cds-theme="dark">
@@ -153,7 +151,6 @@ export function darkTheme() {
   `;
 }
 
-/** @website */
 export function customStyles() {
   return html`
     <style>

--- a/packages/core/src/badge/badge.stories.ts
+++ b/packages/core/src/badge/badge.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -83,7 +83,6 @@ export function color() {
   `;
 }
 
-/** @website */
 export function colorCustom() {
   return html`
     <style>
@@ -141,7 +140,6 @@ export function colorCustom() {
   `;
 }
 
-/** @website */
 export function darkTheme() {
   return html`
     <div cds-layout="horizontal gap:sm" cds-theme="dark">

--- a/packages/core/src/button-inline/button-inline.stories.ts
+++ b/packages/core/src/button-inline/button-inline.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -122,7 +122,6 @@ export function inlineButtonLinks() {
   `;
 }
 
-/** @website */
 export function customStyles() {
   return html`
     <style>

--- a/packages/core/src/button/button.stories.ts
+++ b/packages/core/src/button/button.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -309,7 +309,6 @@ export function loading() {
   `;
 }
 
-/** @website */
 export function darkTheme() {
   return html`
     <div cds-layout="vertical gap:sm" cds-theme="dark">
@@ -379,7 +378,6 @@ export function darkTheme() {
   `;
 }
 
-/** @website */
 export function customStyles() {
   return html`
     <style>

--- a/packages/core/src/button/icon-button.stories.ts
+++ b/packages/core/src/button/icon-button.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -133,7 +133,6 @@ export function loading() {
   `;
 }
 
-/** @website */
 export function darkTheme() {
   return html`
     <div cds-layout="vertical gap:sm" cds-theme="dark">
@@ -173,7 +172,6 @@ export function darkTheme() {
   `;
 }
 
-/** @website */
 export function customStyles() {
   return html`
     <style>

--- a/packages/core/src/card/card.stories.ts
+++ b/packages/core/src/card/card.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -25,7 +25,6 @@ export default {
   },
 };
 
-/** @website **/
 export function Basic(args: { [key: string]: unknown }) {
   return html`<cds-card aria-label="Basic card" ...="${spreadProps(getElementStorybookArgs(args))}">
     <p cds-text="body light">${placeholder}</p>
@@ -301,7 +300,6 @@ export function WithLists() {
   </cds-card>`;
 }
 
-/** @website **/
 export function SocialPost() {
   ClarityIcons.addIcons([
     'batman',

--- a/packages/core/src/checkbox/checkbox.stories.ts
+++ b/packages/core/src/checkbox/checkbox.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -533,7 +533,6 @@ export function compactGroup() {
   `;
 }
 
-/** @website */
 export function darkTheme() {
   return html`
     <cds-form-group layout="horizontal-inline" cds-theme="dark">

--- a/packages/core/src/datalist/datalist.stories.ts
+++ b/packages/core/src/datalist/datalist.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -203,7 +203,6 @@ export function compact() {
   `;
 }
 
-/** @website */
 export function darkTheme() {
   return html`
     <cds-form-group layout="horizontal" cds-theme="dark">

--- a/packages/core/src/divider/divider.stories.ts
+++ b/packages/core/src/divider/divider.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -121,7 +121,6 @@ export function custom() {
   `;
 }
 
-/** @website */
 export function darkTheme() {
   return html`
     <div cds-layout="vertical gap:md" cds-theme="dark">

--- a/packages/core/src/file/file.stories.ts
+++ b/packages/core/src/file/file.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -133,7 +133,6 @@ export function compact() {
   `;
 }
 
-/** @website */
 export function darkTheme() {
   return html`
     <cds-form-group layout="horizontal" cds-theme="dark">

--- a/packages/core/src/input/input.stories.ts
+++ b/packages/core/src/input/input.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -211,7 +211,6 @@ export function supportedTextTypes() {
   `;
 }
 
-/** @website */
 export function darkTheme() {
   return html`
     <cds-form-group layout="horizontal" cds-theme="dark">

--- a/packages/core/src/list/list.stories.ts
+++ b/packages/core/src/list/list.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -469,7 +469,6 @@ export function customSpaceList() {
   `;
 }
 
-/** @website */
 export function darkTheme() {
   return html`
     <div cds-layout="vertical gap:md" cds-theme="dark">

--- a/packages/core/src/password/password.stories.ts
+++ b/packages/core/src/password/password.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -133,7 +133,6 @@ export function compact() {
   `;
 }
 
-/** @website */
 export function darkTheme() {
   return html`
     <cds-form-group layout="horizontal" cds-theme="dark">

--- a/packages/core/src/progress-circle/progress-circle.stories.ts
+++ b/packages/core/src/progress-circle/progress-circle.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -60,7 +60,6 @@ export function status() {
     </div>
   `;
 }
-/** @website */
 export function darkTheme() {
   return html`
     <div cds-layout="horizontal gap:sm" cds-theme="dark">

--- a/packages/core/src/radio/radio.stories.ts
+++ b/packages/core/src/radio/radio.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -492,7 +492,6 @@ export function compactGroup() {
   `;
 }
 
-/** @website */
 export function darkTheme() {
   return html`
     <cds-form-group layout="horizontal-inline" cds-theme="dark">

--- a/packages/core/src/range/range.stories.ts
+++ b/packages/core/src/range/range.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -145,7 +145,6 @@ export function minMax() {
   `;
 }
 
-/** @website */
 export function darkTheme() {
   return html`
     <cds-form-group layout="horizontal" cds-theme="dark">

--- a/packages/core/src/search/search.stories.ts
+++ b/packages/core/src/search/search.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -167,7 +167,6 @@ export function datalist() {
   `;
 }
 
-/** @website */
 export function darkTheme() {
   return html`
     <cds-form-group layout="horizontal" cds-theme="dark">

--- a/packages/core/src/select/select.stories.ts
+++ b/packages/core/src/select/select.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -225,7 +225,6 @@ export function size() {
   `;
 }
 
-/** @website */
 export function darkTheme() {
   return html`
     <cds-form-group layout="horizontal" cds-theme="dark">

--- a/packages/core/src/tag/tag.stories.ts
+++ b/packages/core/src/tag/tag.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -317,7 +317,6 @@ export function tagsAndIcons() {
   `;
 }
 
-/** @website */
 export function darkTheme() {
   return html`
     <div cds-layout="horizontal gap:sm" cds-theme="dark">

--- a/packages/core/src/textarea/textarea.stories.ts
+++ b/packages/core/src/textarea/textarea.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -134,7 +134,6 @@ export function compact() {
   `;
 }
 
-/** @website */
 export function darkTheme() {
   return html`
     <cds-form-group layout="horizontal" cds-theme="dark">

--- a/packages/core/src/time/time.stories.ts
+++ b/packages/core/src/time/time.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -150,7 +150,6 @@ export function timeDatalist() {
   `;
 }
 
-/** @website */
 export function darkTheme() {
   return html`
     <cds-form-group layout="horizontal" cds-theme="dark">

--- a/packages/core/src/toggle/toggle.stories.ts
+++ b/packages/core/src/toggle/toggle.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -565,7 +565,6 @@ export function toggleAlign() {
   `;
 }
 
-/** @website */
 export function darkTheme() {
   return html`
     <cds-form-group layout="horizontal-inline" cds-theme="dark">


### PR DESCRIPTION
We don't want to show all of the custom style and dark theme demos. The light/dark theme will be
a toggle on the website and the custom style demos should remain in advanced content.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
