### PR TITLE
fix(website): navigation page opening in section children

### DIFF
--- a/apps/website/.vuepress/theme/components/Sidebar.vue
+++ b/apps/website/.vuepress/theme/components/Sidebar.vue
@@ -27,7 +27,7 @@
               >
                 <template v-for="(childItem, index) in $options.filters.filterReleasedComponents(item.children)">
                   <router-link
-                    @focus.native="focusToggle(index)"
+                    @focus.native="focusToggle(index, item.children)"
                     class="nav-link"
                     :to="childItem.path"
                     v-if="childItem.type !== 'external' && isBeta(childItem) === false"
@@ -195,14 +195,19 @@ export default {
       // This is because Vue can't detect changes mutated on an array, so this alerts it of changes
       this.$set(this.states, index, !this.states[index]);
     },
-    focusToggle: function (index) {
+    focusToggle: function (index, items) {
       if (this.states[index]) {
         // already open
         return;
-      } else {
-        // open when hidden item is focused
-        this.$set(this.states, index, !this.states[index]);
       }
+
+      // Fix of https://github.com/vmware/clarity/issues/6757
+      if (this.states[index] !== items) {
+        return;
+      }
+
+      // open when hidden item is focused
+      this.$set(this.states, index, !this.states[index]);
     },
     isItemActive: function (childItem) {
       const childItemPath = removePathExt(childItem.path);


### PR DESCRIPTION
Closes #6757 

Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #6757 

## What is the new behavior?

The children of section does not open top sections when navigation is executed

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

