### PR TITLE
fix(angular): use spinner the same size as icon for loading icon buttons

### DIFF
--- a/projects/angular/src/progress/spinner/_spinner.clarity.scss
+++ b/projects/angular/src/progress/spinner/_spinner.clarity.scss
@@ -52,6 +52,16 @@
     }
   }
 
+  .btn-icon:not(.btn-sm) {
+    .spinner {
+      width: 100%;
+      min-width: 100%;
+      height: 0;
+      min-height: 0;
+      padding-bottom: 100%;
+    }
+  }
+
   @keyframes spin {
     0% {
       transform: rotate(0deg);


### PR DESCRIPTION
fixes #5967

The default icon size was 16px and the spinner was 18px causing an ellipsis to show

Signed-off-by: Steve Haar <info@stevehaar.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
The default icon size was 16px and the spinner was 18px causing an ellipsis to show and the spinner to be off center in an icon button when in the loading state.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/vmware/clarity/issues/5967

## What is the new behavior?
The spinner used in a loading icon button will now be the same size as the icon. This _does not_ change the behavior of small icon buttons having a 13px spinner.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Instead of setting the spinner to 100% width, we could hard-code it to be the same width as the default icon size (16px).