### PR TITLE
fix(wizard): poc for focus issue after nav item click

### DIFF
--- a/projects/angular/src/wizard/providers/wizard-navigation.service.spec.ts
+++ b/projects/angular/src/wizard/providers/wizard-navigation.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -10,6 +10,7 @@ import { ClrWizard } from '../wizard';
 
 import { PageCollectionService } from './page-collection.service';
 import { WizardNavigationService } from './wizard-navigation.service';
+import { ClrWizardPage } from '../wizard-page';
 
 export default function (): void {
   describe('Wizard Navigation Service', function () {
@@ -318,6 +319,18 @@ export default function (): void {
       expect(secondPage.completed).toBe(true, 'validate secondPage.completed was turned true as expected');
       expect(thirdPage.completed).toBe(false, 'validate thirdPage.completed is still false as expected');
       expect(fourthPage.completed).toBe(false, 'validate fourthPage.completed is still false as expected');
+    });
+
+    it('.goTo() should emit the current page for navItemChanged subject', function () {
+      // const startPage = wizardNavigationService.pageCollection.getPageByIndex(0);
+      const secondPage = wizardNavigationService.pageCollection.getPageByIndex(1);
+      let pageTest: ClrWizardPage;
+      wizardNavigationService.currentPageChanged.subscribe(page => (pageTest = page));
+
+      expect(pageTest).toBeUndefined();
+      wizardNavigationService.goTo(secondPage, true);
+      context.detectChanges();
+      expect(pageTest).toBe(secondPage);
     });
 
     it('.setFirstPageCurrent() should set the first page as the current page', function () {

--- a/projects/angular/src/wizard/providers/wizard-navigation.service.ts
+++ b/projects/angular/src/wizard/providers/wizard-navigation.service.ts
@@ -5,8 +5,7 @@
  */
 
 import { Injectable, OnDestroy, TemplateRef } from '@angular/core';
-import { Observable } from 'rxjs';
-import { Subject } from 'rxjs';
+import { Subject, Observable } from 'rxjs';
 import { Subscription } from 'rxjs';
 
 import { ClrWizardPage } from '../wizard-page';

--- a/projects/angular/src/wizard/wizard-page.ts
+++ b/projects/angular/src/wizard/wizard-page.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */

--- a/projects/angular/src/wizard/wizard.spec.ts
+++ b/projects/angular/src/wizard/wizard.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -756,6 +756,22 @@ export default function (): void {
     });
 
     describe('View and Behavior', () => {
+      let context: TestContext<ClrWizard, TemplateApiWizardTestComponent>;
+      let wizard: ClrWizard;
+
+      beforeEach(function () {
+        context = this.create(ClrWizard, TemplateApiWizardTestComponent);
+        wizard = context.clarityDirective;
+        context.detectChanges();
+      });
+      describe('Page title focus', () => {
+        it('should be placed on the page title after page change', () => {
+          wizard.pageCollection.lastPage.makeCurrent();
+          context.detectChanges();
+          const titleString = context.hostElement.querySelector('.modal-title').textContent.trim();
+          expect(titleString).toEqual(document.activeElement.textContent.trim());
+        });
+      });
       describe('Close X', () => {
         xit('shows up by default');
 

--- a/projects/angular/src/wizard/wizard.ts
+++ b/projects/angular/src/wizard/wizard.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -434,7 +434,6 @@ export class ClrWizard implements OnDestroy, AfterContentInit, DoCheck {
     if (!pageId) {
       return;
     }
-
     this.navService.goTo(pageId);
   }
 
@@ -471,7 +470,13 @@ export class ClrWizard implements OnDestroy, AfterContentInit, DoCheck {
   }
 
   private listenForPageChanges(): Subscription {
-    return this.navService.currentPageChanged.subscribe(() => this.currentPageChanged.emit());
+    return this.navService.currentPageChanged.subscribe(() => {
+      // Added to address VPAT-749:
+      //   When clicking on a wizard tab, focus should move to that
+      //   tabs content to make the wizard more accessible.
+      this.wizardTitle?.nativeElement.focus();
+      this.currentPageChanged.emit();
+    });
   }
 
   private updateNavOnPageChanges(): void {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
When the ClrWizard component is opened focus is moved directly to the page title. When a user interacts with the wizard and clicks on a nvigation item or a page button that causes the page to change, focus stays on the clicked element. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4211 

## What is the new behavior?
After user interaction that changes the wizard page (content) focus will be moved to the page title element to make it more accessible. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
