### PR TITLE
fix(core:icon): update icon warning color to use the dark color variation

### DIFF
--- a/packages/core/src/icon/icon.element.scss
+++ b/packages/core/src/icon/icon.element.scss
@@ -84,7 +84,7 @@ svg {
 }
 
 :host([status='warning']) {
-  --color: #{$cds-alias-status-warning-shade};
+  --color: #{$cds-alias-status-warning-dark};
 }
 
 :host([status='info']) {
@@ -136,7 +136,7 @@ svg {
 }
 
 :host([badge*='warning']) {
-  --badge-color: #{$cds-alias-status-warning-shade};
+  --badge-color: #{$cds-alias-status-warning-dark};
 }
 
 :host([badge='inherit']) {
@@ -163,7 +163,7 @@ svg {
 }
 
 :host([badge*='warning'][inverse]) {
-  --badge-color: #{$cds-alias-status-warning-shade};
+  --badge-color: #{$cds-alias-status-warning-dark};
 }
 
 :host([badge*='inherit'][inverse]) {


### PR DESCRIPTION
This came up during a review of the documentation. Icon warning colors for icons and badges were not correct. 

# Before
![Screen Shot 2022-01-28 at 1 55 42 PM](https://user-images.githubusercontent.com/433692/151626950-98eab555-460d-4d75-b260-97d2bed6a8ff.png)
![Screen Shot 2022-01-28 at 1 55 35 PM](https://user-images.githubusercontent.com/433692/151626964-a0e0f24e-a131-44be-b827-ea9084fb3191.png)


# After
![Screen Shot 2022-01-28 at 1 54 19 PM](https://user-images.githubusercontent.com/433692/151626848-59a37f59-9c09-46b1-ae35-e894c2a1c2fd.png)
![Screen Shot 2022-01-28 at 1 54 30 PM](https://user-images.githubusercontent.com/433692/151626874-3f12b887-8c0b-48e8-83e3-84f50f558869.png)

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
The warning color was not correct for icons and icon badges. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
The warning color has been updated to use the `--cds-alias-status-warning-dark` color token.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
This may impact applications doing visual regression testing depending on the tolerance values they have configured for the tooling. 
## Other information
