### PR TITLE
fix(accordion): remove role=modal

### DIFF
--- a/projects/angular/src/accordion/accordion-panel.html
+++ b/projects/angular/src/accordion/accordion-panel.html
@@ -3,7 +3,7 @@
     <ng-container *ngIf="panel.status === AccordionStatus.Error">{{commonStrings.keys.danger}}</ng-container>
   </div>
 
-  <div role="group" [ngClass]="getPanelStateClasses(panel)">
+  <div [ngClass]="getPanelStateClasses(panel)">
     <div class="clr-accordion-header">
       <button
         type="button"

--- a/projects/angular/src/accordion/accordion-panel.spec.ts
+++ b/projects/angular/src/accordion/accordion-panel.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -246,7 +246,7 @@ describe('ClrAccordionPanel', () => {
     });
 
     it('should get the appropriate panel class based on current panel state', () => {
-      const panelGroup = panelElement.querySelector('[role="group"]');
+      const panelGroup = panelElement.querySelector('[class*=clr-accordion-panel]');
       const headerButton = panelElement.querySelector('button');
 
       expect(panelGroup.classList.contains('clr-accordion-panel-inactive')).toBe(true);
@@ -257,6 +257,11 @@ describe('ClrAccordionPanel', () => {
 
       expect(panelGroup.classList.contains('clr-accordion-panel-inactive')).toBe(true);
       expect(panelGroup.classList.contains('clr-accordion-panel-open')).toBe(true);
+    });
+
+    it('should not have the [role]="group" attribute', () => {
+      const panelGroup = panelElement.querySelector('[role="group"]');
+      expect(panelGroup).toBeNull('clr-accordion-panels should not have a role');
     });
 
     it('should apply the appropriate class to header if the header has a description', () => {


### PR DESCRIPTION
This PR is a back port of the issue fixed on next. 

The VMware accessibility team identified the role=modal attribute on panel divs
as a violation for VMware specific accessibility criteria. This change removes
the role=group attribute from clr-accordion-panel divs template element.

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Accordion panels have the attribute role="model" on one of the container divs. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
This change removes the role attribute from the accordion panel div container. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
