### PR TITLE
fix(stack-view): improve a11y of stackview component

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -1951,9 +1951,12 @@ export declare class ClrStackBlock implements OnInit {
     expandedChange: EventEmitter<boolean>;
     focused: boolean;
     get getChangedValue(): boolean;
+    get headingLevel(): string;
+    get labelledById(): any;
     get onStackLabelFocus(): boolean;
     get role(): string;
     set setChangedValue(value: boolean);
+    stackBlockTitle: any;
     get tabIndex(): string;
     uniqueId: string;
     constructor(parent: ClrStackBlock, uniqueId: string, commonStrings: ClrCommonStringsService);
@@ -1961,7 +1964,7 @@ export declare class ClrStackBlock implements OnInit {
     getStackChildrenId(): string;
     ngOnInit(): void;
     toggleExpand(): void;
-    static ɵcmp: i0.ɵɵComponentDeclaration<ClrStackBlock, "clr-stack-block", never, { "expanded": "clrSbExpanded"; "expandable": "clrSbExpandable"; "setChangedValue": "clrSbNotifyChange"; "ariaLevel": "clrStackViewLevel"; "ariaSetsize": "clrStackViewSetsize"; "ariaPosinset": "clrStackViewPosinset"; }, { "expandedChange": "clrSbExpandedChange"; }, never, ["clr-stack-label", "*", "clr-stack-block"]>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<ClrStackBlock, "clr-stack-block", never, { "expanded": "clrSbExpanded"; "expandable": "clrSbExpandable"; "setChangedValue": "clrSbNotifyChange"; "ariaLevel": "clrStackViewLevel"; "ariaSetsize": "clrStackViewSetsize"; "ariaPosinset": "clrStackViewPosinset"; }, { "expandedChange": "clrSbExpandedChange"; }, ["stackBlockTitle"], ["clr-stack-label", "*", "clr-stack-block"]>;
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrStackBlock, [{ optional: true; skipSelf: true; }, null, null]>;
 }
 
@@ -2005,15 +2008,24 @@ export declare class ClrStackView {
 }
 
 export declare class ClrStackViewCustomTags {
-    static ɵdir: i0.ɵɵDirectiveDeclaration<ClrStackViewCustomTags, "clr-stack-label, clr-stack-content", never, {}, {}, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<ClrStackViewCustomTags, "clr-stack-content", never, {}, {}, never>;
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrStackViewCustomTags, never>;
+}
+
+export declare class ClrStackViewLabel implements OnInit {
+    set id(val: string);
+    get id(): string;
+    constructor(uniqueId: string);
+    ngOnInit(): void;
+    static ɵcmp: i0.ɵɵComponentDeclaration<ClrStackViewLabel, "clr-stack-label", never, { "id": "id"; }, {}, never, ["*"]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<ClrStackViewLabel, never>;
 }
 
 export declare class ClrStackViewModule {
     constructor();
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrStackViewModule, never>;
     static ɵinj: i0.ɵɵInjectorDeclaration<ClrStackViewModule>;
-    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrStackViewModule, [typeof i1.ClrStackView, typeof i2.ClrStackHeader, typeof i3.ClrStackBlock, typeof i4.ClrStackContentInput, typeof i5.ClrStackViewCustomTags, typeof i6.ClrStackInput, typeof i7.ClrStackSelect], [typeof i8.CommonModule, typeof i9.FormsModule, typeof i10.ClrIconModule, typeof i11.ClrExpandableAnimationModule], [typeof i1.ClrStackView, typeof i2.ClrStackHeader, typeof i3.ClrStackBlock, typeof i4.ClrStackContentInput, typeof i5.ClrStackViewCustomTags, typeof i6.ClrStackInput, typeof i7.ClrStackSelect]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrStackViewModule, [typeof i1.ClrStackView, typeof i2.ClrStackHeader, typeof i3.ClrStackBlock, typeof i4.ClrStackContentInput, typeof i5.ClrStackViewLabel, typeof i5.ClrStackViewCustomTags, typeof i6.ClrStackInput, typeof i7.ClrStackSelect], [typeof i8.CommonModule, typeof i9.FormsModule, typeof i10.ClrIconModule, typeof i11.ClrExpandableAnimationModule], [typeof i1.ClrStackView, typeof i2.ClrStackHeader, typeof i3.ClrStackBlock, typeof i4.ClrStackContentInput, typeof i5.ClrStackViewLabel, typeof i5.ClrStackViewCustomTags, typeof i6.ClrStackInput, typeof i7.ClrStackSelect]>;
 }
 
 export declare class ClrStepButton implements OnInit {

--- a/projects/angular/src/data/stack-view/all.spec.ts
+++ b/projects/angular/src/data/stack-view/all.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -17,10 +17,12 @@ import StackBlockSpecs from './stack-block.spec';
 import StackHeaderSpecs from './stack-header.spec';
 import StackViewSpecs from './stack-view.spec';
 import StackContentInputSpecs from './stack-content-input.spec';
+import StackViewCustomTagSpecs from './stack-view-custom-tags.spec';
 
 describe('Stack View directives', () => {
   StackViewSpecs();
   StackHeaderSpecs();
   StackContentInputSpecs();
   StackBlockSpecs();
+  StackViewCustomTagSpecs();
 });

--- a/projects/angular/src/data/stack-view/stack-block.ts
+++ b/projects/angular/src/data/stack-view/stack-block.ts
@@ -1,11 +1,23 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { Component, EventEmitter, HostBinding, Inject, Input, OnInit, Optional, Output, SkipSelf } from '@angular/core';
+import {
+  Component,
+  ContentChild,
+  EventEmitter,
+  HostBinding,
+  Inject,
+  Input,
+  OnInit,
+  Optional,
+  Output,
+  SkipSelf,
+} from '@angular/core';
 import { ClrCommonStringsService } from '../../utils/i18n/common-strings.service';
 import { UNIQUE_ID, UNIQUE_ID_PROVIDER } from '../../utils/id-generator/id-generator.service';
+import { ClrStackViewLabel } from './stack-view-custom-tags';
 
 @Component({
   selector: 'clr-stack-block',
@@ -22,9 +34,6 @@ import { UNIQUE_ID, UNIQUE_ID_PROVIDER } from '../../utils/id-generator/id-gener
       [attr.tabindex]="tabIndex"
       [attr.aria-expanded]="ariaExpanded"
       [attr.aria-controls]="getStackChildrenId()"
-      [attr.aria-posinset]="ariaPosinset"
-      [attr.aria-level]="ariaLevel"
-      [attr.aria-setsize]="ariaSetsize"
     >
       <cds-icon shape="angle" class="stack-block-caret" *ngIf="expandable" [attr.direction]="caretDirection"></cds-icon>
       <span class="clr-sr-only" *ngIf="getChangedValue">{{ commonStrings.keys.stackViewChanged }}</span>
@@ -38,8 +47,14 @@ import { UNIQUE_ID, UNIQUE_ID_PROVIDER } from '../../utils/id-generator/id-gener
       </div>
     </div>
 
-    <clr-expandable-animation [clrExpandTrigger]="expanded" class="stack-children" [attr.id]="getStackChildrenId()">
-      <div [style.height]="expanded ? 'auto' : 0" role="region" *ngIf="expanded">
+    <clr-expandable-animation [clrExpandTrigger]="expanded" class="stack-children">
+      <div
+        [style.height]="expanded ? 'auto' : 0"
+        role="region"
+        *ngIf="expanded"
+        [attr.id]="getStackChildrenId()"
+        [attr.aria-labelledby]="labelledById"
+      >
         <ng-content select="clr-stack-block"></ng-content>
       </div>
     </clr-expandable-animation>
@@ -53,17 +68,25 @@ import { UNIQUE_ID, UNIQUE_ID_PROVIDER } from '../../utils/id-generator/id-gener
     `,
   ],
   // Make sure the host has the proper class for styling purposes
-  host: { '[class.stack-block]': 'true' },
+  host: {
+    '[class.stack-block]': 'true',
+    '[attr.role]': '"heading"',
+    '[attr.aria-level]': 'headingLevel',
+  },
   providers: [UNIQUE_ID_PROVIDER],
 })
 export class ClrStackBlock implements OnInit {
   @HostBinding('class.stack-block-expanded')
   @Input('clrSbExpanded')
   expanded = false;
+
   @Output('clrSbExpandedChange') expandedChange: EventEmitter<boolean> = new EventEmitter<boolean>(false);
   @HostBinding('class.stack-block-expandable')
   @Input('clrSbExpandable')
   expandable = false;
+
+  @ContentChild(ClrStackViewLabel)
+  stackBlockTitle: any;
 
   focused = false;
   private _changedChildren = 0;
@@ -88,18 +111,38 @@ export class ClrStackBlock implements OnInit {
     }
   }
 
+  get labelledById() {
+    return this.stackBlockTitle.id;
+  }
+
+  get headingLevel() {
+    if (this.ariaLevel) {
+      return this.ariaLevel + '';
+    }
+
+    return this.parent ? '4' : '3';
+  }
+
   /**
    * Depth of the stack view starting from 1 for first level
    */
   @Input('clrStackViewLevel') ariaLevel: number;
 
   /**
+   * @deprecated
    * Total number of rows in a given group
+   * - removed per a11y (see: VPAT-592)
+   * - remains here and unused to avoid breaking change to the public API
+   * - remove in v14
    */
   @Input('clrStackViewSetsize') ariaSetsize: number;
 
   /**
+   * @deprecated
    * The position of the row inside the grouped by level rows
+   * - removed per a11y (see: VPAT-592)
+   * - remains here and unused to avoid breaking change to the public API
+   * - remove in v14
    */
   @Input('clrStackViewPosinset') ariaPosinset: number;
 

--- a/projects/angular/src/data/stack-view/stack-view-custom-tags.spec.ts
+++ b/projects/angular/src/data/stack-view/stack-view-custom-tags.spec.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ClrStackViewModule } from './stack-view.module';
+
+@Component({
+  template: `
+    <clr-stack-label class="one">Title</clr-stack-label>
+    <clr-stack-label class="two" id="ohai">Title</clr-stack-label>
+  `,
+})
+class TestComponent {}
+
+export default function (): void {
+  'use strict';
+  describe('StackView Label', () => {
+    let fixture: ComponentFixture<any>;
+    let compiled: any;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [ClrStackViewModule],
+        declarations: [TestComponent],
+      });
+      fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+      compiled = fixture.nativeElement;
+    });
+
+    afterEach(() => {
+      fixture.destroy();
+    });
+
+    it('projects content', () => {
+      expect(compiled.textContent).toMatch(/Title/);
+    });
+
+    it('auto assigns an id if none is given', () => {
+      const testme = compiled.querySelector('clr-stack-label.one');
+      expect(testme.hasAttribute('id')).toBe(true);
+      expect(testme.getAttribute('id').indexOf('clr-stack-label-clr-id-') > -1).toBe(true);
+    });
+
+    it('keeps the id if the stack-view-label already has one', () => {
+      const testme = compiled.querySelector('clr-stack-label.two');
+      expect(testme.hasAttribute('id')).toBe(true);
+      expect(testme.getAttribute('id')).toBe('ohai');
+    });
+  });
+}

--- a/projects/angular/src/data/stack-view/stack-view-custom-tags.ts
+++ b/projects/angular/src/data/stack-view/stack-view-custom-tags.ts
@@ -1,12 +1,49 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { Directive } from '@angular/core';
+import { Directive, Component, Inject, Input, OnInit } from '@angular/core';
+import { UNIQUE_ID, UNIQUE_ID_PROVIDER } from '../../utils/id-generator/id-generator.service';
 
-@Directive({ selector: 'clr-stack-label, clr-stack-content' })
+@Directive({ selector: 'clr-stack-content' })
 export class ClrStackViewCustomTags {
   // No behavior
   // The only purpose is to "declare" the tag in Angular
+}
+
+@Component({
+  selector: 'clr-stack-label',
+  template: '<ng-content></ng-content>',
+  providers: [UNIQUE_ID_PROVIDER],
+  host: {
+    '[attr.id]': 'id',
+  },
+})
+export class ClrStackViewLabel implements OnInit {
+  constructor(@Inject(UNIQUE_ID) private uniqueId: string) {}
+
+  private _generatedId: string = null;
+
+  private _id: string = null;
+
+  @Input()
+  set id(val: string) {
+    if (typeof val === 'string' && val !== '') {
+      this._id = val;
+    } else {
+      this._id = this._generatedId + '';
+    }
+  }
+  get id() {
+    return this._id;
+  }
+
+  ngOnInit() {
+    this._generatedId = 'clr-stack-label-' + this.uniqueId;
+
+    if (!this.id) {
+      this._id = this._generatedId + '';
+    }
+  }
 }

--- a/projects/angular/src/data/stack-view/stack-view.module.ts
+++ b/projects/angular/src/data/stack-view/stack-view.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -13,7 +13,7 @@ import { ClrStackHeader } from './stack-header';
 import { ClrStackInput } from './stack-input';
 import { ClrStackSelect } from './stack-select';
 import { ClrStackView } from './stack-view';
-import { ClrStackViewCustomTags } from './stack-view-custom-tags';
+import { ClrStackViewCustomTags, ClrStackViewLabel } from './stack-view-custom-tags';
 import { ClrIconModule } from '../../icon/icon.module';
 import { ClrExpandableAnimationModule } from '../../utils/animations/expandable-animation/expandable-animation.module';
 import { ClrStackContentInput } from './stack-content-input';
@@ -24,6 +24,7 @@ export const CLR_STACK_VIEW_DIRECTIVES: Type<any>[] = [
   ClrStackHeader,
   ClrStackBlock,
   ClrStackContentInput,
+  ClrStackViewLabel,
   ClrStackViewCustomTags,
   /**
    * Undocumented experimental feature: inline editing.


### PR DESCRIPTION
Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

Adds several a11y enhancements to the stackview per request from a11y team.

- adds `aria-labelledby` to the `[role="region"]` stack block which points to the `clr-stack-label` element
- added `aria-controls` to the stack-block which points to the stack block child id (for expanding/collapsing)
- removes `posinset` and `setsize` per a11y directions (these were deprecated and essentially no-op in order to fix this without a breaking change
- add `role="heading"` and `aria-level` to the `clr-stack-block` per a11y directions to mitigate issues with buttons inside header
- added functionality to auto-generate an id for `clr-stack-label` if no id is passed so that the stack view can wire up all this a11y code with no code from product devs
- broke out the `clr-stack-label` into a real component; previously it was a no-op directive
- added/updated tests for all of this

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: VPAT-592

## What is the new behavior?

See above.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
