### PR TITLE
fix(website): storybook was hard-setting preview height

### DIFF
--- a/packages/core/.storybook/public/preview.css
+++ b/packages/core/.storybook/public/preview.css
@@ -116,6 +116,10 @@ pre.prismjs {
   background: var(--cds-global-color-gray-50) !important;
 }
 
+.docs-story [class*='css-'] {
+  height: unset;
+}
+
 .docs-story > div:last-child button {
   background: var(--cds-alias-object-container-background) !important;
   color: var(--cds-global-typography-color-500) !important;


### PR DESCRIPTION
Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [x] Other... Please describe: Dependency regression (Storybook)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

After a recent update, storybook began hardsetting demo blocks to 70px...

![Screen Shot 2022-03-10 at 9 26 31 AM](https://user-images.githubusercontent.com/2728359/157684451-54b28b8a-c297-4ec1-aa20-4135f3fa95d0.png)

Issue Number: N/A

## What is the new behavior?

I unset the height...

![Screen Shot 2022-03-10 at 9 38 47 AM](https://user-images.githubusercontent.com/2728359/157684804-3e021834-d8f1-4496-8ac1-4aa2d302712f.png)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
