### PR TITLE
chore(website): add missing sitempa urls

### DIFF
--- a/projects/website/src/sitemap.xml
+++ b/projects/website/src/sitemap.xml
@@ -301,7 +301,19 @@
         <changefreq>daily</changefreq>
     </url>
     <url>
+        <loc>https://clarity.design/news/src/releases/13.x/13.0.0-next.1.html</loc>
+        <changefreq>daily</changefreq>
+    </url>
+    <url>
         <loc>https://clarity.design/news/src/releases/13.x/13.0.0-next.0.html</loc>
+        <changefreq>daily</changefreq>
+    </url>
+    <url>
+        <loc>https://clarity.design/news/src/releases/12.x/12.0.9.html</loc>
+        <changefreq>daily</changefreq>
+    </url>
+    <url>
+        <loc>https://clarity.design/news/src/releases/12.x/12.0.8.html</loc>
         <changefreq>daily</changefreq>
     </url>
     <url>


### PR DESCRIPTION
Signed-off-by: Steve Haar <info@stevehaar.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [x] Other... Please describe:

## What is the current behavior?
13.0.0-next.1.html, 12.0.8.html, and 12.0.9.html sitemap url is generated by the ci build, but is missing from source control.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
added missing sitemap url

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
