### PR TITLE
fix(angular): size button properly when initialized to loading

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -1412,10 +1412,11 @@ export declare class ClrLayoutModule {
     static ɵmod: i0.ɵɵNgModuleDeclaration<ClrLayoutModule, never, never, [typeof i1.ClrMainContainerModule, typeof i2.ClrNavigationModule, typeof i3.ClrTabsModule, typeof i4.ClrVerticalNavModule]>;
 }
 
-export declare class ClrLoading implements OnDestroy {
+export declare class ClrLoading implements AfterViewInit, OnDestroy {
     get loadingState(): boolean | string | ClrLoadingState;
     set loadingState(value: boolean | string | ClrLoadingState);
     constructor(listener: LoadingListener);
+    ngAfterViewInit(): void;
     ngOnDestroy(): void;
     static ngAcceptInputType_loadingState: boolean | ClrLoadingState | null | string;
     static ɵdir: i0.ɵɵDirectiveDeclaration<ClrLoading, "[clrLoading]", never, { "loadingState": "clrLoading"; }, {}, never>;

--- a/projects/angular/src/button/button-group/button.spec.ts
+++ b/projects/angular/src/button/button-group/button.spec.ts
@@ -5,7 +5,7 @@
  */
 
 import { Component, DebugElement, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 
 import { ClrLoadingModule } from '../../utils/loading/loading.module';
 import { ClrLoadingState } from '../../utils/loading/loading';
@@ -198,7 +198,7 @@ export default function (): void {
     });
 
     describe('View Test', () => {
-      beforeEach(() => {
+      beforeEach(fakeAsync(() => {
         TestBed.configureTestingModule({
           imports: [ClrButtonGroupModule, ClrLoadingModule],
           declarations: [ButtonViewTestComponent],
@@ -207,10 +207,12 @@ export default function (): void {
 
         fixture = TestBed.createComponent(ButtonViewTestComponent);
         fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
         debugEl = fixture.debugElement;
         componentInstance = debugEl.componentInstance;
         buttons = debugEl.nativeElement.querySelectorAll('button');
-      });
+      }));
 
       afterEach(() => {
         fixture.destroy();

--- a/projects/angular/src/utils/loading/loading.ts
+++ b/projects/angular/src/utils/loading/loading.ts
@@ -3,7 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { Directive, Input, OnDestroy, Optional } from '@angular/core';
+import { AfterViewInit, Directive, Input, OnDestroy, Optional } from '@angular/core';
 
 import { LoadingListener } from './loading-listener';
 
@@ -15,13 +15,14 @@ export enum ClrLoadingState {
 }
 
 @Directive({ selector: '[clrLoading]' })
-export class ClrLoading implements OnDestroy {
+export class ClrLoading implements AfterViewInit, OnDestroy {
   public static ngAcceptInputType_loadingState: boolean | ClrLoadingState | null | string;
 
   // We find the first parent that handles something loading
   constructor(@Optional() private listener: LoadingListener) {}
 
   private _loadingState: ClrLoadingState | string = ClrLoadingState.DEFAULT;
+  private _viewInitialized = false;
 
   public get loadingState() {
     return this._loadingState;
@@ -40,9 +41,16 @@ export class ClrLoading implements OnDestroy {
     }
 
     this._loadingState = value;
-    if (this.listener) {
+    if (this.listener && this._viewInitialized) {
       this.listener.loadingStateChange(value);
     }
+  }
+
+  ngAfterViewInit() {
+    this._viewInitialized = true;
+    setTimeout(() => {
+      this.listener.loadingStateChange(this._loadingState);
+    });
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
fixes #5967

Signed-off-by: Steve Haar <info@stevehaar.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Initializing a button to loading will cause it to have the width of the button as if it only contained the loading spinner. Subsequently (or just not initially) setting the button to loading, the button will have the width of the button in its default state.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/vmware/clarity/issues/5967

## What is the new behavior?
Buttons initialized in the loading state will have the width of the button in its default state.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Before this commit a button initialized to loading would never have its default state rendered. Without rendering, it's impossible (I think) to determine what the width of the content would be. Therefore, in order for the button initialized to loading to have the width of the button in its default state, we must first render the default state, determine its width, then set the button to the loading state. I could think of two ways to solve this:

1) don't set the button to loading until after the view has initialized and the button has been initially rendered in its default state (we can use `ngAfterViewInit` in either the `clrLoading` directive or the loading button component). To do this we would wait for the view to initialize and then dispatch the state change. This will require a `setTimeout` otherwise we will get an `ExpressionChangedAfterItHasBeenCheckedError` in dev mode.

2) Always render the button's content, just set it to `visibility:hidden` and/or set it to have an absolute position. This way we could get the size of the content without having to show it.

Option 2 seemed more risky since changing the positioning of the content could potentially affect its width, also there could be performance implications with rendering more content. I thought option 1 was best, but please weigh in if you're reading this.

I also had to modify `/golden/clr-angular.d.ts`, so please let me know if there's anything further I need to do.

## Workaround
As a workaround, the developer could take care to not set `clrLoading` to `true` until `ngAfterViewInit`.