### PR TITLE
(backport) fix(alert): replace title with aria-label on icon

### DIFF
--- a/projects/angular/src/emphasis/alert/alert-item.ts
+++ b/projects/angular/src/emphasis/alert/alert-item.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -13,8 +13,9 @@ import { AlertIconAndTypesService } from './providers/icon-and-types.service';
     <div class="alert-icon-wrapper">
       <cds-icon
         class="alert-icon"
+        role="img"
         [attr.shape]="iconService.alertIconShape"
-        [attr.title]="iconService.alertIconTitle"
+        [attr.aria-label]="iconService.alertIconTitle"
       ></cds-icon>
     </div>
     <ng-content></ng-content>

--- a/projects/angular/src/emphasis/alert/alerts.spec.ts
+++ b/projects/angular/src/emphasis/alert/alerts.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -208,6 +208,15 @@ export default function () {
         // no tests for unexpected/unrecognized values because the alert types service ignores them
         // and only changes an alert type when given a known value.
       });
+
+      it('sets an aria label on the icon', function () {
+        const myAlert: ClrAlert = fixture.componentInstance.alertsInstance.currentAlert;
+        myAlert.alertType = 'warning';
+        fixture.detectChanges();
+
+        const icon: Element = fixture.nativeElement.querySelector('cds-icon[role="img"]');
+        expect(icon.getAttribute('aria-label')).toEqual('Warning');
+      });
     });
 
     describe('Supports dynamic alerts', function () {
@@ -236,9 +245,9 @@ export default function () {
         [clrAlertClosed]="false"
         [clrAlertAppLevel]="true"
       >
-        <div class="alert-item">
+        <clr-alert-item>
           <span class="alert-text"> This is the first alert! </span>
-        </div>
+        </clr-alert-item>
       </clr-alert>
       <clr-alert
         [clrAlertType]="'alert-danger'"
@@ -246,9 +255,9 @@ export default function () {
         [clrAlertClosed]="false"
         [clrAlertAppLevel]="true"
       >
-        <div class="alert-item">
+        <clr-alert-item>
           <span class="alert-text"> This is the second alert! </span>
-        </div>
+        </clr-alert-item>
       </clr-alert>
     </clr-alerts>
   `,


### PR DESCRIPTION
Signed-off-by: Ashley Ryan <asryan@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The icon used a `title` attribute to denote the status of the alert, which is not accessible to keyboard users. 

## What is the new behavior?

The icon has `role="img"` and uses `aria-label` to match Core Alerts behavior: https://clarity.design/storybook/core/?path=/story/components-alert--page

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
