### PR TITLE
fix(angular): programmatic open and close dropdown fixes

### DIFF
--- a/projects/angular/src/popover/common/abstract-popover.ts
+++ b/projects/angular/src/popover/common/abstract-popover.ts
@@ -35,6 +35,7 @@ export abstract class AbstractPopover implements AfterViewChecked, OnDestroy {
       if (change) {
         this.anchor();
         this.attachESCListener();
+        this.setRecentlyOpened();
       } else {
         this.release();
         this.detachESCListener();
@@ -43,6 +44,7 @@ export abstract class AbstractPopover implements AfterViewChecked, OnDestroy {
     if (this.toggleService.open) {
       this.anchor();
       this.attachESCListener();
+      this.setRecentlyOpened();
     }
   }
 
@@ -54,6 +56,7 @@ export abstract class AbstractPopover implements AfterViewChecked, OnDestroy {
   private subscription: Subscription;
 
   private updateAnchor = false;
+  private recentlyOpened = false;
 
   protected anchorElem: any;
   protected anchorPoint: Point;
@@ -142,7 +145,7 @@ export abstract class AbstractPopover implements AfterViewChecked, OnDestroy {
         );
       }
       this.documentClickListener = this.renderer.listen('document', 'click', event => {
-        if (event === this.ignore) {
+        if (event === this.ignore || this.recentlyOpened) {
           delete this.ignore;
         } else {
           this.toggleService.open = false;
@@ -166,5 +169,12 @@ export abstract class AbstractPopover implements AfterViewChecked, OnDestroy {
         delete this.documentClickListener;
       }
     }
+  }
+
+  private setRecentlyOpened() {
+    this.recentlyOpened = true;
+    setTimeout(() => {
+      this.recentlyOpened = false;
+    });
   }
 }

--- a/projects/angular/src/popover/dropdown/dropdown.spec.ts
+++ b/projects/angular/src/popover/dropdown/dropdown.spec.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { ClrPopoverToggleService } from '../../utils/popover/providers/popover-toggle.service';
@@ -97,7 +97,7 @@ export default function (): void {
       expect(compiled.textContent.trim()).not.toMatch('Foo');
     });
 
-    it('closes the menu when clicked outside of the host', () => {
+    it('closes the menu when clicked outside of the host', fakeAsync(function () {
       const dropdownToggle: HTMLElement = compiled.querySelector('.dropdown-toggle');
       const outsideButton: HTMLElement = compiled.querySelector('.outside-click-test');
 
@@ -106,6 +106,7 @@ export default function (): void {
 
       // click outside the dropdown
       outsideButton.click();
+      tick();
       fixture.detectChanges();
 
       // check if the click handler is triggered
@@ -115,6 +116,7 @@ export default function (): void {
 
       // click on the dropdown
       dropdownToggle.click();
+      tick();
       fixture.detectChanges();
       expect(compiled.querySelector('.dropdown-item')).not.toBeNull();
 
@@ -126,7 +128,21 @@ export default function (): void {
       expect(fixture.componentInstance.testCnt).toEqual(2);
       // check if the open class is added
       expect(compiled.querySelector('.dropdown-item')).toBeNull();
-    });
+    }));
+
+    it('ignores outside click events immediately after opening', fakeAsync(function () {
+      const dropdownToggle: HTMLElement = compiled.querySelector('.dropdown-toggle');
+      const outsideButton: HTMLElement = compiled.querySelector('.outside-click-test');
+
+      dropdownToggle.click();
+      fixture.detectChanges();
+
+      outsideButton.click();
+      fixture.detectChanges();
+      tick();
+
+      expect(compiled.querySelector('.dropdown-item')).not.toBeNull();
+    }));
 
     it('supports clrMenuClosable option. Closes the dropdown menu when clrMenuClosable is set to true', () => {
       const dropdownToggle: HTMLElement = compiled.querySelector('.dropdown-toggle');

--- a/projects/angular/src/popover/dropdown/providers/dropdown-focus-handler.service.ts
+++ b/projects/angular/src/popover/dropdown/providers/dropdown-focus-handler.service.ts
@@ -66,10 +66,11 @@ export class DropdownFocusHandler implements FocusableItem {
   handleRootFocus() {
     this.toggleService.openChange.subscribe(open => {
       if (!open) {
+        const isFocusedOnItem = this.focusService.current && this.focusService.current !== this;
         // We reset the state of the focus service both on initialization and when closing.
         this.focusService.reset(this);
         // But we only actively focus the trigger when closing, not on initialization.
-        if (this.focusBackOnTrigger) {
+        if (this.focusBackOnTrigger && isFocusedOnItem) {
           this.focus();
         }
       }

--- a/projects/angular/src/popover/dropdown/providers/dropdown-focus-handler.spec.ts
+++ b/projects/angular/src/popover/dropdown/providers/dropdown-focus-handler.spec.ts
@@ -155,13 +155,28 @@ export default function (): void {
         expect(spyBlur).toHaveBeenCalled();
       });
 
-      it('puts focus back on the trigger when the dropdown becomes closed', function (this: TestContext) {
+      it('puts focus back on the trigger when the dropdown becomes closed with a click', function (this: TestContext) {
+        fakeAsync(function (this: TestContext) {
+          this.focusHandler.trigger = this.trigger;
+          this.focusHandler.container = this.container;
+          this.focusHandler.addChildren(this.children);
+          expect(document.activeElement).not.toBe(this.trigger);
+          this.toggleService.toggleWithEvent({});
+          tick();
+          this.toggleService.toggleWithEvent({});
+          tick();
+          expect(document.activeElement).toBe(this.trigger);
+        });
+      });
+
+      it('puts focus back on the trigger when the dropdown becomes closed programmatically', function (this: TestContext) {
         this.focusHandler.trigger = this.trigger;
         this.focusHandler.container = this.container;
+        this.focusHandler.addChildren(this.children);
         expect(document.activeElement).not.toBe(this.trigger);
         this.toggleService.open = true;
         this.toggleService.open = false;
-        expect(document.activeElement).toBe(this.trigger);
+        expect(document.activeElement).toBe(document.body);
       });
 
       it('does not prevent moving focus to a different part of the page', fakeAsync(function (this: TestContext) {

--- a/projects/angular/src/popover/dropdown/providers/dropdown-focus-handler.spec.ts
+++ b/projects/angular/src/popover/dropdown/providers/dropdown-focus-handler.spec.ts
@@ -237,6 +237,16 @@ export default function (): void {
           // but maybe that's too detailed for this unit test? It's just the easiest way to test it right now.
         });
       });
+
+      it('does not move to the first child when opened programmatically', function (this: TestContext) {
+        this.focusHandler.addChildren(this.children);
+        const moveTo = spyOn(this.focusService, 'moveTo');
+        const move = spyOn(this.focusService, 'move');
+        this.toggleService.open = true;
+
+        expect(moveTo).not.toHaveBeenCalled();
+        expect(move).not.toHaveBeenCalled();
+      });
     });
 
     describe('nested dropdown', function () {

--- a/projects/angular/src/popover/signpost/signpost.spec.ts
+++ b/projects/angular/src/popover/signpost/signpost.spec.ts
@@ -11,6 +11,7 @@ import { spec, TestContext } from '../../utils/testing/helpers.spec';
 import { ClrSignpost } from './signpost';
 import { ClrSignpostModule } from './signpost.module';
 import { SignpostIdService } from './providers/signpost-id.service';
+import { fakeAsync, tick } from '@angular/core/testing';
 
 interface Context extends TestContext<ClrSignpost, TestDefaultSignpost | TestCustomTriggerSignpost> {
   toggleService: ClrPopoverToggleService;
@@ -72,8 +73,11 @@ export default function (): void {
         expect(document.activeElement).not.toBe(signpostToggle);
       });
 
-      it('should not get focus back on trigger if signpost gets closed with outside click on another interactive element', function (this: Context) {
+      it('should not get focus back on trigger if signpost gets closed with outside click on another interactive element', fakeAsync(function (
+        this: Context
+      ) {
         this.toggleService.open = true;
+        tick();
         this.detectChanges();
         expect(this.hostElement.querySelector('.signpost-content')).not.toBeNull();
 
@@ -84,10 +88,13 @@ export default function (): void {
 
         expect(this.hostElement.querySelector('.signpost-content')).toBeNull();
         expect(document.activeElement).toBe(this.hostComponent.outsideClickBtn.nativeElement);
-      });
+      }));
 
-      it('should get focus back on trigger if signpost gets closed with outside click on non-interactive element', function (this: Context) {
+      it('should get focus back on trigger if signpost gets closed with outside click on non-interactive element', fakeAsync(function (
+        this: Context
+      ) {
         this.toggleService.open = true;
+        tick();
         this.detectChanges();
         expect(this.hostElement.querySelector('.signpost-content')).not.toBeNull();
 
@@ -96,7 +103,7 @@ export default function (): void {
 
         expect(this.hostElement.querySelector('.signpost-content')).toBeNull();
         expect(document.activeElement).toBe(this.hostElement.querySelector('.signpost-action'));
-      });
+      }));
 
       it('should get focus back on trigger if signpost gets closed while focused element inside content', function (this: Context) {
         this.toggleService.open = true;

--- a/projects/angular/src/utils/popover/providers/popover-toggle.service.spec.ts
+++ b/projects/angular/src/utils/popover/providers/popover-toggle.service.spec.ts
@@ -93,7 +93,7 @@ export default function (): void {
         expect(this.toggleService.openEvent).toBe(openClickEvent);
         this.toggleService.toggleWithEvent(closeClickEvent);
         expect(this.toggleService.open).toBeFalse();
-        expect(this.toggleService.openEvent).toBe(closeClickEvent);
+        expect(this.toggleService.openEvent).toBeUndefined();
       });
 
       /**

--- a/projects/angular/src/utils/popover/providers/popover-toggle.service.ts
+++ b/projects/angular/src/utils/popover/providers/popover-toggle.service.ts
@@ -39,6 +39,9 @@ export class ClrPopoverToggleService {
   public set open(value: boolean) {
     value = !!value;
     if (this._open !== value) {
+      if (!value) {
+        this.openEvent = undefined;
+      }
       this._open = value;
       this._openChange.next(value);
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
From what I can tell, the only way to programmatically (without a click event) open or close a dropdown was to use the `clrIfOpen` directive. This had several issues:

1) opening a dropdown programmatically would sometimes focus the first content item
2) closing a dropdown after programmatically opening would focus the dropdown trigger
3) programmatically opening a dropdown from a click event would not work unless the dropdown had first been opened by a user event

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/vmware/clarity/issues/6462

## What is the new behavior?
1) opening a dropdown programmatically will no longer focus the first content item
2) closing a dropdown after programmatically opening will no longer focus the dropdown trigger
3) dropdowns can now be programmatically opened without issues

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
commit #3 (allow opening popovers programmatically with click events) is a hack. It is the only way I could think of to get this to work. Upon doing some research, I believe that if we used a transparent overlay when a dropdown was opened (like we do in core), then we wouldn't need this hack. However, I didn't think that was something we would want to take on now. If we don't want this fix, then we could use `event.stopPropagation()` as a workaround in the outside click event handler.

I wasn't able to get `[(clrIfOpen)]` two-way binding to work with signposts, which is why I didn't add any additional tests there.

I was a little uncertain when to add tests to `abstract-popover` vs `dropdown` vs `dropdown-focus-handler`, so please let me know if there are better ways to test this. I tried to follow what I thought was the existing patterns in those files.