### PR TITLE
fix(angular:datagrid):  backport - fix typo in commonstrings

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -378,6 +378,10 @@ export interface ClrCommonStrings {
     current: string;
     currentPage: string;
     danger: string;
+    datagridExpandableBeginningOf?: string;
+    datagridExpandableEndOf?: string;
+    datagridExpandableRowContent?: string;
+    datagridExpandableRowsHelperText?: string;
     datagridFilterAriaLabel?: string;
     datagridFilterDialogAriaLabel?: string;
     dategridExpandableBeginningOf?: string;

--- a/projects/angular/src/data/datagrid/datagrid-row-detail.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-row-detail.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -53,15 +53,22 @@ export default function (): void {
       const commonStrings = new ClrCommonStringsService();
       const rows: HTMLElement[] = context.clarityElement.querySelectorAll('.clr-sr-only');
 
+      // TODO: @deprecated - dategrid* keys are deprecated. Remove in v14.
       const first = [
         commonStrings.keys.dategridExpandableBeginningOf,
         commonStrings.keys.dategridExpandableRowContent,
         commonStrings.keys.dategridExpandableRowsHelperText,
+        commonStrings.keys.dategridExpandableBeginningOf || commonStrings.keys.datagridExpandableBeginningOf,
+        commonStrings.keys.dategridExpandableRowContent || commonStrings.keys.datagridExpandableRowContent,
+        commonStrings.keys.dategridExpandableRowsHelperText || commonStrings.keys.datagridExpandableRowsHelperText,
       ];
-      const last = [commonStrings.keys.dategridExpandableEndOf, commonStrings.keys.dategridExpandableRowContent];
+      const last = [
+        commonStrings.keys.dategridExpandableEndOf || commonStrings.keys.datagridExpandableEndOf,
+        commonStrings.keys.dategridExpandableRowContent || commonStrings.keys.datagridExpandableRowContent,
+      ];
 
-      expect(rows[0].innerText).toBe(first.join(' '));
-      expect(rows[1].innerText).toBe(last.join(' '));
+      expect(rows[0].innerText.trim()).toBe(first.join(' ').trim());
+      expect(rows[1].innerText.trim()).toBe(last.join(' ').trim());
     });
 
     it('should add id to the root element', function () {

--- a/projects/angular/src/data/datagrid/datagrid-row-detail.ts
+++ b/projects/angular/src/data/datagrid/datagrid-row-detail.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -20,9 +20,11 @@ import { ClrCommonStringsService } from '../../utils/i18n/common-strings.service
  */
 @Component({
   selector: 'clr-dg-row-detail',
+  // TODO: @deprecated - dategrid* keys are deprecated. Remove in v14.
   template: `
     <div class="clr-sr-only">
-      {{ beginningOfExpandableContentAriaText }} {{ commonStrings.keys.dategridExpandableRowsHelperText }}
+      {{ beginningOfExpandableContentAriaText }}
+      {{ commonStrings.keys.dategridExpandableRowsHelperText || commonStrings.keys.datagridExpandableRowsHelperText }}
     </div>
     <ng-content></ng-content>
     <div class="clr-sr-only">{{ endOfExpandableContentAriaText }}</div>
@@ -67,19 +69,25 @@ export class ClrDatagridRowDetail implements AfterContentInit, OnDestroy {
     this.subscriptions.forEach(sub => sub.unsubscribe());
   }
 
+  // TODO: @deprecated - dategrid* keys are deprecated. Remove in v14.
   @Input('clrRowDetailBeginningAriaText') _beginningOfExpandableContentAriaText: string;
   public get beginningOfExpandableContentAriaText() {
     return (
       this._beginningOfExpandableContentAriaText ||
-      `${this.commonStrings.keys.dategridExpandableBeginningOf} ${this.commonStrings.keys.dategridExpandableRowContent}`
+      `${
+        this.commonStrings.keys.dategridExpandableBeginningOf || this.commonStrings.keys.datagridExpandableBeginningOf
+      } 
+      ${this.commonStrings.keys.dategridExpandableRowContent || this.commonStrings.keys.datagridExpandableRowContent}`
     );
   }
 
+  // TODO: @deprecated - dategrid* keys are deprecated. Remove in v14.
   @Input('clrRowDetailEndAriaText') _endOfExpandableContentAriaText: string;
   public get endOfExpandableContentAriaText() {
     return (
       this._endOfExpandableContentAriaText ||
-      `${this.commonStrings.keys.dategridExpandableEndOf} ${this.commonStrings.keys.dategridExpandableRowContent}`
+      `${this.commonStrings.keys.dategridExpandableEndOf || this.commonStrings.keys.datagridExpandableEndOf} 
+      ${this.commonStrings.keys.dategridExpandableRowContent || this.commonStrings.keys.datagridExpandableRowContent}`
     );
   }
 }

--- a/projects/angular/src/utils/i18n/common-strings.default.ts
+++ b/projects/angular/src/utils/i18n/common-strings.default.ts
@@ -84,8 +84,8 @@ export const commonStringsDefault: ClrCommonStrings = {
   comboboxNoResults: 'No results',
   comboboxOpen: 'Show options',
   // Datagrid expandable rows
-  dategridExpandableBeginningOf: 'Beginning of',
-  dategridExpandableEndOf: 'End of',
-  dategridExpandableRowContent: 'Expandable row content',
-  dategridExpandableRowsHelperText: `Screen reader table commands may not work for viewing expanded content, please use your screen reader's browse mode to read the content exposed by this button`,
+  datagridExpandableBeginningOf: 'Beginning of',
+  datagridExpandableEndOf: 'End of',
+  datagridExpandableRowContent: 'Expandable row content',
+  datagridExpandableRowsHelperText: `Screen reader table commands may not work for viewing expanded content, please use your screen reader's browse mode to read the content exposed by this button`,
 };

--- a/projects/angular/src/utils/i18n/common-strings.interface.ts
+++ b/projects/angular/src/utils/i18n/common-strings.interface.ts
@@ -231,10 +231,26 @@ export interface ClrCommonStrings {
   timelineStepProcessing: string;
 
   // Datagrid Helper text for expandable rows
+  /**
+   * @deprecated Should be removed in v14
+   */
   dategridExpandableBeginningOf?: string;
+  /**
+   * @deprecated Should be removed in v14
+   */
   dategridExpandableEndOf?: string;
+  /**
+   * @deprecated Should be removed in v14
+   */
   dategridExpandableRowContent?: string;
+  /**
+   * @deprecated Should be removed in v14
+   */
   dategridExpandableRowsHelperText?: string;
+  datagridExpandableBeginningOf?: string;
+  datagridExpandableEndOf?: string;
+  datagridExpandableRowContent?: string;
+  datagridExpandableRowsHelperText?: string;
 
   /**
    * Combobox Searching Text

--- a/projects/website/src/app/documentation/demos/i18n/i18n.demo.ts
+++ b/projects/website/src/app/documentation/demos/i18n/i18n.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -132,19 +132,19 @@ export class I18nDemo extends ClarityDocComponent {
     { key: 'timelineStepError', role: 'Used in the aria-label for the error step icon' },
     { key: 'timelineStepProcessing', role: 'Used in the aria-label for the processing step icon' },
     {
-      key: 'dategridExpandableBeginningOf',
+      key: 'datagridExpandableBeginningOf',
       role: 'Beginning of expandable row',
     },
     {
-      key: 'dategridExpandableEndOf',
+      key: 'datagridExpandableEndOf',
       role: 'End of expandable row',
     },
     {
-      key: 'dategridExpandableRowContent',
+      key: 'datagridExpandableRowContent',
       role: 'Describe expandable content region',
     },
     {
-      key: 'dategridExpandableRowsHelperText',
+      key: 'datagridExpandableRowsHelperText',
       role: 'Provide helper text related to expandable rows Accessibility limitation inside the Datagrid',
     },
   ];


### PR DESCRIPTION
• deprecated old typo'd dategrid* common strings

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
