### PR TITLE
fix: refactor and simplify popover outside click listener

### DIFF
--- a/projects/angular/src/popover/common/abstract-popover.spec.ts
+++ b/projects/angular/src/popover/common/abstract-popover.spec.ts
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
 import { Component, ElementRef, Injector, Optional, ViewChild } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { ClrConditionalModule } from '../../utils/conditional/conditional.module';
@@ -150,12 +150,27 @@ describe('Abstract Popover', function () {
       fixture.detectChanges();
     });
 
-    it('does not close toggle service immediately after opening', fakeAsync(() => {
+    it('should close on outside click', () => {
       toggleService.open = true;
       document.dispatchEvent(new Event('click'));
-      tick();
+      expect(toggleService.open).toBe(false);
+    });
 
+    it('should not close if outside click opens popover', () => {
+      const btn = document.createElement('button');
+      btn.setAttribute('type', 'button');
+      document.body.appendChild(btn);
+
+      btn.addEventListener('click', () => {
+        toggleService.open = true;
+      });
+
+      btn.dispatchEvent(new Event('click'));
       expect(toggleService.open).toBe(true);
-    }));
+
+      // popover should stay open if button is clicked again
+      btn.dispatchEvent(new Event('click'));
+      expect(toggleService.open).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
Signed-off-by: stsogoo <stsogoo@vmware.com>

## PR Checklist

Our current popover outside click listener was implemented in a way too complex way. This was partly due to the fact we tried to listen to outside clicks during the bubbling/bubble-up phase. 

This PR sets the outside click listener to the capture phase. With this solution, we don't need to track elements or events we should ignore. It could directly check if the event originates from the host element or one of its children elements (in that case it doesn't try to change `toggle.open`). Also, we could avoid setTimeout solution when a popover is opened by an outside element.

When an outside element's click event triggers a popover, the event first sets the `toggle.open` to true, and then the event bubbles up to document (the root of the dom) to which our outside click listener would be attached so it instantly responds and sets `toggle.open` back to false. With a listener with useCapture, we can capture the event first and then sets the property `toggle.open` so this could help us avoid the instant switch on-and-off issue of the popover.

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
