### PR TITLE
a11y(angular:timeline): remove aria-current announcement

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,9 +1,12 @@
+const commitLintConfig = require('@commitlint/config-conventional');
+
 const scopes = [
   'angular',
   'angular:form',
   'angular:schematics',
   'angular:datagrid',
   'angular:vertical-nav',
+  'angular:timeline',
   'a11y',
   'accordion',
   'alert',
@@ -55,10 +58,14 @@ const scopes = [
   'panel',
 ];
 
+// Merging what @commitlint/config-convensional has with our new two types of commit
+const types = ['a11y', 'release'].concat(commitLintConfig.rules['type-enum'][2]);
+
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'scope-enum': [2, 'always', scopes],
+    'scope-enum': [2, 'always'],
+    'type-enum': [2, 'always', types],
     'header-max-length': [2, 'always', 100],
   },
 };

--- a/projects/angular/src/timeline/timeline-step.ts
+++ b/projects/angular/src/timeline/timeline-step.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -17,13 +17,7 @@ import { isPlatformBrowser } from '@angular/common';
     <ng-content select="clr-timeline-step-header"></ng-content>
     <span class="clr-sr-only">{{ stepTitleText }}</span>
     <ng-container *ngIf="!isProcessing; else processing">
-      <cds-icon
-        [attr.status]="iconStatus"
-        [attr.shape]="iconShape"
-        [attr.aria-label]="iconAriaLabel"
-        [attr.aria-current]="iconAriaCurrent"
-      >
-      </cds-icon>
+      <cds-icon [attr.status]="iconStatus" [attr.shape]="iconShape" [attr.aria-label]="iconAriaLabel"> </cds-icon>
     </ng-container>
     <div class="clr-timeline-step-body">
       <ng-content select="clr-timeline-step-title"></ng-content>


### PR DESCRIPTION
VPAT-644

Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #4603

## What is the new behavior?

Current step is not announced twice. 

There is another fix we did for it on another component that I can't find the PR about but the case was that `aria-current` is not supported by `Firefox` and we can only use `aria-label` that works in every browser.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
