### PR TITLE
docs: add screen reader labels to badge examples

### DIFF
--- a/projects/website/src/app/documentation/demos/badges/badge-colors.demo.html
+++ b/projects/website/src/app/documentation/demos/badges/badge-colors.demo.html
@@ -1,21 +1,21 @@
 <!--
-  ~ Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
 
 <div class="clr-example">
   <div>
-    <span class="badge">1</span>
-    <span class="badge badge-purple">15</span>
-    <span class="badge badge-blue">2</span>
-    <span class="badge badge-orange">3</span>
-    <span class="badge badge-light-blue">12</span>
-    <span class="badge badge-1">90</span>
-    <span class="badge badge-2">51</span>
-    <span class="badge badge-3">25</span>
-    <span class="badge badge-4">32</span>
-    <span class="badge badge-5">57</span>
+    <span class="badge">1 <span class="clr-sr-only">item in a badge</span></span>
+    <span class="badge badge-purple">15 <span class="clr-sr-only">items in a purple badge</span></span>
+    <span class="badge badge-blue">2 <span class="clr-sr-only">items in a blue badge</span></span>
+    <span class="badge badge-orange">3 <span class="clr-sr-only">items in an orange badge</span></span>
+    <span class="badge badge-light-blue">12 <span class="clr-sr-only">items in a light blue badge</span></span>
+    <span class="badge badge-1">90 <span class="clr-sr-only">items in a badge</span></span>
+    <span class="badge badge-2">51 <span class="clr-sr-only">items in a purple badge</span></span>
+    <span class="badge badge-3">25 <span class="clr-sr-only">items in a blue badge</span></span>
+    <span class="badge badge-4">32 <span class="clr-sr-only">items in an orange badge</span></span>
+    <span class="badge badge-5">57 <span class="clr-sr-only">items in a light blue badge</span></span>
   </div>
 </div>
 <clr-code-snippet [clrCode]="htmlExample"></clr-code-snippet>

--- a/projects/website/src/app/documentation/demos/badges/badge-colors.ts
+++ b/projects/website/src/app/documentation/demos/badges/badge-colors.ts
@@ -1,21 +1,21 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { Component } from '@angular/core';
 
 const HTML_EXAMPLE = `
-<span class="badge">1</span>
-<span class="badge badge-purple">15</span>
-<span class="badge badge-blue">2</span>
-<span class="badge badge-orange">3</span>
-<span class="badge badge-light-blue">12</span>
-<span class="badge badge-1">90</span>
-<span class="badge badge-2">51</span>
-<span class="badge badge-3">25</span>
-<span class="badge badge-4">32</span>
-<span class="badge badge-5">57</span>
+<span class="badge">1 <span class="clr-sr-only">item in a badge</span></span>
+<span class="badge badge-purple">15 <span class="clr-sr-only">items in a purple badge</span></span>
+<span class="badge badge-blue">2 <span class="clr-sr-only">items in a blue badge</span></span>
+<span class="badge badge-orange">3 <span class="clr-sr-only">items in an orange badge</span></span>
+<span class="badge badge-light-blue">12 <span class="clr-sr-only">items in a light blue badge</span></span>
+<span class="badge badge-1">90 <span class="clr-sr-only">items in a badge</span></span>
+<span class="badge badge-2">51 <span class="clr-sr-only">items in a purple badge</span></span>
+<span class="badge badge-3">25 <span class="clr-sr-only">items in a blue badge</span></span>
+<span class="badge badge-4">32 <span class="clr-sr-only">items in an orange badge</span></span>
+<span class="badge badge-5">57 <span class="clr-sr-only">items in a light blue badge</span></span>
 `;
 
 @Component({

--- a/projects/website/src/app/documentation/demos/badges/badge-statuses.demo.html
+++ b/projects/website/src/app/documentation/demos/badges/badge-statuses.demo.html
@@ -1,13 +1,13 @@
 <!--
-  ~ Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
 
 <div class="clr-example">
-  <span class="badge badge-info">2</span>
-  <span class="badge badge-success">3</span>
-  <span class="badge badge-warning">12</span>
-  <span class="badge badge-danger">15</span>
+  <span class="badge badge-info">2 <span class="clr-sr-only">items in an info badge</span></span>
+  <span class="badge badge-success">3 <span class="clr-sr-only">items in a sucess badge</span></span>
+  <span class="badge badge-warning">12 <span class="clr-sr-only">items in a warning badge</span></span>
+  <span class="badge badge-danger">15 <span class="clr-sr-only">items in a danger badge</span></span>
 </div>
 <clr-code-snippet [clrCode]="htmlExample"></clr-code-snippet>

--- a/projects/website/src/app/documentation/demos/badges/badge-statuses.ts
+++ b/projects/website/src/app/documentation/demos/badges/badge-statuses.ts
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { Component } from '@angular/core';
 
 const HTML_EXAMPLE = `
-<span class="badge badge-info">2</span>
-<span class="badge badge-success">3</span>
-<span class="badge badge-warning">12</span>
-<span class="badge badge-danger">15</span>
+<span class="badge badge-info">2 <span class="clr-sr-only">items in an info badge</span></span>
+<span class="badge badge-success">3 <span class="clr-sr-only">items in a sucess badge</span></span>
+<span class="badge badge-warning">12 <span class="clr-sr-only">items in a warning badge</span></span>
+<span class="badge badge-danger">15 <span class="clr-sr-only">items in a danger badge</span></span>
 `;
 
 @Component({

--- a/projects/website/src/app/documentation/demos/badges/badges.demo.html
+++ b/projects/website/src/app/documentation/demos/badges/badges.demo.html
@@ -24,7 +24,7 @@
                 <clr-tree>
                   <clr-tree-node>
                     <div class="margin-right-0_25">Inbox</div>
-                    <span class="badge badge-info">1 </span>
+                    <span class="badge badge-info">1 <span class="clr-sr-only">item in inbox</span></span>
                     <ng-template [(clrIfExpanded)]="expanded">
                       <clr-tree-node> New Email 1 </clr-tree-node>
                     </ng-template>
@@ -54,10 +54,15 @@
           <div class="clrweb-DoxMedia has-h4-margin">
             <div class="clr-demo-container">
               <div class="clr-row">
-                <div class="clr-col-12"><b>Notifications</b> <span class="badge badge-info">12</span></div>
+                <div class="clr-col-12">
+                  <b>Notifications</b>
+                  <span class="badge badge-info">12 <span class="clr-sr-only">notifications</span></span>
+                </div>
               </div>
               <div class="clr-row">
-                <div class="clr-col-12"><b>Alerts</b> <span class="badge badge-danger">12</span></div>
+                <div class="clr-col-12">
+                  <b>Alerts</b> <span class="badge badge-danger">12 <span class="clr-sr-only">alerts</span></span>
+                </div>
               </div>
             </div>
           </div>
@@ -83,11 +88,11 @@
               <div class="clrweb-DoxMedia-img">
                 <span class="label label-orange">
                   London (Location)
-                  <span class="badge badge-orange">14</span>
+                  <span class="badge badge-orange">14 <span class="clr-sr-only">items</span></span>
                 </span>
                 <span class="label label-orange">
                   Austin (Location)
-                  <span class="badge badge-orange">99+</span>
+                  <span class="badge badge-orange">99+ <span class="clr-sr-only">items</span></span>
                 </span>
               </div>
             </div>


### PR DESCRIPTION
Signed-off-by: Ashley Ryan <asryan@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The badge examples have no screen reader text indicating the status of the badge

Issue Number: N/A

## What is the new behavior?

Add screen reader text indicating the status of the badges

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
