### PR TITLE
feat(angular): do not preserve width of loading buttons

### DIFF
--- a/projects/angular/src/button/button-loading/loading-button.spec.ts
+++ b/projects/angular/src/button/button-loading/loading-button.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -86,30 +86,6 @@ describe('Loading Buttons', () => {
     fixture.detectChanges();
     expect(fixture.componentInstance.buttonState as ClrLoadingState).toEqual(ClrLoadingState.DEFAULT);
     expect(fixture.componentInstance.loadingButtonInstance.el.nativeElement.attributes.disabled).toBeFalsy();
-  }));
-
-  it('sets an explicit width value of the button when [(clrButtonState)] value is set to LOADING or SUCCESS', fakeAsync(() => {
-    let style = fixture.componentInstance.loadingButtonInstance.el.nativeElement.attributes.style;
-    expect(style).toBeFalsy();
-
-    fixture.componentInstance.buttonState = ClrLoadingState.LOADING;
-    fixture.detectChanges();
-    style = fixture.componentInstance.loadingButtonInstance.el.nativeElement.attributes.style;
-    expect(style).toBeTruthy();
-    expect(style.value).toMatch(/width:*/);
-
-    fixture.componentInstance.buttonState = ClrLoadingState.SUCCESS;
-    fixture.detectChanges();
-    style = fixture.componentInstance.loadingButtonInstance.el.nativeElement.attributes.style;
-    expect(style).toBeTruthy();
-    expect(style.value).toMatch(/width:*/);
-
-    tick(1000);
-    fixture.detectChanges();
-    expect(fixture.componentInstance.buttonState as ClrLoadingState).toEqual(ClrLoadingState.DEFAULT);
-    style = fixture.componentInstance.loadingButtonInstance.el.nativeElement.attributes.style;
-    // here, we check to see if style.value is falsy instead of style, because even though the style is cleared the attribute remains
-    expect(style.value).toBeFalsy();
   }));
 
   it('hides spinner when [(clrButtonState)] value is DEFAULT', () => {

--- a/projects/angular/src/button/button-loading/loading-button.ts
+++ b/projects/angular/src/button/button-loading/loading-button.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -76,19 +76,14 @@ export class ClrLoadingButton implements LoadingListener {
 
     switch (state) {
       case ClrLoadingState.DEFAULT:
-        this.renderer.removeStyle(this.el.nativeElement, 'width');
         this.renderer.removeStyle(this.el.nativeElement, 'transform'); // for chromium render bug see issue https://github.com/vmware/clarity/issues/2700
         if (!this.disabled) {
           this.renderer.removeAttribute(this.el.nativeElement, 'disabled');
         }
         break;
       case ClrLoadingState.LOADING:
-        this.setExplicitButtonWidth();
         this.renderer.setStyle(this.el.nativeElement, 'transform', 'translatez(0)'); // for chromium render bug see issue https://github.com/vmware/clarity/issues/2700
         this.renderer.setAttribute(this.el.nativeElement, 'disabled', '');
-        break;
-      case ClrLoadingState.SUCCESS:
-        this.setExplicitButtonWidth();
         break;
       case ClrLoadingState.ERROR:
         this.loadingStateChange(ClrLoadingState.DEFAULT);
@@ -97,12 +92,5 @@ export class ClrLoadingButton implements LoadingListener {
         break;
     }
     this.clrLoadingChange.emit(state);
-  }
-
-  private setExplicitButtonWidth() {
-    if (this.el.nativeElement && this.el.nativeElement.getBoundingClientRect) {
-      const boundingClientRect = this.el.nativeElement.getBoundingClientRect();
-      this.renderer.setStyle(this.el.nativeElement, 'width', `${boundingClientRect.width}px`);
-    }
   }
 }

--- a/projects/angular/src/progress/spinner/_spinner.clarity.scss
+++ b/projects/angular/src/progress/spinner/_spinner.clarity.scss
@@ -52,16 +52,6 @@
     }
   }
 
-  .btn-icon:not(.btn-sm) {
-    .spinner {
-      width: 100%;
-      min-width: 100%;
-      height: 0;
-      min-height: 0;
-      padding-bottom: 100%;
-    }
-  }
-
   @keyframes spin {
     0% {
       transform: rotate(0deg);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, loading buttons preserve their width when they switched to the loading state.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

fixes https://github.com/vmware/clarity/issues/5967

## What is the new behavior?
Loading buttons will no longer preserve their width. This also fixes styling issues when a button was initialized in the loading state.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other Information
The previous fix for same size icons is no longer needed if the button is not going to preserve its width.