### PR TITLE
fix(core): property initialization

### DIFF
--- a/packages/core/src/breadcrumb/breadcrumb.element.ts
+++ b/packages/core/src/breadcrumb/breadcrumb.element.ts
@@ -27,8 +27,6 @@ export class CdsBreadcrumb extends LitElement {
 
   @querySlot('[slot="cds-separator"]') private customSeparator: HTMLElement;
 
-  role = 'navigation';
-
   render() {
     return html`
       <div class="private-host">
@@ -45,6 +43,11 @@ export class CdsBreadcrumb extends LitElement {
       </div>
       <slot @slotchange=${this.assignSlots}></slot>
     `;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.role = 'navigation';
   }
 
   private get separator() {

--- a/packages/core/src/card/card.element.ts
+++ b/packages/core/src/card/card.element.ts
@@ -49,8 +49,6 @@ import styles from './card.element.scss';
  * @cssprop --cds-card-remove-margin
  */
 export class CdsCard extends CdsInternalPanel {
-  role = 'region';
-
   @globalStyle() globalStyles = css`
     [cds-card-remove-margin] {
       margin-left: calc(-1 * var(--card-remove-margin));
@@ -60,5 +58,10 @@ export class CdsCard extends CdsInternalPanel {
 
   static get styles() {
     return [...super.styles, styles];
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.role = 'region';
   }
 }

--- a/packages/core/src/internal-components/overlay/overlay.element.ts
+++ b/packages/core/src/internal-components/overlay/overlay.element.ts
@@ -63,9 +63,6 @@ export class CdsInternalStaticOverlay extends CdsBaseFocusTrap {
 
   @i18n() i18n = I18nService.keys.overlay;
 
-  @property({ type: String })
-  ariaModal = 'true';
-
   // renderRoot needs delegatesFocus so that focus can cross the shadowDOM
   // inside an element with aria-modal set to true
   /** @private */
@@ -92,6 +89,11 @@ export class CdsInternalStaticOverlay extends CdsBaseFocusTrap {
 
   /* c8 ignore next */
   @query('.overlay-backdrop') protected backdrop: HTMLElement;
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.ariaModal = 'true';
+  }
 
   firstUpdated(props: Map<string, any>) {
     super.firstUpdated(props);

--- a/packages/core/src/internal-components/popup/pointer.element.ts
+++ b/packages/core/src/internal-components/popup/pointer.element.ts
@@ -4,8 +4,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { AriaBooleanAttributeValues, PointerElement, property, state } from '@cds/core/internal';
 import { html, LitElement } from 'lit';
+import { PointerElement, property } from '@cds/core/internal';
 import { getPointer } from './utils/pointer.utils.js';
 import styles from './pointer.element.scss';
 
@@ -27,9 +27,6 @@ import styles from './pointer.element.scss';
  *
  */
 export class CdsInternalPointer extends LitElement implements PointerElement {
-  @state({ type: String, reflect: true, attribute: 'aria-hidden' })
-  protected ariaHiddenAttr: AriaBooleanAttributeValues = 'true';
-
   @property({ type: String })
   axisAlign: 'start' | 'center' | 'end' = 'start';
 
@@ -51,6 +48,11 @@ export class CdsInternalPointer extends LitElement implements PointerElement {
   protected render() {
     // this prevents an impossible state where you have a custom SVG inside of a typed pointer
     return this.type ? getPointer(this.type) : html`<slot></slot>`;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.ariaHidden = 'true';
   }
 
   static get styles() {

--- a/packages/core/src/navigation/navigation-item.element.ts
+++ b/packages/core/src/navigation/navigation-item.element.ts
@@ -71,10 +71,9 @@ export class CdsNavigationItem extends LitElement implements FocusableItem {
   @querySlotAll('[cds-navigation-sr-text]')
   itemText: NodeListOf<HTMLSpanElement>;
 
-  role = 'listitem';
-
   connectedCallback() {
     super.connectedCallback();
+    this.role = 'listitem';
     if (!this.id) {
       this.id = createId();
     }

--- a/packages/core/src/navigation/navigation-start.element.ts
+++ b/packages/core/src/navigation/navigation-start.element.ts
@@ -67,9 +67,6 @@ export class CdsNavigationStart extends LitElement implements FocusableItem {
   @property({ type: Boolean, reflect: true })
   isGroupStart = false;
 
-  @property({ type: String, reflect: true })
-  role = 'listitem';
-
   @property({ type: String })
   navigationGroupId: string;
 
@@ -107,6 +104,7 @@ export class CdsNavigationStart extends LitElement implements FocusableItem {
 
   connectedCallback() {
     super.connectedCallback();
+    this.role = 'listitem';
     if (!this.id) {
       this.id = createId();
     }

--- a/packages/core/src/navigation/navigation.element.ts
+++ b/packages/core/src/navigation/navigation.element.ts
@@ -173,8 +173,6 @@ export class CdsNavigation extends LitElement {
   @querySlotAll('cds-navigation-group')
   protected navigationGroupRefs: NodeListOf<CdsNavigationGroup>;
 
-  role = 'list';
-
   private toggle() {
     this.expandedChange.emit(!this.expanded);
   }
@@ -364,6 +362,7 @@ export class CdsNavigation extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
+    this.role = 'list';
     this.rootNavigationStart?.addEventListener('focus', this.focusRootStart.bind(this));
     this.rootNavigationStart?.addEventListener('blur', this.blurRootStart.bind(this));
     this.rootNavigationStart?.addEventListener('keydown', this.handleRootStartKeys.bind(this));


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Some custom elements fail to instantiate due to a property being set to early in its life cycle. If a native built in property is set that reflects its attribute before the element has been added to the DOM it can throw an exception in some browsers.

See references
- https://stackoverflow.com/questions/43836886/failed-to-construct-customelement-error-when-javascript-file-is-placed-in-head
- https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-conformance

- closes #6589
- closes #6590

## What is the new behavior?
This moves the property to be set in the connectedCallback to prevent the exception. Unfortunately I could not find a great way to test this since this is a life cycle issue controlled by the browser. This will need to be backported to v5

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
