### PR TITLE
fix(tree-view): remove duplicate aria roll from treenode

### DIFF
--- a/projects/angular/src/data/tree-view/tree-node.spec.ts
+++ b/projects/angular/src/data/tree-view/tree-node.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -338,7 +338,8 @@ export default function (): void {
         contentContainer = this.clarityElement.querySelector('.clr-tree-node-content-container');
       });
 
-      it('adds role treeitem to node content container by default', function (this: Context) {
+      it('adds role treeitem to focusable div that contains node content', function (this: Context) {
+        expect(this.clarityElement.hasAttribute('role')).toBe(false, 'no duplicate treeitem role on parent');
         expect(contentContainer.getAttribute('role')).toBe('treeitem');
       });
 

--- a/projects/angular/src/data/tree-view/tree-node.ts
+++ b/projects/angular/src/data/tree-view/tree-node.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -59,7 +59,6 @@ const LVIEW_CONTEXT_INDEX = 8;
     ]),
   ],
   host: {
-    '[attr.role]': '"treeitem"',
     '[class.clr-tree-node]': 'true',
   },
 })

--- a/projects/website/src/sitemap.xml
+++ b/projects/website/src/sitemap.xml
@@ -317,6 +317,10 @@
         <changefreq>daily</changefreq>
     </url>
     <url>
+        <loc>https://clarity.design/news/src/releases/12.x/12.0.11.html</loc>
+        <changefreq>daily</changefreq>
+    </url>
+    <url>
         <loc>https://clarity.design/news/src/releases/12.x/12.0.10.html</loc>
         <changefreq>daily</changefreq>
     </url>


### PR DESCRIPTION
Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: ..from a11y list

## What is the new behavior?

The aria role now only exists on the tree-node's focusable content container. Previously, both the content container of the tree item and its parent angular component had the same role. This was a problem for the a11y team's automated tests.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
