### PR TITLE
fix: render cds-alert-actions in safari

### DIFF
--- a/packages/core/src/alert/alert.element.scss
+++ b/packages/core/src/alert/alert.element.scss
@@ -20,13 +20,6 @@ $lightweight-alert-line-height: $cds-global-typography-body-line-height;
   color: var(--color);
 }
 
-:host([_type='default']) ::slotted(cds-alert-actions),
-:host([_type='banner']) ::slotted(cds-alert-actions) {
-  --action-size: calc(var(--min-height) - #{$cds-global-space-4});
-  white-space: nowrap;
-  display: block;
-}
-
 :host([_type='banner']) {
   --icon-size: #{$cds-global-space-9};
 }
@@ -70,6 +63,13 @@ cds-internal-close-button {
   --action-text-color: var(--color);
   --action-size: #{$lightweight-alert-line-height};
   display: none;
+}
+
+:host([_type='default']) ::slotted(cds-alert-actions),
+:host([_type='banner']) ::slotted(cds-alert-actions) {
+  --action-size: calc(var(--min-height) - #{$cds-global-space-4});
+  white-space: nowrap;
+  display: block;
 }
 
 :host([_type='default']) cds-internal-close-button {


### PR DESCRIPTION
Signed-off-by: stsogoo <stsogoo@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

This fixes the rendering issue of cds-alert-actions in Safari.

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: vpat-8333

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Before:
<img width="974" alt="Screen Shot 2022-02-11 at 10 02 26 AM" src="https://user-images.githubusercontent.com/3958008/153645604-32499b06-1e03-4731-8af8-bfe5b55d56bb.png">
After:
<img width="972" alt="Screen Shot 2022-02-11 at 10 03 06 AM" src="https://user-images.githubusercontent.com/3958008/153645613-652f37db-5283-412f-834c-6cd6d92c1c7f.png">

