### PR TITLE
chore: update GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,8 @@
+blank_issues_enabled: false
 contact_links:
   - name: Feature Request
     url: https://github.com/vmware/clarity/discussions/new
     about: Submit new ideas in our GitHub Discussions forum.
+  - name: Accessibility Issues
+    url: https://github.com/vmware/clarity/wiki/Accessibility-Issues
+    about: Reports specific to accessibility issues or requests.


### PR DESCRIPTION
This adds a new Accessibility issue link in our GitHub issue templates that directs the reporter to review our policies first in the Wiki. We are getting duplicate reports from VMware teams and this can help them understand the process better.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
