### PR TITLE
Address several tree-view element issues

### DIFF
--- a/packages/core/src/tree-view/register.ts
+++ b/packages/core/src/tree-view/register.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -7,6 +7,7 @@
 import '@cds/core/icon/register.js';
 import '@cds/core/internal-components/visual-checkbox/register.js';
 import '@cds/core/progress-circle/register.js';
+import '@cds/core/button-expand/register.js';
 import {
   ClarityMotion,
   AnimationTreeItemExpandName,

--- a/packages/core/src/tree-view/story-utils.ts
+++ b/packages/core/src/tree-view/story-utils.ts
@@ -1,0 +1,57 @@
+/**
+ * @description
+ *
+ * These are storybook utils for creating a dynamic demo.
+ *
+ * @internal
+ */
+export type CheckboxSelection = true | false | 'indeterminate';
+
+export class TreeItem {
+  open = false;
+  show = false;
+  expanded: false;
+  expandable: false;
+  parent: TreeItem | null = null;
+  nodes: TreeItem[] = [];
+
+  private _selected: CheckboxSelection = false;
+
+  set selected(value: CheckboxSelection) {
+    if (value !== this._selected) {
+      this._selected = value;
+
+      if (value !== 'indeterminate') {
+        this.nodes.forEach(n => (n.selected = value));
+      }
+
+      if (this.parent && this.parent.selected !== this.selected) {
+        const selectedItems = this.parent.nodes.filter(n => n.selected === true || n.selected === 'indeterminate');
+
+        if (selectedItems?.length > 0 && selectedItems?.length < this.parent.nodes.length) {
+          this.parent.selected = 'indeterminate';
+        } else if (selectedItems?.length === 0) {
+          this.parent.selected = false;
+        } else {
+          this.parent.selected = true;
+        }
+      }
+    }
+  }
+
+  get selected() {
+    return this._selected;
+  }
+
+  constructor(public id: string) {}
+}
+
+export function createItems(parent?: any, length = 0): TreeItem[] {
+  const nodes: TreeItem[] = [];
+  for (let i = 0; i < length; i++) {
+    const node = new TreeItem(`${parent?.id ? `${parent.id}-` : ''}${i}`);
+    node.parent = parent;
+    nodes.push(node);
+  }
+  return nodes;
+}

--- a/packages/core/src/tree-view/tree-item.element.spec.ts
+++ b/packages/core/src/tree-view/tree-item.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -106,5 +106,15 @@ describe('tree item element', () => {
     expect(item).toBeDefined();
     item.click();
     expect((await event).detail).toBe(true);
+  });
+
+  it('should display the expand button when expandable', async () => {
+    await componentIsStable(component);
+    const expandButtonNull = component.shadowRoot.querySelector('cds-button-expand');
+    expect(expandButtonNull).toBeNull();
+    component.expandable = true;
+    await componentIsStable(component);
+    const expandButton = component.shadowRoot.querySelector('cds-button-expand');
+    expect(expandButton.tagName).toBe('CDS-BUTTON-EXPAND');
   });
 });

--- a/packages/core/src/tree-view/tree-item.element.ts
+++ b/packages/core/src/tree-view/tree-item.element.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -75,6 +75,14 @@ export class CdsTreeItem extends LitElement {
   @property({ type: Boolean, reflect: true })
   expanded = false;
 
+  /**
+   * @description
+   *
+   * Expandable is used (see line 124) to automatically show the cds-button-expand element when a tree-item detects that
+   * there are children. However, when doing investigation into why styles were not applied for tree-items controlled
+   * via *ngIf (or any conditional DOM and code that will put tree-item elements there at some unknown point in the
+   * future) it was re-discovered as a public property without a demo for manual usage.
+   */
   @property({ type: Boolean, reflect: true })
   expandable = false;
 

--- a/packages/core/src/tree-view/tree.stories.mdx
+++ b/packages/core/src/tree-view/tree.stories.mdx
@@ -65,6 +65,18 @@ import '@cds/core/tree-view/register.js';
   <Story id="stories-tree-view--interactive" />
 </Preview>
 
+## Conditional Tree View Items
+
+Conditional DOM requires the expandable attr to tell use that it will be there attr some point.
+
+```html
+<cds-tree-item expanded expandable>Node Content</cds-tree-item>
+```
+
+<Preview>
+  <Story id="stories-tree-view--conditional-items" />
+</Preview>
+
 ## Custom Styles
 
 <Preview>

--- a/packages/core/src/tree-view/tree.stories.ts
+++ b/packages/core/src/tree-view/tree.stories.ts
@@ -1,14 +1,18 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import '@cds/core/alert/register.js';
+import '@cds/core/button/register.js';
 import '@cds/core/icon/register.js';
 import '@cds/core/tree-view/register.js';
 import { CdsTreeItem } from '@cds/core/tree-view';
 
-import { html } from 'lit';
+import { css, html, LitElement } from 'lit';
+import { createItems, TreeItem } from './story-utils.js';
+import { customElement } from '@cds/core/internal';
+import { state } from 'lit/decorators/state.js';
 
 export default {
   title: 'Stories/Tree View',
@@ -378,6 +382,78 @@ export const interactive = () => {
     <a href="#" cds-text="link">link</a>
   `;
 };
+
+export function conditionalItems() {
+  @customElement('demo-conditional-tree')
+  class DemoConditionalTree extends LitElement {
+    @state() nodes: TreeItem[] = [];
+    @state() show = false;
+    @state() checkAll = false;
+    @state() selectableItems = false;
+
+    static styles = [css``];
+
+    constructor() {
+      super();
+      const level1 = 5;
+      const level2 = 3;
+      const level3 = 2;
+
+      this.nodes = createItems(0, level1).map(n => {
+        n.nodes = createItems(n, level2);
+        n.nodes.forEach(c => (c.nodes = createItems(c, level3)));
+        return n;
+      });
+    }
+
+    private generateTreeItems(nodes: TreeItem[]): any {
+      return nodes.map(
+        node => html` <cds-tree-item
+          @expandedChange=${() => this.toggleNode(node)}
+          .expanded=${node.show}
+          .expandable=${node.nodes.length > 0}
+        >
+          ${node.id} content ${node.show ? this.generateTreeItems(node.nodes) : ''}
+        </cds-tree-item>`
+      );
+    }
+
+    render() {
+      return html` <section cds-layout="vertical gap:lg p:lg">
+        <h1 cds-text="heading">Conditional Tree Items</h1>
+        <cds-button @click=${() => (this.show = !this.show)}>Toggle Tree Visibility</cds-button>
+
+        <cds-tree>
+          ${this.show ? this.generateTreeItems(this.nodes) : ''}
+        </cds-tree>
+      </section>`;
+    }
+
+    track(_index: number, node: TreeItem) {
+      return node.id;
+    }
+
+    toggleAll() {
+      this.checkAll = !this.checkAll;
+      this.nodes.forEach(n => (n.selected = this.checkAll));
+    }
+
+    toggleNode(node: TreeItem) {
+      node.show = !node.show;
+      this.nodes = [...this.nodes];
+    }
+
+    toggleNodeSelection(node: TreeItem, checked: boolean) {
+      node.selected = checked;
+      this.nodes = [...this.nodes];
+    }
+
+    createRenderRoot() {
+      return this;
+    }
+  }
+  return html`<demo-conditional-tree></demo-conditional-tree>`;
+}
 
 /** @website */
 export function customStyles() {


### PR DESCRIPTION
This change handles several isses that were encountered when triaging
usage of the cds-tree-item with angular's *ngIf structural directive.

1. This change adds registration of for the new cds-button-expand
   element used in the temlate.
2. This change adds a code comment to further describe both the
   automatic and manual use cases for `expandable`
3. THis change adds a dynamic demo that demonstrates how to use the
   expandable with complex trees
4. This change adds a test in the tree-item spec to make sure the button
   is in the DOM when a cds-tree-item element is `expandable`.

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [x] Other... Please describe:

As described above this adds a demo for conditional DOM on cds-tree-item elements. (think *ngIf for Angular apps). It also adds some context for the expandable property as it has an automatic and a manual use case. Finally, It adds a test into the spec to make sure the button is in the DOM when an element is 'expandable'. 

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Missing register for cds-button-expand, no dev notes for the manual use case of the expandable property and there is no test to make sure the expand button is in the DOM when a cds-tree-item is expandable. 
Issue Number: N/A

## What is the new behavior?
Added register code, added dev context to the expandable property, added a spec for the expandable property. Finally, it adds a demo for conditional cds-tree-items in a complex tree. 
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
