### PR TITLE
fix(core:card): alignment in grid layout - backport v5

### DIFF
--- a/packages/core/src/card/card.element.scss
+++ b/packages/core/src/card/card.element.scss
@@ -1,8 +1,6 @@
 @import './../styles/tokens/generated/index';
 
 :host {
-  --width: fit-content;
-  --height: auto;
   --padding: var(--cds-global-space-6) var(--cds-global-space-8);
 
   --background: #{$cds-alias-object-container-background};
@@ -11,10 +9,4 @@
   --box-shadow: #{$cds-alias-object-shadow-100};
 
   --card-remove-margin: var(--cds-global-space-8);
-}
-
-@supports (-moz-appearance: none) {
-  :host {
-    --width: -moz-fit-content;
-  }
 }

--- a/packages/core/src/card/card.stories.ts
+++ b/packages/core/src/card/card.stories.ts
@@ -385,3 +385,40 @@ export function WithLayoutAndOverflow() {
     </div>
   </cds-card>`;
 }
+
+export function WithinGrid() {
+  return html`<div cds-layout="grid gap:md cols:6 align:stretch">
+    <cds-card aria-labelledby="gridCard1">
+      <h3 id="gridCard1" cds-text="section" cds-layout="p-y:sm">Card Title</h3>
+      <div cds-text="body light" cds-layout="p-y:md">
+        Card Content. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent volutpat tortor eget quam
+        auctor, quis sagittis libero auctor. Nulla augue ante, tincidunt sit amet semper vitae, tempus at ipsum.
+        Vestibulum elementum, turpis quis ullamcorper fermentum, elit turpis placerat ipsum, quis convallis ex nisi sit
+        amet lacus. Ut enim ipsum, tincidunt nec luctus id, pharetra id velit.
+      </div>
+    </cds-card>
+    <cds-card aria-labelledby="gridCard2">
+      <h3 id="gridCard2" cds-text="section" cds-layout="p-y:sm">Card Title</h3>
+      <div cds-text="body light" cds-layout="p-y:md">
+        Card Content.
+      </div>
+    </cds-card>
+    <cds-card aria-labelledby="gridCard3">
+      <h3 id="gridCard3" cds-text="section" cds-layout="p-y:sm">Card Title</h3>
+      <div cds-text="body light" cds-layout="p-y:md">
+        Card Content. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent volutpat tortor eget quam
+        auctor, quis sagittis libero auctor.
+      </div>
+    </cds-card>
+    <cds-card aria-labelledby="gridCard4">
+      <h3 id="gridCard4" cds-text="section" cds-layout="p-y:sm">Card Title</h3>
+      <div cds-text="body light" cds-layout="p-y:md">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent volutpat tortor eget quam auctor, quis
+        sagittis libero auctor. Nulla augue ante, tincidunt sit amet semper vitae, tempus at ipsum. Vestibulum
+        elementum, turpis quis ullamcorper fermentum, elit turpis placerat ipsum, quis convallis ex nisi sit amet lacus.
+        Ut enim ipsum, tincidunt nec luctus id, pharetra id velit. Aliquam nec elit ut neque lacinia mattis id ac lorem.
+        Vivamus egestas massa nulla, ac elementum purus pretium eu.
+      </div>
+    </cds-card>
+  </div>`;
+}


### PR DESCRIPTION
Fixes #6457

Signed-off-by: Ashley Ryan <asryan@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Card Styling inside of a grid loses the align: stretch behavior from the grid layout

Issue Number: #6457 

## What is the new behavior?

Card inherits from Panel, which does render correctly in a grid. This resets the styling back to match Panel styling when in a grid with align stretch/vertical-stretch/horizontal-stretch

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

![image](https://user-images.githubusercontent.com/9469374/146028840-dca5b15a-1a69-4a52-8344-eddfd07dc660.png)
