### PR TITLE
Topic/vpat 691 unique row identifiers

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -495,6 +495,7 @@ export interface ClrCommonStrings {
     rowActions: string;
     select: string;
     selectAll: string;
+    selectedRows: string;
     selection?: string;
     show: string;
     showColumns: string;
@@ -785,11 +786,12 @@ export interface ClrDatagridFilterInterface<T, S = any> {
 
 export declare class ClrDatagridFooter<T = any> {
     SELECTION_TYPE: typeof SelectionType;
+    commonStrings: ClrCommonStringsService;
     detailService: DetailService;
     get hasHideableColumns(): boolean;
     selection: Selection<T>;
     toggle: ClrDatagridColumnToggle;
-    constructor(selection: Selection<T>, detailService: DetailService, columnsService: ColumnsService);
+    constructor(selection: Selection<T>, detailService: DetailService, columnsService: ColumnsService, commonStrings: ClrCommonStringsService);
     static ɵcmp: i0.ɵɵComponentDeclaration<ClrDatagridFooter<any>, "clr-dg-footer", never, {}, {}, ["toggle"], ["clr-dg-column-toggle", "*", "clr-dg-pagination"]>;
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrDatagridFooter<any>, never>;
 }
@@ -892,6 +894,8 @@ export declare class ClrDatagridRow<T = any> implements AfterContentInit, AfterV
     get clrDgDetailCloseLabel(): string;
     set clrDgDetailOpenLabel(label: string);
     get clrDgDetailOpenLabel(): string;
+    set clrDgRowAriaLabel(label: string);
+    get clrDgRowAriaLabel(): string;
     set clrDgSelectable(value: boolean | string);
     get clrDgSelectable(): boolean | string;
     commonStrings: ClrCommonStringsService;
@@ -923,7 +927,7 @@ export declare class ClrDatagridRow<T = any> implements AfterContentInit, AfterV
     ngOnInit(): void;
     toggle(selected?: boolean): void;
     toggleExpand(): void;
-    static ɵcmp: i0.ɵɵComponentDeclaration<ClrDatagridRow<any>, "clr-dg-row", never, { "item": "clrDgItem"; "selected": "clrDgSelected"; "clrDgSelectable": "clrDgSelectable"; "expanded": "clrDgExpanded"; "clrDgDetailOpenLabel": "clrDgDetailOpenLabel"; "clrDgDetailCloseLabel": "clrDgDetailCloseLabel"; }, { "selectedChanged": "clrDgSelectedChange"; "expandedChange": "clrDgExpandedChange"; }, ["dgCells"], ["clr-dg-row-detail", "clr-dg-action-overflow", "clr-dg-cell"]>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<ClrDatagridRow<any>, "clr-dg-row", never, { "item": "clrDgItem"; "selected": "clrDgSelected"; "clrDgSelectable": "clrDgSelectable"; "expanded": "clrDgExpanded"; "clrDgDetailOpenLabel": "clrDgDetailOpenLabel"; "clrDgDetailCloseLabel": "clrDgDetailCloseLabel"; "clrDgRowAriaLabel": "clrDgRowAriaLabel"; }, { "selectedChanged": "clrDgSelectedChange"; "expandedChange": "clrDgExpandedChange"; }, ["dgCells"], ["clr-dg-row-detail", "clr-dg-action-overflow", "clr-dg-cell"]>;
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrDatagridRow<any>, never>;
 }
 

--- a/projects/angular/src/data/datagrid/datagrid-footer.ts
+++ b/projects/angular/src/data/datagrid/datagrid-footer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -10,6 +10,7 @@ import { Selection } from './providers/selection';
 import { SelectionType } from './enums/selection-type';
 import { ColumnsService } from './providers/columns.service';
 import { DetailService } from './providers/detail.service';
+import { ClrCommonStringsService } from '../../utils';
 
 @Component({
   selector: 'clr-dg-footer',
@@ -19,6 +20,7 @@ import { DetailService } from './providers/detail.service';
         <clr-checkbox-wrapper class="datagrid-footer-select">
           <input clrCheckbox type="checkbox" checked="checked" disabled />
           <label>{{ selection.current.length }}</label>
+          <span class="clr-sr-only">{{ commonStrings.keys.selectedRows }}</span>
         </clr-checkbox-wrapper>
       </div>
     </ng-container>
@@ -39,7 +41,8 @@ export class ClrDatagridFooter<T = any> {
   constructor(
     public selection: Selection<T>,
     public detailService: DetailService,
-    private columnsService: ColumnsService
+    private columnsService: ColumnsService,
+    public commonStrings: ClrCommonStringsService
   ) {}
 
   /* reference to the enum so that template can access */

--- a/projects/angular/src/data/datagrid/datagrid-row.html
+++ b/projects/angular/src/data/datagrid/datagrid-row.html
@@ -50,7 +50,7 @@
               [id]="checkboxId"
               [attr.disabled]="clrDgSelectable ? null : true"
               [attr.aria-disabled]="clrDgSelectable ? null : true"
-              [attr.aria-label]="commonStrings.keys.select"
+              [attr.aria-label]="clrDgRowAriaLabel"
             />
             <!-- Usage of class clr-col-null here prevents clr-col-* classes from being added when a datagrid is wrapped inside clrForm -->
             <label [for]="checkboxId" class="clr-control-label clr-col-null">
@@ -78,7 +78,7 @@
             [checked]="selection.currentSingle === item"
             [attr.disabled]="clrDgSelectable ? null : true"
             [attr.aria-disabled]="clrDgSelectable ? null : true"
-            [attr.aria-label]="commonStrings.keys.select"
+            [attr.aria-label]="clrDgRowAriaLabel"
           />
         </div>
         <div
@@ -120,7 +120,7 @@
             #detailButton
             class="datagrid-detail-caret-button"
             [class.is-open]="detailService.isRowOpen(item)"
-            [attr.aria-label]="detailService.isOpen ? clrDgDetailCloseLabel : clrDgDetailOpenLabel"
+            [attr.aria-label]="detailService.isRowOpen(item) ? clrDgDetailCloseLabel : clrDgDetailOpenLabel"
             [attr.aria-expanded]="detailService.isOpen"
             [attr.aria-controls]="detailService.id"
             aria-haspopup="dialog"

--- a/projects/angular/src/data/datagrid/datagrid-row.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-row.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -125,12 +125,26 @@ export default function (): void {
       let context: TestContext<ClrDatagridRow, SelectableRowOrder>;
       let selectionProvider: Selection;
       let checkbox: HTMLElement;
+      let radio: HTMLInputElement;
 
       beforeEach(function () {
         context = this.create(ClrDatagridRow, SelectableRowOrder, DATAGRID_SPEC_PROVIDERS);
         selectionProvider = TestBed.get(Selection);
         TestBed.get(Items).all = [{ id: 1 }, { id: 2 }];
       });
+
+      it('should provide a selection input aria-labels', fakeAsync(function () {
+        // Test multi select rows
+        selectionProvider.selectionType = SelectionType.Multi;
+        context.detectChanges();
+        checkbox = context.clarityElement.querySelector("input[type='checkbox']");
+        expect(checkbox.getAttribute('aria-label')).toBeString('uniq aria-label');
+        // Test single select row
+        selectionProvider.selectionType = SelectionType.Single;
+        context.detectChanges();
+        radio = context.clarityElement.querySelector("input[type='radio']");
+        expect(radio.getAttribute('aria-label')).toBeString('uniq aria-label');
+      }));
 
       it('should toggle when clrDgSelectable is false for type  SelectionType.Multi', () => {
         selectionProvider.selectionType = SelectionType.Multi;
@@ -494,11 +508,14 @@ class SelectableRow {
 }
 
 @Component({
-  template: `<clr-dg-row [clrDgSelectable]="clrDgSelectable" [clrDgItem]="item">None</clr-dg-row>`,
+  template: `<clr-dg-row [clrDgSelectable]="clrDgSelectable" [clrDgItem]="item" [clrDgRowAriaLabel]="ariaLabel"
+    >None</clr-dg-row
+  >`,
 })
 class SelectableRowOrder {
   clrDgSelectable = undefined;
   item: Item = { id: 42 };
+  ariaLabel = 'uniq aria-label';
 }
 
 @Component({ template: `<clr-dg-row [clrDgItem]="item" [(clrDgSelected)]="selected">Hello world</clr-dg-row>` })

--- a/projects/angular/src/data/datagrid/datagrid-row.ts
+++ b/projects/angular/src/data/datagrid/datagrid-row.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -187,6 +187,15 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
   }
   get clrDgDetailCloseLabel(): string {
     return this._detailCloseLabel ? this._detailCloseLabel : this.commonStrings.keys.close;
+  }
+
+  private _rowAriaLabel = '';
+  @Input()
+  set clrDgRowAriaLabel(label: string) {
+    this._rowAriaLabel = label;
+  }
+  get clrDgRowAriaLabel(): string {
+    return this._rowAriaLabel ? this._rowAriaLabel : this.commonStrings.keys.select;
   }
 
   /*****

--- a/projects/angular/src/utils/i18n/common-strings.default.ts
+++ b/projects/angular/src/utils/i18n/common-strings.default.ts
@@ -103,4 +103,9 @@ export const commonStringsDefault: ClrCommonStrings = {
    */
   passwordHide: 'Hide password',
   passwordShow: 'Show password',
+
+  /**
+   * Datagrid footer; sr-only text after the number of selected rows.
+   */
+  selectedRows: 'Selected rows',
 };

--- a/projects/angular/src/utils/i18n/common-strings.interface.ts
+++ b/projects/angular/src/utils/i18n/common-strings.interface.ts
@@ -283,4 +283,9 @@ export interface ClrCommonStrings {
    */
   passwordHide: string;
   passwordShow: string;
+
+  /**
+   * Datagrid footer; sr-only text after the number of selected rows.
+   */
+  selectedRows: string;
 }

--- a/projects/website/src/app/documentation/demos/datagrid/datagrid.demo.html
+++ b/projects/website/src/app/documentation/demos/datagrid/datagrid.demo.html
@@ -7,6 +7,36 @@
       Datagrids are for organizing large volumes of data that users can scan, compare, and perform actions on.
     </h5>
 
+    <h3>API</h3>
+
+    <clr-accordion>
+      <clr-accordion-panel *ngFor="let api of apis">
+        <clr-accordion-title>{{ api.name }} API ({{api.selector}})</clr-accordion-title>
+        <clr-accordion-content class="api-accordion">
+          <table class="table">
+            <thead>
+              <tr>
+                <th class="left">Input/Output</th>
+                <th class="left hidden-xs-down">Type</th>
+                <th class="left hidden-xs-down">Default</th>
+                <th class="left">Effect</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let prop of api.props">
+                <td class="left">
+                  <b>{{ prop.name }}</b>
+                </td>
+                <td class="left hidden-xs-down">{{ prop.type }}</td>
+                <td class="left hidden-xs-down">{{ prop.defaultValue }}</td>
+                <td class="left">{{ prop.description }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </clr-accordion-content>
+      </clr-accordion-panel>
+    </clr-accordion>
+
     <div id="code-examples">
       <p>
         We have {{childRoutes.length}} datagrid demos. Starting with the basics, each demo shows you one or more of the

--- a/projects/website/src/app/documentation/demos/datagrid/datagrid.demo.main.scss
+++ b/projects/website/src/app/documentation/demos/datagrid/datagrid.demo.main.scss
@@ -11,3 +11,18 @@
   column-count: 3;
   list-style-position: inside;
 }
+
+::ng-deep.clr-accordion:not(.clr-stepper-forms) .clr-accordion-inner-content {
+  margin: 0;
+  padding: 0;
+
+  table {
+    margin: 0;
+  }
+}
+
+::ng-deep.clr-accordion-inner-content {
+  margin: 0;
+  padding: 0;
+  overflow: auto;
+}

--- a/projects/website/src/app/documentation/demos/datagrid/datagrid.demo.ts
+++ b/projects/website/src/app/documentation/demos/datagrid/datagrid.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -7,6 +7,7 @@ import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { ClarityDocComponent } from '../clarity-doc';
 import { ActivatedRoute, NavigationEnd, Route, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
+import { multicast } from 'rxjs/operators';
 
 @Component({
   selector: 'clr-datagrid-demo',
@@ -36,6 +37,277 @@ export class DatagridDemo extends ClarityDocComponent implements OnInit, OnDestr
   nextRoute: Route;
 
   parentRoute: string = '';
+  apis = [
+    {
+      name: 'ClrDatagrid',
+      selector: 'clr-datagrid',
+      props: [
+        {
+          name: '[clrDgCLoading]',
+          type: 'Boolean',
+          defaultValue: 'false',
+          description: 'Freezes the datagrid while data is loading',
+        },
+        {
+          name: '(clrDgRefresh)',
+          type: 'ClrDatagridStateInterface<T>',
+          defaultValue: 'n/a',
+          description: 'Output emitted whenever the data needs to be refreshed, based on user action or external ones',
+        },
+        {
+          name: '[(clrDgSelected)]',
+          type: 'T[]',
+          defaultValue: '[]',
+          description: 'An array of all selected items',
+        },
+        {
+          name: '[(clrDgSingleSelected)]',
+          type: 'T',
+          defaultValue: 'undefined',
+          description: 'Selected item in single-select mode.',
+        },
+        {
+          name: '[clrDgSingleSelectionAriaLabel]',
+          type: 'string',
+          defaultValue: 'Single selection header',
+          description: 'Change / over-ride the text for single selection column header',
+        },
+        {
+          name: '[clrDgSingleActionableAriaLabel]',
+          type: 'string',
+          defaultValue: 'Single actionable header',
+          description: 'Change / over-ride the text for single action column header',
+        },
+        {
+          name: '[clrDetailExpandableAriaLabel]',
+          type: 'string',
+          defaultValue: 'Toggle more row content',
+          description: 'Change / over-ride the text for expandable row button.',
+        },
+        {
+          name: '[clrDgDisablePageFocus]',
+          type: 'Boolean',
+          defaultValue: 'false',
+          description: 'Set true to enable focus on the datagrid table container element after page change.',
+        },
+        {
+          name: '[clrDgPreserveSelection]',
+          type: 'boolean',
+          defaultValue: 'false',
+          description:
+            'Set to true to preserve selected rows between data changes. E.g - page changes or filter changes.',
+        },
+      ],
+    },
+    {
+      name: 'ClrDatagridRow',
+      selector: 'clr-dg-row',
+      props: [
+        {
+          name: '[clrDgItem]',
+          type: 'T',
+          defaultValue: '',
+          description: 'A model of the row, used for selection, filtering, sorting and pagination.',
+        },
+        {
+          name: '[(clrDgSelected)]',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: 'Select or de-select an item.',
+        },
+        {
+          name: '[clrDgSelectable]',
+          type: 'boolean',
+          defaultValue: 'true',
+          description:
+            "Set this to false if you don't want the row to be selectable (single or multicast select modes).",
+        },
+        {
+          name: '[clrDgDetailOpenLabel]',
+          type: 'string',
+          defaultValue: 'Open',
+          description: 'A string for the aria-label on the detail pane open button',
+        },
+        {
+          name: '[clrDgDetailCloseLabel]',
+          type: 'string',
+          defaultValue: 'Close',
+          description: 'A string for the aria-label on the detail pane open button',
+        },
+        {
+          name: '[clrDgRowAriaLabel]',
+          type: 'string',
+          defaultValue: '',
+          description: 'A model of the row, used for selection, filtering, sorting and pagination.',
+        },
+      ],
+    },
+    {
+      name: 'ClrDatagridFilter',
+      selector: 'clr-dg-filter',
+      props: [
+        {
+          name: '[(clrDgFilterOpen)]',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: 'Input / Output that sets or emits the open state of a filter.',
+        },
+        {
+          name: '[clrDgFilter]',
+          type: 'ClrDatagridFilterInterface<T> | RegisteredFilter<T, ClrDatagridFilterInterface<T>>',
+          defaultValue: 'n/a',
+          description: 'Bind a custom filter to a column.',
+        },
+        {
+          name: '',
+          type: '',
+          defaultValue: '',
+          description: '',
+        },
+      ],
+    },
+    {
+      name: 'ClrDatagridColumn',
+      selector: 'clr-dg-column',
+      props: [
+        {
+          name: '[clrDgColType]',
+          type: 'string | number',
+          defaultValue: 'string',
+          description: 'Designates usage of the built in string or number filters for a column filter.',
+        },
+        {
+          name: 'clrDgField',
+          type: 'string',
+          defaultValue: 'undefined',
+          description: 'Set the model property that represents data in the column.',
+        },
+        {
+          name: 'clrDgSortBy',
+          type: 'ClrDatagridComparatorInterface<T> | string',
+          defaultValue: 'undefined',
+          description:
+            'Bind to a custom sorting comparator or designate  astring to be used with the build in DatagridPropertyComparator.',
+        },
+        {
+          name: '',
+          type: '',
+          defaultValue: '',
+          description: '',
+        },
+      ],
+    },
+    {
+      name: 'ClrDatagridHideableColumn',
+      selector: '[clrDgHideableColumn]',
+      props: [
+        {
+          name: '[clrDgHideableColumn]',
+          type: '{hidden: boolean}',
+          defaultValue: 'false',
+          description: 'Designate a column to hide-able and pass its visibility state.',
+        },
+        {
+          name: '[(clrDgHidden)]',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: 'Input/Output for the hidden state of a column.',
+        },
+      ],
+    },
+    {
+      name: 'ClrIfDetail',
+      selector: '[clrIfDetail]',
+      props: [
+        {
+          name: '[(clrIfDetail)]',
+          type: 'T',
+          defaultValue: 'Row model <T>',
+          description:
+            'Use this to pass the row model context to the structural directive that toggles the detail pane for a row.',
+        },
+        {
+          name: '',
+          type: '',
+          defaultValue: '',
+          description: '',
+        },
+      ],
+    },
+    {
+      name: 'ClrDatagridItems',
+      selector: '[clrDgItems][clrDgItemsOf]',
+      props: [
+        {
+          name: '[clrDgItemsOf]',
+          type: 'T[]',
+          defaultValue: 'undefined',
+          description:
+            'A structural directive / iterator that uses a list of item models for each of the visible rows in a datagrid.',
+        },
+        {
+          name: '[clrDgItemsTrackBy]',
+          type: 'TrackByFunction<T>',
+          defaultValue: 'undefined',
+          description: 'Use this to pass a TrackBy function for each row item.',
+        },
+      ],
+    },
+    {
+      name: 'ClrDatagridPageSize',
+      selector: 'clr-dg-page-size',
+      props: [
+        {
+          name: '[clrPageSizeOptions]',
+          type: 'number',
+          defaultValue: '0',
+          description: 'Set the size of items for a page.',
+        },
+        {
+          name: '[clrDgItemsTrackBy]',
+          type: 'TrackByFunction<T>',
+          defaultValue: 'undefined',
+          description: 'Use this to pass a TrackBy function for each row item.',
+        },
+      ],
+    },
+    {
+      name: 'ClrDatagridPagination',
+      selector: 'clr-dg-pagination',
+      props: [
+        {
+          name: '[clrDgPageInputDisabled]',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: 'Disable user input for the text input element.',
+        },
+        {
+          name: '[clrDgPageSize]',
+          type: 'number',
+          defaultValue: '0',
+          description: 'Sets the number of row items per page.',
+        },
+        {
+          name: '[clrDgTotalItems]',
+          type: 'number',
+          defaultValue: 'undefined',
+          description: 'A value representing the total number of items in the full dataset.',
+        },
+        {
+          name: '[clrDgLastPage]',
+          type: 'number',
+          defaultValue: 'undefined',
+          description: 'Designate a specific page number as the last page for a dataset.',
+        },
+        {
+          name: '[clrDgPage]',
+          type: 'number',
+          defaultValue: '1',
+          description: 'Sets the current page for a paginated dataset.',
+        },
+      ],
+    },
+  ];
 
   ngOnInit() {
     const tempArr: any[] = this.route.routeConfig.children;

--- a/src/app/datagrid/detail/detail.html
+++ b/src/app/datagrid/detail/detail.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -28,8 +28,9 @@
   <clr-dg-row
     *clrDgItems="let user of users"
     [clrDgItem]="user"
+    [clrDgRowAriaLabel]="'Select row for ' + user.name"
     [clrDgDetailOpenLabel]="'Open row details for ' + user.name"
-    [clrDgDetailCloseLabel]="'Open row details for ' + user.name"
+    [clrDgDetailCloseLabel]="'Close row details for ' + user.name"
   >
     <clr-dg-cell>{{user.id}}</clr-dg-cell>
     <clr-dg-cell>{{user.name}}</clr-dg-cell>

--- a/src/app/datagrid/selection-row-mode/selection-row-mode.html
+++ b/src/app/datagrid/selection-row-mode/selection-row-mode.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -36,7 +36,7 @@
   <clr-dg-column>Creation date</clr-dg-column>
   <clr-dg-column>Favorite color</clr-dg-column>
 
-  <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
+  <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user" [clrDgRowAriaLabel]="'Select row for ' + user.name">
     <clr-dg-cell>{{user.id}}</clr-dg-cell>
     <clr-dg-cell>{{user.name}}</clr-dg-cell>
     <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
@@ -64,7 +64,7 @@
   <clr-dg-column>Creation date</clr-dg-column>
   <clr-dg-column>Favorite color</clr-dg-column>
 
-  <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
+  <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user" [clrDgRowAriaLabel]="'Select row for ' + user.name">
     <clr-dg-cell>{{user.id}}</clr-dg-cell>
     <clr-dg-cell>{{user.name}}</clr-dg-cell>
     <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>

--- a/src/app/datagrid/selection-single/selection-single.html
+++ b/src/app/datagrid/selection-single/selection-single.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -40,7 +40,7 @@
   <clr-dg-column>Creation date</clr-dg-column>
   <clr-dg-column>Favorite color</clr-dg-column>
 
-  <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
+  <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user" [clrDgRowAriaLabel]="'Select row for ' + user.name">
     <clr-dg-cell>{{user.id}}</clr-dg-cell>
     <clr-dg-cell>{{user.name}}</clr-dg-cell>
     <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
@@ -71,7 +71,11 @@
   <clr-dg-column>Creation date</clr-dg-column>
   <clr-dg-column>Favorite color</clr-dg-column>
 
-  <clr-dg-row *clrDgItems="let user of trackByIndexUsers; trackBy: trackByIndex" [clrDgItem]="user">
+  <clr-dg-row
+    *clrDgItems="let user of trackByIndexUsers; trackBy: trackByIndex"
+    [clrDgItem]="user"
+    [clrDgRowAriaLabel]="'Select row for ' + user.name"
+  >
     <clr-dg-cell>{{user.id}}</clr-dg-cell>
     <clr-dg-cell>{{user.name}}</clr-dg-cell>
     <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
@@ -102,7 +106,11 @@
   <clr-dg-column>Creation date</clr-dg-column>
   <clr-dg-column>Favorite color</clr-dg-column>
 
-  <clr-dg-row *clrDgItems="let user of trackByIdUsers; trackBy: trackById" [clrDgItem]="user">
+  <clr-dg-row
+    *clrDgItems="let user of trackByIdUsers; trackBy: trackById"
+    [clrDgItem]="user"
+    [clrDgRowAriaLabel]="'Select row for ' + user.name"
+  >
     <clr-dg-cell>{{user.id}}</clr-dg-cell>
     <clr-dg-cell>{{user.name}}</clr-dg-cell>
     <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
@@ -137,7 +145,11 @@
   <clr-dg-column>Creation date</clr-dg-column>
   <clr-dg-column>Favorite color</clr-dg-column>
 
-  <clr-dg-row *ngFor="let user of trackByIdServerUsers; trackBy: trackById" [clrDgItem]="user">
+  <clr-dg-row
+    *ngFor="let user of trackByIdServerUsers; trackBy: trackById"
+    [clrDgItem]="user"
+    [clrDgRowAriaLabel]="'Select row for ' + user.name"
+  >
     <clr-dg-cell>{{user.id}}</clr-dg-cell>
     <clr-dg-cell>{{user.name}}</clr-dg-cell>
     <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>

--- a/src/app/datagrid/selection/selection.html
+++ b/src/app/datagrid/selection/selection.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+  ~ Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -46,7 +46,11 @@
     <ng-container *clrDgHideableColumn> Favorite color </ng-container>
   </clr-dg-column>
 
-  <clr-dg-row *clrDgItems="let user of clientNoTrackByUsers" [clrDgItem]="user">
+  <clr-dg-row
+    *clrDgItems="let user of clientNoTrackByUsers"
+    [clrDgItem]="user"
+    [clrDgRowAriaLabel]="'Select row for ' + user.name"
+  >
     <clr-dg-cell>{{user.id}}</clr-dg-cell>
     <clr-dg-cell>{{user.name}}</clr-dg-cell>
     <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
@@ -79,7 +83,11 @@
     <ng-container *clrDgHideableColumn> Favorite color </ng-container>
   </clr-dg-column>
 
-  <clr-dg-row *clrDgItems="let user of clientTrackByIndexUsers; trackBy: trackByIndex" [clrDgItem]="user">
+  <clr-dg-row
+    *clrDgItems="let user of clientTrackByIndexUsers; trackBy: trackByIndex"
+    [clrDgItem]="user"
+    [clrDgRowAriaLabel]="'Select row for ' + user.name"
+  >
     <clr-dg-cell>{{user.id}}</clr-dg-cell>
     <clr-dg-cell>{{user.name}}</clr-dg-cell>
     <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
@@ -112,7 +120,11 @@
     <ng-container *clrDgHideableColumn> Favorite color </ng-container>
   </clr-dg-column>
 
-  <clr-dg-row *clrDgItems="let user of clientTrackByIdUsers; trackBy: trackById" [clrDgItem]="user">
+  <clr-dg-row
+    *clrDgItems="let user of clientTrackByIdUsers; trackBy: trackById"
+    [clrDgItem]="user"
+    [clrDgRowAriaLabel]="'Select row for ' + user.name"
+  >
     <clr-dg-cell>{{user.id}}</clr-dg-cell>
     <clr-dg-cell>{{user.name}}</clr-dg-cell>
     <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
@@ -145,7 +157,11 @@
     <ng-container *clrDgHideableColumn> Favorite color </ng-container>
   </clr-dg-column>
 
-  <clr-dg-row *ngFor="let user of serverTrackByIdUsers; trackBy: trackById" [clrDgItem]="user">
+  <clr-dg-row
+    *ngFor="let user of serverTrackByIdUsers; trackBy: trackById"
+    [clrDgItem]="user"
+    [clrDgRowAriaLabel]="'Select row for ' + user.name"
+  >
     <clr-dg-cell>{{user.id}}</clr-dg-cell>
     <clr-dg-cell>{{user.name}}</clr-dg-cell>
     <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Datagrid rows do not have a way for applications to create unique aria-label strings for the single/multi select inputs, the `@Input`s for the detail pane open button open/close string are not documented on the website and the readonly input for multi select count totals does not have meaningful text for screen reader users. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: VPAT-691

## What is the new behavior?
There is a new input for applications to create a unique aria-label on rows that will be applied to the selection inputs. A section is added to the datagrid docs that pulls together public API (`@Input/@Output`) info for all of the datagrid components. And there is a screen reader only string that adds meaningful text to the readonly input that counts selected rows when in multi-select mode. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
