### PR TITLE
fix(angular): allow opening dropdown and signpost with outside click

### DIFF
--- a/projects/angular/src/popover/common/abstract-popover.spec.ts
+++ b/projects/angular/src/popover/common/abstract-popover.spec.ts
@@ -5,7 +5,7 @@
  */
 
 import { Component, ElementRef, Injector, Optional, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { ClrConditionalModule } from '../../utils/conditional/conditional.module';
@@ -22,6 +22,8 @@ class TestPopover extends AbstractPopover {
   constructor(injector: Injector, @Optional() parent: ElementRef) {
     super(injector, parent);
   }
+
+  closeOnOutsideClick = true;
 }
 
 @Component({
@@ -137,5 +139,23 @@ describe('Abstract Popover', function () {
 
     //     expect(popover.ignoredElement).toBeDefined();
     // });
+  });
+
+  describe('Open behavior', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({ declarations: [TestPopover], providers: [ClrPopoverToggleService] });
+      toggleService = TestBed.get(ClrPopoverToggleService);
+      toggleService.open = true;
+      fixture = TestBed.createComponent(TestPopover);
+      fixture.detectChanges();
+    });
+
+    it('does not close toggle service immediately after opening', fakeAsync(() => {
+      toggleService.open = true;
+      document.dispatchEvent(new Event('click'));
+      tick();
+
+      expect(toggleService.open).toBe(true);
+    }));
   });
 });

--- a/projects/angular/src/popover/common/abstract-popover.ts
+++ b/projects/angular/src/popover/common/abstract-popover.ts
@@ -35,6 +35,7 @@ export abstract class AbstractPopover implements AfterViewChecked, OnDestroy {
       if (change) {
         this.anchor();
         this.attachESCListener();
+        this.setRecentlyOpened();
       } else {
         this.release();
         this.detachESCListener();
@@ -43,6 +44,7 @@ export abstract class AbstractPopover implements AfterViewChecked, OnDestroy {
     if (this.toggleService.open) {
       this.anchor();
       this.attachESCListener();
+      this.setRecentlyOpened();
     }
   }
 
@@ -54,6 +56,7 @@ export abstract class AbstractPopover implements AfterViewChecked, OnDestroy {
   private subscription: Subscription;
 
   private updateAnchor = false;
+  private recentlyOpened = false;
 
   protected anchorElem: any;
   protected anchorPoint: Point;
@@ -142,7 +145,7 @@ export abstract class AbstractPopover implements AfterViewChecked, OnDestroy {
         );
       }
       this.documentClickListener = this.renderer.listen('document', 'click', event => {
-        if (event === this.ignore) {
+        if (event === this.ignore || this.recentlyOpened) {
           delete this.ignore;
         } else {
           this.toggleService.open = false;
@@ -166,5 +169,12 @@ export abstract class AbstractPopover implements AfterViewChecked, OnDestroy {
         delete this.documentClickListener;
       }
     }
+  }
+
+  private setRecentlyOpened() {
+    this.recentlyOpened = true;
+    setTimeout(() => {
+      this.recentlyOpened = false;
+    });
   }
 }

--- a/projects/angular/src/popover/dropdown/dropdown.spec.ts
+++ b/projects/angular/src/popover/dropdown/dropdown.spec.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { ClrPopoverToggleService } from '../../utils/popover/providers/popover-toggle.service';
@@ -97,7 +97,7 @@ export default function (): void {
       expect(compiled.textContent.trim()).not.toMatch('Foo');
     });
 
-    it('closes the menu when clicked outside of the host', () => {
+    it('closes the menu when clicked outside of the host', fakeAsync(() => {
       const dropdownToggle: HTMLElement = compiled.querySelector('.dropdown-toggle');
       const outsideButton: HTMLElement = compiled.querySelector('.outside-click-test');
 
@@ -115,6 +115,7 @@ export default function (): void {
 
       // click on the dropdown
       dropdownToggle.click();
+      tick();
       fixture.detectChanges();
       expect(compiled.querySelector('.dropdown-item')).not.toBeNull();
 
@@ -126,7 +127,7 @@ export default function (): void {
       expect(fixture.componentInstance.testCnt).toEqual(2);
       // check if the open class is added
       expect(compiled.querySelector('.dropdown-item')).toBeNull();
-    });
+    }));
 
     it('supports clrMenuClosable option. Closes the dropdown menu when clrMenuClosable is set to true', () => {
       const dropdownToggle: HTMLElement = compiled.querySelector('.dropdown-toggle');

--- a/projects/angular/src/popover/signpost/signpost.spec.ts
+++ b/projects/angular/src/popover/signpost/signpost.spec.ts
@@ -11,6 +11,7 @@ import { spec, TestContext } from '../../utils/testing/helpers.spec';
 import { ClrSignpost } from './signpost';
 import { ClrSignpostModule } from './signpost.module';
 import { SignpostIdService } from './providers/signpost-id.service';
+import { fakeAsync, tick } from '@angular/core/testing';
 
 interface Context extends TestContext<ClrSignpost, TestDefaultSignpost | TestCustomTriggerSignpost> {
   toggleService: ClrPopoverToggleService;
@@ -72,8 +73,11 @@ export default function (): void {
         expect(document.activeElement).not.toBe(signpostToggle);
       });
 
-      it('should not get focus back on trigger if signpost gets closed with outside click on another interactive element', function (this: Context) {
+      it('should not get focus back on trigger if signpost gets closed with outside click on another interactive element', fakeAsync(function (
+        this: Context
+      ) {
         this.toggleService.open = true;
+        tick();
         this.detectChanges();
         expect(this.hostElement.querySelector('.signpost-content')).not.toBeNull();
 
@@ -84,10 +88,13 @@ export default function (): void {
 
         expect(this.hostElement.querySelector('.signpost-content')).toBeNull();
         expect(document.activeElement).toBe(this.hostComponent.outsideClickBtn.nativeElement);
-      });
+      }));
 
-      it('should get focus back on trigger if signpost gets closed with outside click on non-interactive element', function (this: Context) {
+      it('should get focus back on trigger if signpost gets closed with outside click on non-interactive element', fakeAsync(function (
+        this: Context
+      ) {
         this.toggleService.open = true;
+        tick();
         this.detectChanges();
         expect(this.hostElement.querySelector('.signpost-content')).not.toBeNull();
 
@@ -96,7 +103,7 @@ export default function (): void {
 
         expect(this.hostElement.querySelector('.signpost-content')).toBeNull();
         expect(document.activeElement).toBe(this.hostElement.querySelector('.signpost-action'));
-      });
+      }));
 
       it('should get focus back on trigger if signpost gets closed while focused element inside content', function (this: Context) {
         this.toggleService.open = true;


### PR DESCRIPTION
fixes #6462

Signed-off-by: Steve Haar <info@stevehaar.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
* Opening a dropdown from an outside click event would not work unless the dropdown had first been opened by the dropdown trigger.
* Opening a signpost from an outside click event would not work at all.

This was because the outside click event would bubble up to the document and the popover would immediately close due to the document click listener.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/vmware/clarity/issues/6462

## What is the new behavior?
* You are now able to open both a dropdown and a signpost with an outside click event.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
