### PR TITLE
fix(a11y): fix color contrasts for combobox pills border

### DIFF
--- a/projects/angular/src/forms/combobox/_variables.combobox.scss
+++ b/projects/angular/src/forms/combobox/_variables.combobox.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -16,7 +16,7 @@ $clr-combobox-border-radius: $clr_baselineRem_3px !default;
 
 $clr-combobox-input-background-color: $clr-color-neutral-100 !default;
 $clr-combobox-pill-background-color: $clr-color-neutral-0 !default;
-$clr-combobox-pill-border-color: $clr-color-neutral-200 !default;
+$clr-combobox-pill-border-color: $clr-color-neutral-700 !default;
 $clr-combobox-pill-border-radius: $clr_baselineRem_3px !default;
 $clr-combobox-pill-font-color: $clr-color-neutral-800 !default;
 $clr-combobox-filter-highlight: $clr-color-neutral-800 !default;

--- a/projects/angular/src/utils/_theme.dark.clarity.scss
+++ b/projects/angular/src/utils/_theme.dark.clarity.scss
@@ -491,7 +491,7 @@ $clr-forms-range-track-color: hsl(200, 23%, 25%);
 $clr-combobox-border-color: hsl(198, 30%, 8%);
 $clr-combobox-input-background-color: hsl(198, 28%, 18%);
 $clr-combobox-pill-background-color: hsl(201, 30%, 15%);
-$clr-combobox-pill-border-color: hsl(208, 16%, 34%);
+$clr-combobox-pill-border-color: hsl(204, 10%, 60%);
 $clr-combobox-pill-font-color: hsl(0, 0%, 75%);
 $clr-combobox-filter-highlight: hsl(198, 16%, 93%);
 


### PR DESCRIPTION
Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Combobox multi select pills border color contrast too low.

Issue Number: N/A

## What is the new behavior?

Combobox multi select pills border color contrast OK.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
