### PR TITLE
fix(date-picker): better denote selected date

### DIFF
--- a/golden/clr-angular.d.ts
+++ b/golden/clr-angular.d.ts
@@ -465,6 +465,8 @@ export interface ClrCommonStrings {
     datepickerSelectMonthText: string;
     datepickerSelectYearText: string;
     datepickerToggle: string;
+    datepickerToggleChangeDateLabel: string;
+    datepickerToggleChooseDateLabel: string;
     delete?: string;
     detailExpandableAriaLabel: string;
     detailPaneEnd: string;
@@ -1027,10 +1029,11 @@ export declare class ClrDateContainer extends ClrAbstractContainer implements Af
     protected ngControlService: NgControlService;
     get open(): boolean;
     get popoverPosition(): ClrPopoverPosition;
-    constructor(toggleService: ClrPopoverToggleService, dateNavigationService: DateNavigationService, datepickerEnabledService: DatepickerEnabledService, dateFormControlService: DateFormControlService, commonStrings: ClrCommonStringsService, focusService: FocusService, viewManagerService: ViewManagerService, controlClassService: ControlClassService, layoutService: LayoutService, ngControlService: NgControlService, ifControlStateService: IfControlStateService);
+    protected renderer: Renderer2;
+    constructor(renderer: Renderer2, toggleService: ClrPopoverToggleService, dateNavigationService: DateNavigationService, datepickerEnabledService: DatepickerEnabledService, dateFormControlService: DateFormControlService, dateIOService: DateIOService, commonStrings: ClrCommonStringsService, focusService: FocusService, viewManagerService: ViewManagerService, controlClassService: ControlClassService, layoutService: LayoutService, ngControlService: NgControlService, ifControlStateService: IfControlStateService);
     ngAfterViewInit(): void;
     static ɵcmp: i0.ɵɵComponentDeclaration<ClrDateContainer, "clr-date-container", never, { "clrPosition": "clrPosition"; }, {}, never, ["label", "[clrDate]", "clr-control-helper", "clr-control-error", "clr-control-success"]>;
-    static ɵfac: i0.ɵɵFactoryDeclaration<ClrDateContainer, [null, null, null, null, null, null, null, null, { optional: true; }, null, null]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<ClrDateContainer, [null, null, null, null, null, null, null, null, null, null, { optional: true; }, null, null]>;
 }
 
 export declare class ClrDateInput extends WrappedFormControl<ClrDateContainer> implements OnInit, AfterViewInit, OnDestroy {

--- a/projects/angular/src/forms/datepicker/date-container.spec.ts
+++ b/projects/angular/src/forms/datepicker/date-container.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -30,6 +30,7 @@ import { ClrPopoverEventsService } from '../../utils/popover/providers/popover-e
 import { ClrPopoverPositionService } from '../../utils/popover/providers/popover-position.service';
 import { ViewManagerService } from './providers/view-manager.service';
 import { IfControlStateService, CONTROL_STATE } from '../common/if-control-state/if-control-state.service';
+import { DayModel } from './model/day.model';
 
 const DATEPICKER_PROVIDERS: any[] = [
   ClrPopoverEventsService,
@@ -54,6 +55,7 @@ export default function () {
     let context: TestContext<ClrDateContainer, TestComponent>;
     let enabledService: MockDatepickerEnabledService;
     let dateFormControlService: DateFormControlService;
+    let dateNavigationService: DateNavigationService;
     let toggleService: ClrPopoverToggleService;
     let container: any;
 
@@ -72,6 +74,7 @@ export default function () {
       enabledService = context.getClarityProvider(DatepickerEnabledService) as MockDatepickerEnabledService;
       dateFormControlService = context.getClarityProvider(DateFormControlService);
       toggleService = context.getClarityProvider(ClrPopoverToggleService);
+      dateNavigationService = context.getClarityProvider(DateNavigationService);
       container = context.clarityDirective;
     });
 
@@ -163,14 +166,17 @@ export default function () {
         expect(context.clarityElement.className).toContain('clr-form-control-disabled');
       });
 
-      it('has an accessible title on the calendar toggle button', () => {
+      it('has an accessible title and aria-label on the calendar toggle button', async () => {
         const toggleButton: HTMLButtonElement = context.clarityElement.querySelector('.clr-input-group-icon-action');
-        expect(toggleButton.title).toEqual('Toggle datepicker');
-      });
+        expect(toggleButton.title).toEqual('Choose date');
+        expect(toggleButton.attributes['aria-label'].value).toEqual('Choose date');
 
-      it('has an accessible aria-label on the calendar toggle button', () => {
-        const toggleButton: HTMLButtonElement = context.clarityElement.querySelector('.clr-input-group-icon-action');
-        expect(toggleButton.attributes['aria-label'].value).toEqual('Toggle datepicker');
+        dateNavigationService.notifySelectedDayChanged(new DayModel(2022, 1, 1));
+        context.detectChanges();
+        await context.fixture.whenStable();
+
+        expect(toggleButton.title).toEqual('Change date, 02/01/2022');
+        expect(toggleButton.attributes['aria-label'].value).toEqual('Change date, 02/01/2022');
       });
 
       it('supports clrPosition option', () => {

--- a/projects/angular/src/forms/datepicker/day.spec.ts
+++ b/projects/angular/src/forms/datepicker/day.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -127,6 +127,15 @@ export default function () {
         const dayBtn: HTMLButtonElement = context.clarityElement.children[0];
         const dvm: DayViewModel = context.clarityDirective.dayView;
         expect(dayBtn.attributes['aria-label'].value).toEqual(dvm.dayModel.toDateString());
+      });
+
+      it('sets aria-selected when the date is selected', () => {
+        const button: HTMLButtonElement = context.clarityElement.children[0];
+        expect(button.attributes['aria-selected'].value).toBe('false');
+        context.testComponent.dayView.isSelected = true;
+
+        context.detectChanges();
+        expect(button.attributes['aria-selected'].value).toBe('true');
       });
 
       it('updates the focusable date when a button is focused', () => {

--- a/projects/angular/src/forms/datepicker/day.ts
+++ b/projects/angular/src/forms/datepicker/day.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -27,6 +27,7 @@ import { DateNavigationService } from './providers/date-navigation.service';
       (click)="selectDay()"
       (focus)="onDayViewFocus()"
       [attr.aria-label]="dayString"
+      [attr.aria-selected]="dayView.isSelected"
     >
       {{ dayView.dayModel.date }}
     </button>

--- a/projects/angular/src/utils/i18n/common-strings.default.ts
+++ b/projects/angular/src/utils/i18n/common-strings.default.ts
@@ -58,6 +58,8 @@ export const commonStringsDefault: ClrCommonStrings = {
   // Date Picker
   datepickerDialogLabel: 'Choose date',
   datepickerToggle: 'Toggle datepicker',
+  datepickerToggleChooseDateLabel: 'Choose date',
+  datepickerToggleChangeDateLabel: 'Change date, {SELECTED_DATE}',
   datepickerPreviousMonth: 'Previous month',
   datepickerCurrentMonth: 'Current month',
   datepickerNextMonth: 'Next month',

--- a/projects/angular/src/utils/i18n/common-strings.interface.ts
+++ b/projects/angular/src/utils/i18n/common-strings.interface.ts
@@ -207,6 +207,8 @@ export interface ClrCommonStrings {
    */
   datepickerDialogLabel: string;
   datepickerToggle: string;
+  datepickerToggleChooseDateLabel: string;
+  datepickerToggleChangeDateLabel: string;
   datepickerPreviousMonth: string;
   datepickerCurrentMonth: string;
   datepickerNextMonth: string;


### PR DESCRIPTION
- include selected date in button label
- add aria-selected to date in calendar

fixes VPAT-662

Signed-off-by: Ashley Ryan <asryan@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The selected date in the calendar in the modal does not have aria-selected on it after a date has been selected

## What is the new behavior?

Added aria-selected to the button, also changed the label on the button to switch between "Choose date" and "Change date, {date}" when selected.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
