### PR TITLE
fix(modal): let passing different typography for modal title

### DIFF
--- a/projects/angular/src/modal/_modal.clarity.scss
+++ b/projects/angular/src/modal/_modal.clarity.scss
@@ -78,6 +78,11 @@
 
     .modal-title {
       @include css-var(color, clr-modal-title-color, $clr-modal-title-color, $clr-use-custom-properties);
+      margin: 0;
+      padding: 0 $clr_baselineRem_0_125;
+    }
+
+    .modal-title:not([cds-text]) {
       font-size: $clr-modal-title-font-size;
       @include css-var(
         font-family,
@@ -93,9 +98,6 @@
       );
       line-height: $clr-modal-title-line-height;
       letter-spacing: $clr-modal-title-letter-spacing;
-
-      margin: 0;
-      padding: 0 $clr_baselineRem_0_125;
     }
 
     .close {


### PR DESCRIPTION
Fixing issue inside modal window and using typography on modal-title.


When merged need to be backported to older versions.


Close #6605 