### PR TITLE
fix: remove .vscode folder from tracked files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,10 +47,6 @@ node_modules
 
 # IDE - VSCode
 .vscode/*
-!.vscode/settings.json
-# !.vscode/tasks.json
-# !.vscode/launch.json
-# !.vscode/extensions.json
 
 # misc
 .awcache

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "search.followSymlinks": false,
-  "files.exclude": {
-    "**/*.element.css.ts": true,
-    "**/*.global.css.ts": true
-  }
-}


### PR DESCRIPTION
Removing the `.vscode` folder from tracked files. This way additional changes could be made to the editor without affecting everyone else environment.
