### PR TITLE
Updated the close icon's name

### DIFF
--- a/apps/website/.vuepress/code/demos/app-layout/content-container-ng.html
+++ b/apps/website/.vuepress/code/demos/app-layout/content-container-ng.html
@@ -14,7 +14,7 @@
       </div>
     </div>
     <button type="button" class="close" aria-label="Close">
-      <cds-icon aria-hidden="true" shape="close"></cds-icon>
+      <cds-icon aria-hidden="true" shape="window-close"></cds-icon>
     </button>
   </div>
   <header class="header header-6">


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [x] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The close icon on the angular App Layout example code does not load, because it uses the wrong shape name. It uses shape='close', but the correct shape name is 'window-close'.

Issue Number: N/A

## What is the new behavior?

The close icon on the angular App Layout example code DOES load. 


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
