### PR TITLE
topic/loading button min width

### DIFF
--- a/projects/angular/src/button/button-loading/loading-button.spec.ts
+++ b/projects/angular/src/button/button-loading/loading-button.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -117,14 +117,23 @@ describe('Loading Buttons', () => {
     fixture.detectChanges();
     expect(fixture.nativeElement.querySelector('.spinner')).toBeFalsy();
   });
+
+  it('has minimum width of 42px when loading', () => {
+    fixture.componentInstance.buttonContent = '';
+    fixture.detectChanges();
+    fixture.componentInstance.buttonState = ClrLoadingState.LOADING;
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('button').offsetWidth).toBe(42);
+  });
 });
 
 @Component({
-  template: ` <button [(clrLoading)]="buttonState" id="testBtn" [disabled]="disabled">Test 1</button> `,
+  template: ` <button [(clrLoading)]="buttonState" id="testBtn" [disabled]="disabled">{{ buttonContent }}</button> `,
 })
 class TestLoadingButtonComponent {
   @ViewChild(ClrLoadingButton) loadingButtonInstance: ClrLoadingButton;
 
   buttonState: ClrLoadingState = ClrLoadingState.DEFAULT;
   disabled = false;
+  buttonContent = 'Test 1';
 }

--- a/projects/angular/src/button/button-loading/loading-button.ts
+++ b/projects/angular/src/button/button-loading/loading-button.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -8,6 +8,9 @@ import { animate, keyframes, style, transition, trigger } from '@angular/animati
 import { Component, ElementRef, EventEmitter, Input, Output, Renderer2 } from '@angular/core';
 import { ClrLoadingState } from '../../utils/loading/loading';
 import { LoadingListener } from '../../utils/loading/loading-listener';
+
+// minimum width to fit loading spinner
+const MIN_BUTTON_WIDTH = 42;
 
 @Component({
   selector: 'button[clrLoading]',
@@ -102,7 +105,8 @@ export class ClrLoadingButton implements LoadingListener {
   private setExplicitButtonWidth() {
     if (this.el.nativeElement && this.el.nativeElement.getBoundingClientRect) {
       const boundingClientRect = this.el.nativeElement.getBoundingClientRect();
-      this.renderer.setStyle(this.el.nativeElement, 'width', `${boundingClientRect.width}px`);
+      const width = Math.max(MIN_BUTTON_WIDTH, boundingClientRect.width);
+      this.renderer.setStyle(this.el.nativeElement, 'width', `${width}px`);
     }
   }
 }

--- a/projects/angular/src/progress/spinner/_spinner.clarity.scss
+++ b/projects/angular/src/progress/spinner/_spinner.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -54,11 +54,7 @@
 
   .btn-icon:not(.btn-sm) {
     .spinner {
-      width: 100%;
-      min-width: 100%;
-      height: 0;
-      min-height: 0;
-      padding-bottom: 100%;
+      @include min-equilateral($clr_baselineRem_0_65);
     }
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Initializing a button to loading will cause it to have the width of the button as if it only contained the loading spinner. Subsequently (or just not initially) setting the button to loading, the button will have the width of the button in its default state.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/vmware/clarity/issues/5967

## What is the new behavior?
Loading buttons will always have a minimum width so that the spinner will fully show.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
