### PR TITLE
docs: fix vue component for parsing core api key/values

### DIFF
--- a/apps/website/.vuepress/public/versions.json
+++ b/apps/website/.vuepress/public/versions.json
@@ -1,5 +1,6 @@
 [
-  { "version": "v12", "url": "https://angular.clarity.design" },
+  { "version": "v13", "url": "https://angular.clarity.design" },
+  { "version": "v12", "url": "https://v12.clarity.design" },
   { "version": "v5", "url": "https://v5.clarity.design" },
   { "version": "v4", "url": "https://v4.clarity.design/documentation" },
   { "version": "v3", "url": "https://v3.clarity.design" },

--- a/apps/website/.vuepress/theme/global-components/DocWebComponentAPI.vue
+++ b/apps/website/.vuepress/theme/global-components/DocWebComponentAPI.vue
@@ -77,7 +77,7 @@ export default {
   props: ['component'],
   data: function () {
     const CustomElement = API.modules
-      .filter(module => module.path.includes('element.d.ts'))
+      .filter(module => module.path.includes('element.js'))
       .find(
         module =>
           module.declarations &&

--- a/scripts/website.sh
+++ b/scripts/website.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Make sre the environment is ready before the deploy command.
+sleep 5
+
 echo "Deploy a preview that can be promoted to clarity.design when we are ready"
 # Deploy a preview that can be promoted to production when we are ready
 ./node_modules/.bin/netlify deploy --json --dir=./dist/website --message="Website - $GITHUB_REF@$GITHUB_SHA" --site "clarity.design"


### PR DESCRIPTION
Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Website web-component api pages are missing api information. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
The wca output for custom-elements.json recently changed. The website theme has DocWebComponentAPI vue component that finds and renders a components api info. THis updates that in order to find the public API bits and render them on a component api page. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
