### PR TITLE
fix(a11y): wizard TOC state available for SR

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -505,6 +505,8 @@ export interface ClrCommonStrings {
     verticalNavGroupToggle: string;
     verticalNavToggle: string;
     warning: string;
+    wizardStepError: string;
+    wizardStepSuccess: string;
 }
 
 export declare class ClrCommonStringsService {
@@ -2556,6 +2558,7 @@ export declare class ClrWizardStepnav {
 
 export declare class ClrWizardStepnavItem {
     get canNavigate(): boolean;
+    commonStrings: ClrCommonStringsService;
     get hasError(): boolean;
     get id(): string;
     get isComplete(): boolean;
@@ -2565,7 +2568,7 @@ export declare class ClrWizardStepnavItem {
     page: ClrWizardPage;
     pageCollection: PageCollectionService;
     get stepAriaCurrent(): string;
-    constructor(navService: WizardNavigationService, pageCollection: PageCollectionService);
+    constructor(navService: WizardNavigationService, pageCollection: PageCollectionService, commonStrings: ClrCommonStringsService);
     click(): void;
     static ɵcmp: i0.ɵɵComponentDeclaration<ClrWizardStepnavItem, "[clr-wizard-stepnav-item]", never, { "page": "page"; }, {}, never, ["*"]>;
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrWizardStepnavItem, never>;

--- a/projects/angular/src/utils/i18n/common-strings.default.ts
+++ b/projects/angular/src/utils/i18n/common-strings.default.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -88,4 +88,7 @@ export const commonStringsDefault: ClrCommonStrings = {
   dategridExpandableEndOf: 'End of',
   dategridExpandableRowContent: 'Expandable row content',
   dategridExpandableRowsHelperText: `Screen reader table commands may not work for viewing expanded content, please use your screen reader's browse mode to read the content exposed by this button`,
+  // Wizard
+  wizardStepSuccess: 'Completed',
+  wizardStepError: 'Error',
 };

--- a/projects/angular/src/utils/i18n/common-strings.interface.ts
+++ b/projects/angular/src/utils/i18n/common-strings.interface.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -245,4 +245,14 @@ export interface ClrCommonStrings {
   comboboxSelected: string;
   comboboxNoResults: string;
   comboboxOpen: string;
+
+  /**
+   * Wizard: Screen-reader text for completed step.
+   */
+  wizardStepSuccess: string;
+
+  /**
+   * Wizard: Screen-reader text for step with error.
+   */
+  wizardStepError: string;
 }

--- a/projects/angular/src/wizard/wizard-stepnav-item.spec.ts
+++ b/projects/angular/src/wizard/wizard-stepnav-item.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -16,6 +16,7 @@ import { ClrWizardPageNavTitle } from './wizard-page-navtitle';
 import { MockPage } from './wizard-page.mock';
 import { ClrWizardStepnavItem } from './wizard-stepnav-item';
 import { ClrWizardModule } from './wizard.module';
+import { ClrCommonStringsService } from '../utils';
 
 const pageIndex = 0;
 const fakeOutPage = new MockPage(pageIndex);
@@ -476,6 +477,26 @@ export default function (): void {
           fakeOutPage.hasError = true;
           fixture.detectChanges();
           expect(myStepnavItem.querySelector('cds-icon[shape="error-standard"]')).not.toBeNull();
+        });
+
+        it('should have a span with text "Error" when page has an error', () => {
+          fakeOutPage.completed = true;
+          fakeOutPage.hasError = true;
+          fixture.detectChanges();
+          const commonStrings = new ClrCommonStringsService();
+          const spans: NodeList = myStepnavItem.querySelectorAll('span.clr-sr-only');
+          expect(spans.length).toEqual(1);
+          expect(spans[0].textContent).toEqual(commonStrings.keys.wizardStepError);
+        });
+
+        it('should have a span with text "Completed" when page is completed', () => {
+          fakeOutPage.completed = true;
+          fakeOutPage.hasError = false;
+          fixture.detectChanges();
+          const commonStrings = new ClrCommonStringsService();
+          const spans: NodeList = myStepnavItem.querySelectorAll('span.clr-sr-only');
+          expect(spans.length).toEqual(1);
+          expect(spans[0].textContent).toEqual(commonStrings.keys.wizardStepSuccess);
         });
       });
 

--- a/projects/angular/src/wizard/wizard-stepnav-item.ts
+++ b/projects/angular/src/wizard/wizard-stepnav-item.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -9,6 +9,7 @@ import { Component, Input } from '@angular/core';
 import { PageCollectionService } from './providers/page-collection.service';
 import { WizardNavigationService } from './providers/wizard-navigation.service';
 import { ClrWizardPage } from './wizard-page';
+import { ClrCommonStringsService } from '../utils';
 
 @Component({
   selector: '[clr-wizard-stepnav-item]',
@@ -31,6 +32,8 @@ import { ClrWizardPage } from './wizard-page';
       <span class="clr-wizard-stepnav-link-title">
         <ng-template [ngTemplateOutlet]="page.navTitle"></ng-template>
       </span>
+      <span *ngIf="hasError" class="clr-sr-only">{{ commonStrings.keys.wizardStepError }}</span>
+      <span *ngIf="!hasError && isComplete" class="clr-sr-only">{{ commonStrings.keys.wizardStepSuccess }}</span>
     </button>
   `,
   host: {
@@ -49,7 +52,11 @@ import { ClrWizardPage } from './wizard-page';
 export class ClrWizardStepnavItem {
   @Input('page') public page: ClrWizardPage;
 
-  constructor(public navService: WizardNavigationService, public pageCollection: PageCollectionService) {}
+  constructor(
+    public navService: WizardNavigationService,
+    public pageCollection: PageCollectionService,
+    public commonStrings: ClrCommonStringsService
+  ) {}
 
   private pageGuard(): void {
     if (!this.page) {


### PR DESCRIPTION
Resolves https://github.com/vmware/clarity/issues/3976

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Clarity Wizard TOC indicates completion state only with colour. This is not accessible.

## What is the new behavior?

Added support for screen readers for Error and Complete state of TOC item.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
