### PR TITLE
fix(angular): set build compilation mode

### DIFF
--- a/packages/angular/projects/cds-angular/tsconfig.lib.prod.json
+++ b/packages/angular/projects/cds-angular/tsconfig.lib.prod.json
@@ -5,6 +5,6 @@
     "declarationMap": false
   },
   "angularCompilerOptions": {
-    "enableIvy": false
+    "compilationMode": "partial"
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
cds/angular was compiling down to use the view engine output rather than use the recommended partial mode to support both view engine and ivy as described here https://angular.io/guide/angular-compiler-options#compilationmode Will need to backport this to v5


Issue Number: https://github.com/vmware/clarity/issues/6745

## What is the new behavior?
cds/core now compiles the library to the correct build target.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
