### PR TITLE
fix(react): update required message for aria attributes

### DIFF
--- a/packages/core/src/internal/decorators/property.ts
+++ b/packages/core/src/internal/decorators/property.ts
@@ -88,6 +88,19 @@ export function requirePropertyCheck(protoOrDescriptor: any, name: string, optio
   protoOrDescriptor.firstUpdated = firstUpdated;
 }
 
+/**
+ * In React, DOM attributes and properties are camelCase, except for aria- and data- attributes
+ * https://reactjs.org/docs/dom-elements.html
+ *
+ * This will format aria attributes as kebab case, otherwise returning the original property name
+ */
+function getReactPropertyName(propertyName: string) {
+  if (propertyName.startsWith('aria')) {
+    return camelCaseToKebabCase(propertyName);
+  }
+  return propertyName;
+}
+
 function getRequiredMessage(level = 'warning', propertyName: string, tagName: string) {
   const tag = tagName.toLocaleLowerCase();
   return (
@@ -96,7 +109,9 @@ function getRequiredMessage(level = 'warning', propertyName: string, tagName: st
     )}: ${propertyName} is required to use ${tag} component. Set the JS Property or HTML Attribute.\n\n` +
     `${getAngularVersion() ? `Angular: <${tag} [${propertyName}]="..."></${tag}>\n` : ''}` +
     `${getVueVersion() ? `Vue: <${tag} :${propertyName}="..."></${tag}>\n` : ''}` +
-    `${getReactVersion() ? `React: <${kebabCaseToPascalCase(tag)} ${propertyName}={...} />\n` : ''}` +
+    `${
+      getReactVersion() ? `React: <${kebabCaseToPascalCase(tag)} ${getReactPropertyName(propertyName)}={...} />\n` : ''
+    }` +
     `${`HTML: <${tag} ${camelCaseToKebabCase(propertyName)}="..."></${tag}>\n`}` +
     `${`JavaScript: document.querySelector('${tag}').${propertyName} = '...';\n\n`}`
   );

--- a/packages/react/App.tsx
+++ b/packages/react/App.tsx
@@ -6,7 +6,7 @@ import {
   CdsAccordionContent,
 } from './dist/react/accordion/index.js';
 import { CdsAlert, CdsAlertActions, CdsAlertGroup } from './dist/react/alert/index.js';
-import { CdsButton } from './dist/react/button/index.js';
+import { CdsButton, CdsIconButton } from './dist/react/button/index.js';
 import { CdsBadge } from './dist/react/badge/index.js';
 import { CdsCheckbox } from './dist/react/checkbox/index.js';
 import { CdsControl, CdsControlMessage, CdsFormGroup } from './dist/react/forms/index.js';
@@ -40,7 +40,7 @@ import { CdsTree, CdsTreeItem } from './dist/react/tree-view/index.js';
 import { CdsInternalVisualCheckbox } from './dist/react/internal-components/visual-checkbox/index.js';
 import { CdsInternalCloseButton } from './dist/react/internal-components/close-button/index.js';
 import { CdsDropdown } from './dist/react/dropdown/index.js';
-import { CdsInternalPointer } from './dist/react/popup/index.js';
+import { CdsInternalPointer } from './dist/react/internal-components/popup/index.js';
 import { CdsInternalPanel } from './dist/react/internal-components/panel/index.js';
 
 ClarityIcons.addIcons(userIcon, timesIcon);
@@ -475,6 +475,13 @@ export default class App extends React.Component<{}, AppState> {
 
           <h2>Internal Close button</h2>
           <CdsInternalCloseButton />
+
+          <h2>Icon Buttons</h2>
+          <div cds-layout="horizontal gap:md">
+            <CdsIconButton aria-label="My Icon Button">
+              <CdsIcon shape="user" />
+            </CdsIconButton>
+          </div>
 
           <h2>Badge</h2>
           <div cds-layout="horizontal gap:sm">


### PR DESCRIPTION
fixes #6463 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When an ariaLabel is required, like with CdsIconButton, if you don't include it in React, a warning message appears in the console that says to give an `ariaLabel` prop. In React, aria attributes, unlike other attributes are kebab case, so it should be `aria-label`

Issue Number: #6463 

## What is the new behavior?

For attributes that begin with `aria`, the warning message for react will format the property with a hypen

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This still leaves React components with `aria-label` and `ariaLabel` attributes, but that will be addressed separately after discussing with the Lit team.
