### PR TITLE
fix: icon color in disabled buttons

### DIFF
--- a/projects/angular/src/button/_buttons.clarity.scss
+++ b/projects/angular/src/button/_buttons.clarity.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
@@ -397,13 +397,13 @@
 
   .btn-icon {
     min-width: 0;
+  }
 
-    &.disabled,
-    &:disabled {
-      cds-icon,
-      clr-icon {
-        @include css-var(color, clr-btn-icon-disabled-color, $clr-color-neutral-400, $clr-use-custom-properties);
-      }
+  .btn.disabled,
+  .btn:disabled {
+    cds-icon,
+    clr-icon {
+      @include css-var(color, clr-btn-icon-disabled-color, $clr-color-neutral-400, $clr-use-custom-properties);
     }
   }
 

--- a/src/app/button-group/static/icon-buttons/icon-button-group.html
+++ b/src/app/button-group/static/icon-buttons/icon-button-group.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -43,6 +43,38 @@
     <button class="btn">
       <cds-icon shape="cloud"></cds-icon>
       <span class="clr-icon-title">Cloud</span>
+    </button>
+  </div>
+</div>
+
+<div class="clr-example">
+  <div class="btn-group btn-icon">
+    <button class="btn" disabled>
+      <cds-icon shape="home"></cds-icon>
+    </button>
+    <button class="btn" disabled>
+      <cds-icon shape="cog"></cds-icon>
+    </button>
+    <button class="btn" disabled>
+      <cds-icon shape="user"></cds-icon>
+    </button>
+    <button class="btn" disabled>
+      <cds-icon shape="cloud"></cds-icon>
+    </button>
+  </div>
+
+  <div class="btn-group">
+    <button class="btn btn-icon" disabled>
+      <cds-icon shape="home"></cds-icon>
+    </button>
+    <button class="btn btn-icon" disabled>
+      <cds-icon shape="cog"></cds-icon>
+    </button>
+    <button class="btn btn-icon" disabled>
+      <cds-icon shape="user"></cds-icon>
+    </button>
+    <button class="btn btn-icon" disabled>
+      <cds-icon shape="cloud"></cds-icon>
     </button>
   </div>
 </div>

--- a/src/app/buttons/buttons-icons.html
+++ b/src/app/buttons/buttons-icons.html
@@ -1,20 +1,38 @@
 <!--
-  ~ Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
+<h4>Icons in Solid Buttons</h4>
+<button type="submit" class="btn btn-primary"><cds-icon shape="user"></cds-icon> Primary</button>
+<button type="submit" class="btn btn-success"><cds-icon shape="user"></cds-icon> Success</button>
+<button type="submit" class="btn btn-warning"><cds-icon shape="user"></cds-icon> Warning</button>
+<button type="submit" class="btn btn-danger"><cds-icon shape="user"></cds-icon> Danger</button>
 
-<button class="btn btn-primary">
-  <cds-icon shape="home"></cds-icon>
-  Home
-</button>
+<h4>Icons in Disabled Solid Buttons</h4>
+<button type="submit" class="btn btn-primary" disabled><cds-icon shape="user"></cds-icon> Primary</button>
+<button type="submit" class="btn btn-success" disabled><cds-icon shape="user"></cds-icon> Success</button>
+<button type="submit" class="btn btn-warning" disabled><cds-icon shape="user"></cds-icon> Warning</button>
+<button type="submit" class="btn btn-danger" disabled><cds-icon shape="user"></cds-icon> Danger</button>
 
-<button class="btn btn-primary">
-  <cds-icon shape="folder"></cds-icon>
-  Directory
-</button>
+<h4>Icons in Outline Buttons</h4>
+<button type="submit" class="btn btn-outline"><cds-icon shape="user"></cds-icon> Regular</button>
+<button type="submit" class="btn btn-success-outline"><cds-icon shape="user"></cds-icon> Success-Outline</button>
+<button type="submit" class="btn btn-info-outline"><cds-icon shape="user"></cds-icon> Info</button>
+<button type="submit" class="btn btn-warning-outline"><cds-icon shape="user"></cds-icon> Warning</button>
+<button type="submit" class="btn btn-danger-outline"><cds-icon shape="user"></cds-icon> Danger</button>
 
-<button class="btn btn-primary">
-  <cds-icon shape="cog"></cds-icon>
-  Settings
+<h4>Icons in Disabled Outline Buttons</h4>
+<button type="submit" class="btn btn-outline" disabled><cds-icon shape="user"></cds-icon> Regular</button>
+<button type="submit" class="btn btn-success-outline" disabled>
+  <cds-icon shape="user"></cds-icon> Success-Outline
 </button>
+<button type="submit" class="btn btn-info-outline" disabled><cds-icon shape="user"></cds-icon> Info</button>
+<button type="submit" class="btn btn-warning-outline" disabled><cds-icon shape="user"></cds-icon> Warning</button>
+<button type="submit" class="btn btn-danger-outline" disabled><cds-icon shape="user"></cds-icon> Danger</button>
+
+<h4>Icons in Flat Buttons</h4>
+<button type="submit" class="btn btn-link"><cds-icon shape="user"></cds-icon> Regular</button>
+<button type="submit" class="btn btn-link" disabled><cds-icon shape="user"></cds-icon> Disabled</button>
+<button type="submit" class="btn btn-sm btn-link"><cds-icon shape="user"></cds-icon> Regular</button>
+<button type="submit" class="btn btn-sm btn-link" disabled><cds-icon shape="user"></cds-icon> Disabled</button>

--- a/src/app/buttons/real-button.html
+++ b/src/app/buttons/real-button.html
@@ -1,26 +1,32 @@
 <!--
-  ~ Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
 
 <h4>Solid Buttons</h4>
-<button type="submit" class="btn btn-primary">Primary</button>
-<button type="submit" class="btn btn-success">Success</button>
-<button type="submit" class="btn btn-warning">Warning</button>
-<button type="submit" class="btn btn-danger">Danger</button>
-<button type="submit" class="btn" disabled>Disabled</button>
+<div class="clr-example">
+  <button type="submit" class="btn btn-primary">Primary</button>
+  <button type="submit" class="btn btn-success">Success</button>
+  <button type="submit" class="btn btn-warning">Warning</button>
+  <button type="submit" class="btn btn-danger">Danger</button>
+  <button type="submit" class="btn" disabled>Disabled</button>
+</div>
 
 <h4>Outline Buttons</h4>
-<button type="submit" class="btn btn-outline">Regular</button>
-<button type="submit" class="btn btn-success-outline">Success-Outline</button>
-<button type="submit" class="btn btn-info-outline">Info</button>
-<button type="submit" class="btn btn-warning-outline">Warning</button>
-<button type="submit" class="btn btn-danger-outline">Danger</button>
-<button type="submit" class="btn btn-outline" disabled>Disabled</button>
+<div class="clr-example">
+  <button type="submit" class="btn btn-outline">Regular</button>
+  <button type="submit" class="btn btn-success-outline">Success-Outline</button>
+  <button type="submit" class="btn btn-info-outline">Info</button>
+  <button type="submit" class="btn btn-warning-outline">Warning</button>
+  <button type="submit" class="btn btn-danger-outline">Danger</button>
+  <button type="submit" class="btn btn-outline" disabled>Disabled</button>
+</div>
 
 <h4>Flat Buttons</h4>
-<button type="submit" class="btn btn-link">Regular</button>
-<button type="submit" class="btn btn-link" disabled>Disabled</button>
-<button type="submit" class="btn btn-sm btn-link">Regular</button>
-<button type="submit" class="btn btn-sm btn-link" disabled>Disabled</button>
+<div class="clr-example">
+  <button type="submit" class="btn btn-link">Regular</button>
+  <button type="submit" class="btn btn-link" disabled>Disabled</button>
+  <button type="submit" class="btn btn-sm btn-link">Regular</button>
+  <button type="submit" class="btn btn-sm btn-link" disabled>Disabled</button>
+</div>


### PR DESCRIPTION
Signed-off-by: stsogoo <stsogoo@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

Disabled button icons don't show their proper disabled color. This PR fixes the issue. This fix complements https://github.com/vmware/clarity/pull/6715 for the shim.

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Before:
<img width="699" alt="Screen Shot 2022-02-18 at 3 10 56 PM" src="https://user-images.githubusercontent.com/3958008/154773177-d706ac10-0e18-4c0b-ab65-790796cf0cea.png">
After:
<img width="725" alt="Screen Shot 2022-02-18 at 3 10 19 PM" src="https://user-images.githubusercontent.com/3958008/154773180-4fe0cd71-912d-465d-86eb-df01b3d504a6.png">

