### PR TITLE
docs(signpost): make icon trigger an icon button

### DIFF
--- a/projects/website/src/app/documentation/demos/signposts/signpost-triggers.demo.html
+++ b/projects/website/src/app/documentation/demos/signposts/signpost-triggers.demo.html
@@ -3,7 +3,9 @@
     <div class="signpost-item">
       <h6>Clarity Icon</h6>
       <clr-signpost>
-        <clr-icon shape="avatar" class="is-solid has-badge-info" clrSignpostTrigger> </clr-icon>
+        <button class="btn btn-link btn-icon" aria-label="Icon Button Trigger" clrSignpostTrigger>
+          <clr-icon shape="avatar" class="is-solid has-badge-info"> </clr-icon>
+        </button>
         <clr-signpost-content *clrIfOpen [clrPosition]="'bottom-middle'"> Lorem ipsum... </clr-signpost-content>
       </clr-signpost>
     </div>

--- a/projects/website/src/app/documentation/demos/signposts/signpost-triggers.demo.ts
+++ b/projects/website/src/app/documentation/demos/signposts/signpost-triggers.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -26,10 +26,10 @@ export class SignpostTriggersDemo extends ClarityDocComponent {
         <div class="signpost-item">
             <h6>Clarity Icon</h6>
             <clr-signpost>
-                <clr-icon shape="avatar" 
-                          class="is-solid has-badge-info" 
-                          clrSignpostTrigger>
-                </clr-icon>
+                <button class="btn btn-link btn-icon" aria-label="Icon Button Trigger" clrSignpostTrigger>
+                    <clr-icon shape="avatar" class="is-solid has-badge-info">
+                    </clr-icon>
+                </button>
                 <clr-signpost-content [clrPosition]="'bottom-middle'" *clrIfOpen>
                     Lorem ipsum...
                 </clr-signpost-content>


### PR DESCRIPTION
fixes VPAT-643

Signed-off-by: Ashley Ryan <asryan@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently the docs for the signpost trigger use a clr-icon that is not interactable and can't be access via a keyboard

## What is the new behavior?

It now uses a button that can be reached with the keyboard

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
