### PR TITLE
a11y(angular:datagrid): vpat-763

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -696,7 +696,7 @@ export declare class ClrDatagridColumnSeparator implements AfterViewInit, OnDest
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrDatagridColumnSeparator, never>;
 }
 
-export declare class ClrDatagridColumnToggle {
+export declare class ClrDatagridColumnToggle implements OnDestroy {
     get allColumnsVisible(): boolean;
     set allColumnsVisible(value: boolean);
     columnSwitchId: string;
@@ -708,8 +708,9 @@ export declare class ClrDatagridColumnToggle {
     openState: boolean;
     popoverId: string;
     smartPosition: ClrPopoverPosition;
-    constructor(commonStrings: ClrCommonStringsService, columnsService: ColumnsService, columnSwitchId: string, platformId: any, zone: NgZone, popoverId: string);
+    constructor(commonStrings: ClrCommonStringsService, columnsService: ColumnsService, columnSwitchId: string, platformId: any, zone: NgZone, popoverId: string, popoverToggleService: ClrPopoverToggleService);
     allColumnsSelected(): void;
+    ngOnDestroy(): void;
     toggleColumnState(columnState: ColumnState, event: boolean): void;
     toggleSwitchPanel(): void;
     trackByFn(index: number): number;

--- a/projects/angular/src/data/datagrid/datagrid-column-toggle.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-column-toggle.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -107,6 +107,18 @@ export default function (): void {
     });
 
     describe('View', function () {
+      it('manages aria-expanded attr for toggle button', fakeAsync(function () {
+        columnToggle.toggleSwitchPanel();
+        context.detectChanges();
+        tick();
+        // expect it to have aria-expanded = true
+        const toggleBtn = document.querySelector('.column-toggle--action');
+        expect(toggleBtn.getAttribute('aria-expanded')).toBe('true');
+        columnToggle.toggleSwitchPanel();
+        context.detectChanges();
+        tick();
+        expect(toggleBtn.getAttribute('aria-expanded')).toBe('false');
+      }));
       it('toggles switch panel', fakeAsync(function () {
         context.detectChanges();
         expect(document.querySelectorAll('.column-switch').length).toBe(0);
@@ -142,30 +154,12 @@ export default function (): void {
         );
       }));
 
-      it('toggle switch must include attr.title', fakeAsync(function () {
-        columnToggle.toggleSwitchPanel();
-        context.detectChanges();
-        tick();
-        expect(document.querySelector('button.column-toggle--action').attributes['title'].value).toBe(
-          commonStringsDefault.pickColumns
-        );
-      }));
-
       it('toggle switch close button should have aria-label for close', fakeAsync(function () {
         /* Open it */
         columnToggle.toggleSwitchPanel();
         context.detectChanges();
         tick();
         expect(document.querySelector('button.toggle-switch-close-button').attributes['aria-label'].value).toBe(
-          commonStringsDefault.close
-        );
-      }));
-
-      it('toggle close switch must include attr.title', fakeAsync(function () {
-        columnToggle.toggleSwitchPanel();
-        context.detectChanges();
-        tick();
-        expect(document.querySelector('button.toggle-switch-close-button').attributes['title'].value).toBe(
           commonStringsDefault.close
         );
       }));

--- a/projects/angular/src/data/datagrid/datagrid-pagination.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-pagination.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -380,9 +380,9 @@ export default function (): void {
         expect(context.clarityElement.querySelector('.pagination-current').attributes['aria-label'].value).toBe(
           commonStrings.keys.currentPage
         );
-        expect(context.clarityElement.querySelector('.pagination-list span').attributes['aria-label'].value).toBe(
-          commonStrings.keys.totalPages
-        );
+        expect(
+          context.clarityElement.querySelector('.pagination-list span:not(.clr-sr-only)').attributes['aria-label'].value
+        ).toBe(commonStrings.keys.totalPages);
       });
     });
   });

--- a/projects/angular/src/data/datagrid/datagrid-pagination.ts
+++ b/projects/angular/src/data/datagrid/datagrid-pagination.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -38,6 +38,7 @@ import { DetailService } from './providers/detail.service';
           (click)="page.current = 1"
           [attr.aria-label]="commonStrings.keys.firstPage"
         >
+          <span class="clr-sr-only">{{ commonStrings.keys.firstPage }}</span>
           <cds-icon shape="step-forward-2" direction="down"></cds-icon>
         </button>
         <button
@@ -47,6 +48,7 @@ import { DetailService } from './providers/detail.service';
           (click)="page.current = page.current - 1"
           [attr.aria-label]="commonStrings.keys.previousPage"
         >
+          <span class="clr-sr-only">{{ commonStrings.keys.previousPage }}</span>
           <cds-icon shape="angle" direction="left"></cds-icon>
         </button>
         <input
@@ -72,6 +74,7 @@ import { DetailService } from './providers/detail.service';
           (click)="page.current = page.current + 1"
           [attr.aria-label]="commonStrings.keys.nextPage"
         >
+          <span class="clr-sr-only">{{ commonStrings.keys.nextPage }}</span>
           <cds-icon shape="angle" direction="right"></cds-icon>
         </button>
         <button
@@ -81,6 +84,7 @@ import { DetailService } from './providers/detail.service';
           (click)="page.current = page.last"
           [attr.aria-label]="commonStrings.keys.lastPage"
         >
+          <span class="clr-sr-only">{{ commonStrings.keys.lastPage }}</span>
           <cds-icon shape="step-forward-2" direction="up"></cds-icon>
         </button>
       </div>
@@ -97,6 +101,7 @@ import { DetailService } from './providers/detail.service';
           (click)="page.current = page.current - 1"
           [attr.aria-label]="commonStrings.keys.previousPage"
         >
+          <span class="clr-sr-only">{{ commonStrings.keys.previousPage }}</span>
           <cds-icon shape="angle" direction="left"></cds-icon>
         </button>
         <span>{{ page.current }}</span>
@@ -107,6 +112,7 @@ import { DetailService } from './providers/detail.service';
           (click)="page.current = page.current + 1"
           [attr.aria-label]="commonStrings.keys.nextPage"
         >
+          <span class="clr-sr-only">{{ commonStrings.keys.nextPage }}</span>
           <cds-icon shape="angle" direction="right"></cds-icon>
         </button>
       </div>


### PR DESCRIPTION
This change implements fixes for issues reported in vpat-763 report

1. Adds sibling span with button text and .clr-sr-only class
2. Adds aria-expanded attribute to the toggle button in datagrid footer

Signed-off-by: Matt Hippely <mhippely@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Screen readers do not read out button text for the hid/show feature button controls. There is a missing aria-expanded attribute on the main toggle button in the datagrid footer. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Screen readers read out the button text and for the main toggle button in datagrid footer they read out the aria-expanded attribute. 
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
