### PR TITLE
fix(password): add screen-reader only text for password hide/show button

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -479,6 +479,8 @@ export interface ClrCommonStrings {
     next: string;
     nextPage: string;
     open: string;
+    passwordHide: string;
+    passwordShow: string;
     pickColumns: string;
     previous: string;
     previousPage: string;

--- a/projects/angular/src/forms/password/password-container.spec.ts
+++ b/projects/angular/src/forms/password/password-container.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -94,6 +94,13 @@ export default function (): void {
         fixture.componentInstance.toggler = false;
         fixture.detectChanges();
         expect(containerEl.querySelector('button')).toBeFalsy();
+      });
+      it('should provide screen-reader only text for toggle button', () => {
+        const button: HTMLButtonElement = containerEl.querySelector('button');
+        expect(button.textContent).toEqual('Show password');
+        button.click();
+        fixture.detectChanges();
+        expect(button.textContent).toEqual('Hide password');
       });
     });
   });

--- a/projects/angular/src/forms/password/password-container.ts
+++ b/projects/angular/src/forms/password/password-container.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -43,6 +43,9 @@ export const TOGGLE_SERVICE_PROVIDER = { provide: TOGGLE_SERVICE, useFactory: To
               [attr.shape]="show ? 'eye-hide' : 'eye'"
               [attr.title]="show ? commonStrings.keys.hide : commonStrings.keys.show"
             ></cds-icon>
+            <span class="clr-sr-only">{{
+              show ? commonStrings.keys.passwordHide : commonStrings.keys.passwordShow
+            }}</span>
           </button>
         </div>
         <cds-icon

--- a/projects/angular/src/utils/i18n/common-strings.default.ts
+++ b/projects/angular/src/utils/i18n/common-strings.default.ts
@@ -91,4 +91,11 @@ export const commonStringsDefault: ClrCommonStrings = {
   // Wizard
   wizardStepSuccess: 'Completed',
   wizardStepError: 'Error',
+
+  /**
+   * Password Input
+   * Screen-reader text for the hide/show password field button
+   */
+  passwordHide: 'Hide password',
+  passwordShow: 'Show password',
 };

--- a/projects/angular/src/utils/i18n/common-strings.interface.ts
+++ b/projects/angular/src/utils/i18n/common-strings.interface.ts
@@ -255,4 +255,11 @@ export interface ClrCommonStrings {
    * Wizard: Screen-reader text for step with error.
    */
   wizardStepError: string;
+
+  /**
+   * Password Input
+   * Screen-reader text for the hide/show password field button.
+   */
+  passwordHide: string;
+  passwordShow: string;
 }


### PR DESCRIPTION
Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?
This is an update to the Angular form password  control. It adds screen reader only text to the password hide/show button. In addition it also adds the text to the common strings service so that consumers can override or customize as needed. 

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Screen readers cannot read the password hide/show button title. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Screen readers can read the `.clr-sr-only` text inside the password hide/show button. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
