### PR TITLE
fix(dropdown): set min height and width for angle icon

### DIFF
--- a/projects/angular/src/popover/dropdown/_dropdown.clarity.scss
+++ b/projects/angular/src/popover/dropdown/_dropdown.clarity.scss
@@ -34,7 +34,7 @@
         top: 50%;
         transform: translateY(-50%);
         color: inherit;
-        @include equilateral($clr-dropdown-caret-icon-dimension);
+        @include min-equilateral($clr-dropdown-caret-icon-dimension);
       }
 
       // NOTE: cds-icon handles direction internally.
@@ -45,7 +45,7 @@
         position: absolute;
         top: 35%;
         color: inherit;
-        @include equilateral($clr-dropdown-caret-icon-dimension);
+        @include min-equilateral($clr-dropdown-caret-icon-dimension);
       }
 
       &.btn {


### PR DESCRIPTION
- @cds/core is now setting min height and width for all icons.
  So height and width override in dropdown was having no effect. Added min height and width.

Signed-off-by: gerinjacob <gerinjacob@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Size of angle icon inside dropdown is bigger, since it ignores the height and width values set in dropdown style.
min-height and min-width set as part of [629537a](https://github.com/vmware/clarity/commit/629537a5554aa21f7cc0406c2aae02954a576f83) is causing this issue.

Issue Number: N/A

## What is the new behavior?

In addition to height and width also set min height and width in dropdown style.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
