### PR TITLE
fix: ng dropdown toggle icon sizing for v13

### DIFF
--- a/projects/angular/src/layout/nav/_header.clarity.scss
+++ b/projects/angular/src/layout/nav/_header.clarity.scss
@@ -262,9 +262,6 @@
         cds-icon[shape^='angle'],
         clr-icon[shape^='angle'] {
           right: $clr-header-action-caret-icon-right-position;
-        }
-
-        clr-icon[shape^='angle'] {
           top: 44%;
         }
       }

--- a/projects/angular/src/popover/dropdown/_dropdown.clarity.scss
+++ b/projects/angular/src/popover/dropdown/_dropdown.clarity.scss
@@ -37,17 +37,27 @@
       // This results in a different top value.
       cds-icon[shape^='caret'],
       cds-icon[shape^='angle'] {
+        margin-top: unset;
         position: absolute;
         top: 35%;
         color: inherit;
-        min-width: $clr-dropdown-caret-icon-dimension;
-        min-height: $clr-dropdown-caret-icon-dimension;
+        @include equilateral($clr-dropdown-caret-icon-dimension);
+        // need custom property override here to force minimum size of
+        // cds-icon to be 12px across the shadow dom...
+        --cds-global-space-7: $clr-dropdown-caret-icon-dimension;
       }
 
       &.btn {
         padding-right: $clr-btn-horizontal-padding + $clr-dropdown-caret-icon-dimension +
           $clr-dropdown-caret-left-margin;
         text-overflow: unset;
+
+        cds-icon[shape^='caret'],
+        clr-icon[shape^='caret'],
+        cds-icon[shape^='angle'],
+        clr-icon[shape^='angle'] {
+          right: $clr-btn-horizontal-padding;
+        }
       }
 
       &:not(.btn) {


### PR DESCRIPTION
Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

This is a redo of a fix introduced in the v13.0.0 release. The issue is related to the positioning and sizing of the dropdown toggle button's angle/caret icon.

The original fix worked alright for v13 when used with 5.6.2 and later but did not work for 5.6.0.

Restoring the code that made the dropdown toggle work with 5.6.0- broke the toggle icon positioning in 5.6.2. The fix was updating a css custom property that applied to 5.6.2+ and made it work as expected with 5.6.0-.

I tested these changes in v12 and v13 with Core 5.6.0, 5.6.2, and 6.0.0-next.3. The differences between 5.6.0 and 5.6.2+ were the complicating factor.

This will be backported to v12.

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
