### PR TITLE
fix(card): improve demo a11y of clr-ui cards

### DIFF
--- a/projects/angular/src/layout/_card.clarity.scss
+++ b/projects/angular/src/layout/_card.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -129,6 +129,18 @@
     @include css-var(font-weight, clr-card-title-font-weight, $clr-card-title-font-weight, $clr-use-custom-properties);
     font-size: $clr-card-title-font-size;
     letter-spacing: $clr-card-title-letter-spacing;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    &.card-header,
+    &.card-title {
+      margin-top: 0; // removes default margin from clr-ui typography styles
+    }
   }
 
   .card-text {

--- a/projects/website/src/app/documentation/demos/card/card-dropdown.html
+++ b/projects/website/src/app/documentation/demos/card/card-dropdown.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -10,7 +10,7 @@
       <div class="card">
         <div class="card-header">Header</div>
         <div class="card-block">
-          <div class="card-title">Block</div>
+          <h3 class="card-title">Block</h3>
           <div class="card-text">
             Lorem ipsum dolor sit amet, consectetur adipisicing elit. Molestias officiis temporibus quod inventore,
             minus commodi similique corrupti repellat saepe facere aliquam minima deserunt esse nemo, vel illum optio

--- a/projects/website/src/app/documentation/demos/card/card-dropdown.ts
+++ b/projects/website/src/app/documentation/demos/card/card-dropdown.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -9,24 +9,16 @@ const HTML_EXAMPLE = `
 <div class="clr-row">
     <div class="clr-col-lg-6 clr-col-12">
         <div class="card">
-            <div class="card-header">
-                Header
-            </div>
+            <h3 class="card-header">Header</h3>
             <div class="card-block">
-                <div class="card-title">
-                    Block
-                </div>
+                <h4 class="card-title">Block</h4>
                 <div class="card-text">
                     ...
                 </div>
             </div>
             <div class="card-footer">
-                <button class="btn btn-sm btn-link">
-                    Action 1
-                </button>
-                <button class="btn btn-sm btn-link">
-                    Action 2
-                </button>
+                <button class="btn btn-sm btn-link">Action 1</button>
+                <button class="btn btn-sm btn-link">Action 2</button>
                 <div class="dropdown top-left open">
                     <button class="dropdown-toggle btn btn-sm btn-link">
                         Dropdown 1

--- a/projects/website/src/app/documentation/demos/card/card-layout.html
+++ b/projects/website/src/app/documentation/demos/card/card-layout.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -8,9 +8,9 @@
   <div class="clr-row">
     <div class="clr-col-lg-5 clr-col-md-8 clr-col-12">
       <div class="card">
-        <div class="card-header">Header</div>
+        <h3 class="card-header">Header</h3>
         <div class="card-block">
-          <div class="card-title">Block</div>
+          <h4 class="card-title">Block</h4>
           <div class="card-text">
             Card content can contain text, links, images, data visualizations, lists and more.
           </div>

--- a/projects/website/src/app/documentation/demos/card/card-layout.ts
+++ b/projects/website/src/app/documentation/demos/card/card-layout.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -9,13 +9,9 @@ const HTML_EXAMPLE = `
 <div class="clr-row">
     <div class="clr-col-lg-5 clr-col-md-8 clr-col-12">
         <div class="card">
-            <div class="card-header">
-                Header
-            </div>
+            <h3 class="card-header">Header</h3>
             <div class="card-block">
-                <div class="card-title">
-                    Block
-                </div>
+                <h4 class="card-title">Block</h4>
                 <div class="card-text">
                     ...
                 </div>

--- a/projects/website/src/app/documentation/demos/card/card-media-block.html
+++ b/projects/website/src/app/documentation/demos/card/card-media-block.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -8,7 +8,7 @@
   <div class="clr-row">
     <div class="clr-col-lg-6 clr-col-12">
       <div class="card">
-        <div class="card-header">Header</div>
+        <h3>Header</h3>
         <div class="card-block">
           <div class="card-media-block">
             <img src="assets/images/documentation/cards/placeholder_60x60.png" class="card-media-image" />
@@ -30,7 +30,7 @@
     </div>
     <div class="clr-col-lg-6 clr-col-12">
       <div class="card">
-        <div class="card-header">Header</div>
+        <h3>Header</h3>
         <div class="card-block">
           <div class="card-media-block wrap">
             <img src="assets/images/documentation/cards/placeholder_60x60.png" class="card-media-image" />

--- a/projects/website/src/app/documentation/demos/card/card-media-block.ts
+++ b/projects/website/src/app/documentation/demos/card/card-media-block.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -9,19 +9,13 @@ const HTML_EXAMPLE = `
 <div class="clr-row">
     <div class="clr-col-lg-6 clr-col-12">
         <div class="card">
-            <div class="card-header">
-                Header
-            </div>
+            <h3 class="card-header">Header</h3>
             <div class="card-block">
                 <div class="card-media-block">
-                    <img src="..." class="card-media-image">
+                    <img src="..." class="card-media-image" />
                     <div class="card-media-description">
-                        <span class="card-media-title">
-                            Project A
-                        </span>
-                        <span class="card-media-text">
-                            Owner: John Doe
-                        </span>
+                        <span class="card-media-title"> Project A </span>
+                        <span class="card-media-text"> Owner: John Doe </span>
                     </div>
                 </div>
                 <div class="card-text">
@@ -35,19 +29,13 @@ const HTML_EXAMPLE = `
     </div>
     <div class="clr-col-lg-6 clr-col-12">
         <div class="card">
-            <div class="card-header">
-                Header
-            </div>
+            <h3 class="card-header">Header</h3>
             <div class="card-block">
                 <div class="card-media-block wrap">
-                    <img src="..." class="card-media-image">
+                    <img src="..." class="card-media-image" />
                     <div class="card-media-description">
-                        <span class="card-media-title">
-                            Project B
-                        </span>
-                        <span class="card-media-text">
-                            Owner: Jane Doe
-                        </span>
+                        <span class="card-media-title"> Project B </span>
+                        <span class="card-media-text"> Owner: Jane Doe </span>
                     </div>
                 </div>
                 <div class="card-text">

--- a/projects/website/src/app/documentation/demos/card/lists-in-cards.html
+++ b/projects/website/src/app/documentation/demos/card/lists-in-cards.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -8,7 +8,7 @@
   <div class="clr-row">
     <div class="clr-col-lg-4 clr-col-sm-6 clr-col-12">
       <div class="card">
-        <div class="card-header">Unordered Lists</div>
+        <h3 class="card-header">Unordered Lists</h3>
         <div class="card-block">
           Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
         </div>
@@ -43,7 +43,7 @@
     </div>
     <div class="clr-col-lg-4 clr-col-sm-6 clr-col-12">
       <div class="card">
-        <div class="card-header">Ordered Lists</div>
+        <h3 class="card-header">Ordered Lists</h3>
         <div class="card-block">
           Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
         </div>
@@ -78,7 +78,7 @@
     </div>
     <div class="clr-col-lg-4 clr-col-sm-6 clr-col-12">
       <div class="card">
-        <div class="card-header">Unstyled Lists</div>
+        <h3 class="card-header">Unstyled Lists</h3>
         <div class="card-block">
           <p class="card-text">
             Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/projects/website/src/app/documentation/demos/card/lists-in-cards.ts
+++ b/projects/website/src/app/documentation/demos/card/lists-in-cards.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -9,9 +9,7 @@ const HTML_EXAMPLE = `
 <div class="clr-row">
     <div class="clr-col-lg-4 clr-col-sm-6 clr-col-12">
         <div class="card">
-            <div class="card-header">
-                Unordered Lists
-            </div>
+            <h3 class="card-header">Unordered Lists</h3>
             <div class="card-block">
                 ...
             </div>
@@ -46,9 +44,7 @@ const HTML_EXAMPLE = `
     </div>
     <div class="clr-col-lg-4 clr-col-sm-6 clr-col-12">
         <div class="card">
-            <div class="card-header">
-                Ordered Lists
-            </div>
+            <h3 class="card-header">Ordered Lists</h3>
             <div class="card-block">
                 ...
             </div>
@@ -83,12 +79,10 @@ const HTML_EXAMPLE = `
     </div>
     <div class="clr-col-lg-4 clr-col-sm-6 clr-col-12">
         <div class="card">
-            <div class="card-header">
-                Unstyled Lists
-            </div>
+            <h3 class="card-header">Unstyled Lists</h3>
             <div class="card-block">
                 <p class="card-text">
-                    Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                    ...
                 </p>
             </div>
             <div class="card-block">

--- a/src/app/card/card-dropdown.html
+++ b/src/app/card/card-dropdown.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -8,9 +8,9 @@
   <div class="clr-row">
     <div class="clr-col-lg-6 clr-col-12">
       <div class="card">
-        <div class="card-header">Header</div>
+        <h3 class="card-header">Header</h3>
         <div class="card-block">
-          <div class="card-title">Block</div>
+          <h4 class="card-title">Block</h4>
           <div class="card-text">
             Lorem ipsum dolor sit amet, consectetur adipisicing elit. Molestias officiis temporibus quod inventore,
             minus commodi similique corrupti repellat saepe facere aliquam minima deserunt esse nemo, vel illum optio

--- a/src/app/card/card-layout.html
+++ b/src/app/card/card-layout.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -8,9 +8,9 @@
   <div class="clr-row">
     <div class="clr-col-lg-5 clr-col-md-8 clr-col-12">
       <div class="card">
-        <div class="card-header">Header</div>
+        <h3 class="card-header">Header</h3>
         <div class="card-block">
-          <div class="card-title">Block</div>
+          <h4 class="card-title">Block</h4>
           <div class="card-text">
             Card content can contain text, links, images, data visualizations, lists and more.
           </div>

--- a/src/app/card/card-media-block.html
+++ b/src/app/card/card-media-block.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -8,7 +8,7 @@
   <div class="clr-row">
     <div class="clr-col-lg-6 clr-col-12">
       <div class="card">
-        <div class="card-header">Header</div>
+        <h3 class="card-header">Header</h3>
         <div class="card-block">
           <div class="card-media-block">
             <img src="assets/placeholder_60x60.png" />
@@ -30,7 +30,7 @@
     </div>
     <div class="clr-col-lg-6 clr-col-12">
       <div class="card">
-        <div class="card-header">Header</div>
+        <h3 class="card-header">Header</h3>
         <div class="card-block">
           <div class="card-media-block wrap">
             <img src="assets/placeholder_60x60.png" class="card-media-image" />

--- a/src/app/card/card-old.html
+++ b/src/app/card/card-old.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -203,7 +203,7 @@ Use the
   <h6>4. Clickable cards</h6>
   <div class="clr-example">
     <a href="javascript://" class="card clickable">
-      <div class="card-header">Featured</div>
+      <h3 class="card-header">Featured</h3>
       <div class="card-block">
         <h4 class="card-title">Title</h4>
         <p class="card-text">
@@ -218,7 +218,7 @@ Use the
   <h6>5. Other card variations</h6>
   <div class="clr-example">
     <div class="card">
-      <div class="card-header">Featured</div>
+      <h3 class="card-header">Featured</h3>
       <div class="card-block">
         <h4 class="card-title">Special title treatment</h4>
         <p class="card-text">


### PR DESCRIPTION
• update demos to use header tags instead of divs
• update CSS so that header tags can be used as titles/headers for cards

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Demos on the angular website aren't using header tags (`h1..h6`) for titles and headers in cards. This sets a bad example for teams who need to use header tags for a11y.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: vpat-625

## What is the new behavior?

I had to do one minor update in the CSS to remove the default margin applied to all headers when those headers were used as titles/headers in cards. Other than that, it was updating the demos to use `h3...h4` tags instead of `div`s.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
