### PR TITLE
fix(react:button): move loadingStatus logic to `update` event

### DIFF
--- a/packages/core/src/button/button.element.spec.ts
+++ b/packages/core/src/button/button.element.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -260,6 +260,25 @@ describe('button element', () => {
       expect(component.getBoundingClientRect().width.toFixed(3)).toEqual(size.toFixed(3));
       expect(component.hasAttribute('disabled')).toEqual(true);
       expect(component.getAttribute('aria-disabled')).toEqual('true');
+    });
+
+    it('should go back to enabled when loadingState changes back to default', async () => {
+      await componentIsStable(component);
+      component.loadingState = ClrLoadingState.default;
+      await componentIsStable(component);
+      expect(component.disabled).not.toBeTruthy();
+
+      component.loadingState = ClrLoadingState.loading;
+      await componentIsStable(component);
+      expect(component.disabled).toBeTruthy();
+
+      component.loadingState = ClrLoadingState.success;
+      await componentIsStable(component);
+      expect(component.disabled).toBeTruthy();
+
+      component.loadingState = ClrLoadingState.default;
+      await componentIsStable(component);
+      expect(component.disabled).not.toBeTruthy();
     });
 
     it('should stay disabled when loadingState changes to default', async () => {

--- a/packages/react/App.tsx
+++ b/packages/react/App.tsx
@@ -468,9 +468,12 @@ export default class App extends React.Component<{}, AppState> {
             <CdsButton status="primary">primary</CdsButton>
             <CdsButton status="success">success</CdsButton>
             <CdsButton status="danger">danger</CdsButton>
-            <CdsButton status="danger" disabled>
+            <CdsButton status="primary" disabled={true}>
               disabled
             </CdsButton>
+            <CdsButton loadingState="loading">Loading</CdsButton>
+            <CdsButton loadingState="success">Success</CdsButton>
+            <CdsButton loadingState="error">Error</CdsButton>
           </div>
 
           <h2>Internal Close button</h2>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

In React, the `loadingStatus` prop no longer works, devs must use `loading-status`. It last worked in 5.5.0/

Issue Number: #6559

## What is the new behavior?

`loadingStatus` works in React now

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
