### PR TITLE
build: provide tools to validate release and prevent missing packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,11 +59,12 @@
     "build:ci": "npm-run-all build:release build:website build:dev",
     "release:setversion": "node ./scripts/set-version.js",
     "release:add-release-notes": "node ./scripts/website-add-rel-notes.js",
-    "publish": "npm publish ./dist/clr-angular; npm publish ./dist/clr-ui; npm publish ./dist/clr-icons;",
-    "publish:rc": "npm publish ./dist/clr-angular --tag rc; npm publish ./dist/clr-ui --tag rc; npm publish ./dist/clr-icons --tag rc;",
-    "publish:next": "npm publish ./dist/clr-angular --tag next; npm publish ./dist/clr-ui --tag next; npm publish ./dist/clr-icons --tag next;",
-    "publish:local": "npm publish ./dist/clr-icons --registry http://localhost:4873 --tag local; npm publish ./dist/clr-ui --registry http://localhost:4873 --tag local; npm publish ./dist/clr-angular --registry http://localhost:4873 --tag local;",
-    "publish:verify": "node ./scripts/publish-verify.js"
+    "publish": "npm publish ./dist/clr-angular --tag clr12-lts && npm publish ./dist/clr-ui --tag clr12-lts && npm publish ./dist/clr-icons --tag clr12-lts",
+    "publish:rc": "npm publish ./dist/clr-angular --tag rc && npm publish ./dist/clr-ui --tag rc && npm publish ./dist/clr-icons --tag rc",
+    "publish:next": "npm publish ./dist/clr-angular --tag next && npm publish ./dist/clr-ui --tag next && npm publish ./dist/clr-icons --tag next",
+    "publish:local": "npm publish ./dist/clr-icons --registry http://localhost:4873 --tag local && npm publish ./dist/clr-ui --registry http://localhost:4873 --tag local && npm publish ./dist/clr-angular --registry http://localhost:4873 --tag local",
+    "publish:verify": "node ./scripts/publish-verify.js",
+    "publish:verify:registry": "node ./scripts/version-validation.js"
   },
   "private": true,
   "dependencies": {

--- a/scripts/version-validation.js
+++ b/scripts/version-validation.js
@@ -1,0 +1,44 @@
+const { spawn } = require('child_process');
+
+const packageJson = require('../package.json');
+const packages = ['@clr/angular', '@clr/icons', '@clr/ui'];
+
+console.log(`\nVerify that all packages are at the latest version and could be installed from NPM Registry.\n`);
+
+Promise.all(
+  packages.map(package => {
+    const pkg = `${package}@${packageJson.version}`;
+
+    return new Promise((resolve, reject) => {
+      const npm = spawn('npm', ['install', `${pkg}`, '--dry-run']);
+
+      console.log(`\tChecking ${pkg} ...`);
+
+      npm.on('close', code => {
+        if (code !== 0) {
+          reject([pkg, 'npm install failed']);
+        } else {
+          resolve([pkg, 'npm install succeeded']);
+        }
+      });
+    });
+  })
+)
+  .then(result => {
+    console.log(`\n`);
+    result.forEach(res => {
+      console.log(`\tOK : ${res[0]}`);
+    });
+    console.log('\n✅ Verification successful.');
+  })
+  .catch(error => {
+    if (error && Array.isArray(error)) {
+      console.log('\n\nOne or more packages failed verification.\n');
+      console.log(`\tPackage: ${error[0]} was not found into NPM Registry`);
+    }
+    console.log('\n❌ Verification failed.');
+    process.exit(1);
+  })
+  .then(() => {
+    process.exit(0);
+  });


### PR DESCRIPTION
Small changes on the `publish` tasks:

* Replace the `;` with `&&` - this way we expect every sub-command to pass and we gonna break at the first failed command. 
* Provide script to validate based on the `package.json` version - are all packages publish and could be installed if needed (`--dry-run`)
* Set `clr12-lts` tag, when publishing packages - this way we no longer require to make the release from the oldest version to the newer.

The issue solving here is mainly the use of `&&` and expecting all sub-task to pass and try to stop before publishing broken packages.

