### PR TITLE
fix(dropdown): set min height and width for angle icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity",
-  "version": "12.0.7",
+  "version": "12.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity",
-  "version": "12.0.7",
+  "version": "12.0.8",
   "engines": {
     "yarn": "please-use-npm",
     "npm": ">= 6.14.0"

--- a/projects/angular/src/accordion/models/accordion.model.spec.ts
+++ b/projects/angular/src/accordion/models/accordion.model.spec.ts
@@ -55,6 +55,24 @@ describe('AccordionModel', () => {
     expect(accordion.panels[2].open).toBe(false);
   });
 
+  it('should not close all panels when closing an already closed panel', () => {
+    expect(accordion.panels[0].open).toBe(false);
+    expect(accordion.panels[1].open).toBe(false);
+    expect(accordion.panels[2].open).toBe(false);
+
+    accordion.togglePanel(panel1Id);
+
+    expect(accordion.panels[0].open).toBe(true);
+    expect(accordion.panels[1].open).toBe(false);
+    expect(accordion.panels[2].open).toBe(false);
+
+    accordion.togglePanel(panel2Id, false);
+
+    expect(accordion.panels[0].open).toBe(true);
+    expect(accordion.panels[1].open).toBe(false);
+    expect(accordion.panels[2].open).toBe(false);
+  });
+
   it('should allow multiple panels open if in multi panel mode', () => {
     accordion.setStrategy(AccordionStrategy.Multi);
 

--- a/projects/angular/src/accordion/models/accordion.model.ts
+++ b/projects/angular/src/accordion/models/accordion.model.ts
@@ -43,11 +43,12 @@ export class AccordionModel {
 
   togglePanel(panelId: string, open?: boolean) {
     const panelIsOpen = this._panels[panelId].open;
-    if (this.strategy === AccordionStrategy.Default) {
+    const newOpenState = open !== undefined ? open : !panelIsOpen;
+    if (newOpenState && this.strategy === AccordionStrategy.Default) {
       this.closeAllPanels();
     }
 
-    this._panels[panelId].open = open !== undefined ? open : !panelIsOpen;
+    this._panels[panelId].open = newOpenState;
   }
 
   disablePanel(panelId: string, disabled: boolean) {

--- a/projects/angular/src/forms/combobox/combobox.spec.ts
+++ b/projects/angular/src/forms/combobox/combobox.spec.ts
@@ -214,14 +214,14 @@ export default function (): void {
         expect(combobox.getAttribute('placeholder')).toEqual('hello world');
       });
 
-      it('should disable openClose button', () =>
-        fakeAsync(function () {
-          fixture.componentInstance.disabled = true;
-          fixture.detectChanges();
-          tick();
-          const button: HTMLButtonElement = clarityElement.querySelector('.clr-combobox-trigger');
-          expect(button.disabled).toBeTruthy();
-        }));
+      it('should disable openClose button', fakeAsync(function () {
+        fixture.componentInstance.disabled = true;
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+        const button: HTMLButtonElement = clarityElement.querySelector('.clr-combobox-trigger');
+        expect(button.disabled).toBeTruthy();
+      }));
     });
   });
 }

--- a/projects/angular/src/popover/dropdown/_dropdown.clarity.scss
+++ b/projects/angular/src/popover/dropdown/_dropdown.clarity.scss
@@ -34,7 +34,7 @@
         top: 50%;
         transform: translateY(-50%);
         color: inherit;
-        @include equilateral($clr-dropdown-caret-icon-dimension);
+        @include min-equilateral($clr-dropdown-caret-icon-dimension);
       }
 
       // NOTE: cds-icon handles direction internally.
@@ -45,7 +45,7 @@
         position: absolute;
         top: 35%;
         color: inherit;
-        @include equilateral($clr-dropdown-caret-icon-dimension);
+        @include min-equilateral($clr-dropdown-caret-icon-dimension);
       }
 
       &.btn {

--- a/projects/angular/src/popover/dropdown/providers/dropdown-focus-handler.spec.ts
+++ b/projects/angular/src/popover/dropdown/providers/dropdown-focus-handler.spec.ts
@@ -78,23 +78,23 @@ export default function (): void {
         expect(this.fixture.debugElement.injector.get(FocusableItem, null)).toBe(this.focusHandler);
       });
 
-      it('toggles open when arrow up or down on the trigger', function (this: TestContext) {
-        fakeAsync(function (this: TestContext) {
-          expect(this.toggleService.open).toBeFalsy();
-          this.focusHandler.trigger = this.trigger;
+      it('toggles open when arrow up or down on the trigger', fakeAsync(function (this: TestContext) {
+        expect(this.toggleService.open).toBeFalsy();
+        this.focusHandler.trigger = this.trigger;
 
-          this.focusHandler.trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'arrowup' }));
-          expect(this.toggleService.open).toBeTruthy();
+        this.focusHandler.trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'arrowup' }));
+        tick();
+        expect(this.toggleService.open).toBeTruthy();
 
-          //once open, the up/down arrow keys control the focus on menu items, so we close again for the next test
-          this.toggleService.open = false;
-          tick();
-          expect(this.toggleService.open).toBeFalsy();
+        //once open, the up/down arrow keys control the focus on menu items, so we close again for the next test
+        this.toggleService.open = false;
+        tick();
+        expect(this.toggleService.open).toBeFalsy();
 
-          this.focusHandler.trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'arrowdown' }));
-          expect(this.toggleService.open).toBeTruthy();
-        });
-      });
+        this.focusHandler.trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'arrowdown' }));
+        tick();
+        expect(this.toggleService.open).toBeTruthy();
+      }));
 
       it('listens to arrow keys on the trigger', function (this: TestContext) {
         const spy = spyOn(this.focusService, 'listenToArrowKeys');
@@ -222,21 +222,19 @@ export default function (): void {
         expect(this.toggleService.open).toBeTruthy();
       });
 
-      it('moves to the first child when opened with a click', function (this: TestContext) {
-        fakeAsync(function (this: TestContext) {
-          this.focusHandler.addChildren(this.children);
-          const moveTo = spyOn(this.focusService, 'moveTo');
-          const move = spyOn(this.focusService, 'move');
-          this.toggleService.toggleWithEvent({});
-          tick();
+      it('moves to the first child when opened with a click', fakeAsync(function (this: TestContext) {
+        this.focusHandler.addChildren(this.children);
+        const moveTo = spyOn(this.focusService, 'moveTo');
+        const move = spyOn(this.focusService, 'move');
+        this.toggleService.toggleWithEvent({});
+        tick();
 
-          // First we move to the clicked item, which is the trigger,
-          expect(moveTo).toHaveBeenCalledWith(this.focusHandler);
-          // then we move down to the first item,
-          expect(move).toHaveBeenCalledWith(ArrowKeyDirection.DOWN);
-          // but maybe that's too detailed for this unit test? It's just the easiest way to test it right now.
-        });
-      });
+        // First we move to the clicked item, which is the trigger,
+        expect(moveTo).toHaveBeenCalledWith(this.focusHandler);
+        // then we move down to the first item,
+        expect(move).toHaveBeenCalledWith(ArrowKeyDirection.DOWN);
+        // but maybe that's too detailed for this unit test? It's just the easiest way to test it right now.
+      }));
     });
 
     describe('nested dropdown', function () {
@@ -318,16 +316,16 @@ export default function (): void {
         expect(this.toggleService.open).toBeFalsy();
       });
 
-      it('moves to the first child when opened with a click', function (this: TestContext) {
-        fakeAsync(function (this: TestContext) {
-          this.focusHandler.addChildren(this.children);
-          const moveTo = spyOn(this.focusService, 'moveTo');
-          const move = spyOn(this.focusService, 'move');
-          this.toggleService.toggleWithEvent({});
-          expect(moveTo).toHaveBeenCalledWith(this.focusHandler);
-          expect(move).toHaveBeenCalledWith(ArrowKeyDirection.RIGHT);
-        });
-      });
+      it('moves to the first child when opened with a click', fakeAsync(function (this: TestContext) {
+        this.focusHandler.addChildren(this.children);
+        const moveTo = spyOn(this.focusService, 'moveTo');
+        const move = spyOn(this.focusService, 'move');
+        this.toggleService.toggleWithEvent({});
+        tick();
+
+        expect(moveTo).toHaveBeenCalledWith(this.focusHandler);
+        expect(move).toHaveBeenCalledWith(ArrowKeyDirection.RIGHT);
+      }));
     });
   });
 }

--- a/projects/angular/src/progress/spinner/_spinner.clarity.scss
+++ b/projects/angular/src/progress/spinner/_spinner.clarity.scss
@@ -52,6 +52,16 @@
     }
   }
 
+  .btn-icon:not(.btn-sm) {
+    .spinner {
+      width: 100%;
+      min-width: 100%;
+      height: 0;
+      min-height: 0;
+      padding-bottom: 100%;
+    }
+  }
+
   @keyframes spin {
     0% {
       transform: rotate(0deg);

--- a/projects/website/src/releases/12.x/12.0.8.html
+++ b/projects/website/src/releases/12.x/12.0.8.html
@@ -1,0 +1,13 @@
+<!--
+  ~ Copyright (c) 2016-2021 VMWare, Inc. All Rights Reserved.
+  ~ This software is released under MIT License.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+-->
+
+<h2>Bug Fixes</h2>
+<ul class="list">
+  <li bug-fix>
+    Align input placeholder color to core
+    <a href="https://github.com/vmware/clarity/issues/6443" target="_blank"> (#6443) </a>
+  </li>
+</ul>

--- a/projects/website/src/sitemap.xml
+++ b/projects/website/src/sitemap.xml
@@ -301,6 +301,10 @@
         <changefreq>daily</changefreq>
     </url>
     <url>
+        <loc>https://clarity.design/news/src/releases/13.x/13.0.0-next.0.html</loc>
+        <changefreq>daily</changefreq>
+    </url>
+    <url>
         <loc>https://clarity.design/news/src/releases/12.x/12.0.7.html</loc>
         <changefreq>daily</changefreq>
     </url>

--- a/scripts/update-license.js
+++ b/scripts/update-license.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -17,13 +17,12 @@ const path = require('path');
 
 const supported = ['.js', '.ts', '.html', '.css', '.scss', '.sass'];
 
-// Stash unstaged files
-// exec('git stash --keep-index --include-untracked');
-
 // Grab list of staged files
 const files = exec('git diff --name-only --cached --diff-filter=d', {
   encoding: 'utf8',
-}).split('\n');
+})
+  .split('\n')
+  .filter(file => file);
 const year = new Date().getFullYear();
 
 files.forEach(file => {
@@ -38,6 +37,3 @@ files.forEach(file => {
 console.log('Updated license headers');
 
 exec(`git add ${files.map(file => "'" + path.join(__dirname, '../', file) + "'").join(' ')}`);
-
-// Restore from stash
-// exec('git stash pop');


### PR DESCRIPTION
- @cds/core is now setting min height and width for all icons.
  So height and width override in dropdown was having no effect. Added min height and width.

Signed-off-by: gerinjacob <gerinjacob@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Size of angle icon inside dropdown is bigger, since it ignores the height and width values set in dropdown style.
min-height and min-width set as part of https://github.com/vmware/clarity/commit/629537a5554aa21f7cc0406c2aae02954a576f83 is causing this issue.

Issue Number: N/A

## What is the new behavior?

In addition to height and width also set min height and width in dropdown style.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
