### PR TITLE
fix(react): update required message for aria attributes - backport v5

### DIFF
--- a/packages/core/src/internal/decorators/property.ts
+++ b/packages/core/src/internal/decorators/property.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -88,6 +88,19 @@ export function requirePropertyCheck(protoOrDescriptor: any, name: string, optio
   protoOrDescriptor.firstUpdated = firstUpdated;
 }
 
+/**
+ * In React, DOM attributes and properties are camelCase, except for aria- and data- attributes
+ * https://reactjs.org/docs/dom-elements.html
+ *
+ * This will format aria attributes as kebab case, otherwise returning the original property name
+ */
+function getReactPropertyName(propertyName: string) {
+  if (propertyName.startsWith('aria')) {
+    return camelCaseToKebabCase(propertyName);
+  }
+  return propertyName;
+}
+
 function getRequiredMessage(level = 'warning', propertyName: string, tagName: string) {
   const tag = tagName.toLocaleLowerCase();
   return (
@@ -96,7 +109,9 @@ function getRequiredMessage(level = 'warning', propertyName: string, tagName: st
     )}: ${propertyName} is required to use ${tag} component. Set the JS Property or HTML Attribute.\n\n` +
     `${getAngularVersion() ? `Angular: <${tag} [${propertyName}]="..."></${tag}>\n` : ''}` +
     `${getVueVersion() ? `Vue: <${tag} :${propertyName}="..."></${tag}>\n` : ''}` +
-    `${getReactVersion() ? `React: <${kebabCaseToPascalCase(tag)} ${propertyName}={...} />\n` : ''}` +
+    `${
+      getReactVersion() ? `React: <${kebabCaseToPascalCase(tag)} ${getReactPropertyName(propertyName)}={...} />\n` : ''
+    }` +
     `${`HTML: <${tag} ${camelCaseToKebabCase(propertyName)}="..."></${tag}>\n`}` +
     `${`JavaScript: document.querySelector('${tag}').${propertyName} = '...';\n\n`}`
   );


### PR DESCRIPTION
fixes #6463 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When an ariaLabel is required, like with CdsIconButton, if you don't include it in React, a warning message appears in the console that says to give an `ariaLabel` prop. In React, aria attributes, unlike other attributes are kebab case, so it should be `aria-label`

Issue Number: #6463 

## What is the new behavior?

For attributes that begin with `aria`, the warning message for react will format the property with a hypen

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This still leaves React components with `aria-label` and `ariaLabel` attributes, but that will be addressed separately after discussing with the Lit team.
