### PR TITLE
fix(angular): fix ellipsis issue in safari

### DIFF
--- a/projects/angular/src/popover/dropdown/_dropdown.clarity.scss
+++ b/projects/angular/src/popover/dropdown/_dropdown.clarity.scss
@@ -51,6 +51,7 @@
       &.btn {
         padding-right: $clr-btn-horizontal-padding + $clr-dropdown-caret-icon-dimension +
           $clr-dropdown-caret-left-margin;
+        text-overflow: unset;
 
         cds-icon[shape^='caret'],
         clr-icon[shape^='caret'],


### PR DESCRIPTION
Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Dropdown toggles in Clarity Angular get a weird ellipsis in Safari.

<img width="465" alt="Screen Shot 2022-01-11 at 4 18 34 PM" src="https://user-images.githubusercontent.com/2728359/149024116-c5ebaf17-aa75-46ce-a214-69bd3da35337.png">

Issue Number: N/A

## What is the new behavior?

Unsetting `text-overflow` for just the dropdown toggle buttons fixes this issue. 

<img width="430" alt="Screen Shot 2022-01-11 at 4 19 05 PM" src="https://user-images.githubusercontent.com/2728359/149024222-6d1d7f3d-00a7-494e-a287-8cd97138cca1.png">

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

@steve-haar : this is the issue we saw yesterday when I was working on the release. It wound up being an easy fix, just hard to figure out at first.

Once this PR is 👍 , I can backport to v12.