### PR TITLE
fix(wizard): modal-content was not expanding vertically

### DIFF
--- a/projects/angular/src/wizard/_wizard.clarity.scss
+++ b/projects/angular/src/wizard/_wizard.clarity.scss
@@ -72,6 +72,7 @@
       flex: 1 1 auto;
       @include css-var(color, clr-wizard-main-textColor, $clr-wizard-main-textColor, $clr-use-custom-properties);
       width: 100%;
+      min-height: 70vh;
     }
 
     .modal-footer {


### PR DESCRIPTION
Fixing #6650 

The `modal-content` was not expanding vertically - so the footer section that includes the buttons was not stick at the bottom of modal/wizard