### PR TITLE
fix: only focus on modal body if scrollable

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -1495,7 +1495,7 @@ export declare class ClrModal implements OnChanges, OnDestroy {
 }
 
 export declare class ClrModalBody implements OnDestroy {
-    constructor(ngZone: NgZone, renderer: Renderer2, host: ElementRef<HTMLElement>);
+    constructor(renderer: Renderer2, host: ElementRef<HTMLElement>, ngZone: NgZone);
     ngOnDestroy(): void;
     static ɵdir: i0.ɵɵDirectiveDeclaration<ClrModalBody, ".modal-body", never, {}, {}, never>;
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrModalBody, never>;

--- a/projects/angular/src/modal/_modal.clarity.scss
+++ b/projects/angular/src/modal/_modal.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -122,7 +122,7 @@
     }
   }
 
-  .modal-body {
+  .modal-body-wrapper {
     // This doesn't do much, but at least with several paragraphs in the content
     // it doesn't mess up the modal's proportions.
     max-height: 70vh;
@@ -150,7 +150,7 @@
   }
 
   @media screen and (max-width: map-get($clr-grid-breakpoints, md)) and (orientation: landscape) {
-    .modal-body {
+    .modal-body-wrapper {
       max-height: 55vh;
     }
   }
@@ -164,7 +164,7 @@
       padding: 0 $clr_baselineRem_1 $clr_baselineRem_0_5 0;
     }
 
-    .modal-body {
+    .modal-body-wrapper {
       max-height: 55vh;
     }
 

--- a/projects/angular/src/modal/modal-body.ts
+++ b/projects/angular/src/modal/modal-body.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -17,19 +17,19 @@ export class ClrModalBody implements OnDestroy {
   private tabindex = '0';
   private unlisteners: VoidFunction[] = [];
 
-  constructor(ngZone: NgZone, renderer: Renderer2, host: ElementRef<HTMLElement>) {
-    renderer.setAttribute(host.nativeElement, 'tabindex', this.tabindex);
-
+  constructor(private readonly renderer: Renderer2, private readonly host: ElementRef<HTMLElement>, ngZone: NgZone) {
     ngZone.runOutsideAngular(() => {
+      new ResizeObserver(() => this.addOrRemoveTabIndex()).observe(this.host.nativeElement);
+
       this.unlisteners.push(
-        renderer.listen(host.nativeElement, 'mouseup', () => {
+        this.renderer.listen(this.host.nativeElement, 'mouseup', () => {
           // set the tabindex binding back when click is completed with mouseup
-          renderer.setAttribute(host.nativeElement, 'tabindex', this.tabindex);
+          this.addOrRemoveTabIndex();
         }),
-        renderer.listen(host.nativeElement, 'mousedown', () => {
+        this.renderer.listen(this.host.nativeElement, 'mousedown', () => {
           // tabindex = 0 binding should be removed
           // so it won't be focused when click starts with mousedown
-          renderer.removeAttribute(host.nativeElement, 'tabindex');
+          this.removeTabIndex();
         })
       );
     });
@@ -38,6 +38,24 @@ export class ClrModalBody implements OnDestroy {
   ngOnDestroy(): void {
     while (this.unlisteners.length) {
       this.unlisteners.pop()();
+    }
+  }
+
+  private addTabIndex() {
+    this.renderer.setAttribute(this.host.nativeElement, 'tabindex', this.tabindex);
+  }
+
+  private removeTabIndex() {
+    this.renderer.removeAttribute(this.host.nativeElement, 'tabindex');
+  }
+
+  private addOrRemoveTabIndex() {
+    const modalBody = this.host.nativeElement.parentElement;
+
+    if (modalBody.clientHeight < modalBody.scrollHeight) {
+      this.addTabIndex();
+    } else {
+      this.removeTabIndex();
     }
   }
 }

--- a/projects/angular/src/modal/modal.html
+++ b/projects/angular/src/modal/modal.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -38,7 +38,9 @@
             <cds-icon shape="window-close"></cds-icon>
           </button>
         </div>
-        <ng-content select=".modal-body"></ng-content>
+        <div class="modal-body-wrapper">
+          <ng-content select=".modal-body"></ng-content>
+        </div>
         <ng-content select=".modal-footer"></ng-content>
       </div>
     </div>

--- a/projects/angular/src/wizard/_wizard.clarity.scss
+++ b/projects/angular/src/wizard/_wizard.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -373,7 +373,7 @@
       height: 75vh;
     }
 
-    .modal-body {
+    .modal-body-wrapper {
       // overriding forced style on .modal
       max-height: 100%;
     }
@@ -496,7 +496,7 @@
       }
     }
 
-    .modal-body {
+    .modal-body-wrapper {
       height: 100%;
     }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
A modal body will always have a tab index, even if the body is not scrollable.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
closes https://github.com/vmware/clarity/pull/6493

## What is the new behavior?
A modal body should only have a tab index if the content is tall enough to make the body scrollable. If the content is not tall enough, then the modal body is not operable and should not have a tab index. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
