### PR TITLE
fix(angular): fix accordion panel initialization and infinite loop bugs

### DIFF
--- a/projects/angular/src/accordion/models/accordion.model.spec.ts
+++ b/projects/angular/src/accordion/models/accordion.model.spec.ts
@@ -55,6 +55,24 @@ describe('AccordionModel', () => {
     expect(accordion.panels[2].open).toBe(false);
   });
 
+  it('should not close all panels when closing an already closed panel', () => {
+    expect(accordion.panels[0].open).toBe(false);
+    expect(accordion.panels[1].open).toBe(false);
+    expect(accordion.panels[2].open).toBe(false);
+
+    accordion.togglePanel(panel1Id);
+
+    expect(accordion.panels[0].open).toBe(true);
+    expect(accordion.panels[1].open).toBe(false);
+    expect(accordion.panels[2].open).toBe(false);
+
+    accordion.togglePanel(panel2Id, false);
+
+    expect(accordion.panels[0].open).toBe(true);
+    expect(accordion.panels[1].open).toBe(false);
+    expect(accordion.panels[2].open).toBe(false);
+  });
+
   it('should allow multiple panels open if in multi panel mode', () => {
     accordion.setStrategy(AccordionStrategy.Multi);
 

--- a/projects/angular/src/accordion/models/accordion.model.ts
+++ b/projects/angular/src/accordion/models/accordion.model.ts
@@ -43,11 +43,12 @@ export class AccordionModel {
 
   togglePanel(panelId: string, open?: boolean) {
     const panelIsOpen = this._panels[panelId].open;
-    if (this.strategy === AccordionStrategy.Default) {
+    const newOpenState = open !== undefined ? open : !panelIsOpen;
+    if (newOpenState && this.strategy === AccordionStrategy.Default) {
       this.closeAllPanels();
     }
 
-    this._panels[panelId].open = open !== undefined ? open : !panelIsOpen;
+    this._panels[panelId].open = newOpenState;
   }
 
   disablePanel(panelId: string, disabled: boolean) {


### PR DESCRIPTION
Signed-off-by: Steve Haar <info@stevehaar.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
When programmatically closing an already closed accordion panel (clrAccordionPanelOpen) without using `clrAccordionMultiPanel`, any open panels will close. This can cause some weird behaviors including improper initialization and can result in infinite loops when binding to `clrAccordionPanelOpen`.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/vmware/clarity/issues/5822

## What is the new behavior?
When programmatically closing an already closed accordion panel, nothing should happen. This should fix all issues listed in https://github.com/vmware/clarity/issues/5822.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
