### PR TITLE
fix: include source code in source maps for webpack 5

### DIFF
--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -72,7 +72,8 @@ export default [
       dir: config.outDir,
       format: 'esm',
       sourcemap: prod,
-      sourcemapExcludeSources: true,
+      // https://github.com/vmware/clarity/issues/6695
+      sourcemapExcludeSources: false,
       minifyInternalExports: prod,
     },
     plugins: [


### PR DESCRIPTION
Fixes #6695

Signed-off-by: Ashley Ryan <asryan@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Webpack 5 using create-react-app will throw an exception when the app is startied about failing to parse source map

Issue Number: #6695

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

I tested this using `yalc` into a CRA repo where I was able to reproduce the original issue