### PR TITLE
build: remove curl script and add github secret for NETLIFY_AUTH_TOKEN

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'vmware/clarity'
+    if: github.repository == 'vmware/clarity'
 
     steps:
       - uses: actions/checkout@v2
@@ -30,3 +30,4 @@ jobs:
     env:
       CI: true
       NETLIFY_SITE_ID: 03fce0dd-9568-4ab2-a3ea-211d856989db
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/scripts/website.sh
+++ b/scripts/website.sh
@@ -1,20 +1,6 @@
 #!/usr/bin/env bash
 
-echo "Download key-value env variables"
-# This downloads a set of key-value env variables, but blocks any requests that aren't from GitHub Actions
-curl -g https://us-central1-clarity-design-system.cloudfunctions.net/actions -o .env
-# dotenv loads up the env variables into the shell, then deploys through Netlify
-
 echo "Deploy a preview that can be promoted to clarity.design when we are ready"
 # Deploy a preview that can be promoted to production when we are ready
-node -r dotenv/config -- ./node_modules/.bin/netlify deploy --json --dir=./dist/website --message="Website - $GITHUB_REF@$GITHUB_SHA" --site "clarity.design"
+./node_modules/.bin/netlify deploy --json --dir=./dist/website --message="Website - $GITHUB_REF@$GITHUB_SHA" --site "clarity.design"
 
-# echo "Deploy a preview that can be promoted to next.clarity.design when we are ready"
-# # Deploy a version to https://next.clarity.design as 'production'
-# node -r dotenv/config -- ./node_modules/.bin/netlify deploy --json --dir=./dist/website --message="Website - $GITHUB_REF@$GITHUB_SHA" --site "next.clarity.design" > ./logs/next.clarity.design.netlify.json
-
-# echo "Clarity Design Netlify"
-# cat ./logs/clarity.design.netlify.json
-
-# echo "Clarity Next Design Netlify"
-# cat ./logs/next.clarity.design.netlify.json


### PR DESCRIPTION
Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?
Removes the curl script that was downloading the NETLIFY_AUTH_TOKEN from the firebase cloud function. 
It implements a github secret that sets up the environment more securely. 

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently build jobs download the NETLIFY_AUTH_TOKEN for commits and PR's from a firebase cloud function for a small set if github container IP's. While this works and is more secure than commiting the AUTH token to code, its not great either. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
This change adds and configures usage of a github secret to initialize the build environment with a github secret for the NETLIFY_AUTH_TOKEN. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
