### PR TITLE
only commit staged files (core)

### DIFF
--- a/scripts/update-license.js
+++ b/scripts/update-license.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /*
- * Copyright (c) 2016-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -16,11 +16,10 @@ const path = require('path');
 
 const supported = ['.js', '.ts', '.html', '.css', '.scss', '.sass'];
 
-// Stash unstaged files
-// exec('git stash --keep-index --include-untracked');
-
 // Grab list of staged files
-const files = exec('git diff --name-only --cached --diff-filter=d', { encoding: 'utf8' }).split('\n');
+const files = exec('git diff --name-only --cached --diff-filter=d', { encoding: 'utf8' })
+  .split('\n')
+  .filter(file => file);
 const year = new Date().getFullYear();
 
 files.forEach(file => {
@@ -35,6 +34,3 @@ files.forEach(file => {
 console.log('Updated license headers');
 
 exec(`git add ${files.map(file => "'" + path.join(__dirname, '../', file) + "'").join(' ')}`);
-
-// Restore from stash
-// exec('git stash pop');


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, the `update-license.js` script will commit all modified files even if they are not staged. This is because the `git diff` command ends with a new line which is treated as an empty string and is interpreted as the entire directory.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
This PR makes it so that only staged changes would be committed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
I wasn't expecting this behavior and it took me a bit to track down. I did see comments to stash and pop untracked changes. If this is a feature and desired behavior, then I would suggest maybe we move it to a different script file so the behavior can be more easily identified.