### PR TITLE
fix(angular): Combobox clrMulti input handle string value of 'false'

### DIFF
--- a/projects/angular/src/forms/combobox/combobox.spec.ts
+++ b/projects/angular/src/forms/combobox/combobox.spec.ts
@@ -37,7 +37,7 @@ import { ClrComboboxModule } from './combobox.module';
   `,
 })
 class TestComponent {
-  multi: boolean;
+  multi: boolean | string;
   selection: any;
   inputValue: string;
   openState: boolean;
@@ -147,8 +147,20 @@ export default function (): void {
         expect(selectionService.selectionModel instanceof SingleSelectComboboxModel).toBeTrue();
       });
 
-      it('can change to multi model', () => {
+      it('can change to multi model by setting multi to boolean true', () => {
         fixture.componentInstance.multi = true;
+        fixture.detectChanges();
+        expect(selectionService.selectionModel instanceof MultiSelectComboboxModel).toBeTrue();
+      });
+
+      it('can change to single model by setting multi to string "false"', () => {
+        fixture.componentInstance.multi = 'false';
+        fixture.detectChanges();
+        expect(selectionService.selectionModel instanceof SingleSelectComboboxModel).toBeTrue();
+      });
+
+      it('can change to multi model by setting multi to string "true"', () => {
+        fixture.componentInstance.multi = 'true';
         fixture.detectChanges();
         expect(selectionService.selectionModel instanceof MultiSelectComboboxModel).toBeTrue();
       });

--- a/projects/angular/src/forms/combobox/combobox.ts
+++ b/projects/angular/src/forms/combobox/combobox.ts
@@ -194,13 +194,23 @@ export class ClrCombobox<T>
 
   @Input('clrMulti')
   set multiSelect(value: boolean | string) {
-    if (value) {
-      this.optionSelectionService.selectionModel = new MultiSelectComboboxModel<T>();
-    } else {
-      // in theory, setting this again should not cause errors even though we already set it in constructor,
-      // since the initial call to writeValue (caused by [ngModel] input) should happen after this
-      this.optionSelectionService.selectionModel = new SingleSelectComboboxModel<T>();
+    let isMultiSelectModel: boolean;
+
+    switch (true) {
+      case value === 'false' || value === false:
+        isMultiSelectModel = false;
+        break;
+      case value === 'true' || value === true:
+        isMultiSelectModel = true;
+        break;
+      default:
+        isMultiSelectModel = false;
     }
+    // in theory, setting this again should not cause errors even though we already set it in constructor,
+    // since the initial call to writeValue (caused by [ngModel] input) should happen after this
+    this.optionSelectionService.selectionModel = isMultiSelectModel
+      ? new MultiSelectComboboxModel<T>()
+      : new SingleSelectComboboxModel<T>();
     this.updateControlValue();
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #6432

## What is the new behavior?
Combobox Component clrMulti input handles both string and boolean type values.
If clrMulti input is boolean, it will pass the boolean value directly;
If clrMulti input is string: it would treat "false" and empty string to boolean false, it would set to true for all the other strings.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
