### PR TITLE
fix(tree-view): execute expand on enter and enter

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -2296,6 +2296,7 @@ export declare class ClrTreeNode<T> implements OnInit, OnDestroy {
     broadcastFocusOnContainer(): void;
     focusTreeNode(): void;
     isExpandable(): boolean;
+    isSelectable(): boolean;
     ngOnDestroy(): void;
     ngOnInit(): void;
     onKeyDown(event: KeyboardEvent): void;

--- a/projects/angular/src/utils/enums/key-codes.enum.ts
+++ b/projects/angular/src/utils/enums/key-codes.enum.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -14,6 +14,7 @@ export enum KeyCodes {
   Enter = 'Enter',
   Escape = 'Escape',
   Space = 'Space',
+  Spacebar = ' ',
   Home = 'Home',
   End = 'End',
 }


### PR DESCRIPTION
• there was a bug where spacebar was coming through as a blank space
• we weren't catching that, now we are
• made it so the enter and space keys also try to open/close if...
  they are used on a parent tree node

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: vpat 684

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
